### PR TITLE
Objects can move around in the mujoco minimal scene

### DIFF
--- a/descriptions/reachy_mini/mjcf/scenes/minimal.xml
+++ b/descriptions/reachy_mini/mjcf/scenes/minimal.xml
@@ -2,7 +2,6 @@
     <include file="../reachy_mini.xml" />
     <compiler meshdir="../assets" texturedir="../assets" />
     <option>
-        <!-- keep your timestep/integrator settings -->
         <flag multiccd="enable"/>   <!-- multi-contact CCD for convex/mesh pairs -->
     </option>
     <visual>


### PR DESCRIPTION
enabling freejoints for objects, adding pure shape collision for the tabletop, enabling multi contact collision detection in mujoco