### PR TITLE
head z offset (0.177) is now handled directly at the kinematics level

### DIFF
--- a/apps/hello_app/hello_app/main.py
+++ b/apps/hello_app/hello_app/main.py
@@ -18,7 +18,6 @@ class HelloApp(ReachyMiniApp):
 
             yaw = target
             head = np.eye(4)
-            head[:3, 3] = [0, 0, 0.177]
             head[:3, :3] = R.from_euler("xyz", [0, 0, yaw], degrees=False).as_matrix()
 
             reachy_mini.set_position(head=head, antennas=np.array([target, -target]))

--- a/examples/api_playground.py
+++ b/examples/api_playground.py
@@ -19,7 +19,6 @@ def main():
 
             yaw = target
             head = np.eye(4)
-            head[:3, 3] = [0, 0, 0.177]
             head[:3, :3] = R.from_euler("xyz", [0, 0, yaw], degrees=False).as_matrix()
 
             mini.set_position(head=head, antennas=np.array([target, -target]))

--- a/examples/client_example.py
+++ b/examples/client_example.py
@@ -9,7 +9,7 @@ with ReachyMini(spawn_daemon=True, use_sim=False) as reachy_mini:
     try:
         while True:
             pose = np.eye(4)
-            pose[:3, 3][2] = 0.177 + 0.005 * np.sin(
+            pose[:3, 3][2] = 0.005 * np.sin(
                 2 * np.pi * 0.3 * time.time() + np.pi
             )
             euler_rot = [

--- a/examples/hand_track_demo.py
+++ b/examples/hand_track_demo.py
@@ -46,7 +46,6 @@ cap = cv2.VideoCapture(4)
 
 hand_tracker = HandTracker()
 pose = np.eye(4)
-pose[:3, 3][2] = 0.177  # Set the height of the head
 euler_rot = np.array([0.0, 0.0, 0.0])
 kp = 0.3
 t0 = time.time()
@@ -73,7 +72,7 @@ with ReachyMini() as reachy_mini:
                 rot_mat = R.from_euler("xyz", euler_rot, degrees=False).as_matrix()
                 pose[:3, :3] = rot_mat
                 pose[:3, 3][2] = (
-                    error[1] * 0.04 + 0.177
+                    error[1] * 0.04
                 )  # Adjust height based on vertical error
 
                 # antennas = [left_antenna, right_antenna]

--- a/examples/head_track_demo.py
+++ b/examples/head_track_demo.py
@@ -56,7 +56,6 @@ cap = cv2.VideoCapture(4)
 
 head_tracker = HeadTracker()
 pose = np.eye(4)
-pose[:3, 3][2] = 0.177  # Set the height of the head
 euler_rot = np.array([0.0, 0.0, 0.0])
 kp = 0.3
 t0 = time.time()
@@ -82,7 +81,7 @@ with ReachyMini() as reachy_mini:
                 rot_mat = R.from_euler("xyz", euler_rot, degrees=False).as_matrix()
                 pose[:3, :3] = rot_mat
                 pose[:3, 3][2] = (
-                    error[1] * 0.04 + 0.177
+                    error[1] * 0.04
                 )  # Adjust height based on vertical error
 
                 antennas = [left_antenna, right_antenna]

--- a/examples/mirror_xyroll.py
+++ b/examples/mirror_xyroll.py
@@ -75,7 +75,6 @@ def main(draw=True):
                             connection_drawing_spec=mp.solutions.drawing_styles.get_default_face_mesh_contours_style(),
                         )
                     pose = pose_estimator.predict(face_landmarks, img)
-                    pose[:3, 3][2] += 0.177  # Set the height of the head
                     reachy_mini.set_position(head=pose, antennas=np.array([0, 0]))
 
                 cv.imshow("test_window", img)

--- a/examples/remi_outdated/groove_test.py
+++ b/examples/remi_outdated/groove_test.py
@@ -39,7 +39,7 @@ TEST_MOTION_AMPLITUDE_ORI = np.deg2rad(30)
 TEST_MOTION_FREQUENCY_HZ = 0.5 # Static frequency for test limits
 
 # Common Config
-NEUTRAL_POSITION = np.array([0.0, 0.0, 0.177 - 0.0075])
+NEUTRAL_POSITION = np.array([0.0, 0.0, -0.0075])
 NEUTRAL_EULER_ANGLES = np.array([0.0, 0.0, 0.0])
 ACTUATED_JOINT_NAMES = ["1", "2", "3", "4", "5", "6"]
 

--- a/examples/sequence.py
+++ b/examples/sequence.py
@@ -7,7 +7,6 @@ with ReachyMini() as reachy_mini:
     try:
         while True:
             pose = np.eye(4)
-            pose[:3, 3][2] = 0.177  # Set the height of the head
 
             t = 0
             t0 = time.time()
@@ -44,7 +43,6 @@ with ReachyMini() as reachy_mini:
             while time.time() - s < 2.0:
                 t = time.time() - t0
                 pose = np.eye(4)
-                pose[:3, 3][2] = 0.177
                 pose[:3, 3][2] += 0.025 * np.sin(2 * np.pi * 0.5 * t)
                 reachy_mini.set_position(head=pose, antennas=np.array([0, 0]))
                 time.sleep(0.01)
@@ -65,22 +63,22 @@ with ReachyMini() as reachy_mini:
                 pose[:3, 3] = [
                     0.015 * np.sin(2 * np.pi * 1.0 * t),
                     0.015 * np.sin(2 * np.pi * 1.0 * t + np.pi / 2),
-                    0.177,
+                    0.0,
                 ]
                 reachy_mini.set_position(head=pose, antennas=np.array([0, 0]))
                 time.sleep(0.01)
 
-            pose[:3, 3] = [0, 0, 0.177]
+            pose[:3, 3] = [0, 0, 0.0]
             reachy_mini.set_position(head=pose, antennas=np.array([0, 0]))
 
             time.sleep(0.5)
 
-            pose[:3, 3] = [0.02, 0.02, 0.177]
+            pose[:3, 3] = [0.02, 0.02, 0.0]
             reachy_mini.set_position(head=pose, antennas=np.array([0, 0]))
 
             time.sleep(0.5)
 
-            pose[:3, 3] = [0.00, 0.02, 0.177]
+            pose[:3, 3] = [0.00, 0.02, 0.0]
             euler_rot = np.array([0, 0, 0.5])
             rot_mat = R.from_euler("xyz", euler_rot, degrees=False).as_matrix()
             pose[:3, :3] = rot_mat
@@ -88,7 +86,7 @@ with ReachyMini() as reachy_mini:
 
             time.sleep(0.5)
 
-            pose[:3, 3] = [0.00, -0.02, 0.177]
+            pose[:3, 3] = [0.00, -0.02, 0.0]
             euler_rot = np.array([0, 0, -0.5])
             rot_mat = R.from_euler("xyz", euler_rot, degrees=False).as_matrix()
             pose[:3, :3] = rot_mat
@@ -96,7 +94,7 @@ with ReachyMini() as reachy_mini:
 
             time.sleep(0.5)
 
-            pose[:3, 3] = [0, 0, 0.177]
+            pose[:3, 3] = [0, 0, 0.0]
             reachy_mini.set_position(head=pose, antennas=np.array([0, 0]))
 
             time.sleep(2)

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -20,7 +20,6 @@ pygame.mixer.init()
 
 # Behavior definitions
 INIT_HEAD_POSE = np.eye(4)
-INIT_HEAD_POSE[2, 3] = 0.177
 
 SLEEP_HEAD_JOINT_POSITIONS = [
     0.0,

--- a/src/reachy_mini/utils.py
+++ b/src/reachy_mini/utils.py
@@ -5,6 +5,19 @@ from typing import Callable, Optional
 
 import numpy as np
 import psutil
+from scipy.spatial.transform import Rotation as R
+
+
+def create_head_pose(x=0, y=0, z=0, roll=0, pitch=0, yaw=0, mm=False, degrees=True):
+    pose = np.eye(4)
+    rot = R.from_euler("xyz", [roll, pitch, yaw], degrees=degrees).as_matrix()
+    pose[:3, :3] = rot
+    pose[:, 3] = [x, y, z, 0]
+    if mm:
+        pose[:3, 3] /= 1000
+
+    return pose
+
 
 InterpolationFunc = Callable[[float], np.ndarray]
 


### PR DESCRIPTION
We want the "zero" position of the robot to be with the head "up" (with `z = 0.177`) for the user. They shouldn't need to handle the offset themselves.

Offset is added and subtracted in `ik()` and `fk()`

![Capture d’écran du 2025-06-18 11-51-52](https://github.com/user-attachments/assets/efc32d52-3583-4474-903a-47d45cfc9ba2)

![Capture d’écran du 2025-06-18 11-51-57](https://github.com/user-attachments/assets/d4c2d8be-dc9f-4406-a198-5b9fb30695a5)

Also removed all occurrences of the offset being added  manually in all the codebase

@matthieu-lapeyre I also added your `create_head_pose()` function in `utils.py`

- [x] Tested in simulation
- [x] Tested on the real robot