### PR TITLE
reduce the ik and fk calls to only the necessary ones

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -50,10 +50,13 @@ class Backend:
         # For Forward kinematics (around 0.25deg) 
         # - FK is calculated at each timestep and is susceptible to noise
         self._fk_kin_tolerance = 4e-3   # rads
-        # For Inverse kinematics (around 1mm and 0.1 degrees) 
+        # For Inverse kinematics (around 0.5mm and 0.1 degrees) 
         # - IK is calculated only when the head pose is set by the user 
-        self._ik_kin_tolerance = 1e-3  # rads and m
-        
+        self._ik_kin_tolerance = {
+            "rad": 2e-3,  # rads
+            "m": 0.5e-3  # m
+        }
+
     def wrapped_run(self):
         """Run the backend in a try-except block to store errors."""
         try:
@@ -111,8 +114,9 @@ class Backend:
         #check if the pose is the same as the current one
         if self.head_pose is not None and \
             self._last_body_yaw is not None and \
-            np.allclose(self._last_body_yaw, body_yaw, atol=self._ik_kin_tolerance) and \
-            np.allclose(self.head_pose, pose, atol=self._ik_kin_tolerance):
+            np.allclose(self._last_body_yaw, body_yaw, atol=self._ik_kin_tolerance["rad"]) and \
+            np.allclose(self.head_pose[:3, 3], pose[:3, 3], atol=self._ik_kin_tolerance["m"]) and \
+            np.allclose(self.head_pose[:3, :3], pose[:3, :3], atol=self._ik_kin_tolerance["rad"]):
             # If the pose is the same, do not recompute IK
             return
         


### PR DESCRIPTION
This PR optimises the code not to run the FK and IK on every single step of the runtime. 
Basically it checks if the head pose is equal (close) to the last head pose and if the joint positions are close to the last joint positions and only calculates the IK and FK if there have been some changes. 

In my experience, this reduces the CPU load a lot:
before:
<img width="1150" height="315" alt="image" src="https://github.com/user-attachments/assets/69e5d5d2-3e4f-42bb-8207-d4fcbd07fc35" />


after:
<img width="1168" height="230" alt="image" src="https://github.com/user-attachments/assets/fcdf771f-a456-4c09-9a91-cc1902e5eec6" />

In case of my PC (an old i5) this made the simulaiton/robot usable. If I do not do this optimisation the reachy-mini is just not usable. If I put a 1second sinus on the antennas the simulation takes over 10 seconds to execute the sinus. 
 
 
**IMPORTANT** 
In order for this optimisation to work we need to set the treshold (tolerance). I've put it into a `Backend` class property `_kinematics_computation_tolerance` and set it to `1e-3`. The lower it is the more often the kinematics will be calculated basically. 
In my tests the `1e-3` I dont see any influence on the robot behavior. But there might be a use-case where we set this tolerance to lower values maybe. 
- 1e-3 corresponds to 1mm more and to 0.001 rad ~ 0.05 degrees 
We could maybe implement this threshold check on our own so that the threshold corresponds to for example 0.1mm and 0.1deg. 
But for the moment I've chosen the simplicity (`np.allclose`)