### PR TITLE
relax numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = ""
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "numpy==2.2.5",
+    "numpy>=2.2.5",
     "scipy==1.15.3",
     "mujoco==3.3.0",
     "onshape-to-robot==1.7.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = ""
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "numpy>=2.2.5",
+    "numpy>=2.2.5,<2.3.0",
     "scipy==1.15.3",
     "mujoco==3.3.0",
     "onshape-to-robot==1.7.6",


### PR DESCRIPTION
Small PR to relax `numpy` version to `>=2.2.5,<2.3.0` for compatibility

This change is based on the `148-temporary-motion-record-system branch`.
It aligns `reachy_mini` with other repos (`reachy2_emotions`) by unpinning the `numpy` version to avoid dependency conflicts