### PR TITLE
Move `viewer.sync()` in the 50hz loop in mujoco backend

### DIFF
--- a/src/reachy_mini/daemon/backend/mujoco/backend.py
+++ b/src/reachy_mini/daemon/backend/mujoco/backend.py
@@ -135,9 +135,9 @@ class MujocoBackend(Backend):
                                 }
                             ).encode("utf-8")
                         )
+                    viewer.sync()   
 
                 mujoco.mj_step(self.model, self.data)  # type: ignore
-                viewer.sync()
 
                 took = time.time() - start_t
                 time.sleep(max(0, self.model.opt.timestep - took))


### PR DESCRIPTION
It seems we were trying to render at 500Hz (my bad sorry)

Moving `viewer.sync()` in the decimated portion of the loop, meaning we now render at 50Hz,  seems to greatly reduce the cpu load.

Before : 

<img width="659" height="66" alt="Capture d’écran du 2025-08-06 15-25-57" src="https://github.com/user-attachments/assets/f5d83251-e05c-4bac-b9ea-8875129332e8" />

After : 

<img width="659" height="66" alt="Capture d’écran du 2025-08-06 15-26-19" src="https://github.com/user-attachments/assets/6fd40a08-dd75-4db7-9007-e96757246180" />
