### PR TITLE
bug #194: disconnect client in __del__

### DIFF
--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -117,6 +117,14 @@ class ReachyMini:
             ]
         )
 
+    def __del__(self):
+        """Destroy the Reachy Mini instance.
+
+        The client is disconnected explicitly to avoid a thread pending issue.
+
+        """
+        self.client.disconnect()
+
     def __enter__(self) -> "ReachyMini":
         """Context manager entry point for Reachy Mini."""
         return self


### PR DESCRIPTION
Fix @alozowski [issue](https://github.com/pollen-robotics/reachy_mini_conversation_demo/blob/4441051732d821622b193dfa1293bee6e90623fb/src/reachy_mini_conversation_demo/test_stop.py#L28) when  `current_robot.client.disconnect()` is commented. We should have to call this explicitly.

I've added it to the _del_ of ReachyMini. 

This is temporary anyway if @pierre-rouanet is removing zenoh for the rest api.