### PR TITLE
fix the dummy link orientation for yaw constraint

### DIFF
--- a/src/reachy_mini/descriptions/reachy_mini/urdf/robot.urdf
+++ b/src/reachy_mini/descriptions/reachy_mini/urdf/robot.urdf
@@ -3290,7 +3290,7 @@ https://cad.onshape.com/documents/7836ed39be931c6ece17e007/w/39d557f31a0ba179c9e
   </link>
   <!-- Joint from pp01071_turning_bowl to dc15_a01_case_b_dummy -->
   <joint name="dummy_yaw" type="fixed">
-    <origin xyz="0 0 0" rpy="3.14 0 1.57"/>
+    <origin xyz="0 0 0" rpy="3.14 0 -1.57"/>
     <!-- <origin xyz="4.85723e-17 -5.60663e-19 0.0339" rpy="3.14159 -2.22045e-16 1.5708"/> -->
     <parent link="body_down_3dprint"/>
     <!-- <parent link="dc15_a01_case_b_dummy"/>   -->

--- a/src/reachy_mini/descriptions/reachy_mini/urdf/robot_no_collision.urdf
+++ b/src/reachy_mini/descriptions/reachy_mini/urdf/robot_no_collision.urdf
@@ -2324,7 +2324,7 @@ https://cad.onshape.com/documents/7836ed39be931c6ece17e007/w/39d557f31a0ba179c9e
   </link>
   <!-- Joint from pp01071_turning_bowl to dc15_a01_case_b_dummy -->
   <joint name="dummy_yaw" type="fixed">
-    <origin xyz="0 0 0" rpy="3.14 0 1.57"/>
+    <origin xyz="0 0 0" rpy="3.14 0 -1.57"/>
     <!-- <origin xyz="4.85723e-17 -5.60663e-19 0.0339" rpy="3.14159 -2.22045e-16 1.5708"/> -->
     <parent link="body_down_3dprint"/>
     <!-- <parent link="dc15_a01_case_b_dummy"/>   -->

--- a/src/reachy_mini/kinematics/placo_kinematics.py
+++ b/src/reachy_mini/kinematics/placo_kinematics.py
@@ -87,10 +87,10 @@ class PlacoKinematics:
         # Add the constraint between the rotated torso and the head
         # This will allow independent control of the torso and the head yaw
         # until this constraint is reached
-        # yaw_constraint = self.ik_solver.add_yaw_constraint(
-        #     "dummy_torso_yaw", "head", np.deg2rad(65.0)
-        # )
-        # yaw_constraint.configure("rel_yaw", "hard")
+        yaw_constraint = self.ik_solver.add_yaw_constraint(
+            "dummy_torso_yaw", "head", np.deg2rad(65.0)
+        )
+        yaw_constraint.configure("rel_yaw", "hard")
 
         # Add the constraint to avoid the head from looking too far behind
         # Mostly due to some numerical problems 180 is always a bit tricky
@@ -107,10 +107,10 @@ class PlacoKinematics:
             "body_foot_3dprint", "head", np.deg2rad(40.0)
         )
         self.fk_cone.configure("cone", "hard")
-        # self.fk_yaw_constraint = self.fk_solver.add_yaw_constraint(
-        #     "dummy_torso_yaw", "head", np.deg2rad(65.0)
-        # )
-        # self.fk_yaw_constraint.configure("rel_yaw", "hard")
+        self.fk_yaw_constraint = self.fk_solver.add_yaw_constraint(
+            "dummy_torso_yaw", "head", np.deg2rad(65.0)
+        )
+        self.fk_yaw_constraint.configure("rel_yaw", "hard")
 
         # Add a cone constraint for the head to not exceed a certain angle
         # This is to avoid the head from looking too far up or down


### PR DESCRIPTION
Relative yaw constraint between the head and the torso depends on the orientaiton of the dummy link in the urdf. 
This PR fixes the its orientation for the new urdf. 

