### PR TITLE
Fixed the gravity compensation on the beta version

### DIFF
--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -408,9 +408,9 @@ class RobotBackend(Backend):
         # Conversion factor from Nm to mA for the Stewart platform motors
         # The torque constant is not linear, so we need to use a correction factor
         # This is a magic number that should be determined experimentally
-        # For currents under 30mA, the constant is around 3
+        # For currents under 30mA, the constant is around 4.0
         # Then it drops to 1.0 for currents above 1.5A
-        correction_factor = 3.0
+        correction_factor = 4.0
         # Get the current head joint positions
         head_joints = self.get_present_head_joint_positions()
         gravity_torque = self.head_kinematics.compute_gravity_torque(  # type: ignore [union-attr]


### PR DESCRIPTION
The gravity compensation did not work as well on betas as for alphas. 

I am not 100% sure what the real reason is but the fix is the increase in the torque constant correction factor from 3.0 to 4.0. 

Tested on the reachy mini at Hugging Face's Paris office. 

