### PR TITLE
Capping the max value of t in reachy_mini.py:async_play_move() to move.duration - epsilon

### DIFF
--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -686,7 +686,7 @@ class ReachyMini:
 
         t0 = time.time()
         while time.time() - t0 < move.duration:
-            t = time.time() - t0
+            t = min(time.time() - t0, move.duration - 1e-2)
 
             head, antennas, body_yaw = move.evaluate(t)
             if head is not None:


### PR DESCRIPTION
I let it run for ~10mn and it didn't crash (it crashed after ~15-30s before)

```python
from reachy_mini import ReachyMini
from reachy_mini.motion.recorded_move import RecordedMove, RecordedMoves

with ReachyMini() as reachy:
    recorded_moves = RecordedMoves("pollen-robotics/reachy-mini-dances-library")
    while True:
        move: RecordedMove = recorded_moves.get("dizzy_spin")
        reachy.play_move(move, initial_goto_duration=1.0)
        continue
```