### PR TITLE
refactor(audio): improve device selection and reduce code duplication in sounddevice backend" --body

### DIFF
--- a/src/reachy_mini/media/audio_sounddevice.py
+++ b/src/reachy_mini/media/audio_sounddevice.py
@@ -199,22 +199,22 @@ class SoundDeviceAudio(AudioBase):
         devices = sd.query_devices()
         channel_key = f"max_{device_type}_channels"
 
-        # return default device with appropriate channels
-        for idx, dev in enumerate(devices):
-            if dev.get(channel_key, 0) > 0:
-                return idx
-
-        # Log warning if default device not found
-        self.logger.warning(
-            f"No default {device_type} found. Trying another device containing '{name_contains}'."
-        )
-
-        # Fallback: Search for device by specific name
+        # First try: Search for device by specific name (e.g., "respeaker")
         for idx, dev in enumerate(devices):
             if (
                 name_contains.lower() in dev["name"].lower()
                 and dev.get(channel_key, 0) > 0
             ):
+                return idx
+
+        # Log warning if device with specific name not found
+        self.logger.warning(
+            f"No {device_type} device containing '{name_contains}' found. Using first available {device_type} device."
+        )
+
+        # Fallback: Return first device with appropriate channels
+        for idx, dev in enumerate(devices):
+            if dev.get(channel_key, 0) > 0:
                 return idx
 
         raise RuntimeError(


### PR DESCRIPTION
## Summary
This PR improves audio device selection logic and refactors duplicated code in the sounddevice backend.

## Background
The original get_input_device_id() and get_output_device_id() methods had some areas for improvement:
1. Device fallback behavior: When the named device wasn’t found, both methods returned sd.default.device[1], which represents the default output device. This could cause issues for get_input_device_id() when trying to use an output device for recording.
2. Code organization: The two methods contained nearly identical logic that could be extracted into a shared helper.

## Changes

This PR introduces the following improvements:
- Extracts shared device-finding logic into a _find_device_id(name_contains, device_type) helper method
- Uses dynamic channel_key based on device type: "max_input_channels" or "max_output_channels"
- Implements proper fallback: searches for the first available device with the appropriate channel type
- Provides clearer error messages via RuntimeError when no suitable device is available
- Fixes a small typo: logger.warningt → logger.warning

## Testing
- Tested on macOS without ReSpeaker device
- Verified proper fallback to system default audio devices
- Confirmed input/output device types are correctly distinguished
- No crashes when the named device (“respeaker”) is not found

## Result
Both methods now consistently return valid devices of the correct type (input or output), which should help prevent issues when audio hardware configurations vary across different systems.