### PR TITLE
Fix for audio default device

### DIFF
--- a/src/reachy_mini/media/audio_sounddevice.py
+++ b/src/reachy_mini/media/audio_sounddevice.py
@@ -219,7 +219,7 @@ class SoundDeviceAudio(AudioBase):
         )
         return self._safe_query_device('input')
 
-    def _safe_query_device(self, kind: str) -> int | None:
+    def _safe_query_device(self, kind: str) -> int:
         try:
             return int(sd.query_devices(None, kind)['index'])
         except sd.PortAudioError:


### PR DESCRIPTION
These functions' docs claim to return the default audio device if 'respeaker' isn't found, but they actually return the second audio device in the list from sounddevices. My fix returns the currently selected audio device for both input and output. These may differ from one another. In my current system, I have a device for macbook microphone and another one for macbook speakers. Same for the airpods, two different sound devices for input and output :) 