### PR TITLE
Add a route to retrieve a curated list of apps for the dashboard.

### DIFF
--- a/src/reachy_mini/apps/__init__.py
+++ b/src/reachy_mini/apps/__init__.py
@@ -1,20 +1,22 @@
 """Metadata about apps."""
 
-from dataclasses import dataclass, field
+from dataclasses import field
 from enum import Enum
 from typing import Any, Dict
+
+from pydantic import BaseModel
 
 
 class SourceKind(str, Enum):
     """Kinds of app source."""
 
     HF_SPACE = "hf_space"
+    DASHBOARD_SELECTION = "dashboard_selection"
     LOCAL = "local"
     INSTALLED = "installed"
 
 
-@dataclass
-class AppInfo:
+class AppInfo(BaseModel):
     """Metadata about an app."""
 
     name: str

--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -167,6 +167,8 @@ class AppManager:
             return await local_common_venv.list_available_apps()
         elif source == SourceKind.LOCAL:
             return []
+        elif source == SourceKind.DASHBOARD_SELECTION:
+            return await hf_space.get_dashboard_selection_apps()
         else:
             raise NotImplementedError(f"Unknown source kind: {source}")
 

--- a/src/reachy_mini/apps/sources/hf_space.py
+++ b/src/reachy_mini/apps/sources/hf_space.py
@@ -1,6 +1,7 @@
 """Hugging Face Spaces app source."""
 
 import aiohttp
+from pydantic import BaseModel
 
 from .. import AppInfo, SourceKind
 
@@ -23,3 +24,38 @@ async def list_available_apps() -> list[AppInfo]:
             )
         )
     return apps
+
+
+async def app_info_from_space_url(space_url: str) -> AppInfo:
+    """Get app info from a Hugging Face Space URL."""
+    space_url = "/".join(space_url.rstrip("/").split("/")[-2:])
+    url = f"https://huggingface.co/api/spaces/{space_url}"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            item = await response.json()
+
+    return AppInfo(
+        name=item["id"].split("/")[-1],
+        description=item["cardData"].get("short_description", ""),
+        url=f"https://huggingface.co/spaces/{item['id']}",
+        source_kind=SourceKind.HF_SPACE,
+        extra=item,
+    )
+
+
+class DashboardAppList(BaseModel):
+    """Model for dashboard app list."""
+
+    dashboard_selected_apps: list[AppInfo]
+
+
+async def get_dashboard_selection_apps() -> list[AppInfo]:
+    """Get the list of apps selected for the dashboard."""
+    dashboard_list_url = "https://huggingface.co/spaces/pollen-robotics/Reachy-Mini_Best_Spaces/raw/main/dashboard-app-list.json"
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(dashboard_list_url) as response:
+            data = await response.text()
+
+    apps = DashboardAppList.model_validate_json(data)
+    return apps.dashboard_selected_apps

--- a/src/reachy_mini/daemon/app/dashboard/static/js/appstore.js
+++ b/src/reachy_mini/daemon/app/dashboard/static/js/appstore.js
@@ -5,7 +5,7 @@ const hfAppsStore = {
         await hfAppsStore.displayAvailableApps(appsData);
     },
     fetchAvailableApps: async () => {
-        const resAvailable = await fetch('/api/apps/list-available');
+        const resAvailable = await fetch('/api/apps/list-available/dashboard_selection');
         const appsData = await resAvailable.json();
         return appsData;
     },


### PR DESCRIPTION
This PR provides a way to define a list of apps that will be directly shown in the dashboard/desktop app. This way we can:
- make sure the first app that users will try will work, have been tested, etc.
- change this list whenever we want without having to update the daemon/dashboard/desktop app.

## Technicals details 

- [x] Create a list of "selected apps" for the dashboard here: https://huggingface.co/spaces/pollen-robotics/Reachy-Mini_Best_Spaces/blob/main/generate-dashboard-list.py
- [x] Retrieve and parse this json from the AppManager of the daemon
- [x] The list can be retrieved via /api/apps/list-available/dashboard_selection