### PR TITLE
Add /api/camera/stream endpoint for MJPEG video streaming

### DIFF
--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -25,6 +25,7 @@ from fastapi.templating import Jinja2Templates
 from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.app.routers import (
     apps,
+    camera,
     daemon,
     kinematics,
     motors,
@@ -104,6 +105,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
 
     router = APIRouter(prefix="/api")
     router.include_router(apps.router)
+    router.include_router(camera.router)
     router.include_router(daemon.router)
     router.include_router(kinematics.router)
     router.include_router(motors.router)

--- a/src/reachy_mini/daemon/app/routers/camera.py
+++ b/src/reachy_mini/daemon/app/routers/camera.py
@@ -1,23 +1,28 @@
 """Camera streaming API routes."""
 
 import asyncio
+from typing import AsyncGenerator
 
 import cv2
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 
-from ...backend.mujoco.backend import MujocoBackend
-from ...daemon import Daemon
 from reachy_mini.media.camera_constants import CameraResolution
 from reachy_mini.media.camera_opencv import OpenCVCamera
+
+from ...backend.abstract import Backend
+from ...backend.mujoco.backend import MujocoBackend
+from ...daemon import Daemon
 from ..dependencies import get_backend, get_daemon
 
 router = APIRouter(prefix="/camera")
 
-_shared_camera = None
+_shared_camera: OpenCVCamera | None = None
 _camera_refs = 0
 
-async def _get_shared_camera(is_sim: bool):
+
+async def _get_shared_camera(is_sim: bool) -> OpenCVCamera:
+    """Get or create shared camera instance."""
     global _shared_camera, _camera_refs
     if _shared_camera is None:
         _shared_camera = OpenCVCamera(log_level="WARNING", resolution=CameraResolution.R1280x720)
@@ -25,7 +30,9 @@ async def _get_shared_camera(is_sim: bool):
     _camera_refs += 1
     return _shared_camera
 
-def _release_camera():
+
+def _release_camera() -> None:
+    """Release camera reference and close if no more clients."""
     global _shared_camera, _camera_refs
     _camera_refs -= 1
     if _camera_refs <= 0 and _shared_camera is not None:
@@ -33,14 +40,18 @@ def _release_camera():
         _shared_camera = None
         _camera_refs = 0
 
+
 @router.get("/stream")
 async def stream_camera(
-    backend=Depends(get_backend),
-    daemon: Daemon=Depends(get_daemon),
+    backend: Backend = Depends(get_backend),
+    daemon: Daemon = Depends(get_daemon),
 ) -> StreamingResponse:
     """Stream camera feed as MJPEG."""
-    async def _stream():
-        is_sim = daemon.status().simulation_enabled and isinstance(backend, MujocoBackend)
+
+    async def _stream() -> AsyncGenerator[bytes, None]:
+        is_sim = bool(
+            daemon.status().simulation_enabled and isinstance(backend, MujocoBackend)
+        )
         cam = await _get_shared_camera(is_sim)
         try:
             while True:
@@ -53,5 +64,6 @@ async def stream_camera(
                 await asyncio.sleep(0.04)
         finally:
             _release_camera()
+
     return StreamingResponse(_stream(), media_type="multipart/x-mixed-replace; boundary=frame")
 

--- a/src/reachy_mini/daemon/app/routers/camera.py
+++ b/src/reachy_mini/daemon/app/routers/camera.py
@@ -1,7 +1,11 @@
+"""Camera streaming API routes."""
+
 import asyncio
+
 import cv2
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
+
 from ...backend.mujoco.backend import MujocoBackend
 from ...daemon import Daemon
 from reachy_mini.media.camera_constants import CameraResolution
@@ -34,6 +38,7 @@ async def stream_camera(
     backend=Depends(get_backend),
     daemon: Daemon=Depends(get_daemon),
 ) -> StreamingResponse:
+    """Stream camera feed as MJPEG."""
     async def _stream():
         is_sim = daemon.status().simulation_enabled and isinstance(backend, MujocoBackend)
         cam = await _get_shared_camera(is_sim)

--- a/src/reachy_mini/daemon/app/routers/camera.py
+++ b/src/reachy_mini/daemon/app/routers/camera.py
@@ -1,0 +1,52 @@
+import asyncio
+import cv2
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+from ...backend.mujoco.backend import MujocoBackend
+from ...daemon import Daemon
+from reachy_mini.media.camera_constants import CameraResolution
+from reachy_mini.media.camera_opencv import OpenCVCamera
+from ..dependencies import get_backend, get_daemon
+
+router = APIRouter(prefix="/camera")
+
+_shared_camera = None
+_camera_refs = 0
+
+async def _get_shared_camera(is_sim: bool):
+    global _shared_camera, _camera_refs
+    if _shared_camera is None:
+        _shared_camera = OpenCVCamera(log_level="WARNING", resolution=CameraResolution.R1280x720)
+        _shared_camera.open(udp_camera="udp://@127.0.0.1:5005" if is_sim else None)
+    _camera_refs += 1
+    return _shared_camera
+
+def _release_camera():
+    global _shared_camera, _camera_refs
+    _camera_refs -= 1
+    if _camera_refs <= 0 and _shared_camera is not None:
+        _shared_camera.close()
+        _shared_camera = None
+        _camera_refs = 0
+
+@router.get("/stream")
+async def stream_camera(
+    backend=Depends(get_backend),
+    daemon: Daemon=Depends(get_daemon),
+) -> StreamingResponse:
+    async def _stream():
+        is_sim = daemon.status().simulation_enabled and isinstance(backend, MujocoBackend)
+        cam = await _get_shared_camera(is_sim)
+        try:
+            while True:
+                f = cam.read()
+                if f is not None:
+                    f = cv2.resize(f, (640, 480))
+                    _, j = cv2.imencode(".jpg", f, [cv2.IMWRITE_JPEG_QUALITY, 80])
+                    if _:
+                        yield b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + j.tobytes() + b"\r\n"
+                await asyncio.sleep(0.04)
+        finally:
+            _release_camera()
+    return StreamingResponse(_stream(), media_type="multipart/x-mixed-replace; boundary=frame")
+

--- a/src/reachy_mini/daemon/app/routers/camera.py
+++ b/src/reachy_mini/daemon/app/routers/camera.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import AsyncGenerator
 
 import cv2
+import numpy as np
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 
@@ -57,8 +58,8 @@ async def stream_camera(
             while True:
                 f = cam.read()
                 if f is not None:
-                    f = cv2.resize(f, (640, 480))
-                    _, j = cv2.imencode(".jpg", f, [cv2.IMWRITE_JPEG_QUALITY, 80])
+                    resized = np.asarray(cv2.resize(f, (640, 480)), dtype=np.uint8)
+                    _, j = cv2.imencode(".jpg", resized, [cv2.IMWRITE_JPEG_QUALITY, 80])
                     if _:
                         yield b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + j.tobytes() + b"\r\n"
                 await asyncio.sleep(0.04)

--- a/src/reachy_mini/daemon/backend/mujoco/backend.py
+++ b/src/reachy_mini/daemon/backend/mujoco/backend.py
@@ -167,8 +167,8 @@ class MujocoBackend(Backend):
         if not self.headless:
             viewer.sync()
 
-            rendering_thread = Thread(target=self.rendering_loop, daemon=True)
-            rendering_thread.start()
+        rendering_thread = Thread(target=self.rendering_loop, daemon=True)
+        rendering_thread.start()
 
         # 3) now enter your normal loop
         while not self.should_stop.is_set():


### PR DESCRIPTION
- Add camera router with /stream endpoint
- Support both simulation (UDP) and real robot (hardware camera)
- Share single camera instance between all clients
- Optimize with 640x480 resolution and 80% JPEG quality
- Ensure Mujoco rendering loop starts in headless mode for UDP stream