### PR TITLE
feat(sound in recorded moves): adding the ability to play the sound associated to a recorded move

### DIFF
--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -368,7 +368,7 @@ with ReachyMini() as mini:
 
     for move_name in recorded_moves.list_moves():
         print(f"Playing move: {move_name}")
-        mini.play_move(recorded_moves.get(move_name), initial_goto_duration=1.0)
+        mini.play_move(recorded_moves.get(move_name), initial_goto_duration=1.0, play_sound=True, final_goto_duration=1.0)
 ```
 
 The `initial_goto_duration` argument for `play_move()` allows you to smoothly go to the starting position of the move before starting to execute it.

--- a/examples/recorded_moves_example.py
+++ b/examples/recorded_moves_example.py
@@ -16,7 +16,7 @@ def main(dataset_path: str) -> None:
     recorded_moves = RecordedMoves(dataset_path)
 
     print("Connecting to Reachy Mini...")
-    with ReachyMini(use_sim=False, media_backend="no_media") as reachy:
+    with ReachyMini(use_sim=False, media_backend="default") as reachy:
         print("Connection successful! Starting dance sequence...\n")
         try:
             while True:
@@ -24,7 +24,12 @@ def main(dataset_path: str) -> None:
                     move: RecordedMove = recorded_moves.get(move_name)
                     print(f"Playing move: {move_name}: {move.description}\n")
                     # print(f"params: {move.move_params}")
-                    reachy.play_move(move, initial_goto_duration=1.0)
+                    reachy.play_move(
+                        move,
+                        initial_goto_duration=1.0,
+                        play_sound=True,
+                        final_goto_duration=1.0,
+                    )
 
         except KeyboardInterrupt:
             print("\n Sequence interrupted by user. Shutting down.")

--- a/src/reachy_mini/daemon/app/routers/move.py
+++ b/src/reachy_mini/daemon/app/routers/move.py
@@ -200,7 +200,11 @@ async def play_recorded_move_dataset(
         move = recorded_moves.get(move_name)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    return create_move_task(backend.play_move(move))
+    return create_move_task(
+        backend.play_move(
+            move, initial_goto_duration=1.0, final_goto_duration=1.0, play_sound=True
+        )
+    )
 
 
 @router.post("/stop")

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -333,7 +333,7 @@ class Backend:
         play_frequency: float = 100.0,
         initial_goto_duration: float = 0.0,
         final_goto_duration: float = 0.0,
-        play_sound=False,
+        play_sound: bool = False,
     ) -> None:
         """Asynchronously play a Move.
 
@@ -364,7 +364,7 @@ class Backend:
         sleep_period = 1.0 / play_frequency
 
         if play_sound and move.sound is not None:
-            self.play_sound(move.sound)
+            self.play_sound(str(move.sound))
 
         t0 = time.time()
         while time.time() - t0 < move.duration:

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -332,15 +332,24 @@ class Backend:
         move: Move,
         play_frequency: float = 100.0,
         initial_goto_duration: float = 0.0,
+        final_goto_duration: float = 0.0,
+        play_sound=False,
     ) -> None:
         """Asynchronously play a Move.
 
         Args:
             move (Move): The Move object to be played.
             play_frequency (float): The frequency at which to evaluate the move (in Hz).
-            initial_goto_duration (float): Duration for an initial goto to the move's starting position. If 0.0, no initial goto is performed.
+            initial_goto_duration (float): Duration for the initial goto to the starting position of the move (in seconds). If 0, no initial goto is performed.
+            final_goto_duration (float): Duration for the final goto to the initial position (in seconds). If 0, no final goto is performed.
+            play_sound (bool): If True, the sound associated with the move is played.
 
         """
+        if final_goto_duration > 0.0:
+            initial_head_pose = self.get_present_head_pose()
+            initial_antennas_positions = self.get_present_antenna_joint_positions()
+            initial_body_yaw = self.get_present_body_yaw()
+
         if initial_goto_duration > 0.0:
             start_head_pose, start_antennas_positions, start_body_yaw = move.evaluate(
                 0.0
@@ -351,11 +360,15 @@ class Backend:
                 duration=initial_goto_duration,
                 body_yaw=start_body_yaw,
             )
+
         sleep_period = 1.0 / play_frequency
+
+        if play_sound and move.sound is not None:
+            self.play_sound(move.sound)
 
         t0 = time.time()
         while time.time() - t0 < move.duration:
-            t = time.time() - t0
+            t = min(time.time() - t0, move.duration - 1e-2)
 
             head, antennas, body_yaw = move.evaluate(t)
             if head is not None:
@@ -370,6 +383,14 @@ class Backend:
                 await asyncio.sleep(sleep_period - elapsed)
             else:
                 await asyncio.sleep(0.001)
+
+        if final_goto_duration > 0.0:
+            await self.goto_target(
+                head=initial_head_pose,
+                antennas=initial_antennas_positions,
+                body_yaw=initial_body_yaw,
+                duration=final_goto_duration,
+            )
 
     async def goto_target(
         self,

--- a/src/reachy_mini/motion/move.py
+++ b/src/reachy_mini/motion/move.py
@@ -1,6 +1,7 @@
 """Module for defining motion moves on the ReachyMini robot."""
 
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
@@ -8,6 +9,11 @@ import numpy.typing as npt
 
 class Move(ABC):
     """Abstract base class for defining a move on the ReachyMini robot."""
+
+    @property
+    def sound(self) -> Path | None:
+        """Sound associated with the move."""
+        return None
 
     @property
     @abstractmethod

--- a/src/reachy_mini/motion/recorded_move.py
+++ b/src/reachy_mini/motion/recorded_move.py
@@ -20,9 +20,10 @@ def lerp(v0: float, v1: float, alpha: float) -> float:
 class RecordedMove(Move):
     """Represent a recorded move."""
 
-    def __init__(self, move: Dict[str, Any]) -> None:
+    def __init__(self, move: Dict[str, Any], sound: Path | None = None) -> None:
         """Initialize RecordedMove."""
         self.move = move
+        self.sound = sound
 
         self.description: str = self.move["description"]
         self.timestamps: List[float] = self.move["time"]
@@ -105,6 +106,7 @@ class RecordedMoves:
         self.hf_dataset_name = hf_dataset_name
         self.local_path = snapshot_download(self.hf_dataset_name, repo_type="dataset")
         self.moves: Dict[str, Any] = {}
+        self.sounds: Dict[str, Path] = {}
 
         self.process()
 
@@ -118,6 +120,11 @@ class RecordedMoves:
             move = json.load(open(move_path, "r"))
             self.moves[move_name] = move
 
+            if move_path.with_suffix(".wav").exists():
+                self.sounds[move_name] = move_path.with_suffix(".wav")
+            else:
+                self.sounds[move_name] = None
+
     def get(self, move_name: str) -> RecordedMove:
         """Get a recorded move by name."""
         if move_name not in self.moves:
@@ -125,7 +132,7 @@ class RecordedMoves:
                 f"Move {move_name} not found in recorded moves library {self.hf_dataset_name}"
             )
 
-        return RecordedMove(self.moves[move_name])
+        return RecordedMove(self.moves[move_name], self.sounds[move_name])
 
     def list_moves(self) -> List[str]:
         """List all moves in the loaded library."""

--- a/src/reachy_mini/motion/recorded_move.py
+++ b/src/reachy_mini/motion/recorded_move.py
@@ -23,7 +23,7 @@ class RecordedMove(Move):
     def __init__(self, move: Dict[str, Any], sound: Path | None = None) -> None:
         """Initialize RecordedMove."""
         self.move = move
-        self.sound = sound
+        self._sound = sound
 
         self.description: str = self.move["description"]
         self.timestamps: List[float] = self.move["time"]
@@ -34,6 +34,16 @@ class RecordedMove(Move):
         self.dt: float = (self.timestamps[-1] - self.timestamps[0]) / len(
             self.timestamps
         )
+
+    @property
+    def sound(self) -> Path | None:
+        """Sound associated with the move."""
+        return self._sound
+
+    @sound.setter
+    def sound(self, sound: Path | None) -> None:
+        """Set the sound associated with the move."""
+        self._sound = sound
 
     @property
     def duration(self) -> float:
@@ -106,7 +116,7 @@ class RecordedMoves:
         self.hf_dataset_name = hf_dataset_name
         self.local_path = snapshot_download(self.hf_dataset_name, repo_type="dataset")
         self.moves: Dict[str, Any] = {}
-        self.sounds: Dict[str, Path] = {}
+        self.sounds: Dict[str, Path | None] = {}
 
         self.process()
 

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -548,6 +548,17 @@ class ReachyMini:
         """
         return self.client.get_current_head_pose()
 
+    def get_current_body_yaw(self) -> float:
+        """Get the current body yaw.
+
+        Get the current body yaw in radians.
+
+        Returns:
+            float: The current body yaw in radians.
+
+        """
+        return self.get_current_joint_positions()[0][0]
+
     def _set_joint_positions(
         self,
         head_joint_positions: list[float] | None = None,
@@ -686,7 +697,7 @@ class ReachyMini:
         play_frequency: float = 100.0,
         initial_goto_duration: float = 0.0,
         final_goto_duration: float = 0.0,
-        play_sound=False,
+        play_sound: bool = False,
     ) -> None:
         """Asynchronously play a Move.
 
@@ -699,9 +710,9 @@ class ReachyMini:
 
         """
         if final_goto_duration > 0.0:
-            initial_head_pose = self.get_present_head_pose()
+            initial_head_pose = self.get_current_head_pose()
             initial_antennas_positions = self.get_present_antenna_joint_positions()
-            initial_body_yaw = self.get_present_body_yaw()
+            initial_body_yaw = self.get_current_body_yaw()
 
         if initial_goto_duration > 0.0:
             start_head_pose, start_antennas_positions, start_body_yaw = move.evaluate(
@@ -717,7 +728,7 @@ class ReachyMini:
         sleep_period = 1.0 / play_frequency
 
         if play_sound and move.sound is not None:
-            self.media.play_sound(move.sound)
+            self.media.play_sound(str(move.sound))
 
         t0 = time.time()
         while time.time() - t0 < move.duration:


### PR DESCRIPTION
This PR adds two features in the `play_move` method :
1. The ability to play the sound associated with the recorded move
2. The possibility to come back to the initial position of the robot once the recorded move is played 

By default, both are disabled, but both are enable in the dashboard for demonstration purposes.