### PR TITLE
fixed automatics body yaw

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -593,7 +593,7 @@ class Backend:
             body_yaw (float): The yaw angle of the body.
 
         """
-        self.head_kinematics.start_body_yaw = body_yaw
+        self.head_kinematics.set_automatic_body_yaw(automatic_body_yaw=body_yaw)
 
     def get_urdf(self) -> str:
         """Get the URDF representation of the robot."""

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -586,11 +586,11 @@ class Backend:
         if antennas_joint_positions is not None:
             self.current_antenna_joint_positions = antennas_joint_positions
 
-    def set_automatic_body_yaw(self, body_yaw: float) -> None:
+    def set_automatic_body_yaw(self, body_yaw: bool) -> None:
         """Set the automatic body yaw.
 
         Args:
-            body_yaw (float): The yaw angle of the body.
+            body_yaw (bool): The yaw angle of the body.
 
         """
         self.head_kinematics.set_automatic_body_yaw(automatic_body_yaw=body_yaw)

--- a/src/reachy_mini/kinematics/analytical_kinematics.py
+++ b/src/reachy_mini/kinematics/analytical_kinematics.py
@@ -30,11 +30,16 @@ SLEEP_HEAD_POSE = np.array(
 class AnalyticalKinematics:
     """Reachy Mini Analytical Kinematics class, implemented in Rust with python bindings."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self, 
+        automatic_body_yaw: bool = True
+        ) -> None:
         """Initialize."""
         assets_root_path: str = str(files(reachy_mini).joinpath("assets/"))
         data_path = assets_root_path + "/kinematics_data.json"
         data = json.load(open(data_path, "rb"))
+        
+        self.automatic_body_yaw = automatic_body_yaw
 
         self.head_z_offset = data["head_z_offset"]
 
@@ -74,9 +79,23 @@ class AnalyticalKinematics:
         _pose = pose.copy()
         _pose[:3, 3][2] += self.head_z_offset
 
-        stewart_joints = self.kin.inverse_kinematics(_pose, body_yaw)  # type: ignore[arg-type]
+        reachy_joints = []
+        if self.automatic_body_yaw:
+            # inverse kinematics solution that modulates the body yaw to 
+            # stay within the mechanical limits (max_body_yaw) 
+            # additionally it makes sure the the relative yaw between the body and the head
+            # stays within the mechanical limits (max_relative_yaw)
+            reachy_joints = self.kin.inverse_kinematics_safe(_pose,  # type: ignore[arg-type]
+                                                            body_yaw = body_yaw, 
+                                                            max_relative_yaw = np.deg2rad(65), 
+                                                            max_body_yaw = np.deg2rad(160))  
+        else:
+            # direct inverse kinematics solution with given body yaw
+            # it does not modify the body yaw
+            stewart_joints = self.kin.inverse_kinematics(_pose, body_yaw)  # type: ignore[arg-type]
+            reachy_joints = [body_yaw] + stewart_joints
 
-        return np.array([body_yaw] + stewart_joints)
+        return np.array(reachy_joints)
 
     def fk(
         self,
@@ -122,3 +141,12 @@ class AnalyticalKinematics:
         T_world_platform[:3, 3][2] -= self.head_z_offset
 
         return T_world_platform
+    
+    def set_automatic_body_yaw(self, automatic_body_yaw: bool) -> None:
+        """Set the automatic body yaw.
+
+        Args:
+            automatic_body_yaw (bool): Whether to enable automatic body yaw.
+
+        """
+        self.automatic_body_yaw = automatic_body_yaw

--- a/src/reachy_mini/kinematics/nn_kinematics.py
+++ b/src/reachy_mini/kinematics/nn_kinematics.py
@@ -19,7 +19,7 @@ class NNKinematics:
         self.fk_infer = OnnxInfer(self.fk_model_path)
         self.ik_infer = OnnxInfer(self.ik_model_path)
 
-        self.start_body_yaw = 0.0  # No used, kept for compatibility
+        self.automatic_body_yaw = False  # No used, kept for canaompatibility
 
     def ik(
         self,
@@ -75,6 +75,16 @@ class OnnxInfer:
         outputs = self.ort_session.run(None, {"input": [input]})
         res: npt.NDArray[np.float64] = outputs[0][0]
         return res
+    
+    
+    def set_automatic_body_yaw(self, automatic_body_yaw: bool) -> None:
+        """Set the automatic body yaw.
+
+        Args:
+            automatic_body_yaw (bool): Whether to enable automatic body yaw.
+
+        """
+        self.automatic_body_yaw = automatic_body_yaw
 
 
 if __name__ == "__main__":

--- a/src/reachy_mini/kinematics/nn_kinematics.py
+++ b/src/reachy_mini/kinematics/nn_kinematics.py
@@ -60,6 +60,15 @@ class NNKinematics:
         return pose
 
 
+    def set_automatic_body_yaw(self, automatic_body_yaw: bool) -> None:
+        """Set the automatic body yaw.
+
+        Args:
+            automatic_body_yaw (bool): Whether to enable automatic body yaw.
+
+        """
+        self.automatic_body_yaw = automatic_body_yaw
+        
 class OnnxInfer:
     """Infer an onnx model."""
 
@@ -77,14 +86,6 @@ class OnnxInfer:
         return res
     
     
-    def set_automatic_body_yaw(self, automatic_body_yaw: bool) -> None:
-        """Set the automatic body yaw.
-
-        Args:
-            automatic_body_yaw (bool): Whether to enable automatic body yaw.
-
-        """
-        self.automatic_body_yaw = automatic_body_yaw
 
 
 if __name__ == "__main__":

--- a/src/reachy_mini/kinematics/placo_kinematics.py
+++ b/src/reachy_mini/kinematics/placo_kinematics.py
@@ -147,8 +147,8 @@ class PlacoKinematics:
         if not self.automatic_body_yaw:
             self.ik_yaw_joint_task.configure("joints", "soft", 5e-5)
         else:
-            self.ik_yaw_joint_task.configure("joints", "soft", 1.0)
-
+            self.ik_yaw_joint_task.configure("joints", "soft", 3.0)
+            
         # joint limit tasks (values form URDF)
         self.ik_solver.enable_velocity_limits(True)
         self.ik_solver.enable_joint_limits(True)
@@ -635,14 +635,19 @@ class PlacoKinematics:
         # Compute the gravity torque
         return grav_torque_actuated
 
-    def set_automatic_body_yaw(self, body_yaw: float) -> None:
+    def set_automatic_body_yaw(self, automatic_body_yaw: bool) -> None:
         """Set the automatic body yaw.
 
         Args:
-            body_yaw (float): The yaw angle of the body.
+            automatic_body_yaw (bool): Whether to enable automatic body yaw.
 
         """
-        self.start_body_yaw = body_yaw
+        self.automatic_body_yaw = automatic_body_yaw
+        
+        if not self.automatic_body_yaw:
+            self.ik_yaw_joint_task.configure("joints", "soft", 3.0)
+        else:
+            self.ik_yaw_joint_task.configure("joints", "soft", 5e-5)
 
     def get_joint(self, joint_name: str) -> float:
         """Get the joint object by its name."""

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -66,7 +66,7 @@ class ReachyMini:
         spawn_daemon: bool = False,
         use_sim: bool = False,
         timeout: float = 5.0,
-        automatic_body_yaw: bool = False,
+        automatic_body_yaw: bool = True,
         log_level: str = "INFO",
         media_backend: str = "default",
     ) -> None:


### PR DESCRIPTION
This PR fixes the behavior for automatic body yaw flag for placo and analytic kinematics

Behaviors 

`automatic_body_yaw` | `placo` | `AnalyticKinematics`
--- | -- | ---
`True` |  Body yaw automatically adapted if the head yaw is high. Head yaw is almost always equal to the target head yaw. <br> If target head yaw - target body yaw > 65 deg: <br> target body yaw ≠ body yaw <br> target head yaw = head yaw <video src="https://github.com/user-attachments/assets/8226571e-c059-486c-b462-f96f716e00b3"> |  body yaw adapted automatically in order to maintain the relative distance between the body yaw and the head yaw under 65deg. <br> If target head yaw - target body yaw > 65 deg: <br> target body yaw ≠ body yaw <br> target head yaw = head yaw <video src="https://github.com/user-attachments/assets/e398948b-7b04-483f-a7c9-72351c495002">  
`False` |  Body yaw trying to stay at the target body yaw. Head yaw will not always be able to reach the target head yaw.<br> If target head yaw - target body yaw > 65 deg: <br> target body yaw ≈ body yaw <br> target head yaw ≠ head yaw  <video src="https://github.com/user-attachments/assets/f842dcc5-f762-46ca-bd0b-3632f985490c">| body yaw fixed <br> If target head yaw - target body yaw > 65 deg: <br>target body yaw = body yaw <br> target head yaw ≠ head yaw <video src="https://github.com/user-attachments/assets/4f96cd16-39c3-4658-b2c9-929179c87c22">

From this point on the `automatic_body_yaw` will be `True` by default. 
- It was `False` by default before, but the flag was not used
- The default behaviour does not change with this PR (only the default value of the flag)