### PR TITLE
Add sound to emotions example

### DIFF
--- a/examples/recorded_moves_example.py
+++ b/examples/recorded_moves_example.py
@@ -6,25 +6,33 @@ python3 recorded_moves_example.py -l [dance, emotions]
 """
 
 import argparse
+from pathlib import Path
 
 from reachy_mini import ReachyMini
 from reachy_mini.motion.recorded_move import RecordedMove, RecordedMoves
 
 
-def main(dataset_path: str) -> None:
+def main(dataset_path: str, library_type: str) -> None:
     """Connect to Reachy and run the main demonstration loop."""
     recorded_moves = RecordedMoves(dataset_path)
 
     print("Connecting to Reachy Mini...")
-    with ReachyMini(use_sim=False, media_backend="no_media") as reachy:
-        print("Connection successful! Starting dance sequence...\n")
+    # Use default media backend for emotions to enable sound, no_media for dances
+    media_backend = "default" if library_type == "emotions" else "no_media"
+    with ReachyMini(use_sim=False, media_backend=media_backend) as reachy:
+        print(f"Connection successful! Starting {library_type} sequence...\n")
         try:
             while True:
                 for move_name in recorded_moves.list_moves():
                     move: RecordedMove = recorded_moves.get(move_name)
-                    print(f"Playing move: {move_name}: {move.description}\n")
-                    # print(f"params: {move.move_params}")
+                    print(f"Playing move: {move_name}: {move.description}")
+                    
+                    # Play sound if available and file exists (for emotions library)
+                    if move.sound_path and Path(move.sound_path).exists():
+                        reachy.media.play_sound(move.sound_path)
+                    
                     reachy.play_move(move, initial_goto_duration=1.0)
+                    print()
 
         except KeyboardInterrupt:
             print("\n Sequence interrupted by user. Shutting down.")
@@ -44,4 +52,4 @@ if __name__ == "__main__":
         if args.library == "dance"
         else "pollen-robotics/reachy-mini-emotions-library"
     )
-    main(dataset_path)
+    main(dataset_path, args.library)

--- a/src/reachy_mini/motion/recorded_move.py
+++ b/src/reachy_mini/motion/recorded_move.py
@@ -26,6 +26,7 @@ class RecordedMove(Move):
         Args:
             move: Dictionary containing the move data.
             sound_path: Optional path to the sound file to play with this move.
+
         """
         self.move = move
         self.sound_path = sound_path


### PR DESCRIPTION
This PR adds support for playing audio files alongside recorded moves when starting the example script.
Try run `python examples/recorded_moves_example.py -l emotions` to play all emotions with synchronised sound effects.