### PR TITLE
Normalize input audio in callback to prevent multichannel dilution

### DIFF
--- a/src/reachy_mini/media/audio_sounddevice.py
+++ b/src/reachy_mini/media/audio_sounddevice.py
@@ -61,9 +61,16 @@ class SoundDeviceAudio(AudioBase):
             self.logger.warning(f"SoundDevice status: {status}")
 
         data = indata.copy()
-        
-        if data.ndim > 1:
-            data = data[:, :2].mean(axis=1)
+
+        if data.ndim == 2:
+            channels = data.shape[1]
+            if channels > 4:
+                data = data[:, :2]
+        elif data.ndim == 1:
+            pass 
+        else:
+            self.logger.error(f"Unexpected audio data shape: {data.shape}")
+            return 
 
         self._buffer.append(data)
 


### PR DESCRIPTION
NOTE:
	This method currently fixes input-hardware quirks where requesting 1 channel we may still get more
	Extra channels are virtual, empty, or noise. Averaging all channels causes silence
	Hardware provides stereo (CH0/CH1), but extra junk channels are possible
	Expecting that downstream code should always receive a clean (N,) mono array

Handles mono, stero, and multi-channel input

Fixes #465