### PR TITLE
fix(audio channel): making the handling of multiple audio channels more robust with the sounddevice backend.

### DIFF
--- a/src/reachy_mini/media/audio_base.py
+++ b/src/reachy_mini/media/audio_base.py
@@ -18,6 +18,7 @@ class AudioBase(ABC):
     """Abstract class for opening and managing audio devices."""
 
     SAMPLE_RATE = 16000  # respeaker samplerate
+    CHANNELS = 2  # respeaker channels
 
     def __init__(self, log_level: str = "INFO") -> None:
         """Initialize the audio device."""
@@ -47,6 +48,14 @@ class AudioBase(ABC):
     def get_output_audio_samplerate(self) -> int:
         """Get the outputsamplerate of the audio device."""
         return self.SAMPLE_RATE
+
+    def get_input_channels(self) -> int:
+        """Get the number of input channels of the audio device."""
+        return self.CHANNELS   
+
+    def get_output_channels(self) -> int:
+        """Get the number of output channels of the audio device."""
+        return self.CHANNELS
 
     @abstractmethod
     def stop_recording(self) -> None:

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -57,7 +57,7 @@ class GStreamerAudio(AudioBase):
     def _init_pipeline_record(self, pipeline: Gst.Pipeline) -> None:
         self._appsink_audio = Gst.ElementFactory.make("appsink")
         caps = Gst.Caps.from_string(
-            f"audio/x-raw,rate={self.SAMPLE_RATE},channels=2,format=F32LE,layout=interleaved"
+            f"audio/x-raw,rate={self.SAMPLE_RATE},channels={self.CHANNELS},format=F32LE,layout=interleaved"
         )
         self._appsink_audio.set_property("caps", caps)
         self._appsink_audio.set_property("drop", True)  # avoid overflow
@@ -97,7 +97,7 @@ class GStreamerAudio(AudioBase):
         self._appsrc.set_property("format", Gst.Format.TIME)
         self._appsrc.set_property("is-live", True)
         caps = Gst.Caps.from_string(
-            f"audio/x-raw,format=F32LE,channels=1,rate={self.SAMPLE_RATE},layout=interleaved"
+            f"audio/x-raw,format=F32LE,channels={self.CHANNELS},rate={self.SAMPLE_RATE},layout=interleaved"
         )
         self._appsrc.set_property("caps", caps)
 
@@ -167,6 +167,14 @@ class GStreamerAudio(AudioBase):
     def get_output_audio_samplerate(self) -> int:
         """Get the output samplerate of the audio device."""
         return self.SAMPLE_RATE
+
+    def get_input_channels(self) -> int:
+        """Get the number of input channels of the audio device."""
+        return self.CHANNELS
+
+    def get_output_channels(self) -> int:
+        """Get the number of output channels of the audio device."""
+        return self.CHANNELS
 
     def stop_recording(self) -> None:
         """Release the camera resource."""

--- a/src/reachy_mini/media/media_manager.py
+++ b/src/reachy_mini/media/media_manager.py
@@ -201,6 +201,20 @@ class MediaManager:
             return -1
         return self.audio.get_output_audio_samplerate()
 
+    def get_input_channels(self) -> int:
+        """Get the number of input channels of the audio device."""
+        if self.audio is None:
+            self.logger.warning("Audio system is not initialized.")
+            return -1
+        return self.audio.get_input_channels()
+
+    def get_output_channels(self) -> int:
+        """Get the number of output channels of the audio device."""
+        if self.audio is None:
+            self.logger.warning("Audio system is not initialized.")
+            return -1
+        return self.audio.get_output_channels()
+
     def stop_recording(self) -> None:
         """Stop recording audio."""
         if self.audio is None:
@@ -225,6 +239,28 @@ class MediaManager:
         if self.audio is None:
             self.logger.warning("Audio system is not initialized.")
             return
+
+        if data.ndim > 2 or data.ndim == 0:
+            self.logger.warning(f"Audio samples arrays must have at most 2 dimensions and at least 1 dimension, got {data.ndim}")
+            return
+        
+        # Transpose data to match sounddevice channels last convention
+        if data.ndim == 2 and data.shape[1] > data.shape[0]:
+            data = data.T
+
+        # Fit data to match output stream channels
+        output_channels = self.get_output_channels()
+
+        # Mono input to multiple channels output : duplicate to fit
+        if data.ndim == 1 and output_channels > 1:
+            data = np.column_stack((data,) * output_channels)
+        # Lower channels input to higher channels output : reduce to mono and duplicate to fit
+        elif data.ndim == 2 and data.shape[1] < output_channels:
+            data = np.column_stack((data[:,0],) * output_channels)
+        # Higher channels input to lower channels output : crop to fit
+        elif data.ndim == 2 and data.shape[1] > output_channels:
+            data = data[:, :output_channels]
+
         self.audio.push_audio_sample(data)
 
     def stop_playing(self) -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -23,43 +23,43 @@ def test_play_sound_default_backend() -> None:
 def test_push_audio_sample_default_backend() -> None:
     """Test pushing an audio sample with the default backend."""
     media = MediaManager(backend=MediaBackend.DEFAULT_NO_VIDEO)
-    media.audio.start_playing()
+    media.start_playing()
 
     #Stereo, channels last
     data = np.random.random((media.get_output_audio_samplerate(), 2)).astype(np.float32)
-    media.audio.push_audio_sample(data)
+    media.push_audio_sample(data)
     time.sleep(1)
 
     #Mono, channels last
     data = np.random.random((media.get_output_audio_samplerate(), 1)).astype(np.float32)
-    media.audio.push_audio_sample(data)
+    media.push_audio_sample(data)
     time.sleep(1)
 
     #Multiple channels, channels last
     data = np.random.random((media.get_output_audio_samplerate(), 10)).astype(np.float32)
-    media.audio.push_audio_sample(data)
+    media.push_audio_sample(data)
     time.sleep(1)
 
     #Stereo, channels first
     data = np.random.random((2, media.get_output_audio_samplerate())).astype(np.float32)
-    media.audio.push_audio_sample(data)
+    media.push_audio_sample(data)
     time.sleep(1)
 
     # No assertion: test passes if no exception is raised.
     # Sound should be audible if the audio device is correctly set up.
 
     data = np.array(0).astype(np.float32)
-    media.audio.push_audio_sample(data)
+    media.push_audio_sample(data)
     time.sleep(1)
 
     data = np.random.random((media.get_output_audio_samplerate(), 2, 2)).astype(np.float32)
-    media.audio.push_audio_sample(data)
+    media.push_audio_sample(data)
     time.sleep(1)
 
     # No assertion: test passes if no exception is raised.
     # No sound should be audible if the audio device is correctly set up.
 
-    media.audio.stop_playing()
+    media.stop_playing()
 
 @pytest.mark.audio
 def test_record_audio_and_file_exists() -> None:


### PR DESCRIPTION
This PR makes the handling of multiple channels audio inputs/outputs more robust with sounddevice backend : 

- If the input device (microphone) has more than `MAX_INPUT_CHANNELS = 2` channels, all the channels above `MAX_INPUT_CHANNELS` will be cropped out. This fix is inspired by #472 and solves #465. 
That way, `get_audio_sample` will **always** return a 2D numpy array with shape `(samples, channels)` with `channels <= MAX_INPUT_CHANNELS`.

- If the output device (speaker) has more than one output channel, and has been fed with mono-channel data, the data will be replicated over all the channels below `MAX_OUTPUT_CHANNELS = 2` (again because of #465). The same rationale will be applied if the provided data does not have enough channels to fill all the output channels of the device. Inversely, if stereo-channel data is fed to a speaker with only one channel, the second channel will be cropped out to fit the output.
That way `push_audio_sample` will accept **any** 1D/2D numpy array with either one dimension larger than the other (assumption : `channels < samples`).