### PR TITLE
492 fix shutdown gpio switching due to motor overload

### DIFF
--- a/src/reachy_mini/daemon/app/services/gpio_shutdown/shutdown_monitor.py
+++ b/src/reachy_mini/daemon/app/services/gpio_shutdown/shutdown_monitor.py
@@ -11,7 +11,7 @@ shutdown_button = Button(23, pull_up=False)
 
 def released() -> None:
     """Handle shutdown button released."""
-    for _ in range(10):
+    for _ in range(200):
         time.sleep(0.001)
 
         if shutdown_button.is_pressed:


### PR DESCRIPTION
Cf:
https://www.notion.so/pollen-robotics/Crashing-under-heavy-current-consumption-2c36d6bd061880dea39ace34d6f7be4a

This is mainly a hardware problem based on a power supply version (6.8V) that is NOT the one that is shipped with the final product.

Regardless I think we should push this minor fix, that was tuned to cover the duration of the "power outage" (~130ms measured, this patch waits for 200ms), just in case.