### PR TITLE
Update reachy-mini version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2907,7 +2907,7 @@ wheels = [
 
 [[package]]
 name = "reachy-mini"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Update reachy-mini to 1.1.4 in the lock file