### PR TITLE
Objects on the floor in mujoco minimal scene

### DIFF
--- a/src/reachy_mini/descriptions/reachy_mini/mjcf/scenes/minimal.xml
+++ b/src/reachy_mini/descriptions/reachy_mini/mjcf/scenes/minimal.xml
@@ -108,6 +108,7 @@
             <!-- <joint name="table_joint" type="free" /> -->
             <!-- replace the table top collision with a box -->
             <geom class="collision"
+                name="table_top_collision"
                 type="box"
                 size="0.56 0.03 0.35"
                 pos="0 0.77 0"


### PR DESCRIPTION
collisions are disabled at startup for smoother wake up animations. But they were disabled for everything, so the objects fell to the ground. Found a way to not disable collisions for the objects in the minimal scene