### PR TITLE
Fix SDK audio example

### DIFF
--- a/docs/SDK/python-sdk.md
+++ b/docs/SDK/python-sdk.md
@@ -45,7 +45,7 @@ Reachy uses `sounddevice` for audio I/O.
 sample = mini.media.get_audio_sample()
 
 # Play
-mini.media.play_audio("hello.wav")
+mini.media.play_sound("wake_up.wav")
 # Or push raw chunks:
 # mini.media.push_audio_sample(chunk)
 ```


### PR DESCRIPTION
The example written in the README file did not work anymore, so I changed the method play_audio by play_sound, and changed the audio file because "hello.wav" is not in the media assets.