### PR TITLE
Tentative fix

### DIFF
--- a/src/reachy_mini/daemon/app/routers/move.py
+++ b/src/reachy_mini/daemon/app/routers/move.py
@@ -230,6 +230,10 @@ async def set_target(
     backend: Backend = Depends(get_backend),
 ) -> dict[str, str]:
     """POST route to set a single FullBodyTarget."""
+    if backend.is_move_running:
+        # Avoid fighting with the daemon while a trajectory is running
+        backend.logger.warning("Ignoring set_target request: move already running.")
+        return {"status": "ignored", "reason": "move_running"}
     backend.set_target(
         head=target.target_head_pose.to_pose_array()
         if target.target_head_pose

--- a/src/reachy_mini/io/zenoh_server.py
+++ b/src/reachy_mini/io/zenoh_server.py
@@ -118,6 +118,17 @@ class ZenohServer(AbstractServer):
         data = sample.payload.to_string()
         command = json.loads(data)
         with self._lock:
+            block_targets = self.backend.is_move_running  # Prevent concurrent target updates from different clients
+
+            def _maybe_ignore(field: str) -> bool:
+                """Return True if the command should be ignored while a move runs."""
+                if not block_targets:
+                    return False
+                self.backend.logger.warning(
+                    f"Ignoring {field} command: a move is currently running."
+                )
+                return True
+
             if "torque" in command:
                 if (
                     command["ids"] is not None
@@ -129,19 +140,31 @@ class ZenohServer(AbstractServer):
                     else:
                         self.backend.set_motor_control_mode(MotorControlMode.Disabled)
             if "head_joint_positions" in command:
-                self.backend.set_target_head_joint_positions(
-                    np.array(command["head_joint_positions"])
-                )
+                if _maybe_ignore("head_joint_positions"):
+                    pass
+                else:
+                    self.backend.set_target_head_joint_positions(
+                        np.array(command["head_joint_positions"])
+                    )
             if "head_pose" in command:
-                self.backend.set_target_head_pose(
-                    np.array(command["head_pose"]).reshape(4, 4)
-                )
+                if _maybe_ignore("head_pose"):
+                    pass
+                else:
+                    self.backend.set_target_head_pose(
+                        np.array(command["head_pose"]).reshape(4, 4)
+                    )
             if "body_yaw" in command:
-                self.backend.set_target_body_yaw(command["body_yaw"])
+                if _maybe_ignore("body_yaw"):
+                    pass
+                else:
+                    self.backend.set_target_body_yaw(command["body_yaw"])
             if "antennas_joint_positions" in command:
-                self.backend.set_target_antenna_joint_positions(
-                    np.array(command["antennas_joint_positions"]),
-                )
+                if _maybe_ignore("antennas_joint_positions"):
+                    pass
+                else:
+                    self.backend.set_target_antenna_joint_positions(
+                        np.array(command["antennas_joint_positions"]),
+                    )
             if "gravity_compensation" in command:
                 try:
                     if command["gravity_compensation"]:


### PR DESCRIPTION
This patch is a partial fix to the problem.

This patch only guards moves that the daemon itself runs. Anything that calls backend.play_move() (including /move/play/..., /move/goto, /move/wake_up) now acquires the RLock, so:
- A daemon play_move or goto_target cannot overlap with another daemon play_move. New requests are
    rejected with a warning.
- While that daemon-managed move is running, direct set_target traffic from HTTP or the Zenoh server is ignored => so a client spamming set_target() cannot fight a daemon playback. (maybe the warning spams too much?)

What this fix does not cover is any situation where multiple SDK clients drive motions purely through the SDK (e.g. each calling mini.play_move() or spamming set_target).

A fix for all cases is a bit more complicated. One way of doing it is for clients to acquire a lock from the daemon (given only of the daemon is idle). But this means identifying the client.