### PR TITLE
add a method to clear the output buffer with audio sound device. Help…

### DIFF
--- a/src/reachy_mini/media/audio_sounddevice.py
+++ b/src/reachy_mini/media/audio_sounddevice.py
@@ -171,7 +171,7 @@ class SoundDeviceAudio(AudioBase):
 
     def start_playing(self) -> None:
         """Open the audio output stream."""
-        self._output_buffer.clear()  # Clear any old data
+        self.clear_output_buffer()
 
         if self._output_stream is not None:
             self.stop_playing()
@@ -242,6 +242,7 @@ class SoundDeviceAudio(AudioBase):
             self._output_stream.stop()
             self._output_stream.close()
             self._output_stream = None
+            self.clear_output_buffer()
             self.logger.info("SoundDevice audio output stream closed.")
 
     def play_sound(self, sound_file: str) -> None:


### PR DESCRIPTION
Add a method to clear the output buffer with audio sound device. Helpful to make interruptions work in other apps like the conversation app. 
The context here is that the audio sounddevice has this output queue which might be populated, and to really make the robot stop speaking we need to empty it. Without this, the conversation app feels less responsive. Plus, the code was there already for gstreamer, so this should be rather straight forward to merge.