### PR TITLE
bug #579: remove optional --stream.

### DIFF
--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -49,8 +49,6 @@ class Args:
     wireless_version: bool = False
     desktop_app_daemon: bool = False
 
-    stream: bool = False
-
     serialport: str = "auto"
     hardware_config_filepath: str | None = None
 
@@ -131,7 +129,6 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
     app.state.args = args
     app.state.daemon = Daemon(
         robot_name=args.robot_name,
-        stream=args.stream,
         wireless_version=args.wireless_version,
         desktop_app_daemon=args.desktop_app_daemon,
     )
@@ -267,13 +264,6 @@ def main() -> None:
         action="store_true",
         default=default_args.desktop_app_daemon,
         help="Use the desktop version of Reachy Mini (default: False).",
-    )
-
-    parser.add_argument(
-        "--stream",
-        action="store_true",
-        default=default_args.stream,
-        help="Enable webrtc streaming. For wireless version only (default: False).",
     )
 
     parser.add_argument(

--- a/src/reachy_mini/daemon/app/services/wireless/launcher.sh
+++ b/src/reachy_mini/daemon/app/services/wireless/launcher.sh
@@ -2,4 +2,4 @@
 /venvs/src/reachy_mini/src/reachy_mini/daemon/app/services/wireless/generate_asoundrc.sh
 source /venvs/mini_daemon/bin/activate
 export GST_PLUGIN_PATH=$GST_PLUGIN_PATH:/opt/gst-plugins-rs/lib/aarch64-linux-gnu/
-python -m reachy_mini.daemon.app.main --wireless-version --stream --no-autostart
+python -m reachy_mini.daemon.app.main --wireless-version --no-autostart

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -44,7 +44,6 @@ class Daemon:
         log_level: str = "INFO",
         robot_name: str = "reachy_mini",
         wireless_version: bool = False,
-        stream: bool = False,
         desktop_app_daemon: bool = False,
     ) -> None:
         """Initialize the Reachy Mini daemon."""
@@ -71,7 +70,6 @@ class Daemon:
             state=DaemonState.NOT_INITIALIZED,
             wireless_version=wireless_version,
             desktop_app_daemon=desktop_app_daemon,
-            stream_enabled=stream,
             simulation_enabled=None,
             backend_status=None,
             error=None,
@@ -83,11 +81,7 @@ class Daemon:
         self._webrtc: Optional[Any] = (
             None  # type GstWebRTC imported for wireless version only
         )
-        if stream:
-            if not wireless_version:
-                raise RuntimeError(
-                    "WebRTC streaming is only supported for wireless version. Use --wireless-version flag."
-                )
+        if wireless_version:
             from reachy_mini.media.webrtc_daemon import GstWebRTC
 
             self._webrtc = GstWebRTC(log_level)
@@ -640,7 +634,6 @@ class DaemonStatus:
     state: DaemonState
     wireless_version: bool
     desktop_app_daemon: bool
-    stream_enabled: bool
     simulation_enabled: Optional[bool]
     backend_status: Optional[RobotBackendStatus | MujocoBackendStatus]
     error: Optional[str] = None

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -106,16 +106,6 @@ class ReachyMini:
             ]
         )
 
-        # When connecting to a remote robot, check if streaming is available
-        if not localhost_only and media_backend == "default":
-            daemon_status = self.client.get_status()
-            if daemon_status.get("wireless_version") and daemon_status.get("stream_enabled"):
-                self.logger.info("Remote connection detected with streaming enabled - using WebRTC backend.")
-                media_backend = "webrtc"
-            else:
-                self.logger.info("Remote connection detected without streaming - disabling media. Start daemon with '--stream' flag to enable WebRTC.")
-                media_backend = "no_media"
-
         self.media_manager = self._configure_mediamanager(media_backend, log_level)
 
     def __del__(self) -> None:
@@ -124,7 +114,7 @@ class ReachyMini:
         The client is disconnected explicitly to avoid a thread pending issue.
 
         """
-        if hasattr(self, 'client'):
+        if hasattr(self, "client"):
             self.client.disconnect()
 
     def __enter__(self) -> "ReachyMini":
@@ -153,11 +143,6 @@ class ReachyMini:
                         "Non-wireless version detected, daemon should use the flag '--wireless-version'. Reverting to default"
                     )
                     mbackend = MediaBackend.DEFAULT
-                elif not daemon_status.get("stream_enabled"):
-                    self.logger.warning(
-                        "WebRTC requested but streaming is not enabled on daemon. Start daemon with '--stream' flag. Reverting to no_media"
-                    )
-                    mbackend = MediaBackend.NO_MEDIA
                 else:
                     self.logger.info("WebRTC backend configured successfully.")
                     mbackend = MediaBackend.WEBRTC


### PR DESCRIPTION
There is no need for --stream anymore since it is always started on the wireless.
It fixes the bug where this argument is not present on the launcher of the wireless in production