### PR TITLE
Updating doc with missed deps required by a brand new MBP

### DIFF
--- a/docs/SDK/installation.md
+++ b/docs/SDK/installation.md
@@ -237,6 +237,7 @@ uv add reachy-mini --extra mujoco
 In your terminal, run:
 ```bash
 git clone https://github.com/pollen-robotics/reachy_mini && cd reachy_mini
+brew install cmake pkg-config cairo
 uv sync
 ```
 


### PR DESCRIPTION
On a brand new mbp it is required to install some missed deps in order to let it run. 
Added the bash command in the doc to install those deps (cmake, pkg-config, cairo).