### PR TITLE
reflash motor on start

### DIFF
--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -28,6 +28,7 @@ from reachy_mini.io import (
     ZenohServer,
 )
 from reachy_mini.media.media_manager import MediaManager
+from reachy_mini.tools.reflash_motors import reflash_motors
 
 from .backend.mujoco import MujocoBackend, MujocoBackendStatus
 from .backend.robot import RobotBackend, RobotBackendStatus
@@ -578,6 +579,7 @@ class Daemon:
         use_audio: bool,
         websocket_uri: Optional[str],
         hardware_config_filepath: str | None = None,
+        reflash_motors_on_start: bool = True,
     ) -> "RobotBackend | MujocoBackend":
         if sim:
             return MujocoBackend(
@@ -610,6 +612,10 @@ class Daemon:
             self.logger.info(
                 f"Creating RobotBackend with parameters: serialport={serialport}, check_collision={check_collision}, kinematics_engine={kinematics_engine}"
             )
+
+            if reflash_motors_on_start:
+                reflash_motors(serialport)
+
             return RobotBackend(
                 serialport=serialport,
                 log_level=self.log_level,

--- a/src/reachy_mini/tools/reflash_motors.py
+++ b/src/reachy_mini/tools/reflash_motors.py
@@ -15,7 +15,7 @@ BAUDRATE = 1000000
 
 
 def main() -> None:
-    """Reflash Reachy Mini's motors."""
+    """Entry point for the reflash_motors script."""
     parser = argparse.ArgumentParser(
         description="Reflash Reachy Mini motors' firmware.",
     )
@@ -28,13 +28,19 @@ def main() -> None:
         "If not specified, the script will try to automatically find it.",
     )
     args = parser.parse_args()
+    reflash_motors(args.serialport)
 
+
+def reflash_motors(serialport=None) -> None:
+    """Reflash Reachy Mini's motors."""
     console = Console()
 
-    config_file_path = str(files(reachy_mini).joinpath("assets/config/hardware_config.yaml"))
+    config_file_path = str(
+        files(reachy_mini).joinpath("assets/config/hardware_config.yaml")
+    )
     config = parse_yaml_config(config_file_path)
     motors = list(config.motors.keys())
-    if args.serialport is None:
+    if serialport is None:
         console.print(
             "Which version of Reachy Mini are you using?",
         )

--- a/src/reachy_mini/tools/reflash_motors.py
+++ b/src/reachy_mini/tools/reflash_motors.py
@@ -2,6 +2,7 @@
 
 import argparse
 from importlib.resources import files
+from typing import Optional
 
 import questionary
 from rich.console import Console
@@ -31,7 +32,7 @@ def main() -> None:
     reflash_motors(args.serialport)
 
 
-def reflash_motors(serialport=None) -> None:
+def reflash_motors(serialport: Optional[str] = None) -> None:
     """Reflash Reachy Mini's motors."""
     console = Console()
 


### PR DESCRIPTION
Temporary : Always run reflash motors when starting the daemon. This adds ~5s to the startup sequence on a wireless