### PR TITLE
Added flag to let an app start when robot startup

### DIFF
--- a/src/reachy_mini/apps/startup_config.py
+++ b/src/reachy_mini/apps/startup_config.py
@@ -1,0 +1,141 @@
+"""Utility functions for managing app startup preferences."""
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _get_venv_parent_dir() -> Path:
+    """Get the parent directory of the current venv (OS-agnostic)."""
+    executable = Path(sys.executable)
+    
+    # Determine expected subdirectory based on platform
+    import platform as platform_module
+    expected_subdir = "Scripts" if platform_module.system() == "Windows" else "bin"
+    
+    # Go up from bin/python or Scripts/python.exe to venv dir, then to parent
+    if executable.parent.name == expected_subdir:
+        venv_dir = executable.parent.parent
+        return venv_dir.parent
+    
+    # Fallback: assume we're already in the venv root
+    return executable.parent.parent
+
+
+def get_startup_config_path() -> Path:
+    """Get the path to the startup configuration file."""
+    venv_parent_dir = _get_venv_parent_dir()
+    config_path = venv_parent_dir / "app_startup_config.json"
+    return config_path
+
+
+def load_startup_config() -> dict[str, bool]:
+    """Load the startup configuration from file.
+    
+    Returns:
+        Dictionary mapping app names to their startup preference (True = start at startup).
+    """
+    config_path = get_startup_config_path()
+    
+    if not config_path.exists():
+        return {}
+    
+    try:
+        with open(config_path, "r") as f:
+            config = json.load(f)
+            # Validate that all values are booleans
+            return {app_name: bool(value) for app_name, value in config.items()}
+    except (json.JSONDecodeError, IOError) as e:
+        logger.warning(f"Failed to load startup config from {config_path}: {e}")
+        return {}
+
+
+def save_startup_config(config: dict[str, bool]) -> None:
+    """Save the startup configuration to file.
+    
+    Args:
+        config: Dictionary mapping app names to their startup preference.
+    """
+    config_path = get_startup_config_path()
+    
+    try:
+        # Ensure parent directory exists
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=2)
+    except IOError as e:
+        logger.error(f"Failed to save startup config to {config_path}: {e}")
+        raise
+
+
+def get_app_startup_preference(app_name: str) -> bool:
+    """Get the startup preference for a specific app.
+    
+    Args:
+        app_name: Name of the app.
+        
+    Returns:
+        True if the app should start at startup, False otherwise.
+    """
+    config = load_startup_config()
+    return config.get(app_name, False)
+
+
+def set_app_startup_preference(app_name: str, start_at_startup: bool) -> None:
+    """Set the startup preference for a specific app.
+    
+    Only one app can be set to start at startup at a time. If setting an app to True,
+    all other apps will be cleared.
+    
+    Args:
+        app_name: Name of the app.
+        start_at_startup: True if the app should start at startup, False otherwise.
+        
+    Raises:
+        ValueError: If multiple apps are already set to start at startup (invalid state).
+    """
+    config = load_startup_config()
+    
+    # Validate that at most one app is set to start at startup
+    apps_to_start = [name for name, should_start in config.items() if should_start]
+    if len(apps_to_start) > 1:
+        logger.error(f"Invalid state: multiple apps set to start at startup: {apps_to_start}. Clearing all.")
+        # Clear all apps to reset the state
+        config = {}
+    elif len(apps_to_start) == 1 and start_at_startup and apps_to_start[0] != app_name:
+        # Another app is already set to start, clear it
+        config.pop(apps_to_start[0], None)
+    
+    if start_at_startup:
+        config[app_name] = True
+    else:
+        # Remove the entry if set to False (to keep config clean)
+        config.pop(app_name, None)
+    
+    save_startup_config(config)
+
+
+def get_apps_to_start_at_startup() -> list[str]:
+    """Get the list of app names that should start at startup.
+    
+    Validates that at most one app is set to start. If multiple apps are found,
+    clears all and returns an empty list.
+    
+    Returns:
+        List of app names that have start_at_startup set to True (max 1).
+    """
+    config = load_startup_config()
+    apps_to_start = [app_name for app_name, should_start in config.items() if should_start]
+    
+    # If multiple apps are set, clear all and reset
+    if len(apps_to_start) > 1:
+        logger.error(f"Invalid state: multiple apps set to start at startup: {apps_to_start}. Clearing all.")
+        save_startup_config({})
+        return []
+    
+    return apps_to_start
+

--- a/src/reachy_mini/daemon/app/dashboard/static/js/apps.js
+++ b/src/reachy_mini/daemon/app/dashboard/static/js/apps.js
@@ -7,6 +7,7 @@ const installedApps = {
     currentlyRunningApp: null,
     busy: false,
     toggles: {},
+    startupCheckboxes: {},
 
     startApp: async (appName) => {
         if (installedApps.busy) {
@@ -91,34 +92,45 @@ const installedApps = {
         appsListElement.innerHTML = '';
 
         if (!appsData || appsData.length === 0) {
-            appsListElement.innerHTML = '<li>No installed apps found.</li>';
+            const emptyRow = document.createElement('tr');
+            const emptyCell = document.createElement('td');
+            emptyCell.colSpan = 4;
+            emptyCell.className = 'text-gray-500 text-center py-8';
+            emptyCell.textContent = 'No installed apps found.';
+            emptyRow.appendChild(emptyCell);
+            appsListElement.appendChild(emptyRow);
             return;
         }
 
         const runningApp = await installedApps.getRunningApp();
 
         installedApps.toggles = {};
-        appsData.forEach(app => {
-            const li = document.createElement('li');
-            li.className = 'app-list-item';
+        installedApps.startupCheckboxes = {};
+        
+        // Create all app rows
+        for (const app of appsData) {
             const isRunning = (app.name === runningApp);
-            li.appendChild(installedApps.createAppElement(app, isRunning));
-            appsListElement.appendChild(li);
-        });
+            const row = await installedApps.createAppElement(app, isRunning);
+            appsListElement.appendChild(row);
+        }
     },
 
-    createAppElement: (app, isRunning) => {
-        const container = document.createElement('div');
-        container.className = 'grid grid-cols-[auto_6rem_2rem] justify-stretch gap-x-2';
+    createAppElement: async (app, isRunning) => {
+        const row = document.createElement('tr');
+        row.className = 'hover:bg-gray-50 transition-colors';
 
-        const title = document.createElement('div');
+        // App name cell (left aligned)
+        const nameCell = document.createElement('td');
+        nameCell.className = 'py-3 px-4';
+        const titleDiv = document.createElement('div');
+        titleDiv.className = 'flex items-center';
         const titleSpan = document.createElement('span');
-        titleSpan.className = 'installed-app-title top-1/2 ';
+        titleSpan.className = 'installed-app-title';
         titleSpan.innerHTML = app.name;
-        title.appendChild(titleSpan);
+        titleDiv.appendChild(titleSpan);
         if (app.extra && app.extra.custom_app_url) {
             const settingsLink = document.createElement('a');
-            settingsLink.className = 'installed-app-settings ml-2 text-gray-500 cursor-pointer';
+            settingsLink.className = 'installed-app-settings ml-2 text-gray-400 hover:text-gray-600 cursor-pointer transition-colors';
             settingsLink.innerHTML = '⚙️';
 
             const url = new URL(app.extra.custom_app_url);
@@ -127,15 +139,19 @@ const installedApps = {
             settingsLink.href = url.toString();
             settingsLink.target = '_blank';
             settingsLink.rel = 'noopener noreferrer';
-            title.appendChild(settingsLink);
+            titleDiv.appendChild(settingsLink);
         }
-        container.appendChild(title);
-        const slider = document.createElement('div');
-        const toggle = new ToggleSlider({
+        nameCell.appendChild(titleDiv);
+        row.appendChild(nameCell);
+        
+        // Status toggle cell
+        const statusCell = document.createElement('td');
+        statusCell.className = 'py-3 px-4 text-center';
+        const statusToggle = new ToggleSlider({
             checked: isRunning,
             onChange: (checked) => {
                 if (installedApps.busy) {
-                    toggle.setChecked(!checked);
+                    statusToggle.setChecked(!checked);
                     return;
                 }
                 if (checked) {
@@ -145,14 +161,96 @@ const installedApps = {
                 }
             }
         });
-        installedApps.toggles[app.name] = toggle;
-        slider.appendChild(toggle.element);
-        container.appendChild(slider);
+        installedApps.toggles[app.name] = statusToggle;
+        statusCell.appendChild(statusToggle.element);
+        row.appendChild(statusCell);
+        
+        // Startup checkbox cell
+        const startupCell = document.createElement('td');
+        startupCell.className = 'py-3 px-4 text-center';
+        
+        const startupLabel = document.createElement('label');
+        startupLabel.className = 'flex items-center justify-center gap-2 cursor-pointer group';
+        
+        const startupCheckbox = document.createElement('input');
+        startupCheckbox.type = 'checkbox';
+        startupCheckbox.id = `startup-${app.name}`;
+        startupCheckbox.name = `startup-${app.name}`;
+        startupCheckbox.className = 'w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 focus:ring-2 cursor-pointer transition-all';
+        startupCheckbox.checked = false;
+        
+        // Load initial startup preference
+        (async () => {
+            try {
+                const resp = await fetch(`/api/apps/startup-preference/${app.name}`);
+                if (resp.ok) {
+                    const data = await resp.json();
+                    startupCheckbox.checked = data.start_at_startup === true;
+                }
+            } catch (e) {
+                console.error(`Failed to load startup preference for ${app.name}:`, e);
+            }
+        })();
+        
+        // Handle checkbox change - only one app can be set to start at startup
+        startupCheckbox.addEventListener('change', async (e) => {
+            const newValue = e.target.checked;
+            
+            // If this checkbox is being checked, uncheck all others
+            if (newValue) {
+                for (const [otherAppName, otherCheckbox] of Object.entries(installedApps.startupCheckboxes)) {
+                    if (otherAppName !== app.name && otherCheckbox.checked) {
+                        // Uncheck the other checkbox
+                        otherCheckbox.checked = false;
+                        // Also save the preference for the other app
+                        try {
+                            await fetch(`/api/apps/startup-preference/${otherAppName}`, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ start_at_startup: false })
+                            });
+                        } catch (error) {
+                            console.error(`Failed to save startup preference for ${otherAppName}:`, error);
+                        }
+                    }
+                }
+            }
+            
+            // Save the preference for this app
+            try {
+                const resp = await fetch(`/api/apps/startup-preference/${app.name}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ start_at_startup: newValue })
+                });
+                if (!resp.ok) {
+                    throw new Error(`HTTP error! status: ${resp.status}`);
+                }
+            } catch (error) {
+                console.error(`Failed to save startup preference for ${app.name}:`, error);
+                // Revert checkbox state on error
+                startupCheckbox.checked = !newValue;
+            }
+        });
+        
+        const startupSpan = document.createElement('span');
+        startupSpan.className = 'text-sm text-gray-600 group-hover:text-gray-800 transition-colors';
+        startupSpan.textContent = 'Start at startup';
+        
+        startupLabel.appendChild(startupCheckbox);
+        startupLabel.appendChild(startupSpan);
+        startupCell.appendChild(startupLabel);
+        row.appendChild(startupCell);
+        
+        installedApps.startupCheckboxes[app.name] = startupCheckbox;
 
+        // Actions cell
+        const actionsCell = document.createElement('td');
+        actionsCell.className = 'py-3 px-4 text-center';
         const remove = document.createElement('button');
         remove.innerHTML = '🗑️';
-        remove.className = '-translate-y-1 text-xl';
-        container.appendChild(remove);
+        remove.className = 'text-xl hover:opacity-70 hover:scale-110 cursor-pointer transition-all p-1';
+        remove.title = 'Remove app';
         remove.onclick = async () => {
             console.log(`Removing ${app.name}...`);
             const resp = await fetch(`/api/apps/remove/${app.name}`, { method: 'POST' });
@@ -161,8 +259,10 @@ const installedApps = {
 
             installedApps.appUninstallLogHandler(app.name, jobId);
         };
+        actionsCell.appendChild(remove);
+        row.appendChild(actionsCell);
 
-        return container;
+        return row;
     },
 
     getRunningApp: async () => {

--- a/src/reachy_mini/daemon/app/dashboard/templates/sections/apps.html
+++ b/src/reachy_mini/daemon/app/dashboard/templates/sections/apps.html
@@ -1,8 +1,19 @@
 <section class="w-full">
     <div class="app-section">
         <div class="app-section-title">Applications</div>
-        <div class="">
-            <ul id="installed-apps" class="overflow-y-auto max-h-96"></ul>
+        <div class="mt-4 overflow-y-auto max-h-96">
+            <table class="w-full">
+                <thead class="bg-gray-50 sticky top-0">
+                    <tr class="border-b border-gray-200">
+                        <th class="text-left text-sm font-semibold text-gray-700 py-3 px-4">App Name</th>
+                        <th class="text-center text-sm font-semibold text-gray-700 py-3 px-4">Status</th>
+                        <th class="text-center text-sm font-semibold text-gray-700 py-3 px-4">Start at startup</th>
+                        <th class="text-center text-sm font-semibold text-gray-700 py-3 px-4">Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="installed-apps" class="divide-y divide-gray-100">
+                </tbody>
+            </table>
         </div>
     </div>
 </section>


### PR DESCRIPTION
<img width="1104" height="851" alt="image" src="https://github.com/user-attachments/assets/899ea57e-0ac8-4cd5-af5f-5066a18bc818" />

### 1. Startup Configuration Module (src/reachy_mini/apps/startup_config.py)
Created a utility module to manage app startup preferences
Preferences are stored in a JSON file (app_startup_config.json) in the venv parent directory
Functions to load, save, get, and set startup preferences for apps

### 2. API Endpoints (updated src/reachy_mini/daemon/app/routers/apps.py)
GET /api/apps/startup-preference/{app_name} - Get the startup preference for an app
POST /api/apps/startup-preference/{app_name} - Set the startup preference for an app

### 3. UI Updates (updated src/reachy_mini/daemon/app/dashboard/static/js/apps.js)
Added a checkbox next to each app's enable/disable toggle
The checkbox is labeled "Start at startup"
Checkbox state is loaded from the backend when the app list is displayed
Changes are saved to the backend when the checkbox is toggled
Updated the grid layout to accommodate the new checkbox column

### 4. Auto-start Logic (updated src/reachy_mini/daemon/app/main.py)
Added logic in the daemon startup lifecycle to automatically start apps that are marked to start at startup
Only the first app in the list is started (since only one app can run at a time)
Includes error handling if the auto-start fails
The checkbox appears next to each app's toggle in the dashboard. When checked, that app will automatically start when the daemon starts up. 

The preference is persisted in a JSON configuration file.