### PR TITLE
fix(SDK installation): switch uv add to uv pip install

### DIFF
--- a/docs/SDK/installation.md
+++ b/docs/SDK/installation.md
@@ -223,12 +223,12 @@ Choose your installation method:
 
 In your terminal, run:
 ```bash
-uv add reachy-mini
+uv pip install "reachy-mini"
 ```
 
 If you want to use the simulation mode, you need to add the `mujoco` extra:
 ```bash
-uv add reachy-mini --extra mujoco
+uv pip install "reachy-mini[mujoco]"
 ```
 
 ### 🔧 Option B: Install from Source  


### PR DESCRIPTION
This PR fixes the `error: No `pyproject.toml` found in current directory or any parent directory` issue caused by `uv add` when the user does not have an actual project to work on (Pipit packages only).