### PR TITLE
feat(bluetooth): add WIFI_RESET command to clear known networks

### DIFF
--- a/src/reachy_mini/daemon/app/services/bluetooth/commands/WIFI_RESET.sh
+++ b/src/reachy_mini/daemon/app/services/bluetooth/commands/WIFI_RESET.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+nmcli --escape yes -t -f NAME,TYPE connection show | grep ':802-11-wireless$' | while IFS= read -r line; do
+  conn="${line%:802-11-wireless}"
+  conn="${conn//\\:/\:}"
+  [ "$conn" != "Hotspot" ] && nmcli connection delete "$conn" 2>/dev/null
+done
+systemctl restart reachy-mini-daemon.service


### PR DESCRIPTION
## Summary

Add new BLE command `CMD_WIFI_RESET` that clears all saved WiFi networks and reverts to hotspot mode.

## Use cases

- Factory reset network configuration before lending/selling the robot
- Relocating robot to a new environment (old networks no longer relevant)
- Troubleshooting network issues (e.g., saved network with wrong password causing connection loops)

## Changes

- Add `WIFI_RESET.sh` script in `commands/` directory (6 lines)

## Usage

Via BLE (nRF Connect or desktop app):
```
PIN_xxxxx → CMD_WIFI_RESET
```

## Design decision

Kept separate from `SOFTWARE_RESET` to give users choice:
- `SOFTWARE_RESET`: reset venvs only
- `WIFI_RESET`: reset networks only