### PR TITLE
Add selective motor control API

### DIFF
--- a/src/reachy_mini/daemon/app/routers/motors.py
+++ b/src/reachy_mini/daemon/app/routers/motors.py
@@ -3,7 +3,9 @@
 Provides endpoints to get and set the motor control mode.
 """
 
-from fastapi import APIRouter, Depends
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from ....daemon.backend.abstract import Backend, MotorControlMode
@@ -24,6 +26,15 @@ class MotorStatus(BaseModel):
     mode: MotorControlMode
 
 
+class MotorModeRequest(BaseModel):
+    """Optional request body for selective motor control.
+
+    If motors is None or empty, all motors are affected.
+    """
+
+    motors: Optional[List[str]] = None
+
+
 @router.get("/status")
 async def get_motor_status(backend: Backend = Depends(get_backend)) -> MotorStatus:
     """Get the current status of the motors."""
@@ -33,9 +44,32 @@ async def get_motor_status(backend: Backend = Depends(get_backend)) -> MotorStat
 @router.post("/set_mode/{mode}")
 async def set_motor_mode(
     mode: MotorControlMode,
+    request: Optional[MotorModeRequest] = None,
     backend: Backend = Depends(get_backend),
 ) -> dict[str, str]:
-    """Set the motor control mode."""
-    backend.set_motor_control_mode(mode)
+    """Set the motor control mode.
 
-    return {"status": f"motors changed to {mode} mode"}
+    Optionally pass JSON body with 'motors' list to affect only specific motors.
+    Example: {"motors": ["left_antenna", "right_antenna"]}
+
+    Available motor names: body_rotation, stewart_1-6, left_antenna, right_antenna
+    """
+    # If no specific motors requested, use global mode change
+    if request is None or not request.motors:
+        backend.set_motor_control_mode(mode)
+        return {"status": f"all motors changed to {mode} mode"}
+
+    # Selective motor control
+    if mode not in [MotorControlMode.Enabled, MotorControlMode.Disabled]:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Selective motor control only supports 'enabled' or 'disabled', not '{mode}'"
+        )
+
+    try:
+        backend.set_motor_torque_ids(request.motors, mode == MotorControlMode.Enabled)
+        return {"status": f"motors {request.motors} changed to {mode} mode"}
+    except KeyError as e:
+        raise HTTPException(status_code=400, detail=f"Unknown motor name: {e}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -519,6 +519,8 @@ class RobotBackend(Backend):
 
         if on:
             self.c.enable_torque_on_ids(ids_int)
+            # Enable position updates in control loop
+            self._torque_enabled = True
         else:
             self.c.disable_torque_on_ids(ids_int)
 


### PR DESCRIPTION
Add selective motor control API

## Motivation

When running Reachy Mini in "always-on" mode (e.g., as an ambient assistant), I want to keep all motors **disabled** to save power and reduce wear. However, when detecting certain keyword sounds (like a wake word), I want to activate **only the antennas** to provide visual feedback without moving the head or body.

## Changes

- Added optional `motors` parameter to `POST /api/motors/set_mode/{mode}` endpoint
- When `motors` list is provided, only those specific motors are affected
- When `motors` is omitted or empty, all motors are affected (existing behavior preserved)

## Usage

```bash
# Disable all motors
curl -X POST http://reachy-mini:8000/api/motors/set_mode/disabled

# Enable only antennas
curl -X POST http://reachy-mini:8000/api/motors/set_mode/enabled \
  -H "Content-Type: application/json" \
  -d '{"motors": ["left_antenna", "right_antenna"]}'
```
  
## Testing
Tested on Reachy Mini Wireless running version 1.2.4 patched with this PR. Verified that:
- Antennas can be selectively enabled while head/body motors remain disabled
- Position commands work correctly for enabled motors only
- Body stays compliant (no torque) when only antennas are enabled
- Full sequence tested: sleep → disable all → enable antennas only → move antennas (head/body stayed limp) → enable all → wake up