### PR TITLE
fix(windows): resolve pwd import error and Unicode console encoding issues

### DIFF
--- a/src/reachy_mini/utils/wireless_version/startup_check.py
+++ b/src/reachy_mini/utils/wireless_version/startup_check.py
@@ -7,9 +7,14 @@ Also checks and updates the bluetooth service if needed.
 
 import filecmp
 import logging
-import pwd
+import platform
 import subprocess
 from pathlib import Path
+
+if platform.system() != "Windows":
+    import pwd
+else:
+    pwd = None
 
 logger = logging.getLogger(__name__)
 USER = "pollen"
@@ -25,8 +30,10 @@ def check_and_fix_venvs_ownership(
         custom_logger: Optional logger to use instead of the module logger
 
     """
+    if pwd is None:
+        return
+
     try:
-        # Get pollen user's UID
         pollen_uid = pwd.getpwnam(USER).pw_uid
     except KeyError:
         print(f"User '{USER}' does not exist on this system")


### PR DESCRIPTION
## Summary
- Fix `pwd` module import error on Windows by making it conditional
- Replace Unicode emoji with ASCII alternatives for Windows console compatibility

## Problem
Windows users encounter two errors when using the SDK:

1. `ModuleNotFoundError: No module named 'pwd'` when importing the daemon
2. `UnicodeEncodeError: 'charmap' codec can't encode character '\u2705'` when the motor setup runs

## Solution
1. `startup_check.py`: Conditionally import `pwd` only on non-Windows systems (same pattern as PR #299 for `fcntl`)
2. `setup_motor.py`: Detect console encoding at startup; use ✅/❌ on UTF-8 consoles, fall back to `[OK]`/`[FAIL]` on Windows

## Test plan
- [x] Verified daemon imports successfully on Windows
- [x] Verified motor communication works on Windows (COM5)
- [x] Robot responds correctly (wake up, head movement)