### PR TITLE
Added a host parameter to connect to a reachy on WiFi network

### DIFF
--- a/docs/SDK/quickstart.md
+++ b/docs/SDK/quickstart.md
@@ -39,7 +39,7 @@ The **Daemon** is a background service that handles the low-level communication 
 
 **Step 2:** Create a new file called `hello.py` and copy-paste the following code into it:
 
-> Tip: If you are using a Reachy Mini Wireless and running the script on your computer, you need to do `ReachyMini(localhost_only=False)`
+> Tip: If you are using a Reachy Mini Wireless and running the script on your computer, you need to do `ReachyMini(localhost_only=False)` or specify the robot's address directly with `ReachyMini(host="reachy-mini.local")`
 ```python
 from reachy_mini import ReachyMini
 

--- a/src/reachy_mini/io/zenoh_client.py
+++ b/src/reachy_mini/io/zenoh_client.py
@@ -19,21 +19,32 @@ import zenoh
 from reachy_mini.io.abstract import AbstractClient
 from reachy_mini.io.protocol import AnyTaskRequest, TaskProgress, TaskRequest
 
+DEFAULT_ZENOH_PORT = 7447
+
 
 class ZenohClient(AbstractClient):
     """Zenoh client for Reachy Mini."""
 
-    def __init__(self, prefix: str, localhost_only: bool = True):
+    def __init__(
+        self, prefix: str, localhost_only: bool = True, host: str | None = None
+    ):
         """Initialize the Zenoh client.
 
         Args:
             prefix: The Zenoh prefix to use for communication (used to identify multiple robots).
-            localhost_only: If True, connect to localhost only
+            localhost_only: If True, connect to localhost only. Ignored if host is provided.
+            host: Hostname or IP address of the robot (e.g., "reachy-mini.local" or "192.168.1.100").
+                If provided, overrides localhost_only.
 
         """
         self.prefix = prefix
 
-        if localhost_only:
+        if host is not None:
+            endpoint = f"tcp/{host}:{DEFAULT_ZENOH_PORT}"
+            c = zenoh.Config.from_json5(
+                json.dumps({"mode": "client", "connect": {"endpoints": [endpoint]}})
+            )
+        elif localhost_only:
             c = zenoh.Config.from_json5(
                 json.dumps(
                     {"mode": "client", "connect": {"endpoints": ["tcp/localhost:7447"]}}

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -70,12 +70,14 @@ class ReachyMini:
         automatic_body_yaw: bool = True,
         log_level: str = "INFO",
         media_backend: str = "default",
+        host: str | None = None,
     ) -> None:
         """Initialize the Reachy Mini robot.
 
         Args:
             robot_name (str): Name of the robot, defaults to "reachy_mini".
             localhost_only (bool): If True, will only connect to localhost daemons, defaults to True.
+                Ignored if host is provided.
             spawn_daemon (bool): If True, will spawn a daemon to control the robot, defaults to False.
             use_sim (bool): If True and spawn_daemon is True, will spawn a simulated robot, defaults to True.
             timeout (float): Timeout for the client connection, defaults to 5.0 seconds.
@@ -84,6 +86,8 @@ class ReachyMini:
             media_backend (str): Use "no_media" to disable media entirely. Any other value
                 triggers auto-detection: Lite uses OpenCV, Wireless uses GStreamer (local)
                 or WebRTC (remote) based on environment.
+            host (str | None): Hostname or IP address of the robot (e.g., "reachy-mini.local").
+                If provided, overrides localhost_only.
 
         It will try to connect to the daemon, and if it fails, it will raise an exception.
 
@@ -92,7 +96,7 @@ class ReachyMini:
         self.logger.setLevel(log_level)
         self.robot_name = robot_name
         daemon_check(spawn_daemon, use_sim)
-        self.client = ZenohClient(robot_name, localhost_only)
+        self.client = ZenohClient(robot_name, localhost_only, host=host)
         self.client.wait_for_connection(timeout=timeout)
         self.set_automatic_body_yaw(automatic_body_yaw)
         self._last_head_pose: Optional[npt.NDArray[np.float64]] = None

--- a/uv.lock
+++ b/uv.lock
@@ -2907,7 +2907,7 @@ wheels = [
 
 [[package]]
 name = "reachy-mini"
-version = "1.2.2"
+version = "1.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2933,6 +2933,7 @@ dependencies = [
     { name = "scipy" },
     { name = "sounddevice" },
     { name = "soundfile" },
+    { name = "toml" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
 ]
@@ -2950,6 +2951,7 @@ dev = [
     { name = "ruff" },
     { name = "rustypot" },
     { name = "types-requests" },
+    { name = "types-toml" },
     { name = "urdf-parser-py" },
 ]
 examples = [
@@ -3027,7 +3029,9 @@ requires-dist = [
     { name = "semver", marker = "extra == 'wireless-version'", specifier = ">=3,<4" },
     { name = "sounddevice", specifier = "==0.5.1" },
     { name = "soundfile", specifier = "==0.13.1" },
+    { name = "toml" },
     { name = "types-requests", marker = "extra == 'dev'" },
+    { name = "types-toml", marker = "extra == 'dev'" },
     { name = "urdf-parser-py", marker = "extra == 'dev'", specifier = "==0.0.4" },
     { name = "urdf-parser-py", marker = "extra == 'rerun'", specifier = "==0.0.4" },
     { name = "uvicorn", extras = ["standard"] },


### PR DESCRIPTION
The issue:
My reachy-mini(Wireless) is accessible on host `reachy-mini.local`, the daemon runs on `reachy-mini.local:7447`,
Currently, it is not possible to connect to my robot using SDK, as the host is hardcoded to localhost:7447.

This PR adds a host parameter to ReachyMini initializer allowing to connect to a robot on a Wifi Network.

```
with ReachyMini(hostname="reachy-mini.local", media_backend="no_media") as mini:
    print("Connected to Reachy Mini! ")
    
    # Wiggle antennas
    print("Wiggling antennas...")
    mini.goto_target(antennas=[0.5, -0.5], duration=0.5)
    mini.goto_target(antennas=[-0.5, 0.5], duration=0.5)
    mini.goto_target(antennas=[0, 0], duration=0.5)

    print("Done!")
 ```