### PR TITLE
fix(media): audio_gstreamer linux support

### DIFF
--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -41,7 +41,7 @@ class GStreamerAudio(AudioBase):
     DEFAULT_LATENCY_US = 30000
     DEFAULT_BUFFER_US = 200000
 
-    def __init__(self, log_level: str = "INFO", pcm_type: str = "plughw") -> None:
+    def __init__(self, log_level: str = "INFO", alsa_pcm_type: str = "plughw") -> None:
         """Initialize the GStreamer audio."""
         super().__init__(log_level=log_level)
         Gst.init(None)
@@ -52,7 +52,7 @@ class GStreamerAudio(AudioBase):
         self._is_linux = sys.platform.startswith("linux")
 
         self._id_audio_card = get_respeaker_card_number()
-        self._pcm_type = pcm_type
+        self._alsa_pcm_type = alsa_pcm_type
         self._pipeline_record = Gst.Pipeline.new("audio_recorder")
         self._appsink_audio: Optional[GstApp] = None
         self._init_pipeline_record(self._pipeline_record)
@@ -86,9 +86,9 @@ class GStreamerAudio(AudioBase):
         self._appsink_audio.set_property("max-buffers", 200)
 
         if self._is_linux and self._id_audio_card != -1:
-            self.logger.info(f"Using alsasrc device {self._pcm_type}:{self._id_audio_card},0")
+            self.logger.info(f"Using alsasrc device {self._alsa_pcm_type}:{self._id_audio_card},0")
             audiosrc = Gst.ElementFactory.make("alsasrc")
-            audiosrc.set_property("device", f"{self._pcm_type}:{self._id_audio_card},0")
+            audiosrc.set_property("device", f"{self._alsa_pcm_type}:{self._id_audio_card},0")
             
             audiosrc.set_property("latency-time", self.DEFAULT_LATENCY_US)
             audiosrc.set_property("buffer-time", self.DEFAULT_BUFFER_US)
@@ -141,7 +141,7 @@ class GStreamerAudio(AudioBase):
             audiosink = Gst.ElementFactory.make("autoaudiosink")  # use default speaker
         else:
             audiosink = Gst.ElementFactory.make("alsasink")
-            audiosink.set_property("device", f"{self._pcm_type}:{self._id_audio_card},0")
+            audiosink.set_property("device", f"{self._alsa_pcm_type}:{self._id_audio_card},0")
 
         pipeline.add(queue)
         pipeline.add(audiosink)

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -200,7 +200,7 @@ class GStreamerAudio(AudioBase):
             return None
             
         try:
-            return data.reshape(-1, 2)
+            return data.reshape(-1, self.CHANNELS)
         except ValueError as e:
             self.logger.error(f"Shape mismatch! Buffer size doesn't match channels. Error: {e}")
             return None

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -1,10 +1,11 @@
-"""GStreamer camera backend.
+"""GStreamer audio backend.
 
-This module provides an implementation of the CameraBase class using GStreamer.
-By default the module directly returns JPEG images as output by the camera.
+This module provides an implementation of the AudioBase class using GStreamer.
+By default the module directly returns audio stream by ReStreamer
 """
 
 import os
+import sys
 from threading import Thread
 from typing import Optional
 
@@ -21,7 +22,7 @@ try:
     import gi
 except ImportError as e:
     raise ImportError(
-        "The 'gi' module is required for GStreamerCamera but could not be imported. \
+        "The 'gi' module is required for GStreamerAudio but could not be imported. \
                       Please install the GStreamer backend: pip install .[gstreamer]."
     ) from e
 
@@ -37,7 +38,10 @@ from .audio_base import AudioBase  # noqa: E402
 class GStreamerAudio(AudioBase):
     """Audio implementation using GStreamer."""
 
-    def __init__(self, log_level: str = "INFO") -> None:
+    DEFAULT_LATENCY_US = 30000
+    DEFAULT_BUFFER_US = 200000
+
+    def __init__(self, log_level: str = "INFO", pcm_type: str = "plughw") -> None:
         """Initialize the GStreamer audio."""
         super().__init__(log_level=log_level)
         Gst.init(None)
@@ -45,8 +49,10 @@ class GStreamerAudio(AudioBase):
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()
 
-        self._id_audio_card = get_respeaker_card_number()
+        self._is_linux = sys.platform.startswith("linux")
 
+        self._id_audio_card = get_respeaker_card_number()
+        self._pcm_type = pcm_type
         self._pipeline_record = Gst.Pipeline.new("audio_recorder")
         self._appsink_audio: Optional[GstApp] = None
         self._init_pipeline_record(self._pipeline_record)
@@ -65,41 +71,50 @@ class GStreamerAudio(AudioBase):
 
     def _init_pipeline_record(self, pipeline: Gst.Pipeline) -> None:
         self._appsink_audio = Gst.ElementFactory.make("appsink")
-        caps = Gst.Caps.from_string(
-            f"audio/x-raw,rate={self.SAMPLE_RATE},channels={self.CHANNELS},format=F32LE,layout=interleaved"
+        
+        # 1. Define the target caps (What we WANT: 16k, F32LE)
+        caps_string = (
+            f"audio/x-raw,rate={self.SAMPLE_RATE},"
+            f"channels={self.CHANNELS},"
+            f"format=F32LE,layout=interleaved"
         )
+        caps = Gst.Caps.from_string(caps_string)
+        
+        # Configure AppSink
         self._appsink_audio.set_property("caps", caps)
-        self._appsink_audio.set_property("drop", True)  # avoid overflow
+        self._appsink_audio.set_property("drop", True)
         self._appsink_audio.set_property("max-buffers", 200)
 
-        audiosrc: Optional[Gst.Element] = None
-        if self._id_audio_card == -1:
-            audiosrc = Gst.ElementFactory.make("autoaudiosrc")  # use default mic
-        elif has_reachymini_asoundrc():
-            # reachy mini wireless has a preconfigured asoundrc
+        if self._is_linux and self._id_audio_card != -1:
+            self.logger.info(f"Using alsasrc device {self._pcm_type}:{self._id_audio_card},0")
             audiosrc = Gst.ElementFactory.make("alsasrc")
-            audiosrc.set_property("device", "reachymini_audio_src")
+            audiosrc.set_property("device", f"{self._pcm_type}:{self._id_audio_card},0")
+            
+            audiosrc.set_property("latency-time", self.DEFAULT_LATENCY_US)
+            audiosrc.set_property("buffer-time", self.DEFAULT_BUFFER_US)
         else:
-            audiosrc = Gst.ElementFactory.make("alsasrc")
-            audiosrc.set_property("device", f"hw:{self._id_audio_card},0")
+            self.logger.info("Using autoaudiosrc (System Default)")
+            audiosrc = Gst.ElementFactory.make("autoaudiosrc")
 
         queue = Gst.ElementFactory.make("queue")
         audioconvert = Gst.ElementFactory.make("audioconvert")
         audioresample = Gst.ElementFactory.make("audioresample")
+        
+        elements = [audiosrc, queue, audioconvert, audioresample, self._appsink_audio]
+        if not all(elements):
+            raise RuntimeError("Failed to create required GStreamer elements")
 
-        if not all([audiosrc, queue, audioconvert, audioresample, self._appsink_audio]):
-            raise RuntimeError("Failed to create GStreamer elements")
+        for elem in elements:
+            pipeline.add(elem)
 
-        pipeline.add(audiosrc)
-        pipeline.add(queue)
-        pipeline.add(audioconvert)
-        pipeline.add(audioresample)
-        pipeline.add(self._appsink_audio)
-
-        audiosrc.link(queue)
-        queue.link(audioconvert)
-        audioconvert.link(audioresample)
-        audioresample.link(self._appsink_audio)
+        if not audiosrc.link(queue):
+            raise RuntimeError("Failed to link audiosrc -> queue")
+        if not queue.link(audioconvert):
+            raise RuntimeError("Failed to link queue -> audioconvert")
+        if not audioconvert.link(audioresample):
+            raise RuntimeError("Failed to link audioconvert -> audioresample")
+        if not audioresample.link(self._appsink_audio):
+            raise RuntimeError("Failed to link audioresample -> appsink")
 
     def __del__(self) -> None:
         """Destructor to ensure gstreamer resources are released."""
@@ -124,13 +139,9 @@ class GStreamerAudio(AudioBase):
         audiosink: Optional[Gst.Element] = None
         if self._id_audio_card == -1:
             audiosink = Gst.ElementFactory.make("autoaudiosink")  # use default speaker
-        elif has_reachymini_asoundrc():
-            # reachy mini wireless has a preconfigured asoundrc
-            audiosink = Gst.ElementFactory.make("alsasink")
-            audiosink.set_property("device", "reachymini_audio_sink")
         else:
             audiosink = Gst.ElementFactory.make("alsasink")
-            audiosink.set_property("device", f"hw:{self._id_audio_card},0")
+            audiosink.set_property("device", f"{self._pcm_type}:{self._id_audio_card},0")
 
         pipeline.add(queue)
         pipeline.add(audiosink)
@@ -160,30 +171,39 @@ class GStreamerAudio(AudioBase):
         """Open the audio card using GStreamer."""
         self._pipeline_record.set_state(Gst.State.PLAYING)
 
-    def _get_sample(self, appsink: GstApp.AppSink) -> Optional[bytes]:
-        sample = appsink.try_pull_sample(20_000_000)
-        if sample is None:
-            return None
+    def _get_sample(self, appsink: GstApp.AppSink) -> Optional[npt.NDArray[np.float32]]:
         data = None
+        sample = appsink.try_pull_sample(20_000_000)
+
         if isinstance(sample, Gst.Sample):
             buf = sample.get_buffer()
-            if buf is None:
+            if buf is not None:
+                success, mapinfo = buf.map(Gst.MapFlags.READ)
+                if success:
+                    try:
+                        data = np.frombuffer(mapinfo.data, dtype=np.float32).copy()
+                    finally:
+                        buf.unmap(mapinfo)
+                else:
+                    self.logger.error("Failed to map buffer")
+            else:
                 self.logger.warning("Buffer is None")
 
-            data = buf.extract_dup(0, buf.get_size())
         return data
 
     def get_audio_sample(self) -> Optional[npt.NDArray[np.float32]]:
-        """Read a sample from the audio card. Returns the sample or None if error.
-
-        Returns:
-            Optional[npt.NDArray[np.float32]]: The captured sample in raw format, or None if error.
-
-        """
-        sample = self._get_sample(self._appsink_audio)
-        if sample is None:
+        """Read a sample from the audio card."""
+        if self._appsink_audio is None:
             return None
-        return np.frombuffer(sample, dtype=np.float32).reshape(-1, 2)
+        data = self._get_sample(self._appsink_audio)
+        if data is None:
+            return None
+            
+        try:
+            return data.reshape(-1, 2)
+        except ValueError as e:
+            self.logger.error(f"Shape mismatch! Buffer size doesn't match channels. Error: {e}")
+            return None
 
     def get_input_audio_samplerate(self) -> int:
         """Get the input samplerate of the audio device."""
@@ -202,7 +222,7 @@ class GStreamerAudio(AudioBase):
         return self.CHANNELS
 
     def stop_recording(self) -> None:
-        """Release the camera resource."""
+        """Release the audio resource."""
         self._pipeline_record.set_state(Gst.State.NULL)
 
     def start_playing(self) -> None:

--- a/src/reachy_mini/media/media_manager.py
+++ b/src/reachy_mini/media/media_manager.py
@@ -36,6 +36,7 @@ class MediaManager:
         log_level: str = "INFO",
         use_sim: bool = False,
         signalling_host: str = "localhost",
+        alsa_pcm_type: str = "plughw",
     ) -> None:
         """Initialize the audio device."""
         self.logger = logging.getLogger(__name__)
@@ -44,23 +45,24 @@ class MediaManager:
         self.camera: Optional[CameraBase] = None
         self.audio: Optional[AudioBase] = None
 
+
         match backend:
             case MediaBackend.NO_MEDIA:
                 self.logger.info("No media backend selected.")
             case MediaBackend.DEFAULT:
                 self.logger.info("Using default media backend (OpenCV + SoundDevice).")
                 self._init_camera(use_sim, log_level)
-                self._init_audio(log_level)
+                self._init_audio(log_level, alsa_pcm_type)
             case MediaBackend.DEFAULT_NO_VIDEO:
                 self.logger.info("Using default media backend (SoundDevice only).")
-                self._init_audio(log_level)
+                self._init_audio(log_level, alsa_pcm_type)
             case MediaBackend.GSTREAMER:
                 self.logger.info("Using GStreamer media backend.")
                 self._init_camera(use_sim, log_level)
-                self._init_audio(log_level)
+                self._init_audio(log_level, alsa_pcm_type)
             case MediaBackend.GSTREAMER_NO_VIDEO:
                 self.logger.info("Using GStreamer audio backend.")
-                self._init_audio(log_level)
+                self._init_audio(log_level, alsa_pcm_type)
             case MediaBackend.WEBRTC:
                 self.logger.info("Using WebRTC GStreamer backend.")
                 self._init_webrtc(log_level, signalling_host, 8443)
@@ -119,7 +121,7 @@ class MediaManager:
             return None
         return self.camera.read()
 
-    def _init_audio(self, log_level: str) -> None:
+    def _init_audio(self, log_level: str, alsa_pcm_type: str) -> None:
         """Initialize the audio system."""
         self.logger.debug("Initializing audio...")
         if (
@@ -137,7 +139,7 @@ class MediaManager:
             self.logger.info("Using GStreamer audio backend.")
             from reachy_mini.media.audio_gstreamer import GStreamerAudio
 
-            self.audio = GStreamerAudio(log_level=log_level)
+            self.audio = GStreamerAudio(log_level=log_level, alsa_pcm_type=alsa_pcm_type)
         else:
             raise NotImplementedError(f"Audio backend {self.backend} not implemented.")
 

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -70,6 +70,7 @@ class ReachyMini:
         automatic_body_yaw: bool = True,
         log_level: str = "INFO",
         media_backend: str = "default",
+        alsa_pcm_type: str = "plughw",
     ) -> None:
         """Initialize the Reachy Mini robot.
 
@@ -84,6 +85,7 @@ class ReachyMini:
             media_backend (str): Use "no_media" to disable media entirely. Any other value
                 triggers auto-detection: Lite uses OpenCV, Wireless uses GStreamer (local)
                 or WebRTC (remote) based on environment.
+            alsa_pcm_type (str): ALSA PCM type, defaults to "plughw". Relevant for GStreamer audio backend.
 
         It will try to connect to the daemon, and if it fails, it will raise an exception.
 
@@ -108,7 +110,7 @@ class ReachyMini:
             ]
         )
 
-        self.media_manager = self._configure_mediamanager(media_backend, log_level)
+        self.media_manager = self._configure_mediamanager(media_backend, log_level, alsa_pcm_type)
 
     def __del__(self) -> None:
         """Destroy the Reachy Mini instance.
@@ -134,7 +136,7 @@ class ReachyMini:
         return self.media_manager
 
     def _configure_mediamanager(
-        self, media_backend: str, log_level: str
+        self, media_backend: str, log_level: str, alsa_pcm_type: str
     ) -> MediaManager:
         daemon_status = self.client.get_status()
         is_wireless = daemon_status.get("wireless_version", False)
@@ -179,6 +181,7 @@ class ReachyMini:
             backend=mbackend,
             log_level=log_level,
             signalling_host=self.client.get_status()["wlan_ip"],
+            alsa_pcm_type=alsa_pcm_type,
         )
 
     def set_target(


### PR DESCRIPTION
(Description as courtesy of Qodo for OS repositories)

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Expose ALSA PCM type configuration through ReachyMini initialization

- Fix audio device selection logic for Linux systems with proper PCM type support

- Improve buffer handling with proper GStreamer buffer mapping and error checking

- Add latency and buffer time configuration for audio source elements

- Simplify audio sink device selection

- Enhance error handling with detailed link validation in pipeline construction
___

### Diagram Walkthroughs

#### Exposing alsa_pcm_type
```mermaid
flowchart LR
  RM["ReachyMini.__init__"] -- "alsa_pcm_type" --> CMM["_configure_mediamanager"]
  CMM -- "alsa_pcm_type" --> MM["MediaManager.__init__"]
  MM -- "alsa_pcm_type" --> IA["_init_audio"]
  IA -- "alsa_pcm_type" --> GSA["GStreamerAudio.__init__"]
  GSA -- "uses as" --> ALSA["ALSA device config"]
```

#### audio_gstreamer internals
```mermaid
flowchart LR
  A["Audio Device Selection"] -->|"Linux + RespeakerCard"| B["ALSAsrc with PCM Type"]
  A -->|"Default/Non-Linux"| C["AutoAudioSrc"]
  B -->|"Latency/Buffer Config"| D["Audio Pipeline"]
  C -->|"Standard Config"| D
  D -->|"Proper Buffer Mapping"| E["Float32 Audio Data"]
  E -->|"Reshape to Channels"| F["Output Array"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, enhancement, error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_gstreamer.py</strong><dd><code>Enhanced audio device handling and buffer management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/reachy_mini/media/audio_gstreamer.py

<ul><li>Fixed module docstring from "camera" to "audio" and updated import <br>statements<br> <li> Added <code>pcm_type</code> parameter to constructor with default value "plughw" <br>for flexible device naming<br> <li> Introduced platform detection (<code>sys.platform</code>) to conditionally apply <br>Linux-specific audio configurations<br> <li> Refactored audio source selection logic to use PCM type format <br>(<code>plughw:card,0</code>) instead of deprecated asoundrc<br> <li> Added latency and buffer time properties (<code>DEFAULT_LATENCY_US</code>, <br><code>DEFAULT_BUFFER_US</code>) to audio source for better performance<br> <li> Improved buffer handling in <code>_get_sample()</code> with proper GStreamer buffer <br>mapping using <code>buf.map()</code> and explicit error handling<br> <li> Enhanced pipeline element linking with individual validation checks <br>and descriptive error messages<br> <li> Simplified audio sink device selection by removing asoundrc-specific <br>logic<br> <li> Removed file-based sound playback implementation and replaced with <br>warning log<br> <li> Fixed return type annotation in <code>_get_sample()</code> from bytes to numpy <br>array</ul>


</details>


  </td>
  <td><a href="https://github.com/OriNachum/reachy_mini/pull/2/files#diff-ac5ad1c41ba2494e8c1c9ba1d97050619cab5c67019ad5fa265f8de9ffcba364">+75/-85</a>&nbsp; </td>

</tr>
</table></td></tr></tbody>

<thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_gstreamer.py</strong><dd><code>Rename PCM type parameter to ALSA PCM type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/reachy_mini/media/audio_gstreamer.py

<ul><li>Renamed parameter <code>pcm_type</code> to <code>alsa_pcm_type</code> in <code>__init__</code> method<br> <li> Updated instance variable from <code>self._pcm_type</code> to <code>self._alsa_pcm_type</code><br> <li> Updated all references to use new variable name in pipeline <br>initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/OriNachum/reachy_mini/pull/4/files#diff-ac5ad1c41ba2494e8c1c9ba1d97050619cab5c67019ad5fa265f8de9ffcba364">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>media_manager.py</strong><dd><code>Add ALSA PCM type parameter to MediaManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/reachy_mini/media/media_manager.py

<ul><li>Added <code>alsa_pcm_type</code> parameter to <code>MediaManager.__init__</code> with default <br>value "plughw"<br> <li> Updated <code>_init_audio</code> method signature to accept <code>alsa_pcm_type</code> parameter<br> <li> Propagated <code>alsa_pcm_type</code> to all <code>_init_audio</code> calls across different <br>backend cases<br> <li> Passed <code>alsa_pcm_type</code> to <code>GStreamerAudio</code> instantiation</ul>


</details>


  </td>
  <td><a href="https://github.com/OriNachum/reachy_mini/pull/4/files#diff-e1f16750c5837c9673d0b12e38d8a6845934ffd59e3a754e2686b741e027fabd">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reachy_mini.py</strong><dd><code>Expose ALSA PCM type configuration in ReachyMini</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/reachy_mini/reachy_mini.py

<ul><li>Added <code>alsa_pcm_type</code> parameter to <code>ReachyMini.__init__</code> with default <br>value "plughw"<br> <li> Updated docstring to document the new ALSA PCM type parameter<br> <li> Modified <code>_configure_mediamanager</code> method to accept and pass <br><code>alsa_pcm_type</code><br> <li> Propagated <code>alsa_pcm_type</code> to <code>MediaManager</code> instantiation</ul>


</details>


  </td>
  <td><a href="https://github.com/OriNachum/reachy_mini/pull/4/files#diff-18e0f0951b7f04009dc705c24b3b49157efc0406cbbd5ac45d5d3f51d49eb153">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


