### PR TITLE
docs: add procedure to install daemon from branch

### DIFF
--- a/docs/platforms/reachy_mini/advanced_rpi_setup.md
+++ b/docs/platforms/reachy_mini/advanced_rpi_setup.md
@@ -111,41 +111,4 @@ gst-launch-1.0 audiotestsrc ! audioconvert ! audioresample ! opusenc ! audio/x-o
 
 ## 8. Install Daemon from a Specific Branch
 
-> **⚠️ For developers/testers only.** Use this to test a feature branch before it's released.
-
-### Prerequisites
-- SSH access to the robot
-- The robot connected to Wi-Fi (or via Hotspot)
-
-### Procedure
-
-1. **SSH into the robot:**
-   ```bash
-   ssh pollen@reachy-mini.local
-   # password: root
-   ```
-
-2. **Activate the daemon virtual environment:**
-   ```bash
-   source /venvs/mini_daemon/bin/activate
-   ```
-
-3. **Install the branch:**
-   ```bash
-   pip install --no-cache-dir --force-reinstall git+https://github.com/pollen-robotics/reachy_mini.git@<branch-name>
-   ```
-   Replace `<branch-name>` with the target branch (e.g., `develop`, `feature/my-feature`).
-
-4. **Restart the daemon:**
-   ```bash
-   sudo systemctl restart reachy-mini-daemon
-   ```
-
-5. **Verify the installation:**
-   ```bash
-   pip show reachy-mini | grep Version
-   ```
-
-### Rollback to Factory Version
-
-If something goes wrong, use the **SOFTWARE_RESET** command via Bluetooth to restore the factory daemon. See the [Reset Guide](reset.md) for instructions.
+Follow the dedicated instructions in the [Install Daemon from Branch guide](install_daemon_from_branch.md).

--- a/docs/platforms/reachy_mini/get_started.md
+++ b/docs/platforms/reachy_mini/get_started.md
@@ -78,4 +78,5 @@ If you need to reinstall the Raspberry Pi from scratch or create a custom image,
 
 👉 **[Manual Raspberry Pi Installation](advanced_rpi_setup.md)**
 
+👉 **[Install Daemon from a Specific Branch](install_daemon_from_branch.md)**
 

--- a/docs/platforms/reachy_mini/install_daemon_from_branch.md
+++ b/docs/platforms/reachy_mini/install_daemon_from_branch.md
@@ -1,0 +1,44 @@
+# Install the Daemon from a Specific Branch
+
+> **⚠️ Developers/Testers Only**
+>
+> Use this guide to install the Reachy Mini daemon from a GitHub branch before it is officially released.
+
+## Prerequisites
+
+- SSH access to your Reachy Mini (`pollen@reachy-mini.local`, password `root`).
+- The robot connected to your Wi-Fi (or reachable through the hotspot).
+
+## Procedure
+
+1. **SSH into the robot:**
+   ```bash
+   ssh pollen@reachy-mini.local
+   # password: root
+   ```
+
+2. **Activate the daemon virtual environment:**
+   ```bash
+   source /venvs/mini_daemon/bin/activate
+   ```
+
+3. **Install the branch:**
+   ```bash
+   pip install --no-cache-dir --force-reinstall \
+     git+https://github.com/pollen-robotics/reachy_mini.git@<branch-name>
+   ```
+   Replace `<branch-name>` with the branch you want to test (e.g., `develop`, `feature/my-feature`).
+
+4. **Restart the daemon:**
+   ```bash
+   sudo systemctl restart reachy-mini-daemon
+   ```
+
+5. **Verify the installation:**
+   ```bash
+   pip show reachy-mini | grep Version
+   ```
+
+## Rollback to Factory Version
+
+If the branch causes issues, trigger the **SOFTWARE_RESET** command (via Bluetooth) to reinstall the factory daemon. See the [Reset Guide](reset.md) for detailed steps.


### PR DESCRIPTION
Adds a new section to `advanced_rpi_setup.md` explaining how to install the daemon from a specific GitHub branch via SSH.

Useful for developers/testers who need to test feature branches before release.

Includes:
- Step-by-step SSH procedure
- pip install command with `--no-cache-dir --force-reinstall`
- Rollback instructions via SOFTWARE_RESET