### PR TITLE
Update installation command for reachy-mini with gstreamer

### DIFF
--- a/docs/SDK/gstreamer-installation.md
+++ b/docs/SDK/gstreamer-installation.md
@@ -170,7 +170,7 @@ When installing Reachy Mini Python package, you will also need to add the `gstre
 ### Install from PyPI
 
 ```bash
-uv add reachy-mini --extra gstreamer
+uv pip install "reachy-mini[gstreamer]"
 ```
 
 ### Install from source


### PR DESCRIPTION
Changes install command when not building from source to the uv pip install variant found on `develop/docs/SDK/installation.md`, but for gstreamer instead of mujoco used there.