### PR TITLE
fix(stop): switching from stop() to pause() to avoid webrtc restart issue

### DIFF
--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -353,7 +353,8 @@ class Daemon:
                 self.websocket_server.stop()
 
             if self._webrtc:
-                self._webrtc.stop()
+                # We use pause() instead of stop() to keep the signalling server running and the producer registered, allowing proper restart.
+                self._webrtc.pause()
 
             if goto_sleep_on_stop:
                 try:


### PR DESCRIPTION
This PR is a replicate of @cdussieux https://github.com/pollen-robotics/reachy_mini/pull/649 implementing the variant suggested by @FabienDanieau.