### PR TITLE
fix(ci timeout): adding a timeout on the pytest CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 jobs:
   pytest:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]


### PR DESCRIPTION
This PR adds a timeout on the Pytest CI to avoid hanging for hours