### PR TITLE
bug #665: remove socket path if it exists

### DIFF
--- a/src/reachy_mini/media/webrtc_daemon.py
+++ b/src/reachy_mini/media/webrtc_daemon.py
@@ -4,11 +4,13 @@ Starts a gstreamer webrtc pipeline to stream video and audio.
 """
 
 import logging
+import os
 from threading import Thread
 from typing import Optional, Tuple, cast
 
 import gi
 
+from reachy_mini.daemon.utils import CAMERA_SOCKET_PATH, is_local_camera_available
 from reachy_mini.media.camera_constants import (
     ArducamSpecs,
     CameraSpecs,
@@ -156,7 +158,10 @@ class GstWebRTC:
         tee = Gst.ElementFactory.make("tee")
         # make camera accessible to other applications via unixfdsrc/sink
         unixfdsink = Gst.ElementFactory.make("unixfdsink")
-        unixfdsink.set_property("socket-path", "/tmp/reachymini_camera_socket")
+        if is_local_camera_available():
+            # prevent crash if socket already exists
+            os.remove(CAMERA_SOCKET_PATH)
+        unixfdsink.set_property("socket-path", CAMERA_SOCKET_PATH)
         queue_unixfd = Gst.ElementFactory.make("queue", "queue_unixfd")
         queue_encoder = Gst.ElementFactory.make("queue", "queue_encoder")
         v4l2h264enc = Gst.ElementFactory.make("v4l2h264enc")


### PR DESCRIPTION
Small bug fix. It seems that the camera socket is not removed if the daemon is not properly closed. This happens mostly in dev situations. If so the gstreamer pipeline fails to start.
I just remove the existing socket, if any, to prevent this.