### PR TITLE
fix(backend choice): relaxing constraints on backend choice for Lite and Wireless versions

### DIFF
--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -9,6 +9,7 @@ It also includes methods for multimedia interactions like playing sounds and loo
 import asyncio
 import json
 import logging
+import platform
 import time
 from typing import Dict, List, Literal, Optional, Union, cast
 
@@ -216,6 +217,10 @@ class ReachyMini:
                     if mbackend == MediaBackend.WEBRTC:
                         self.logger.warning(f"Incompatible media backend on Lite: {media_backend}, using default backend.")
                         mbackend = MediaBackend.DEFAULT
+                    #TODO : Remove when wheel is released !
+                    elif "gstreamer" in media_backend.lower() and (platform.system() == "Darwin" or platform.system() == "Windows"):
+                        self.logger.warning(f"Unsupported media backend on Lite for {platform.system()}: {media_backend}, using default backend.")
+                        mbackend = MediaBackend.DEFAULT_NO_VIDEO if "no_video" in media_backend.lower() else MediaBackend.DEFAULT
                     else:
                         self.logger.info(
                             "Auto-detected: Lite. "


### PR DESCRIPTION
This PR adds back partial media backend choice, especially on the Lite version (where only the webrtc backend is not available) and for `no_video` backends.