### PR TITLE
Wireless connection mode

### DIFF
--- a/src/reachy_mini/io/zenoh_client.py
+++ b/src/reachy_mini/io/zenoh_client.py
@@ -5,7 +5,6 @@ robot. It subscribes to joint positions updates and allows sending commands to t
 """
 
 import json
-import logging
 import threading
 import time
 from dataclasses import dataclass
@@ -24,27 +23,27 @@ from reachy_mini.io.protocol import AnyTaskRequest, TaskProgress, TaskRequest
 class ZenohClient(AbstractClient):
     """Zenoh client for Reachy Mini."""
 
-    def __init__(self, prefix: str, localhost_only: Optional[bool] = None, host: Optional[str] = None):
+    def __init__(self, prefix: str, localhost_only: Optional[bool] = None, host_addr: Optional[str] = None):
         """Initialize the Zenoh client.
 
         Args:
             prefix: The Zenoh prefix to use for communication (used to identify multiple robots).
-            localhost_only: (Deprecated) If True, connect to localhost only. Use 'host="localhost"' instead.
-            host: If specified, connect to this host only
+            localhost_only: If True, connect to localhost only.
+            host_addr: If specified, connect to this host only.
 
         """
-        self.logger = logging.getLogger(__name__)
         self.prefix = prefix
-        if host:
+        
+        if localhost_only and host_addr and host_addr not in ["localhost", "127.0.0.1"]:
+            raise ValueError("host_addr must be 'localhost' or '127.0.0.1' when localhost_only is True.")
+                    
+        if host_addr:
             c = zenoh.Config.from_json5(
                 json.dumps(
-                    {"mode": "client", "connect": {"endpoints": [f"tcp/{host}:7447"]}}
+                    {"mode": "client", "connect": {"endpoints": [f"tcp/{host_addr}:7447"]}}
                 )
             )
         elif localhost_only:
-            self.logger.warning(
-                "The 'localhost_only' argument is deprecated. Please use 'host=\"localhost\"' instead."
-            )
             c = zenoh.Config.from_json5(
                 json.dumps(
                     {"mode": "client", "connect": {"endpoints": ["tcp/localhost:7447"]}}

--- a/src/reachy_mini/io/zenoh_client.py
+++ b/src/reachy_mini/io/zenoh_client.py
@@ -29,13 +29,15 @@ class ZenohClient(AbstractClient):
 
         Args:
             prefix: The Zenoh prefix to use for communication (used to identify multiple robots).
-            localhost_only: If True, connect to localhost only.
-            host_addr: If specified, connect to this host only.
+            localhost_only: If True or None with no host_addr, connect to localhost only.
+            host_addr: If specified, connect to this host only. If None and localhost_only is False, connect to the first robot found on the network.   
 
         """
         self.prefix = prefix
         
-        if localhost_only and host_addr and host_addr not in ["localhost", "127.0.0.1"]:
+        if localhost_only is None and host_addr is None:
+            localhost_only = True # Preserve old behavior when called with only prefix
+        elif localhost_only and host_addr and host_addr not in ["localhost", "127.0.0.1"]:
             raise ValueError("host_addr must be 'localhost' or '127.0.0.1' when localhost_only is True.")
                     
         if host_addr:

--- a/src/reachy_mini/io/zenoh_client.py
+++ b/src/reachy_mini/io/zenoh_client.py
@@ -5,6 +5,7 @@ robot. It subscribes to joint positions updates and allows sending commands to t
 """
 
 import json
+import logging
 import threading
 import time
 from dataclasses import dataclass
@@ -23,17 +24,26 @@ from reachy_mini.io.protocol import AnyTaskRequest, TaskProgress, TaskRequest
 class ZenohClient(AbstractClient):
     """Zenoh client for Reachy Mini."""
 
-    def __init__(self, prefix: str, localhost_only: bool = True):
+    def __init__(self, prefix: str, localhost_only: Optional[bool] = None, host: Optional[str] = None):
         """Initialize the Zenoh client.
 
         Args:
             prefix: The Zenoh prefix to use for communication (used to identify multiple robots).
-            localhost_only: If True, connect to localhost only
+            host: If specified, connect to this host only
 
         """
+        self.logger = logging.getLogger(__name__)
         self.prefix = prefix
-
-        if localhost_only:
+        if host:
+            c = zenoh.Config.from_json5(
+                json.dumps(
+                    {"mode": "client", "connect": {"endpoints": [f"tcp/{host}:7447"]}}
+                )
+            )
+        elif localhost_only:
+            self.logger.warning(
+                "The 'localhost_only' argument is deprecated. Please use 'host=\"localhost\"' instead."
+            )
             c = zenoh.Config.from_json5(
                 json.dumps(
                     {"mode": "client", "connect": {"endpoints": ["tcp/localhost:7447"]}}

--- a/src/reachy_mini/io/zenoh_client.py
+++ b/src/reachy_mini/io/zenoh_client.py
@@ -29,6 +29,7 @@ class ZenohClient(AbstractClient):
 
         Args:
             prefix: The Zenoh prefix to use for communication (used to identify multiple robots).
+            localhost_only: (Deprecated) If True, connect to localhost only. Use 'host="localhost"' instead.
             host: If specified, connect to this host only
 
         """

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -11,7 +11,7 @@ import json
 import logging
 import platform
 import time
-from typing import Dict, List, Literal, Optional, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 import cv2
 import numpy as np
@@ -328,7 +328,7 @@ class ReachyMini:
         self,
         host: Union[str, bool, None] = None,
         timeout: float = 5.0,
-        **kwargs,
+        **kwargs: Any,
     ) -> ZenohClient:
         """Connect once with the requested tunneling mode and guard cleanup."""
         # Backward compatibility for localhost_only argument passed as positional bool

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -50,7 +50,7 @@ SLEEP_HEAD_POSE = np.array(
     ]
 )
 
-ConnectionMode = Literal["auto", "localhost_only", "wireless","network"]
+ConnectionMode = Literal["auto", "localhost_only", "wireless", "network"]
 
 
 class ReachyMini:

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -350,6 +350,10 @@ class ReachyMini:
         return client, "localhost_only"
 
     def _connect_wireless(self, timeout: float) -> tuple[ZenohClient, ConnectionMode]:
+        # For mDNS/DNS-based discovery we use a `.local` hostname derived from `robot_name`.
+        # Underscores are replaced with hyphens because many hostname resolvers and mDNS
+        # implementations expect hostnames without underscores; this is the convention used
+        # for Reachy Mini wireless hostnames.
         client = self._connect_single(
             host_addr=f"{self.robot_name.replace('_', '-')}.local", timeout=timeout
         )

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -316,8 +316,8 @@ class ReachyMini:
                                 "Make sure a Reachy Mini daemon is running and accessible."
                             )
                         raise err
-            self.logger.info("Connection mode selected: %s", selected)  # type: ignore
-            return client, selected  # type: ignore
+            self.logger.info("Connection mode selected: %s", selected)
+            return client, selected
 
         if requested_mode == "localhost_only":
             try:

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -313,11 +313,11 @@ class ReachyMini:
         return client, selected
 
     def _connect_localhost(self, timeout: float) -> tuple[ZenohClient, ConnectionMode]:
-        client = self._connect_single(host="localhost", timeout=timeout)
+        client = self._connect_single(host_addr="localhost", timeout=timeout)
         return client, "localhost_only"
 
     def _connect_wireless(self, timeout: float) -> tuple[ZenohClient, ConnectionMode]:
-        client = self._connect_single(host=f"{self.robot_name.replace('_', '-')}.local", timeout=timeout)
+        client = self._connect_single(host_addr=f"{self.robot_name.replace('_', '-')}.local", timeout=timeout)
         return client, "wireless"
 
     def _connect_network(self, timeout: float) -> tuple[ZenohClient, ConnectionMode]:
@@ -326,30 +326,11 @@ class ReachyMini:
 
     def _connect_single(
         self,
-        host: Union[str, bool, None] = None,
+        host_addr: Optional[str] = None,
         timeout: float = 5.0,
         **kwargs: Any,
     ) -> ZenohClient:
-        """Connect once with the requested tunneling mode and guard cleanup."""
-        # Backward compatibility for localhost_only argument passed as positional bool
-        if isinstance(host, bool):
-            self.logger.warning(
-                "The 'localhost_only' argument is deprecated. Please use 'host=\"localhost\"' instead."
-            )
-            host = "localhost" if host else None
-
-        # Backward compatibility for localhost_only argument passed as keyword
-        if "localhost_only" in kwargs:
-            self.logger.warning(
-                "The 'localhost_only' argument is deprecated. Please use 'host=\"localhost\"' instead."
-            )
-            if kwargs["localhost_only"]:
-                host = "localhost"
-
-        # Ensure host is treated as str or None for ZenohClient
-        host = host if isinstance(host, str) else None
-
-        client = ZenohClient(self.robot_name, host=host)
+        client = ZenohClient(self.robot_name, host_addr=host_addr)
         try:
             client.wait_for_connection(timeout=timeout)
         except Exception:

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -11,7 +11,7 @@ import json
 import logging
 import platform
 import time
-from typing import Any, Dict, List, Literal, Optional, Union, cast
+from typing import Dict, List, Literal, Optional, Union, cast
 
 import cv2
 import numpy as np
@@ -327,8 +327,7 @@ class ReachyMini:
     def _connect_single(
         self,
         host_addr: Optional[str] = None,
-        timeout: float = 5.0,
-        **kwargs: Any,
+        timeout: float = 5.0
     ) -> ZenohClient:
         client = ZenohClient(self.robot_name, host_addr=host_addr)
         try:


### PR DESCRIPTION
This PR intend to improve developer experience of Reachy Mini Wireless owners.

### 🚀 Description

This PR introduces a new `wireless` connection mode to improve connectivity reliability, particularly on networks where UDP broadcast/multicast used for network discovery is blocked or unreliable (e.g., standard Google Fiber routers).

It also updates the `auto` connection logic in `src/reachy_mini/reachy_mini.py` to attempt a direct mDNS connection based on robot name (e.g. `reachy-mini.local` for Reachy Mini Wireless) before falling back to network discovery.

### 📝 Changes

- **New "Wireless" Mode**: Added `connection_mode="wireless"` to `ReachyMini` in `src/reachy_mini/reachy_mini.py`. This attempts a direct TCP connection to the robot using its mDNS hostname (`reachy-mini.local`).
- **Improved Auto-Connect Logic**: The `auto` mode fallback sequence in `src/reachy_mini/reachy_mini.py` has been updated to:
  - `localhost` (local daemon)
  - `wireless` (direct mDNS connection)
  - `network` (network discovery)
- **Zenoh Client Update**: Updated `ZenohClient` in `src/reachy_mini/io/zenoh_client.py` to accept a specific `host` string, enabling direct TCP connections to any target.

### ⚠️ Deprecations

- **`ZenohClient.__init__` in `src/reachy_mini/io/zenoh_client.py`**:
    - **Deprecated Argument**: `localhost_only`
    - **Reason**: Replaced by the more generic `host` argument to support specific remote targets.
    - **Behavior**: Usage will trigger a `logging.warning` but remains functional.

- **`ReachyMini._connect_single` (internal) in `src/reachy_mini/reachy_mini.py`**:
    - **Deprecated Argument**: `localhost_only`
    - **Reason**: Replaced by `host` to align with `ZenohClient` updates.
    - **Behavior**: Usage will trigger a `logging.warning` but remains functional.

### 🔗 Backward Compatibility

- **Fully Backward Compatible**: Existing code relying on the default `auto` mode will benefit from improved connectivity without changes.
- **Legacy Arguments**: Calls explicitly using `localhost_only=True` will continue to function correctly, emitting a warning to encourage migration.