### PR TITLE
fix: add null check in stop_recording to prevent daemon error state

### DIFF
--- a/src/reachy_mini/media/audio_sounddevice.py
+++ b/src/reachy_mini/media/audio_sounddevice.py
@@ -228,8 +228,8 @@ class SoundDeviceAudio(AudioBase):
         See AudioBase.stop_recording() for complete documentation.
         """
         if self._input_stream is not None:
-            self._input_stream.stop()  # type: ignore[attr-defined]
-            self._input_stream.close()  # type: ignore[attr-defined]
+            self._input_stream.stop()
+            self._input_stream.close()
             self._input_stream = None
             self.logger.info("SoundDevice audio stream closed.")
 

--- a/src/reachy_mini/media/audio_sounddevice.py
+++ b/src/reachy_mini/media/audio_sounddevice.py
@@ -227,10 +227,11 @@ class SoundDeviceAudio(AudioBase):
 
         See AudioBase.stop_recording() for complete documentation.
         """
-        if self._is_recording:
+        if self._is_recording and self._input_stream is not None:
             self._input_stream.stop()  # type: ignore[attr-defined]
             self._input_stream.close()  # type: ignore[attr-defined]
             self._input_stream = None
+            self._is_recording = False
             self.logger.info("SoundDevice audio stream closed.")
 
     def push_audio_sample(self, data: npt.NDArray[np.float32]) -> None:

--- a/src/reachy_mini/media/audio_sounddevice.py
+++ b/src/reachy_mini/media/audio_sounddevice.py
@@ -227,11 +227,10 @@ class SoundDeviceAudio(AudioBase):
 
         See AudioBase.stop_recording() for complete documentation.
         """
-        if self._is_recording and self._input_stream is not None:
+        if self._input_stream is not None:
             self._input_stream.stop()  # type: ignore[attr-defined]
             self._input_stream.close()  # type: ignore[attr-defined]
             self._input_stream = None
-            self._is_recording = False
             self.logger.info("SoundDevice audio stream closed.")
 
     def push_audio_sample(self, data: npt.NDArray[np.float32]) -> None:


### PR DESCRIPTION
## Problem
When the daemon tries to stop (e.g., after clicking Power Off on a WiFi-connected Reachy), it can get stuck in an ERROR state with the message:
```
'NoneType' object has no attribute 'close'
```

This happens because `_is_recording` can be `True` while `_input_stream` is `None`, causing the `close()` call to fail.

Once in ERROR state, the daemon cannot recover without a manual restart, preventing subsequent WiFi connections.

## Solution
- Add null check for `_input_stream` before calling `stop()`/`close()`
- Reset `_is_recording` flag after successful cleanup

## Testing
1. Connect to Reachy via WiFi
2. Put robot to sleep
3. Click Power Off
4. Verify daemon state is `stopped` (not `error`)
5. Reconnect via WiFi - should work