### PR TITLE
Add uv-lock-check action

### DIFF
--- a/.github/workflows/uv-lock-check.yml
+++ b/.github/workflows/uv-lock-check.yml
@@ -1,0 +1,14 @@
+name: uv.lock check
+
+on:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+
+jobs:
+  uv-lock-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hbelmiro/uv-lock-check@v0.2.0


### PR DESCRIPTION
This PR adds a uv.lock file check. It only runs on pull_request events, and even then only if the PR changes pyproject.toml or uv.lock. If a PR touches only code, docs, or tests, this workflow is skipped entirely. This enforces "if you change dependencies, you must update uv.lock", automatically.

>Note: I verified it works in [this conversation app PR](https://github.com/pollen-robotics/reachy_mini_conversation_app/pull/172)