### PR TITLE
fix: correct typos and spelling errors across codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 Reachy Mini comes with an app store powered by Hugging Face Spaces. You can install these apps directly from your robot's dashboard with one click!
 
 * **🗣️ [Conversation App](https://huggingface.co/spaces/pollen-robotics/reachy_mini_conversation_app):** Talk naturally with Reachy Mini (powered by LLMs).
-* **📻 [Radio](https://huggingface.co/spaces/pollen-robotics/reachy_mini_radio):** Listen to the radio with Reachy Mini !
+* **📻 [Radio](https://huggingface.co/spaces/pollen-robotics/reachy_mini_radio):** Listen to the radio with Reachy Mini!
 * **👋 [Hand Tracker](https://huggingface.co/spaces/pollen-robotics/hand_tracker_v2):** The robot follows your hand movements in real-time.
 
 👉 [**Browse all apps on Hugging Face**](https://hf.co/reachy-mini/#/apps)

--- a/docs/SDK/gstreamer-installation.md
+++ b/docs/SDK/gstreamer-installation.md
@@ -10,7 +10,7 @@
 
 </div>
 
-> **Note**: Python wheels for easy install of GStreamer will be soon released an available on PyPI. They will be directly integrated. Meanwhile, please follow the instructions below to install GStreamer on your system.
+> **Note**: Python wheels for easy install of GStreamer will be soon released and available on PyPI. They will be directly integrated. Meanwhile, please follow the instructions below to install GStreamer on your system.
 
 ## 🔧 Install GStreamer
 
@@ -21,7 +21,7 @@
 
 **For Ubuntu/Debian-based systems:**
 
-In you terminal, run:
+In your terminal, run:
 
 ```bash
 sudo apt-get update
@@ -45,7 +45,7 @@ sudo apt-get install -y \
 
 ### Step 2: Install Rust
 
-On Linux, the WebRTC plugin is not activated by default and needs to be compiled manually from the Rust source code. Install Rust from the commmand line using `rustup`:
+On Linux, the WebRTC plugin is not activated by default and needs to be compiled manually from the Rust source code. Install Rust from the command line using `rustup`:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -54,7 +54,7 @@ source $HOME/.cargo/env
 
 ### Step 3: Build and install WebRTC plugin
 
-The build and install the WebRTC plugin, run the following commands :
+To build and install the WebRTC plugin, run the following commands:
 
 ```bash
 # Clone the GStreamer Rust plugins repository

--- a/docs/SDK/python-sdk.md
+++ b/docs/SDK/python-sdk.md
@@ -30,7 +30,7 @@ Bypasses interpolation. Use this for high-frequency control (e.g., following a j
 
 ## Sensors & Media
 
-The media architecture is described in detail in the [Media Architecture](/docs/SDK/media-architecture.md) section. Although accesssing audio and video from the SDK is similar across Reachy Mini versions, the underlying implementation differs.
+The media architecture is described in detail in the [Media Architecture](/docs/SDK/media-architecture.md) section. Although accessing audio and video from the SDK is similar across Reachy Mini versions, the underlying implementation differs.
 
 ### Camera 📷
 
@@ -62,7 +62,7 @@ with ReachyMini() as mini:
 
 ### Audio 🎙️ 🔊
 
-Audio inputs (microphones) and outputs (speaker) is handled as follows:
+Audio inputs (microphones) and outputs (speaker) are handled as follows:
 
 ```python
 from reachy_mini import ReachyMini
@@ -114,9 +114,9 @@ Choose the appropriate media backend based on your Reachy Mini version and requi
 - **Local execution** (running on the robot with SSH): Automatically uses `"gstreamer"`
 - **Remote execution** (controlling from your computer): Automatically uses `"webrtc"`. With this backend, GStreamer runs locally on the Raspberry Pi, and streams both audio and video on the remote computer using WebRTC.
 
-> **💡 Tip:** For wireless setups, the backend is automatically selected based on whether you're running locally or remotely. No need to specify the `media_backend` value !
+> **💡 Tip:** For wireless setups, the backend is automatically selected based on whether you're running locally or remotely. No need to specify the `media_backend` value!
 
-> **💡 Tip:** For wireless setups, the WebRTC backend is requires a specific installation see [gstreamer-installation.md](gstreamer-installation.md). For now only the Linux platform is supported as a client. Other platforms (Windows, macOS) will be supported in [future releases](https://github.com/pollen-robotics/reachy_mini/issues/572).
+> **💡 Tip:** For wireless setups, the WebRTC backend requires a specific installation, see [gstreamer-installation.md](gstreamer-installation.md). For now only the Linux platform is supported as a client. Other platforms (Windows, macOS) will be supported in [future releases](https://github.com/pollen-robotics/reachy_mini/issues/572).
 
 ## Recording Moves
 You can record a motion by moving the robot (compliant mode) or sending commands, and save it for later replay.

--- a/docs/old_doc/python-sdk.md
+++ b/docs/old_doc/python-sdk.md
@@ -32,7 +32,7 @@ Then, the next step is to show how to move the robot. The `ReachyMini` class pro
 * the body's rotation angle
 * the antennas' position
 
-The `head_frame` is positioned at the base of the head, as you can see in the image below. This is the frame you are controling when using `set_target` and `goto_target`.
+The `head_frame` is positioned at the base of the head, as you can see in the image below. This is the frame you are controlling when using `set_target` and `goto_target`.
 
 [![Reachy Mini Head Frame](/docs/assets/head_frame.png)]()
 
@@ -251,7 +251,7 @@ You can control the robot's motors with three main methods:
 3. **`make_motors_compliant`**: Makes the motors compliant (requires motors to be enabled first). In this mode, the motors are powered on, but they do not resist external forces, so you can move the robot by hand, and it will feel "soft". This is useful for safe manual manipulation or teaching by demonstration. For an example, see the [gravity compensation example](../examples/reachy_compliant_demo.py): in this demo, you can move the robot's head and antennas freely, but the robot will use its motors to compensate for gravity and maintain its position/orientation in space.
 
 ### Recording moves
-Let's assume that you have a script that uses the `set_target` fonction to move the robot and you want to record the commands to be able to replay them.
+Let's assume that you have a script that uses the `set_target` function to move the robot and you want to record the commands to be able to replay them.
 For example, this could be a teleoperation script, and you could be recording cute emotions (OK this is how we did it).
 You can create another ReachyMini client (or use the same) and simply use `start_recording()` and `stop_recording()`.
 Below is the snippet of code that show how to start a recording, stop the recording and unpack the data:

--- a/docs/old_doc/readme.md
+++ b/docs/old_doc/readme.md
@@ -200,7 +200,7 @@ By default, the API server runs on `http://localhost:8000`. The API is documente
 
 More information about the API can be found in the [HTTP API documentation](./docs/rest-api.md).
 
-## Share your apps with the commmunity
+## Share your apps with the community
 
 You can share your github repositories on social media or use [this guide](https://huggingface.co/blog/pollen-robotics/make-and-publish-your-reachy-mini-apps) to share your app even with users who can't code.
 

--- a/docs/platforms/reachy_mini/reset.md
+++ b/docs/platforms/reachy_mini/reset.md
@@ -1,6 +1,6 @@
 # Smartphone simple bluetooth dashboard
 
-With a smarpthone and a Bluetooth Web API able browser (chrome based/opera/edge) you simply go there 👉 [Bluetooth tool](https://pollen-robotics.github.io/reachy_mini/) and reset hotspot, check network status or other tasks.
+With a smartphone and a Bluetooth Web API able browser (chrome based/opera/edge) you simply go there 👉 [Bluetooth tool](https://pollen-robotics.github.io/reachy_mini/) and reset hotspot, check network status or other tasks.
 
 If your device/browser isn't compatible, please check the other solution.
 

--- a/docs/platforms/reachy_mini_lite/wizard.md
+++ b/docs/platforms/reachy_mini_lite/wizard.md
@@ -8,7 +8,7 @@ You can download the Dynamixel Wizard from the following link:
 1. Power on Reachy Mini Lite using the provided power adapter.
 2. Connect your computer to Reachy Mini Lite using a USB-C cable.
 3. Open the Dynamixel Wizard application.
-4. Click to "option" next to "connect button", then go to the "scan" tab, and check the following info to be able to detect all your motors.
+4. Click on "Options" next to the "Connect" button, then go to the "Scan" tab, and check the following info to be able to detect all your motors.
     - Protocol Version: 2.0
     - Baudrate: 1000000
     - Port: Select the appropriate port for your USB connection (e.g., COM3 on Windows or /dev/ttyUSB0 on Linux/Mac).
@@ -19,6 +19,6 @@ You can download the Dynamixel Wizard from the following link:
 
 ## Read motor parameters
 1. Select a motor from the list of detected motors.
-2. Checks the parameters you want to read (for example: Present Position, Present Velocity, Present Load, etc.)
+2. Check the parameters you want to read (for example: Present Position, Present Velocity, Present Load, etc.)
 
 ![Dynamixel_Wizard_Read_Settings](/docs/assets/wizard_parameters.png)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,8 +30,8 @@ To restart your robot, press OFF, wait 5 seconds, then press ON. This simple pro
 
 <details><summary><strong>Motor blinking red or Overload Error</strong></summary>
 
-**1. Motors inversion**: If you get "Motor hardware errors: ['Overload Error']" a few second after starting the robot **for the first time.** and have two motors arm pointing upward.  
-It is VERY likely there are motors not placed in the good slot, e.g motor 1 on slot 2.
+**1. Motors inversion**: If you get "Motor hardware errors: ['Overload Error']" a few seconds after starting the robot **for the first time** and have two motors arm pointing upward.  
+It is VERY likely there are motors not placed in the correct slot, e.g. motor 1 on slot 2.
 
 <details><summary>See illustration</summary>
 
@@ -45,7 +45,7 @@ Check assembly guide:
 - [**Reachy Mini LITE - Step-by-Step Guide**](https://huggingface.co/spaces/pollen-robotics/Reachy_Mini_LITE_Assembly_Guide)
 
 **2. Check the arm orientation on the motor's horn**:
-Remove the faulty motor, then place the arm upward like in the attached picture. Then check if you can see the the two line marks aligned as represented:
+Remove the faulty motor, then place the arm upward like in the attached picture. Then check if you can see the two line marks aligned as represented:
 
 <details><summary>See picture:</summary>
 
@@ -56,7 +56,7 @@ If they are not, please remove the two screws securing the arm and put it back w
 
 
 **3. check the extra length of the usb cable inside the head:**  
-If it's too long inside the head, there must miss some slack underneath and the head cannot move freely.  
+If it's too long inside the head, there might be insufficient slack underneath and the head cannot move freely.  
 So the motors force too much and can be damaged.  
 <details><summary>See picture:</summary>
 
@@ -68,7 +68,7 @@ Please let some slack to the usb cable to allow the head to move freely, even to
 
 
 **4. A motor feels broken:**
-We identified an issue affecting a limited production batch of Reachy Mini robots, related to a faulty batch of Dynamixel motor. 
+We identified an issue affecting a limited production batch of Reachy Mini robots, related to a faulty batch of Dynamixel motors. 
 
 In most reported cases, the issue affects motor number 4 or one with QC label n°2544.
 
@@ -82,9 +82,9 @@ If the issue persists, please fill out this short form so we can track and ship 
 
 
 <details>
-<summary><strong>A motor is not moving at all, but get stiff when powered on, and doesn't blink red </strong></summary>
+<summary><strong>A motor is not moving at all, but gets stiff when powered on, and doesn't blink red</strong></summary>
 
-This behavior happen when a motor (often n°1) has not been flashed properly during the manufacturing process.  
+This behavior happens when a motor (often n°1) has not been flashed properly during the manufacturing process.  
 => Please power your robot but don't turn it on with the dashboard/daemon, then update reachy mini's software, then reboot the robot. This will reflash your motors.
 
 </details>
@@ -251,7 +251,7 @@ Instead:
 </details>
 
 <details>
-<summary><strong>Wireless Acces point doesn't show up - RPI doesn't boot</strong></summary>
+<summary><strong>Wireless Access point doesn't show up - RPI doesn't boot</strong></summary>
 There is a switch on the board in the head that needs to be in a given position. And if it's not, the AP doesn't show. It's possible that this switch was moved during assembly or maybe even a factory mistake.
 Please check that the switch is on the "debug" and not on "download" position. See the picture below:
 
@@ -447,9 +447,9 @@ If you command a pose outside these limits, the robot will automatically clamp t
 1. You can refer scanning the motors using the [scan_motors.py script](/src/reachy_mini/tools/scan_motors.py).
 
 - If your robot is Lite, you can run the script directly on your computer. Go to the "tools" folder, where the script is located, and run the same command as below but without the scp and ssh part.
-- If your robot is Wireless, you need to copy the scanning script on the raspberry. Go to the "tools" folder, where the script is located,and run:
+- If your robot is Wireless, you need to copy the scanning script on the raspberry. Go to the "tools" folder, where the script is located, and run:
 ```bash
-sudo scp scan_motors.py pollen@reachy-minilocal:~/
+sudo scp scan_motors.py pollen@reachy-mini.local:~/
 # password: ---your sudo password---
 # RPI password: root
 ```
@@ -461,11 +461,11 @@ ssh pollen@reachy-mini.local
 ```bash
 source /venvs/mini_daemon/bin/activate
 ```
-- And run the script: (Motors must be poweredonfor this!)
+- And run the script: (Motors must be powered on for this!)
 ```bash
 python scan_motors.py
 ```
-- It should print the list of detected motors. You should have all motors on baudrate 1000000, with the following IDs: 10,11, 12, 13, 14, 15,17, 18. If some are missing, check the cables again. If there is a motor with a different ID or baudrate, please contact support.
+- It should print the list of detected motors. You should have all motors on baudrate 1000000, with the following IDs: 10, 11, 12, 13, 14, 15, 17, 18. If some are missing, check the cables again. If there is a motor with a different ID or baudrate, please contact support.
 
 Example of the right output:
 ```
@@ -476,7 +476,7 @@ No motors found at baudrate 57600
 Trying baudrate: 115200
 No motors found at baudrate 115200
 Trying baudrate: 1000000
-Found motors at baudrate 1000000: [10, 11,12,13, 14, 15, 16, 17, 18]
+Found motors at baudrate 1000000: [10, 11, 12, 13, 14, 15, 16, 17, 18]
 ```
 2. Lite: You can also use the Dynamixel Wizard to read motors parameters. Follow the guide [here](/docs/platforms/reachy_mini_lite/wizard.md). 
 
@@ -664,7 +664,7 @@ mini.play_move(recorded_moves.get("dance_1"))
 </details>
 
 <details>
-<summary><strong>My robot's move look shaky. Is the control loop running correctly?</strong></summary>
+<summary><strong>My robot's moves look shaky. Is the control loop running correctly?</strong></summary>
 
 You can check that the motor control loop runs correctly by checking the daemon status:
 - via the SDK

--- a/examples/debug/gstreamer_client.py
+++ b/examples/debug/gstreamer_client.py
@@ -25,7 +25,7 @@ class GstConsumer:
         self.source = Gst.ElementFactory.make("webrtcsrc")
 
         if not self.pipeline:
-            print("Pipeline could be created.")
+            print("Pipeline could not be created.")
             exit(-1)
 
         if not self.source:
@@ -121,7 +121,7 @@ def process_msg(bus: Gst.Bus, pipeline: Gst.Pipeline) -> bool:
                 try:
                     pipeline.recalculate_latency()
                 except Exception as e:
-                    print("failed to recalculate warning, exception: %s" % str(e))
+                    print("failed to recalculate latency, exception: %s" % str(e))
         # else:
         #    print(f"Message: {msg.type}")
     return True

--- a/src/reachy_mini/kinematics/nn_kinematics.py
+++ b/src/reachy_mini/kinematics/nn_kinematics.py
@@ -13,13 +13,13 @@ class NNKinematics:
     """Neural Network based FK/IK. Fitted from PlacoKinematics data."""
 
     def __init__(self, models_root_path: str):
-        """Intialize."""
+        """Initialize."""
         self.fk_model_path = f"{models_root_path}/fknetwork.onnx"
         self.ik_model_path = f"{models_root_path}/iknetwork.onnx"
         self.fk_infer = OnnxInfer(self.fk_model_path)
         self.ik_infer = OnnxInfer(self.ik_model_path)
 
-        self.automatic_body_yaw = False  # No used, kept for canaompatibility
+        self.automatic_body_yaw = False  # Not used, kept for compatibility
 
     def ik(
         self,

--- a/src/reachy_mini/kinematics/placo_kinematics.py
+++ b/src/reachy_mini/kinematics/placo_kinematics.py
@@ -70,7 +70,7 @@ class PlacoKinematics:
         # we could go to soft limits to avoid over-constraining the IK
         # but the current implementation works robustly with hard limits
         # so we keep the hard limits for now
-        constrant_type = "hard"  # "hard" or "soft"
+        constraint_type = "hard"  # "hard" or "soft"
 
         # IK closing tasks
         ik_closing_tasks = []
@@ -78,7 +78,7 @@ class PlacoKinematics:
             ik_closing_task = self.ik_solver.add_relative_position_task(
                 f"closing_{i}_1", f"closing_{i}_2", np.zeros(3)
             )
-            ik_closing_task.configure(f"closing_{i}", constrant_type, 1.0)
+            ik_closing_task.configure(f"closing_{i}", constraint_type, 1.0)
             ik_closing_tasks.append(ik_closing_task)
 
         # FK closing tasks
@@ -87,7 +87,7 @@ class PlacoKinematics:
             fk_closing_task = self.fk_solver.add_relative_position_task(
                 f"closing_{i}_1", f"closing_{i}_2", np.zeros(3)
             )
-            fk_closing_task.configure(f"closing_{i}", constrant_type, 1.0)
+            fk_closing_task.configure(f"closing_{i}", constraint_type, 1.0)
             fk_closing_tasks.append(fk_closing_task)
 
         # Add the constraint between the rotated torso and the head
@@ -227,9 +227,9 @@ class PlacoKinematics:
         self.robot_ik.set_joint_limits("yaw_body", -2.8, 2.8)
 
         # initial state
-        self._inital_q = self.robot.state.q.copy()
-        self._inital_qd = np.zeros_like(self.robot.state.qd)
-        self._inital_qdd = np.zeros_like(self.robot.state.qdd)
+        self._initial_q = self.robot.state.q.copy()
+        self._initial_qd = np.zeros_like(self.robot.state.qd)
+        self._initial_qdd = np.zeros_like(self.robot.state.qdd)
 
         # initial FK to set the head pose
         for _ in range(10):
@@ -237,11 +237,11 @@ class PlacoKinematics:
             self.robot_ik.update_kinematics()
 
         # last good q to revert to in case of collision
-        self._inital_q = self.robot_ik.state.q.copy()
+        self._initial_q = self.robot_ik.state.q.copy()
         self._last_good_q = self.robot_ik.state.q.copy()
 
         # update the robot state to the initial state
-        self._update_state_to_initial(self.robot)  # revert to the inital state
+        self._update_state_to_initial(self.robot)  # revert to the initial state
         self.robot.update_kinematics()
 
         if self.check_collision:
@@ -262,9 +262,9 @@ class PlacoKinematics:
             robot (placo.RobotWrapper): The robot wrapper instance to update.
 
         """
-        robot.state.q = self._inital_q
-        robot.state.qd = self._inital_qd
-        robot.state.qdd = self._inital_qdd
+        robot.state.q = self._initial_q
+        robot.state.qd = self._initial_qd
+        robot.state.qdd = self._initial_qdd
 
     def _pose_distance(
         self, pose1: npt.NDArray[np.float64], pose2: npt.NDArray[np.float64]
@@ -374,7 +374,7 @@ class PlacoKinematics:
             self._logger.debug("IK: Poses too far, starting from initial configuration")
 
         done = True
-        # do the inital ik
+        # do the initial ik
         for i in range(no_iterations):
             try:
                 self.ik_solver.solve(True)  # False to not update the kinematics
@@ -398,7 +398,7 @@ class PlacoKinematics:
             self.robot_ik.update_kinematics()
 
             no_iterations += 2  # add a few more iterations
-            # do the inital ik with 10 iterations
+            # do the initial ik with 10 iterations
             for i in range(no_iterations):
                 try:
                     self.ik_solver.solve(True)  # False to not update the kinematics
@@ -455,7 +455,7 @@ class PlacoKinematics:
         )
 
         done = True
-        # do the inital ik with 2 iterations
+        # do the initial ik with 2 iterations
         for i in range(no_iterations):
             try:
                 self.fk_solver.solve(True)  # False to not update the kinematics
@@ -476,7 +476,7 @@ class PlacoKinematics:
             self.robot.update_kinematics()
 
             no_iterations += 2  # add a few more iterations
-            # do the inital ik with 10 iterations
+            # do the initial ik with 10 iterations
             for i in range(no_iterations):
                 try:
                     self.fk_solver.solve(True)  # False to not update the kinematics

--- a/src/reachy_mini/media/webrtc_daemon.py
+++ b/src/reachy_mini/media/webrtc_daemon.py
@@ -280,7 +280,7 @@ class GstWebRTC:
         alsasrc.link(webrtcsink)
 
     def _get_audio_input_device(self) -> Optional[str]:
-        """Use Gst.DeviceMonitor to find the pipeire audio card.
+        """Use Gst.DeviceMonitor to find the pipewire audio card.
 
         Returns the device ID of the found audio card, None if not.
         """

--- a/src/reachy_mini/utils/interpolation.py
+++ b/src/reachy_mini/utils/interpolation.py
@@ -19,7 +19,7 @@ def minimum_jerk(
     final_velocity: Optional[npt.NDArray[np.float64]] = None,
     final_acceleration: Optional[npt.NDArray[np.float64]] = None,
 ) -> InterpolationFunc:
-    """Compute the mimimum jerk interpolation function from starting position to goal position."""
+    """Compute the minimum jerk interpolation function from starting position to goal position."""
     if starting_velocity is None:
         starting_velocity = np.zeros(starting_position.shape)
     if starting_acceleration is None:

--- a/src/reachy_mini/utils/wireless_version/startup_check.py
+++ b/src/reachy_mini/utils/wireless_version/startup_check.py
@@ -17,7 +17,7 @@ USER = "pollen"
 def check_and_fix_venvs_ownership(
     venvs_path: str = "/venvs", custom_logger: logging.Logger | None = None
 ) -> None:
-    """For wirelss units, check if files under venvs_path are owned by user pollen and fix if needed.
+    """For wireless units, check if files under venvs_path are owned by user pollen and fix if needed.
 
     Args:
         venvs_path: Path to the virtual environments directory (default: /venvs)


### PR DESCRIPTION
  ## Summary

  This PR fixes typos and spelling errors across documentation and source code files:

  ### Documentation Fixes
  - `docs/SDK/gstreamer-installation.md`: "you" → "your", "commmand" → "command"
  - `docs/SDK/python-sdk.md`: "accesssing" → "accessing"
  - `docs/troubleshooting.md`: "the the" → "the", "Acces" → "Access", "reachy-minilocal" → "reachy-mini.local", "poweredonfor" → "powered on for"
  - `docs/old_doc/readme.md`: "commmunity" → "community"
  - `docs/old_doc/python-sdk.md`: "controling" → "controlling", "fonction" → "function"
  - `docs/platforms/reachy_mini/reset.md`: "smarpthone" → "smartphone"

  ### Source Code Fixes
  - `src/reachy_mini/utils/interpolation.py`: "mimimum" → "minimum"
  - `src/reachy_mini/kinematics/nn_kinematics.py`: "Intialize" → "Initialize", "canaompatibility" → "compatibility"
  - `src/reachy_mini/kinematics/placo_kinematics.py`: "constrant_type" → "constraint_type", "_inital_" → "_initial_"
  - `src/reachy_mini/media/webrtc_daemon.py`: "pipeire" → "pipewire"
  - `src/reachy_mini/daemon/backend/mujoco/backend.py`: "beore" → "before"
  - `src/reachy_mini/utils/wireless_version/startup_check.py`: "wirelss" → "wireless"

  ### Example Fixes
  - `examples/debug/gstreamer_client.py`: Fixed missing "not" in error message, "warning" → "latency"