### PR TITLE
Feat/custom bluetooth hotspot

### DIFF
--- a/src/reachy_mini/daemon/app/routers/wifi_config.py
+++ b/src/reachy_mini/daemon/app/routers/wifi_config.py
@@ -18,7 +18,8 @@ error: Exception | None = None
 logger = logging.getLogger(__name__)
 
 def get_pin() -> str:
-    """Extract the last 5 digits of the serial number from dfu-util -l output.
+    """Extract the last 5 digits of the serial number from dfu-util output.
+    
     Replicate of the bluetooth_service.py get_pin() function to avoid dbus imports.
     """
     default_pin = "46879"
@@ -268,7 +269,7 @@ def check_if_connection_active(name: str) -> bool:
 
 
 def get_wifi_connection_ssid(name: str) -> str:
-    """Get the SSID of a Wifi connection"""
+    """Get the SSID of a Wifi connection."""
     for conn in get_wifi_connections():
         if conn.name == name:
             conn_data = nmcli.connection.show(name,True)    #Get details of the connection including secrets

--- a/src/reachy_mini/daemon/app/routers/wifi_config.py
+++ b/src/reachy_mini/daemon/app/routers/wifi_config.py
@@ -1,16 +1,13 @@
 """WiFi Configuration Routers."""
 
 import logging
+import subprocess
 from enum import Enum
 from threading import Lock, Thread
 
 import nmcli
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-
-HOTSPOT_SSID = "reachy-mini-ap"
-HOTSPOT_PASSWORD = "reachy-mini"
-
 
 router = APIRouter(
     prefix="/wifi",
@@ -19,6 +16,29 @@ router = APIRouter(
 busy_lock = Lock()
 error: Exception | None = None
 logger = logging.getLogger(__name__)
+
+def get_pin() -> str:
+    """Extract the last 5 digits of the serial number from dfu-util -l output.
+    Replicate of the bluetooth_service.py get_pin() function to avoid dbus imports.
+    """
+    default_pin = "46879"
+    try:
+        result = subprocess.run(["dfu-util", "-l"], capture_output=True, text=True)
+        lines = result.stdout.splitlines()
+        for line in lines:
+            if "serial=" in line:
+                # Extract serial number
+                serial_part = line.split("serial=")[-1].strip().strip('"')
+                if len(serial_part) >= 5:
+                    return serial_part[-5:]
+        return default_pin  # fallback if not found
+    except Exception as e:
+        logger.error(f"Error getting pin from serial: {e}")
+        return default_pin
+
+HOTSPOT_BASE_SSID = "reachy-mini-ap"
+HOTSPOT_SSID = f"{HOTSPOT_BASE_SSID}-{get_pin()[-3:]}"
+HOTSPOT_PASSWORD = "reachy-mini"
 
 
 class WifiMode(Enum):

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -787,8 +787,9 @@ def get_hotspot_ip() -> str:
 def main():
     """Run the Bluetooth Command Service."""
     pin = get_pin()
+    name = f"ReachyMini-{pin[-3:]}"
 
-    bt_service = BluetoothCommandService(device_name="ReachyMini", pin_code=pin)
+    bt_service = BluetoothCommandService(device_name=name, pin_code=pin)
     bt_service.run()
 
 


### PR DESCRIPTION
This PR adds suffixes to Reachy Mini bluetooth and wifi hotspot names to help differentiating between multiple robots. For now the suffixes are defined as the last 3 digits of the serial number of the robot.