### PR TITLE
docs(reflsh pi macos): adding docs for reflashing the pi from macos

### DIFF
--- a/docs/platforms/reachy_mini/reflash_the_rpi_ISO.md
+++ b/docs/platforms/reachy_mini/reflash_the_rpi_ISO.md
@@ -44,12 +44,6 @@ export PATH="$HOME/.local/bin:$PATH"
 bmaptool --version
 ```
 
-**Alternative (Homebrew):**
-
-```bash
-brew install bmap-tools
-```
-
 </details>
 
 ---
@@ -63,13 +57,7 @@ brew install bmap-tools
    ```bash
    sudo ./rpiboot -d mass-storage-gadget64
    ```
-
-   You should see something like:
-   ```
-   Waiting for BCM2835/6/7/2711/2712...
-   ```
-   This is expected — the command is waiting for the robot to be connected over USB.
-
+   
 3. Set the switch to **DOWNLOAD (SW1)** on the head PCB:
 
    [![pcb_usb_and_switch](/docs/assets/pcb_usb_and_switch.png)]()


### PR DESCRIPTION
This PR adds docs on how to refresh the Pi from macOS using bmfptool and rpiboot 🎉 