### PR TITLE
Remove early return optimization in set_motor_control_mode()

### DIFF
--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -544,10 +544,6 @@ class RobotBackend(Backend):
 
     def set_motor_control_mode(self, mode: MotorControlMode) -> None:
         """Set the motor control mode."""
-        # Check if the mode is already set
-        if mode == self.motor_control_mode:
-            return
-
         if mode == MotorControlMode.Enabled:
             if self.motor_control_mode == MotorControlMode.GravityCompensation:
                 # First, make sure we switch to position control


### PR DESCRIPTION
Test script to reproduce the bug:
```
#!/usr/bin/env python3
"""
Minimal reproduction of the motor enable/disable bug in reachy_mini SDK.

BUG: After selective disable_motors(ids=[...]), enable_motors() doesn't work.
     The enable_motors() call is silently ignored due to a state tracking issue.

EXPECTED: enable_motors() should re-enable all motors regardless of prior state.
ACTUAL: enable_motors() does nothing if motor_control_mode is already "Enabled",
        even though some motors were selectively disabled.

ROOT CAUSE (in reachy_mini/daemon/backend/robot/backend.py):
- set_motor_torque_ids() disables specific motors but doesn't update motor_control_mode
- set_motor_control_mode() has early return: if mode == self.motor_control_mode: return
- So enable_motors() -> set_motor_control_mode(Enabled) returns early (already "Enabled")

WORKAROUND: Call disable_motors() (all) before enable_motors()
"""

import time
from reachy_mini import ReachyMini
from reachy_mini.reachy_mini import INIT_HEAD_POSE

# Same motors that fire_nation_attacked disables during gameplay
SELECTIVE_MOTORS = [
    "body_rotation",
    "stewart_1",
    "stewart_2",
    "stewart_3",
    "stewart_4",
    "stewart_5",
    "stewart_6",
]


def test_bug():
    print("=== Motor Enable/Disable Bug Reproduction ===\n")

    with ReachyMini() as mini:
        # Step 1: Start with all motors enabled
        print("[1] Enabling all motors...")
        mini.enable_motors()
        mini.goto_target(head=INIT_HEAD_POSE, antennas=[0.0, 0.0], duration=1.0)
        print("    Motors enabled, robot at INIT pose.\n")

        # Step 2: Selectively disable some motors (like fire_nation does)
        print(f"[2] Selectively disabling motors: {SELECTIVE_MOTORS}")
        mini.disable_motors(ids=SELECTIVE_MOTORS)
        print("    Head should now be compliant (you can move it by hand).\n")

        input("    >>> Press Enter to try enabling motors again...")

        # Step 3: Try to enable all motors - THIS IS THE BUG
        print("\n[3] Calling enable_motors() to re-enable all...")
        mini.enable_motors()
        print("    Trying to move to INIT pose...")
        mini.goto_target(head=INIT_HEAD_POSE, antennas=[0.0, 0.0], duration=1.0)

        print("\n[!] BUG: If the head is still compliant, enable_motors() didn't work!")
        print("    The robot should have moved to INIT pose but likely didn't.\n")

        input("    >>> Press Enter to apply the workaround...")

        # Step 4: Workaround - disable all first, then enable
        print("\n[4] WORKAROUND: disable_motors() then enable_motors()...")
        mini.disable_motors()  # <-- This resets motor_control_mode to Disabled
        mini.enable_motors()   # <-- Now this actually enables because mode changed
        mini.goto_target(head=INIT_HEAD_POSE, antennas=[0.0, 0.0], duration=1.0)
        print("    Robot should now move to INIT pose correctly.\n")

        print("[5] Test complete. Disabling motors...")
        mini.disable_motors()


if __name__ == "__main__":
    test_bug()

```