### PR TITLE
feat(daemon): add autostart app configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,6 @@ $RECYCLE.BIN/
 src/reachy_mini_dashboard/installed_apps/*
 examples/debug/measures/*
 .DS_Store
+
+# Claude Code
+CLAUDE.md

--- a/src/reachy_mini/daemon/app/dashboard/templates/sections/apps.html
+++ b/src/reachy_mini/daemon/app/dashboard/templates/sections/apps.html
@@ -1,6 +1,25 @@
 <section class="w-full">
     <div class="app-section">
         <div class="app-section-title">Applications</div>
+
+        <!-- Autostart Configuration -->
+        <div id="autostart-config" class="mb-4 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
+            <div class="flex items-center justify-between gap-4">
+                <div class="flex items-center gap-2">
+                    <label for="autostart-select" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                        Start on boot:
+                    </label>
+                    <select id="autostart-select" class="text-sm border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="">None (disabled)</option>
+                    </select>
+                </div>
+                <button id="autostart-save" class="px-3 py-1 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed">
+                    Save
+                </button>
+            </div>
+            <p id="autostart-status" class="mt-2 text-xs text-gray-500 dark:text-gray-400"></p>
+        </div>
+
         <div class="">
             <ul id="installed-apps" class="overflow-y-auto max-h-96"></ul>
         </div>

--- a/src/reachy_mini/daemon/config.py
+++ b/src/reachy_mini/daemon/config.py
@@ -1,0 +1,80 @@
+"""Daemon configuration management.
+
+Handles loading and saving daemon configuration from ~/.reachy_mini/daemon_config.yaml.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+CONFIG_DIR = Path.home() / ".reachy_mini"
+CONFIG_FILE = CONFIG_DIR / "daemon_config.yaml"
+
+
+@dataclass
+class AutostartConfig:
+    """Configuration for app autostart on daemon boot."""
+
+    enabled: bool = False
+    app_name: str | None = None
+
+
+@dataclass
+class DaemonConfig:
+    """Root daemon configuration."""
+
+    autostart: AutostartConfig = field(default_factory=AutostartConfig)
+
+
+def load_daemon_config() -> DaemonConfig:
+    """Load daemon configuration from disk.
+
+    Returns defaults if the file is missing or malformed.
+    """
+    if not CONFIG_FILE.exists():
+        logger.debug(f"Config file {CONFIG_FILE} not found, using defaults")
+        return DaemonConfig()
+
+    try:
+        with open(CONFIG_FILE, "r") as f:
+            data = yaml.safe_load(f) or {}
+
+        autostart_data = data.get("autostart", {})
+        autostart = AutostartConfig(
+            enabled=autostart_data.get("enabled", False),
+            app_name=autostart_data.get("app_name"),
+        )
+
+        return DaemonConfig(autostart=autostart)
+
+    except yaml.YAMLError as e:
+        logger.warning(f"Malformed config file {CONFIG_FILE}: {e}, using defaults")
+        return DaemonConfig()
+    except Exception as e:
+        logger.warning(f"Error reading config file {CONFIG_FILE}: {e}, using defaults")
+        return DaemonConfig()
+
+
+def save_daemon_config(config: DaemonConfig) -> None:
+    """Save daemon configuration to disk.
+
+    Creates the config directory if it doesn't exist.
+    """
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+    data: dict[str, Any] = {
+        "autostart": {
+            "enabled": config.autostart.enabled,
+            "app_name": config.autostart.app_name,
+        }
+    }
+
+    with open(CONFIG_FILE, "w") as f:
+        yaml.safe_dump(data, f, default_flow_style=False)
+
+    logger.info(f"Saved daemon config to {CONFIG_FILE}")

--- a/tests/test_autostart_config.py
+++ b/tests/test_autostart_config.py
@@ -1,0 +1,186 @@
+"""Tests for daemon autostart configuration."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from reachy_mini.daemon.config import (
+    CONFIG_FILE,
+    AutostartConfig,
+    DaemonConfig,
+    load_daemon_config,
+    save_daemon_config,
+)
+
+
+@pytest.fixture
+def temp_config_dir(tmp_path: Path):
+    """Temporarily redirect config file to a temp directory."""
+    temp_config = tmp_path / "daemon_config.yaml"
+    with patch("reachy_mini.daemon.config.CONFIG_FILE", temp_config):
+        with patch("reachy_mini.daemon.config.CONFIG_DIR", tmp_path):
+            yield tmp_path, temp_config
+
+
+class TestAutostartConfig:
+    """Tests for AutostartConfig dataclass."""
+
+    def test_defaults(self):
+        config = AutostartConfig()
+        assert config.enabled is False
+        assert config.app_name is None
+
+    def test_with_values(self):
+        config = AutostartConfig(enabled=True, app_name="test-app")
+        assert config.enabled is True
+        assert config.app_name == "test-app"
+
+
+class TestDaemonConfig:
+    """Tests for DaemonConfig dataclass."""
+
+    def test_defaults(self):
+        config = DaemonConfig()
+        assert isinstance(config.autostart, AutostartConfig)
+        assert config.autostart.enabled is False
+
+
+class TestLoadDaemonConfig:
+    """Tests for load_daemon_config function."""
+
+    def test_missing_file_returns_defaults(self, temp_config_dir):
+        """Config file missing should return defaults."""
+        _, temp_config = temp_config_dir
+        assert not temp_config.exists()
+
+        config = load_daemon_config()
+        assert config.autostart.enabled is False
+        assert config.autostart.app_name is None
+
+    def test_valid_config_file(self, temp_config_dir):
+        """Valid config file should be loaded correctly."""
+        tmp_path, temp_config = temp_config_dir
+
+        data = {"autostart": {"enabled": True, "app_name": "my-app"}}
+        with open(temp_config, "w") as f:
+            yaml.safe_dump(data, f)
+
+        config = load_daemon_config()
+        assert config.autostart.enabled is True
+        assert config.autostart.app_name == "my-app"
+
+    def test_malformed_yaml_returns_defaults(self, temp_config_dir):
+        """Malformed YAML should return defaults with warning."""
+        _, temp_config = temp_config_dir
+
+        with open(temp_config, "w") as f:
+            f.write("invalid: yaml: content: [")
+
+        config = load_daemon_config()
+        assert config.autostart.enabled is False
+        assert config.autostart.app_name is None
+
+    def test_partial_config_uses_defaults(self, temp_config_dir):
+        """Missing fields should use defaults."""
+        _, temp_config = temp_config_dir
+
+        data = {"autostart": {"enabled": True}}  # Missing app_name
+        with open(temp_config, "w") as f:
+            yaml.safe_dump(data, f)
+
+        config = load_daemon_config()
+        assert config.autostart.enabled is True
+        assert config.autostart.app_name is None
+
+    def test_empty_file_returns_defaults(self, temp_config_dir):
+        """Empty file should return defaults."""
+        _, temp_config = temp_config_dir
+
+        temp_config.touch()
+
+        config = load_daemon_config()
+        assert config.autostart.enabled is False
+
+
+class TestSaveDaemonConfig:
+    """Tests for save_daemon_config function."""
+
+    def test_save_creates_file(self, temp_config_dir):
+        """Save should create file if it doesn't exist."""
+        _, temp_config = temp_config_dir
+        assert not temp_config.exists()
+
+        config = DaemonConfig(
+            autostart=AutostartConfig(enabled=True, app_name="test-app")
+        )
+        save_daemon_config(config)
+
+        assert temp_config.exists()
+
+        with open(temp_config, "r") as f:
+            data = yaml.safe_load(f)
+
+        assert data["autostart"]["enabled"] is True
+        assert data["autostart"]["app_name"] == "test-app"
+
+    def test_save_overwrites_existing(self, temp_config_dir):
+        """Save should overwrite existing config."""
+        _, temp_config = temp_config_dir
+
+        # Write initial config
+        with open(temp_config, "w") as f:
+            yaml.safe_dump({"autostart": {"enabled": False, "app_name": "old-app"}}, f)
+
+        # Save new config
+        config = DaemonConfig(
+            autostart=AutostartConfig(enabled=True, app_name="new-app")
+        )
+        save_daemon_config(config)
+
+        with open(temp_config, "r") as f:
+            data = yaml.safe_load(f)
+
+        assert data["autostart"]["enabled"] is True
+        assert data["autostart"]["app_name"] == "new-app"
+
+    def test_save_disabled_config(self, temp_config_dir):
+        """Save disabled config should clear app_name."""
+        _, temp_config = temp_config_dir
+
+        config = DaemonConfig(autostart=AutostartConfig(enabled=False, app_name=None))
+        save_daemon_config(config)
+
+        with open(temp_config, "r") as f:
+            data = yaml.safe_load(f)
+
+        assert data["autostart"]["enabled"] is False
+        assert data["autostart"]["app_name"] is None
+
+
+class TestRoundTrip:
+    """Tests for save/load roundtrip."""
+
+    def test_roundtrip_enabled(self, temp_config_dir):
+        """Config should survive save/load roundtrip."""
+        original = DaemonConfig(
+            autostart=AutostartConfig(enabled=True, app_name="roundtrip-app")
+        )
+
+        save_daemon_config(original)
+        loaded = load_daemon_config()
+
+        assert loaded.autostart.enabled == original.autostart.enabled
+        assert loaded.autostart.app_name == original.autostart.app_name
+
+    def test_roundtrip_disabled(self, temp_config_dir):
+        """Disabled config should survive roundtrip."""
+        original = DaemonConfig(autostart=AutostartConfig(enabled=False, app_name=None))
+
+        save_daemon_config(original)
+        loaded = load_daemon_config()
+
+        assert loaded.autostart.enabled is False
+        assert loaded.autostart.app_name is None


### PR DESCRIPTION
## Summary
- Allow users to configure an app to automatically start when the Reachy Mini daemon boots
- This enables non-technical users (kids, etc.) to enjoy the robot without accessing the dashboard after power-on

## Changes
- Add daemon config module (`~/.reachy_mini/daemon_config.yaml`) for persistent settings
- Add `GET/POST /api/apps/autostart` API endpoints with app installation validation
- Add autostart hook in daemon lifespan (after `daemon.start()` completes)
- Add dashboard UI with dropdown selector and save button
- Add unit tests for config load/save with edge cases (missing file, malformed YAML, etc.)

## Config Format
```yaml
autostart:
  enabled: true
  app_name: "conversation-app"
```

## Test Plan
- [x] Unit tests pass (`pytest tests/test_autostart_config.py -vv` - 13 tests)
- [x] Lint passes (`ruff check`)
- [x] Manual test: Configure autostart via dashboard, reboot, verify app starts
- [x] Manual test: Uninstall autostart app, reboot, verify warning logged

Closes #638