### PR TITLE
App assistant now also checks the "src" layout & allows an app to be named differently from the package

### DIFF
--- a/src/reachy_mini/apps/assistant.py
+++ b/src/reachy_mini/apps/assistant.py
@@ -299,12 +299,16 @@ def check(console: Console, app_path: str) -> None:
         sys.exit(1)
     console.print("✅ index.html and style.css exist in the root of the app.")
 
-    # - pkg_name and pkg_name/__init__.py exists
-    if not os.path.exists(os.path.join(abs_app_path, pkg_name)) or not os.path.exists(
-        os.path.join(abs_app_path, pkg_name, "__init__.py")
-    ):
-        console.print(f"❌ Package folder '{pkg_name}' is missing", style="bold red")
-        sys.exit(1)
+    # Check both flat and src layout
+    pkg_path = abs_app_path / pkg_name
+    if not (pkg_path / "__init__.py").exists():
+        pkg_path = abs_app_path / "src" / pkg_name
+        if not (pkg_path / "__init__.py").exists():
+            console.print(f"❌ Package folder '{pkg_name}' not found", style="bold red")
+            console.print(f"   Checked: {abs_app_path / pkg_name}/", style="dim")
+            console.print(f"   Checked: {abs_app_path / 'src' / pkg_name}/", style="dim")
+            sys.exit(1)
+    console.print(f"✅ Package '{pkg_name}' found at {pkg_path.relative_to(abs_app_path)}/")
 
     if "entry-points" not in pyproject_content["project"]:
         console.print(
@@ -337,21 +341,13 @@ def check(console: Console, app_path: str) -> None:
         )
         sys.exit(1)
 
-    # - <app_name>/__init__.py exists
-    pkg_path = Path(abs_app_path) / pkg_name
-    init_file = pkg_path / "__init__.py"
 
-    if not init_file.exists():
-        console.print("❌ __init__.py is missing", style="bold red")
-        sys.exit(1)
-
-    console.print(f"✅ {app_name}/__init__.py exists.")
-
+    # - main.py exists
     main_file = pkg_path / "main.py"
     if not main_file.exists():
         console.print("❌ main.py is missing", style="bold red")
         sys.exit(1)
-    console.print(f"✅ {app_name}/main.py exists.")
+    console.print(f"✅ {pkg_path.relative_to(abs_app_path)}/main.py exists.")
 
     # - <app_name>/main.py contains a class named <AppName> that inherits from ReachyMiniApp
     with open(main_file, "r") as f:


### PR DESCRIPTION
**BEFORE:** 
`reachy_mini_app_assistant check` was checking only a flat layout, with the package named similar to the app. 

For instance "my-app" had to have the following structure.
```
my_app/
└── my_app/
    └── main.py
```

There was two problems with :
   - the Conversation App was not checked as valid because it had a "src" layout
   - forking the conversation app was cumbersome since the app had to be named after the package

**NOW:**
The app assistant check will also check and validate a layout like

```
my_app/
└── src/
    └── my_package/
        └── main.py
```

The first commit introduces checking for the src/ layout
The second commit allows the app name to be different from the package name. Note that the class name is still expected to be a CamelCase version of the package name.

(1) Now the conversation app is validated by the assistant app check because the src/ layout is also checked (first commit)
(2) We can clone it, naming the app differently but keeping the package name

This has been checked on the reachy_mini_astronomer app which is a simple clone of the conversation app see https://huggingface.co/spaces/dlouapre/reachy_mini_astronomer/tree/main

The astronomer app has the following structure

```
reachy_mini_astronomer/
└── src/
    └── reachy_mini_conversation_app/
        └── main.py
```
(class name in main.py is still ReachyMiniConversationApp)

