### PR TITLE
Reduce number of write calls by checking last send position

### DIFF
--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -110,8 +110,8 @@ class RobotBackend(Backend):
         self.target_head_joint_current = None  # Placeholder for head joint torque
 
         # Track last sent positions to avoid redundant writes
-        self._last_sent_head_positions = None
-        self._last_sent_antenna_positions = None
+        self._last_sent_head_positions: npt.NDArray[np.float64] | None = None
+        self._last_sent_antenna_positions: npt.NDArray[np.float64] | None = None
 
         if hardware_error_check_frequency <= 0:
             raise ValueError(
@@ -188,9 +188,9 @@ class RobotBackend(Backend):
 
         if self._torque_enabled:
             if self._current_head_operation_mode != 0:  # if position control mode
-                if (
-                    self.target_head_joint_positions is not None
-                    and not np.array_equal(self.target_head_joint_positions, self._last_sent_head_positions)
+                if self.target_head_joint_positions is not None and (
+                    self._last_sent_head_positions is None
+                    or not np.array_equal(self.target_head_joint_positions, self._last_sent_head_positions)
                 ):
                     self.c.set_stewart_platform_position(
                         self.target_head_joint_positions[1:].tolist()
@@ -212,9 +212,9 @@ class RobotBackend(Backend):
                     # self.c.set_body_rotation_goal_current(int(self.target_head_joint_current[0]))
 
             if self._current_antennas_operation_mode != 0:  # if position control mode
-                if (
-                    self.target_antenna_joint_positions is not None
-                    and not np.array_equal(self.target_antenna_joint_positions, self._last_sent_antenna_positions)
+                if self.target_antenna_joint_positions is not None and (
+                    self._last_sent_antenna_positions is None
+                    or not np.array_equal(self.target_antenna_joint_positions, self._last_sent_antenna_positions)
                 ):
                     self.c.set_antennas_positions(
                         self.target_antenna_joint_positions.tolist()


### PR DESCRIPTION
This PR makes it possible to check for last set **target** head and antenna position to avoid resetting target position despite it not changing. This reduces overall load of CPU / energy.

This also makes it possible to use write raw method for directly interacting with the motors. 

This also makes the behavior of the motor more consistent whether the daemon is on or off. 