### PR TITLE
fix: app startup failure for name mismatches in separate venvs

### DIFF
--- a/src/reachy_mini/apps/sources/local_common_venv.py
+++ b/src/reachy_mini/apps/sources/local_common_venv.py
@@ -442,7 +442,7 @@ def _find_metadata_for_entry_point(ep_name: str) -> dict:  # type: ignore
 
 def _extract_package_info_from_pyproject(target_path: str) -> dict[str, str | None]:
     """Extract package name and entry point name from pyproject.toml file."""
-    import toml  # type: ignore
+    import toml
 
     pyproject_path = Path(target_path) / "pyproject.toml"
 


### PR DESCRIPTION
Fixes issue #777 
- added `_extract_package_info_from_pyproject` function to extract the real entry point from `pyproject.toml` during installation 
- use the stored `entry_point_name` instead of the space name when loading apps from separate venvs
- add fallback to app name for the apps installed before this fix so that users won't have problem (at least for the apps that don't have mismatch. otherwise, they will fail after this fix and they would need to uninstall and install the app because we are checking different variable from the metadata)