### PR TITLE
779 allow for motor data streaming via webrtc statecommand

### DIFF
--- a/examples/debug/gstreamer_client.py
+++ b/examples/debug/gstreamer_client.py
@@ -1,6 +1,7 @@
 """Simple gstreamer webrtc consumer example."""
 
 import argparse
+import time
 from threading import Thread
 
 import gi
@@ -26,6 +27,8 @@ class GstConsumer:
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()
 
+        self._data_channel = None
+
         self.pipeline = Gst.Pipeline.new("webRTC-consumer")
         self.source = Gst.ElementFactory.make("webrtcsrc")
 
@@ -41,6 +44,9 @@ class GstConsumer:
             exit(-1)
 
         self.pipeline.add(self.source)
+
+        # Connect early to catch webrtcbin creation and set up data channel handler
+        self.source.connect("deep-element-added", self._on_element_added)
 
         peer_id = find_producer_peer_id_by_name(
             signalling_host, signalling_port, peer_name
@@ -58,6 +64,15 @@ class GstConsumer:
         self.pipeline.query(query)
         print(f"Pipeline latency {query.parse_latency()}")
 
+    def _on_element_added(
+        self, _bin: Gst.Bin, _sub_bin: Gst.Bin, element: Gst.Element
+    ) -> None:
+        """Handle element addition to catch webrtcbin early for data channel setup."""
+        if element.get_name().startswith("webrtcbin"):
+            print(f"webrtcbin detected: {element.get_name()}")
+            # Connect to data channel signal early
+            element.connect("on-data-channel", self._on_data_channel)
+
     def _configure_webrtcbin(self, webrtcsrc: Gst.Element) -> None:
         if isinstance(webrtcsrc, Gst.Bin):
             webrtcbin_name = "webrtcbin0"
@@ -65,6 +80,32 @@ class GstConsumer:
             assert webrtcbin is not None
             # jitterbuffer has a default 200 ms buffer.
             webrtcbin.set_property("latency", 50)
+
+    def _on_data_channel(self, _webrtcbin: Gst.Element, channel: Gst.Element) -> None:
+        """Handle incoming data channel from the server."""
+        print(f"Data channel received: {channel.get_property('label')}")
+        self._data_channel = channel
+        channel.connect("on-open", self._on_data_channel_open)
+        channel.connect("on-close", self._on_data_channel_close)
+        channel.connect("on-message-string", self._on_data_channel_message)
+        channel.connect("on-error", self._on_data_channel_error)
+
+    def _on_data_channel_open(self, _channel: Gst.Element) -> None:
+        """Handle data channel open event."""
+        print("Data channel opened")
+
+    def _on_data_channel_close(self, _channel: Gst.Element) -> None:
+        """Handle data channel close event."""
+        print("Data channel closed")
+        self._data_channel = None
+
+    def _on_data_channel_message(self, _channel: Gst.Element, message: str) -> None:
+        """Handle incoming data channel message."""
+        print(f"Data channel message: {message}")
+
+    def _on_data_channel_error(self, _channel: Gst.Element, error: str) -> None:
+        """Handle data channel error."""
+        print(f"Data channel error: {error}")
 
     def webrtcsrc_pad_added_cb(self, webrtcsrc: Gst.Element, pad: Gst.Pad) -> None:
         """Add webrtcsrc elements when a new pad is added."""
@@ -133,6 +174,29 @@ def process_msg(bus: Gst.Bus, pipeline: Gst.Pipeline) -> bool:
     return True
 
 
+def command_sender_loop(consumer: GstConsumer) -> None:
+    """Loop to send commands over the data channel."""
+    import json
+
+    import numpy as np
+
+    from reachy_mini.utils import create_head_pose
+
+    freq = 0.25
+    amp = 20.0
+
+    while True:
+        if consumer._data_channel:
+            yaw = amp * np.sin(2.0 * np.pi * freq * time.time())
+            cmd = create_head_pose(yaw=yaw, degrees=True)
+            msg = {
+                "set_target": cmd.tolist(),
+            }
+            consumer._data_channel.emit("send-string", json.dumps(msg))
+
+        time.sleep(0.01)
+
+
 def main() -> None:
     """Run the main function."""
     parser = argparse.ArgumentParser(description="webrtc gstreamer simple consumer")
@@ -153,6 +217,9 @@ def main() -> None:
         "reachymini",
     )
     consumer.play()
+
+    t = Thread(target=lambda: command_sender_loop(consumer), daemon=True)
+    t.start()
 
     # Wait until error or EOS
     bus = consumer.get_bus()

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -17,7 +17,7 @@ import typing
 from abc import abstractmethod
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Dict, Optional
+from typing import Annotated, Any, Callable, Dict, Optional
 
 import numpy as np
 import zenoh
@@ -176,6 +176,11 @@ class Backend:
         self._play_move_lock = threading.RLock()
         self._active_move_depth = (
             0  # Tracks nested acquisitions within the owning thread
+        )
+
+        # WebRTC support
+        self._send_message_to_webrtc: Optional[Callable[[Optional[str], str], None]] = (
+            None
         )
 
     # Life cycle methods
@@ -837,3 +842,19 @@ class Backend:
             "passive_7_y": self.head_kinematics.get_joint("passive_7_y"),  # type: ignore [union-attr]
             "passive_7_z": self.head_kinematics.get_joint("passive_7_z"),  # type: ignore [union-attr]
         }
+
+    def setup_webrtc_interface(self, gst_webrtc: Any) -> None:
+        """Set up the WebRTC interface for motor control.
+
+        Args:
+            gst_webrtc (Any): The GstWebRTC instance to setup.
+
+        """
+        gst_webrtc.set_message_handler(self._handle_webrtc_message)
+        self._send_message_to_webrtc = gst_webrtc.send_data_message
+
+    def _handle_webrtc_message(self, message: str) -> None:
+        message_data = json.loads(message)
+        if "set_target" in message_data:
+            target_pose = message_data["set_target"]
+            self.set_target_head_pose(np.array(target_pose))

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -853,7 +853,7 @@ class Backend:
         gst_webrtc.set_message_handler(self._handle_webrtc_message)
         self._send_message_to_webrtc = gst_webrtc.send_data_message
 
-    def _handle_webrtc_message(self, message: str) -> None:
+    def _handle_webrtc_message(self, peer_id: str, message: str) -> None:
         message_data = json.loads(message)
         if "set_target" in message_data:
             target_pose = message_data["set_target"]

--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -257,6 +257,14 @@ class RobotBackend(Backend):
                         )
                     )
 
+                    if self._send_message_to_webrtc is not None:
+                        message = json.dumps(
+                            {
+                                "head_pose": self.get_present_head_pose().tolist(),
+                            }
+                        )
+                        self._send_message_to_webrtc(None, message)
+
                     # Publish IMU data if available
                     if self.imu_publisher is not None and self.bmi088 is not None:
                         imu_data = self.get_imu_data()

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -300,6 +300,7 @@ class Daemon:
             await asyncio.sleep(
                 0.2
             )  # Give some time for the backend to release the audio device
+            self.backend.setup_webrtc_interface(self._webrtc)
             self._webrtc.start()
 
         self.logger.info("Daemon started successfully.")

--- a/src/reachy_mini/media/webrtc_daemon.py
+++ b/src/reachy_mini/media/webrtc_daemon.py
@@ -31,7 +31,7 @@ Example usage:
 import logging
 import os
 from threading import Thread
-from typing import Optional, Tuple, cast
+from typing import Callable, Optional, Tuple, cast
 
 import gi
 
@@ -119,6 +119,7 @@ class GstWebRTC:
 
         self._configure_video(cam_path, self._pipeline_sender, webrtcsink)
         self._configure_audio(self._pipeline_sender, webrtcsink)
+        self._configure_data()
 
         self._pipeline_receiver = Gst.Pipeline.new("reachymini_webrtc_receiver")
         self._bus_receiver = self._pipeline_receiver.get_bus()
@@ -161,7 +162,10 @@ class GstWebRTC:
         return webrtcsink
 
     def _consumer_added(
-        self, webrtcbin: Gst.Bin, arg1: Gst.Element, udata: bytes
+        self,
+        webrtcsink: Gst.Bin,
+        peer_id: str,
+        webrtcbin: Gst.Element,
     ) -> None:
         self._logger.info("consumer added")
 
@@ -170,6 +174,8 @@ class GstWebRTC:
         )
 
         GLib.timeout_add_seconds(5, self._dump_latency)
+
+        self._setup_data_channel(peer_id, webrtcbin)
 
     def _configure_receiver(self, pipeline: Gst.Pipeline) -> None:
         udpsrc = Gst.ElementFactory.make("udpsrc")
@@ -403,6 +409,82 @@ class GstWebRTC:
 
         self._pipeline_sender.set_state(Gst.State.NULL)
         self._pipeline_receiver.set_state(Gst.State.NULL)
+
+    # Data channel setup / handling
+    def set_message_handler(
+        self,
+        handler: Callable[[str, str], None],  # cb(peer_id, message)
+    ) -> None:
+        """Set a callback for incoming data channel messages.
+
+        Args:
+            handler: Callback function that receives (peer_id, message)
+
+        """
+        self._on_data_message = handler
+
+    def send_data_message(self, peer_id: Optional[str], message: str) -> None:
+        """Send a message to connected peers via data channel.
+
+        Args:
+            message: The string message to send
+            peer_id: If specified, send only to this peer. Otherwise broadcast to all.
+
+        """
+        if peer_id:
+            if peer_id in self._data_channels:
+                self._data_channels[peer_id].emit("send-string", message)
+            else:
+                self._logger.warning(f"No data channel for peer {peer_id}")
+        else:
+            # Broadcast to all connected peers
+            for channel in self._data_channels.values():
+                channel.emit("send-string", message)
+
+    def _configure_data(self) -> None:
+        self._logger.debug("Configuring data channel")
+        self._data_channels: dict[str, Gst.Element] = {}  # peer_id -> channel
+        self._on_data_message: Optional[Callable[[str, str], None]] = None
+
+    def _setup_data_channel(self, peer_id: str, webrtcbin: Gst.Element) -> None:
+        self._logger.debug(f"Setting up data channel for peer {peer_id}")
+
+        # Create data channel options
+        options = Gst.Structure.from_string("options,ordered=true")[0]
+
+        # Create the data channel
+        channel = webrtcbin.emit("create-data-channel", "data", options)
+        if channel:
+            self._logger.debug(f"Data channel created for peer {peer_id}")
+            self._data_channels[peer_id] = channel
+
+            # Connect to data channel signals
+            channel.connect("on-open", self._on_data_channel_open, peer_id)
+            channel.connect("on-close", self._on_data_channel_close, peer_id)
+            channel.connect("on-message-string", self._on_data_channel_message, peer_id)
+            channel.connect("on-error", self._on_data_channel_error, peer_id)
+        else:
+            self._logger.error(f"Failed to create data channel for peer {peer_id}")
+
+    def _on_data_channel_open(self, channel: Gst.Element, peer_id: str) -> None:
+        self._logger.info(f"Data channel opened for peer {peer_id}")
+
+    def _on_data_channel_close(self, channel: Gst.Element, peer_id: str) -> None:
+        self._logger.info(f"Data channel closed for peer {peer_id}")
+        if peer_id in self._data_channels:
+            del self._data_channels[peer_id]
+
+    def _on_data_channel_message(
+        self, channel: Gst.Element, message: str, peer_id: str
+    ) -> None:
+        self._logger.info(f"Data channel message from peer {peer_id}: {message}")
+        if self._on_data_message:
+            self._on_data_message(peer_id, message)
+
+    def _on_data_channel_error(
+        self, channel: Gst.Element, error: str, peer_id: str
+    ) -> None:
+        self._logger.error(f"Data channel error for peer {peer_id}: {error}")
 
 
 if __name__ == "__main__":

--- a/src/reachy_mini/media/webrtc_daemon.py
+++ b/src/reachy_mini/media/webrtc_daemon.py
@@ -119,7 +119,10 @@ class GstWebRTC:
 
         self._configure_video(cam_path, self._pipeline_sender, webrtcsink)
         self._configure_audio(self._pipeline_sender, webrtcsink)
-        self._configure_data()
+
+        self._logger.debug("Configuring data channel")
+        self._data_channels: dict[str, Gst.Element] = {}  # peer_id -> channel
+        self._on_data_message: Optional[Callable[[str, str], None]] = None
 
         self._pipeline_receiver = Gst.Pipeline.new("reachymini_webrtc_receiver")
         self._bus_receiver = self._pipeline_receiver.get_bus()
@@ -167,7 +170,7 @@ class GstWebRTC:
         peer_id: str,
         webrtcbin: Gst.Element,
     ) -> None:
-        self._logger.info("consumer added")
+        self._logger.info(f"consumer added with peer id: {peer_id}")
 
         Gst.debug_bin_to_dot_file(
             self._pipeline_sender, Gst.DebugGraphDetails.ALL, "pipeline_full"
@@ -440,11 +443,6 @@ class GstWebRTC:
             # Broadcast to all connected peers
             for channel in self._data_channels.values():
                 channel.emit("send-string", message)
-
-    def _configure_data(self) -> None:
-        self._logger.debug("Configuring data channel")
-        self._data_channels: dict[str, Gst.Element] = {}  # peer_id -> channel
-        self._on_data_message: Optional[Callable[[str, str], None]] = None
 
     def _setup_data_channel(self, peer_id: str, webrtcbin: Gst.Element) -> None:
         self._logger.debug(f"Setting up data channel for peer {peer_id}")


### PR DESCRIPTION
WIP, more to open discussion/testing rather than merging now.

I add a DataChannel to the existing GstWebrtc. 

I made some really basic connections with the backend (only head_pose in state, only set_target head in command). My idea was
- first, we can use this for testing/validating the process
- it will make more sense to me, to make the proper integration with the backend as we clean up the daemon/backend. Right now, it's completely tangled between backend/zenoh/routers.

What do you say @FabienDanieau? @cdussieux if you want to play as well, you should have all the basics needed for your space.


--- 

How to test/use

* install this branch on your wireless
* restart daemon service
* start daemon for the webrtc loop to start
* run the examples/debug/gstreamer_client.py (it will make the robot do a gentle sinus on yaw and print current state)