### PR TITLE
fix(gst init): fixing Gst.init() call by substituing [] to None

### DIFF
--- a/examples/debug/gstreamer_client.py
+++ b/examples/debug/gstreamer_client.py
@@ -21,7 +21,7 @@ class GstConsumer:
         peer_name: str,
     ) -> None:
         """Initialize the consumer with signalling server details and peer name."""
-        Gst.init(None)
+        Gst.init([])
         self._loop = GLib.MainLoop()
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -78,7 +78,7 @@ class GStreamerAudio(AudioBase):
     def __init__(self, log_level: str = "INFO") -> None:
         """Initialize the GStreamer audio."""
         super().__init__(log_level=log_level)
-        Gst.init(None)
+        Gst.init([])
         self._loop = GLib.MainLoop()
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()

--- a/src/reachy_mini/media/camera_gstreamer.py
+++ b/src/reachy_mini/media/camera_gstreamer.py
@@ -81,7 +81,7 @@ class GStreamerCamera(CameraBase):
     ) -> None:
         """Initialize the GStreamer camera."""
         super().__init__(log_level=log_level)
-        Gst.init(None)
+        Gst.init([])
         self._loop = GLib.MainLoop()
         self._thread_bus_calls: Optional[Thread] = None
 

--- a/src/reachy_mini/media/webrtc_client_gstreamer.py
+++ b/src/reachy_mini/media/webrtc_client_gstreamer.py
@@ -104,7 +104,7 @@ class GstWebRTCClient(CameraBase, AudioBase):
 
         """
         super().__init__(log_level=log_level)
-        Gst.init(None)
+        Gst.init([])
         self._loop = GLib.MainLoop()
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()

--- a/src/reachy_mini/media/webrtc_daemon.py
+++ b/src/reachy_mini/media/webrtc_daemon.py
@@ -94,7 +94,7 @@ class GstWebRTC:
         self._logger = logging.getLogger(__name__)
         self._logger.setLevel(log_level)
 
-        Gst.init(None)
+        Gst.init([])
         self._loop = GLib.MainLoop()
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()


### PR DESCRIPTION
This PR fixes a bug introduced by the latest GStreamer version (1.28). Until now, `Gst.init(None)` was working correctly (initialization without arguments), but starting from version 1.28, this syntax will make the initialization crash. 

Using `Gst.init([])` instead fixes the issue while achieving the same result.

Tested on macOS (GStreamer@1.28) and Ubuntu (GStreamer@1.24).