### PR TITLE
docs: improve SDK fallback guidance for desktop app compatibility

### DIFF
--- a/docs/source/platforms/reachy_mini_lite/get_started.md
+++ b/docs/source/platforms/reachy_mini_lite/get_started.md
@@ -23,7 +23,12 @@ Reachy Mini comes as a kit. Building it is the first step of your journey!
 
 ## 3. 📥 Download Reachy Mini Control
 
-> **🚧 🪟 WINDOWS USERS ONLY:** The Reachy Mini Control app for **Windows** is currently being finalized and will be available in a few days. **Windows users** can use the [Python SDK](../../SDK/readme.md) to control your robot directly in the meantime.
+> [!WARNING]
+> **⚠️ Desktop App Compatibility:**
+> - **Windows users:** The Reachy Mini Control app for Windows is currently being finalized and will be available in a few days.
+> - **ARM64 systems (DGX, Jetson, etc.) and unusual Linux distributions:** The desktop app may not work on your system.
+>
+> **Alternative:** If the desktop app doesn't work on your setup, you can install and use the [Python SDK](../../SDK/readme.md) directly - it's a fully supported and valid way to control your robot!
 
 The **Reachy Mini Control** desktop app is the command center for your robot. It includes the dashboard, visualization tools, and app launcher—no command line required.
 

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -212,6 +212,7 @@ You do not need to install them.
 
 - With Reachy Mini (Wireless), the daemon is already running on the embedded Raspberry Pi.
 - With Reachy Mini Lite, you can use [the desktop app](./platforms/reachy_mini_lite/get_started.md).
+- If the desktop app doesn't work on your system (e.g., ARM64, unusual distributions), you can [install and use the Python SDK](./SDK/installation.md) directly - it's a fully supported alternative!
 
 </details>
 


### PR DESCRIPTION
## Summary
Makes it clearer that the Python SDK is a fully supported alternative when the desktop app doesn't work on certain systems (ARM64, unusual Linux distributions).

## Background
This addresses feedback from Discord where a colleague from Asus was setting up Reachy on a DGX-type machine (Ubuntu, arm64). The desktop app doesn't work on arm64, and after trying to build it himself without success, he eventually installed the SDK directly - but that path wasn't clearly documented as a valid option.

## Changes
- **Enhanced warning in Lite get_started guide**: Changed to proper `[!WARNING]` format for better visibility
- **Added explicit mention of ARM64 systems**: DGX, Jetson, and unusual Linux distributions
- **Updated troubleshooting FAQ**: Added note about SDK as alternative for incompatible systems
- **Clarified SDK status**: Made it clear the SDK is not just a workaround but a fully supported path

## Files Changed
- `docs/source/platforms/reachy_mini_lite/get_started.md`: Enhanced compatibility warning
- `docs/source/troubleshooting.md`: Added SDK alternative to daemon FAQ

## Testing
- [x] Reviewed warning format displays correctly in markdown
- [x] Verified links to SDK documentation are correct
- [x] Checked that guidance is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)