### PR TITLE
docs: add AI agent prompt to quickstart and SDK readme

### DIFF
--- a/docs/source/SDK/quickstart.md
+++ b/docs/source/SDK/quickstart.md
@@ -117,6 +117,14 @@ python hello.py
 Encountering an issue? 👉 **[Check the Troubleshooting & FAQ Guide](../troubleshooting.md)**
 
 
+## Using an AI Coding Agent?
+
+If you're using an AI agent like **Claude Code**, **Codex**, or **Copilot**, you can start building apps right away. Just paste this prompt:
+
+> *I'd like to create a Reachy Mini app. Start by reading https://github.com/pollen-robotics/reachy_mini/blob/develop/agents.md*
+
+This guide gives your AI agent everything it needs to know about the SDK, best practices, and available tools.
+
 ## Next Steps
 * **[Python SDK](python-sdk.md)**: Learn to move, see, speak, and hear.
 * **[Browse the Examples Folder](https://github.com/pollen-robotics/reachy_mini/tree/main/examples)**

--- a/docs/source/SDK/readme.md
+++ b/docs/source/SDK/readme.md
@@ -31,7 +31,11 @@ We provide a collection of ready-to-run scripts to help you understand how to us
 
 ## 🤖 AI-Assisted Development
 
-Using an AI coding assistant (Claude, GPT, Copilot, etc.)? Check out [**agents.md**](../../agents.md) in the repo root - it helps AI agents understand the SDK and guide you through app development.
+Using an AI coding agent (Claude Code, Codex, Copilot, etc.)? You can start building apps right away. Paste this prompt to your agent:
+
+> *I'd like to create a Reachy Mini app. Start by reading https://github.com/pollen-robotics/reachy_mini/blob/develop/agents.md*
+
+This [**agents.md**](../../agents.md) guide gives AI agents everything they need: SDK patterns, best practices, example apps, and step-by-step skills.
 
 ## ❓ Troubleshooting
 


### PR DESCRIPTION
- Add copy-pasteable AI agent prompt to quickstart and SDK readme
- Points users to agents.md for AI-assisted app development
