### PR TITLE
fix(apps): cleanup orphaned app processes on daemon restart

### DIFF
--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -101,7 +101,10 @@ class AppManager:
                 if not cmd_exe.startswith(prefix) and not exe.startswith(prefix):
                     continue
 
-                # Must match *_venv/bin/python pattern (but NOT .venv — that's the daemon itself)
+                # Must match *_venv/{bin,Scripts}/python pattern
+                # (but NOT .venv — that's the daemon itself)
+                # Linux/macOS: *_venv/bin/python
+                # Windows:     *_venv/Scripts/python.exe
                 check_path = cmd_exe if cmd_exe.startswith(prefix) else exe
                 path_parts = check_path.split(os.sep)
                 is_app_venv_python = False
@@ -110,7 +113,7 @@ class AppManager:
                         part.endswith("_venv")
                         and part != ".venv"
                         and i + 1 < len(path_parts)
-                        and path_parts[i + 1] == "bin"
+                        and path_parts[i + 1] in ("bin", "Scripts")
                     ):
                         is_app_venv_python = True
                         break

--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -64,6 +64,86 @@ class AppManager:
         self.desktop_app_daemon = desktop_app_daemon
         self.running_on_wireless = wireless_version
         self.daemon = daemon
+        self._cleanup_orphaned_apps()
+
+    def _cleanup_orphaned_apps(self) -> None:
+        """Kill orphaned app subprocesses left by a previous daemon session.
+
+        When the daemon restarts, app subprocesses from the previous session
+        may still be running. This method detects and terminates them to prevent
+        conflicts (e.g., two processes sending commands to the robot simultaneously).
+        """
+        try:
+            venv_parent = str(local_common_venv._get_venv_parent_dir())
+        except Exception:
+            return
+
+        daemon_pid = os.getpid()
+        try:
+            daemon_children = {
+                c.pid for c in psutil.Process(daemon_pid).children(recursive=True)
+            }
+        except psutil.NoSuchProcess:
+            daemon_children = set()
+
+        orphans: list[psutil.Process] = []
+        for proc in psutil.process_iter(["pid", "exe", "cmdline"]):
+            try:
+                exe = proc.info.get("exe") or ""
+                cmdline = proc.info.get("cmdline") or []
+
+                # Must be under the venv parent directory
+                if not exe.startswith(venv_parent + os.sep):
+                    continue
+
+                # Must match *_venv/bin/python pattern (but NOT .venv — that's the daemon itself)
+                exe_parts = exe.split(os.sep)
+                is_app_venv_python = False
+                for i, part in enumerate(exe_parts):
+                    if (
+                        part.endswith("_venv")
+                        and part != ".venv"
+                        and i + 1 < len(exe_parts)
+                        and exe_parts[i + 1] == "bin"
+                    ):
+                        is_app_venv_python = True
+                        break
+                if not is_app_venv_python:
+                    continue
+
+                # Must be a module execution (python -m ...)
+                if "-m" not in cmdline:
+                    continue
+
+                # Must NOT be the current daemon or its children
+                pid = proc.info["pid"]
+                if pid == daemon_pid or pid in daemon_children:
+                    continue
+
+                orphans.append(proc)
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                continue
+
+        for proc in orphans:
+            pid = proc.pid
+            try:
+                self.logger.info(f"Terminating orphaned app process (PID {pid})")
+                proc.terminate()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+
+        # Wait for graceful shutdown, then force-kill survivors
+        if orphans:
+            _, alive = psutil.wait_procs(orphans, timeout=3)
+            for proc in alive:
+                try:
+                    self.logger.warning(
+                        f"Force-killing orphaned app process (PID {proc.pid})"
+                    )
+                    self._kill_process_tree(proc.pid)
+                    proc.kill()
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
 
     async def close(self) -> None:
         """Clean up the AppManager, stopping any running app."""

--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -92,19 +92,25 @@ class AppManager:
                 exe = proc.info.get("exe") or ""
                 cmdline = proc.info.get("cmdline") or []
 
-                # Must be under the venv parent directory
-                if not exe.startswith(venv_parent + os.sep):
+                # Use cmdline[0] as primary path — psutil.exe() resolves symlinks
+                # which loses the original venv path information
+                cmd_exe = cmdline[0] if cmdline else ""
+
+                # Must be under the venv parent directory (check both exe and cmdline[0])
+                prefix = venv_parent + os.sep
+                if not cmd_exe.startswith(prefix) and not exe.startswith(prefix):
                     continue
 
                 # Must match *_venv/bin/python pattern (but NOT .venv — that's the daemon itself)
-                exe_parts = exe.split(os.sep)
+                check_path = cmd_exe if cmd_exe.startswith(prefix) else exe
+                path_parts = check_path.split(os.sep)
                 is_app_venv_python = False
-                for i, part in enumerate(exe_parts):
+                for i, part in enumerate(path_parts):
                     if (
                         part.endswith("_venv")
                         and part != ".venv"
-                        and i + 1 < len(exe_parts)
-                        and exe_parts[i + 1] == "bin"
+                        and i + 1 < len(path_parts)
+                        and path_parts[i + 1] == "bin"
                     ):
                         is_app_venv_python = True
                         break


### PR DESCRIPTION
## Summary

- When the daemon restarts, app subprocesses spawned by the previous `AppManager` remain running as orphans
- The new daemon's `AppManager` initializes with `current_app = None`, unaware of these orphans
- Both the orphaned app and the new daemon send commands to the robot simultaneously, causing conflicts

This PR adds `_cleanup_orphaned_apps()` to `AppManager.__init__()` that detects and terminates orphaned app processes on startup.

## Detection criteria (all must match)

- Executable path is under `_get_venv_parent_dir()`
- Matches `*_venv/bin/python` pattern (`.venv` excluded to protect the daemon itself)
- Command line contains `-m` (module execution pattern)
- PID is not the current daemon or any of its children

## Termination strategy

1. `SIGTERM` for graceful shutdown (3-second timeout)
2. `_kill_process_tree()` + `kill()` for force termination of survivors

## Changes

- `src/reachy_mini/apps/manager.py`: Added `_cleanup_orphaned_apps()` method + 1-line call in `__init__`

## Test plan

- [ ] Start daemon → start an app → restart daemon only → verify orphaned process is cleaned up
- [ ] Verify daemon's own process is not falsely terminated
- [ ] Verify no errors when no orphaned processes exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)