### PR TITLE
Run webrtc async call in threaded loop.

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -850,7 +850,13 @@ class Backend:
             gst_webrtc (Any): The GstWebRTC instance to setup.
 
         """
-        gst_webrtc.set_message_handler(self._handle_webrtc_message)
+        _loop = asyncio.new_event_loop()
+        threading.Thread(target=_loop.run_forever, daemon=True).start()
+
+        def _threadsafe_handler(peer_id: str, message: str) -> None:
+            _loop.call_soon_threadsafe(self._handle_webrtc_message, peer_id, message)
+
+        gst_webrtc.set_message_handler(_threadsafe_handler)
         self._send_message_to_webrtc = gst_webrtc.send_data_message
 
     def _handle_webrtc_message(self, peer_id: str, message: str) -> None:


### PR DESCRIPTION
As mentioned in #846, the async call will fail from the webrtc handler.

```2026-02-17 14:52:15,766 - reachy_mini.media.webrtc_daemon - INFO - Data channel message from peer 8cbc2082-27b4-402f-8b46-9e13a66e1003: {"goto_target":{"head":[[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]}}
2026-02-17 14:52:15,766 - reachy_mini.daemon.backend.robot.backend - ERROR - WebRTC command error: no running event loop
/Users/pierrerouanet/Dev/mini/reachy_mini/src/reachy_mini/daemon/backend/abstract.py:872: RuntimeWarning: coroutine 'Backend._webrtc_goto' was never awaited
```

I've added a run loop to make sure they are always scheduled.
Don't hesitate to change it if you have a better/cleaner fix.