### PR TITLE
fix(documentation upload): removing branches filters

### DIFF
--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -3,9 +3,6 @@ name: Upload PR Documentation
 on:
   workflow_run:
     workflows: ["Build HF PR Documentation"]
-    branches:
-      - main
-      - develop
     types:
       - completed
 


### PR DESCRIPTION
This PR follows Transformers and LeRobot patterns for the documentation upload workflow, that is, no branches filters to trigger the upload when the build is done.