### PR TITLE
Exposing reachy's limitation to the SDK

### DIFF
--- a/docs/source/SDK/core-concept.md
+++ b/docs/source/SDK/core-concept.md
@@ -36,10 +36,12 @@ Reachy Mini has physical and software limits to prevent self-collision and damag
 
 | Joint / Axis | Limit Range |
 | :--- | :--- |
-| **Head Pitch/Roll** | [-40°, +40°] |
-| **Head Yaw** | [-180°, +180°] |
+| **Head cone (tilt)** | Max 35° from vertical (pitch/roll coupled) |
+| **Head Yaw** | [-179°, +179°] |
 | **Body Yaw** | [-160°, +160°] |
-| **Yaw Delta** | Max 65° difference between Head and Body Yaw |
+| **Yaw Delta** | Max 55° difference between Head and Body Yaw |
+
+You can read these limits in code via `mini.limits` and check reachability with `mini.is_reachable(head_pose, body_yaw)`.
 
 ## Motor Modes
 

--- a/docs/source/SDK/python-sdk.md
+++ b/docs/source/SDK/python-sdk.md
@@ -28,6 +28,10 @@ with ReachyMini() as mini:
 ### Instant Control (`set_target`)
 Bypasses interpolation. Use this for high-frequency control (e.g., following a joystick or generated trajectory).
 
+### Limits and reachability
+* **`mini.limits`** — Task-space motion limits (head cone, head yaw, body yaw, yaw delta). Use this to know the physical envelope instead of probing.
+* **`mini.is_reachable(head_pose, body_yaw=0.0)`** — Returns `True` if the given 4×4 head pose is reachable for the given body yaw. Raises `ConnectionError` if the daemon REST endpoint is unreachable. Use before sending additive or extreme poses to avoid the robot holding at the last valid pose without feedback.
+
 ## Sensors & Media
 
 The media architecture is described in detail in the [Media Architecture](media-architecture.md) section. Although accesssing audio and video from the SDK is similar across Reachy Mini versions, the underlying implementation differs.

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -337,10 +337,12 @@ Refer to the [Reachy Mini Hardware page](./platforms/reachy_mini/hardware.md) fo
 
 If you command a pose outside these limits, the robot will automatically clamp to the nearest safe pose.
 
-* **Body Yaw:** [-180°, 180°].
-* **Head Pitch/Roll:** [-40°, 40°].
-* **Head Yaw:** [-180°, 180°].
-* **Combined Limit:** The difference between `body_yaw` and `head_yaw` must be within **[-65°, 65°]**.
+* **Body Yaw:** [-160°, 160°].
+* **Head cone (tilt):** Max 35° from vertical (pitch/roll coupled).
+* **Head Yaw:** [-179°, 179°].
+* **Combined Limit:** The difference between `body_yaw` and `head_yaw` must be within **[-55°, 55°]**.
+
+In code, use `mini.limits` to read these values and `mini.is_reachable(head_pose, body_yaw)` to check if a pose is reachable before sending it.
 
 </details>
 

--- a/src/reachy_mini/daemon/app/models.py
+++ b/src/reachy_mini/daemon/app/models.py
@@ -137,6 +137,15 @@ class FullBodyTarget(BaseModel):
     }
 
 
+class KinematicsLimits(BaseModel):
+    """Task-space motion limits for the robot."""
+
+    head_cone_angle_deg: float
+    head_yaw_deg: dict[str, float]
+    body_yaw_deg: dict[str, float]
+    yaw_delta_max_deg: float
+
+
 class DoAInfo(BaseModel):
     """Direction of Arrival info from the microphone array."""
 
@@ -155,3 +164,4 @@ class FullState(BaseModel):
     timestamp: datetime | None = None
     passive_joints: list[float] | None = None
     doa: DoAInfo | None = None
+    ik_status: str | None = None  # "ok", "clamped", "unreachable" when with_ik_status=True

--- a/src/reachy_mini/daemon/app/routers/kinematics.py
+++ b/src/reachy_mini/daemon/app/routers/kinematics.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 
 from ....daemon.backend.abstract import Backend
 from ..dependencies import get_backend
+from ..models import FullBodyTarget
 
 router = APIRouter(
     prefix="/kinematics",
@@ -37,6 +38,31 @@ async def get_kinematics_info(
             "collision check": backend.check_collision,
         }
     }
+
+
+@router.get("/limits")
+async def get_kinematics_limits(
+    backend: Backend = Depends(get_backend),
+) -> dict[str, Any]:
+    """Get the task-space motion limits of the robot."""
+    return {"limits": backend.get_limits()}
+
+
+@router.post("/is_reachable")
+async def check_reachable(
+    target: FullBodyTarget,
+    backend: Backend = Depends(get_backend),
+) -> dict[str, bool]:
+    """Check if a target pose is within the reachable workspace."""
+    if target.target_head_pose is None:
+        raise HTTPException(
+            status_code=422,
+            detail="target_head_pose is required",
+        )
+    pose = target.target_head_pose.to_pose_array()
+    body_yaw = target.target_body_yaw if target.target_body_yaw is not None else 0.0
+    reachable = backend.is_pose_reachable(pose, body_yaw)
+    return {"reachable": reachable}
 
 
 @router.get("/urdf")

--- a/src/reachy_mini/daemon/app/routers/state.py
+++ b/src/reachy_mini/daemon/app/routers/state.py
@@ -84,6 +84,7 @@ async def get_full_state(
     with_target_antenna_positions: bool = False,
     with_passive_joints: bool = False,
     with_doa: bool = False,
+    with_ik_status: bool = False,
     use_pose_matrix: bool = False,
     backend: Backend = Depends(get_backend),
 ) -> FullState:
@@ -122,6 +123,8 @@ async def get_full_state(
         doa_result = backend.audio.get_DoA()
         if doa_result:
             result["doa"] = DoAInfo(angle=doa_result[0], speech_detected=doa_result[1])
+    if with_ik_status:
+        result["ik_status"] = backend.ik_status.value
 
     result["timestamp"] = datetime.now(timezone.utc)
     return FullState.model_validate(result)
@@ -141,6 +144,7 @@ async def ws_full_state(
     with_target_antenna_positions: bool = False,
     with_passive_joints: bool = False,
     with_doa: bool = False,
+    with_ik_status: bool = False,
     use_pose_matrix: bool = False,
     backend: Backend = Depends(ws_get_backend),
 ) -> None:
@@ -161,6 +165,7 @@ async def ws_full_state(
                 with_target_antenna_positions=with_target_antenna_positions,
                 with_passive_joints=with_passive_joints,
                 with_doa=with_doa,
+                with_ik_status=with_ik_status,
                 use_pose_matrix=use_pose_matrix,
                 backend=backend,
             )

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -48,8 +48,24 @@ class MotorControlMode(str, Enum):
     GravityCompensation = "gravity_compensation"  # Torque ON and controlled in current to compensate for gravity
 
 
+class IKStatus(str, Enum):
+    """Status of the last inverse kinematics computation."""
+
+    OK = "ok"  # target achieved
+    CLAMPED = "clamped"  # IK found a valid solution but constraints limited it
+    UNREACHABLE = "unreachable"  # IK failed entirely, holding last valid pose
+
+
 class Backend:
     """Base class for robot backends, simulated or real."""
+
+    # Task-space motion limits (physical envelope); same for all kinematics engines
+    LIMITS: Dict[str, Any] = {
+        "head_cone_angle_deg": 35.0,  # max tilt from vertical (pitch/roll coupled)
+        "head_yaw_deg": {"min": -179.0, "max": 179.0},
+        "body_yaw_deg": {"min": -160.0, "max": 160.0},
+        "yaw_delta_max_deg": 55.0,  # max |head_yaw - body_yaw|
+    }
 
     def __init__(
         self,
@@ -148,6 +164,7 @@ class Backend:
             None  # Placeholder for head joint torque
         )
         self.ik_required = False  # Flag to indicate if IK computation is required
+        self.ik_status: IKStatus = IKStatus.OK  # Status of last IK (ok, clamped, unreachable)
 
         self.is_shutting_down = False
 
@@ -271,6 +288,19 @@ class Backend:
         """
         self.imu_publisher = publisher
 
+    def get_limits(self) -> Dict[str, Any]:
+        """Return the task-space motion limits of the robot."""
+        return dict(self.LIMITS)
+
+    def is_pose_reachable(
+        self,
+        pose: Annotated[NDArray[np.float64], (4, 4)],
+        body_yaw: float = 0.0,
+    ) -> bool:
+        """Return True if the given head pose is reachable for the given body yaw."""
+        joints = self.head_kinematics.ik(pose, body_yaw=body_yaw)
+        return joints is not None and not np.any(np.isnan(joints))
+
     def update_target_head_joints_from_ik(
         self,
         pose: Annotated[NDArray[np.float64], (4, 4)] | None = None,
@@ -296,6 +326,7 @@ class Backend:
         # Compute the inverse kinematics to get the head joint positions
         joints = self.head_kinematics.ik(pose, body_yaw=body_yaw)
         if joints is None or np.any(np.isnan(joints)):
+            self.ik_status = IKStatus.UNREACHABLE
             raise ValueError("WARNING: Collision detected or head pose not achievable!")
 
         # update the target head pose and body yaw
@@ -303,6 +334,18 @@ class Backend:
         self._last_target_body_yaw = body_yaw
 
         self.target_head_joint_positions = joints
+        # Detect clamping: achieved pose differs from requested (IK solved constrained QP)
+        achieved_pose = self.head_kinematics.fk(joints)
+        if achieved_pose is not None:
+            dist_translation, dist_angle, _ = distance_between_poses(
+                achieved_pose, pose
+            )
+            if dist_translation > 1e-3 or dist_angle > np.deg2rad(1.0):
+                self.ik_status = IKStatus.CLAMPED
+            else:
+                self.ik_status = IKStatus.OK
+        else:
+            self.ik_status = IKStatus.OK
 
     def set_target_head_pose(
         self,

--- a/src/reachy_mini/daemon/backend/mujoco/backend.py
+++ b/src/reachy_mini/daemon/backend/mujoco/backend.py
@@ -21,7 +21,7 @@ import numpy.typing as npt
 
 import reachy_mini
 
-from ..abstract import Backend, MotorControlMode
+from ..abstract import Backend, IKStatus, MotorControlMode
 from .utils import (
     get_actuator_names,
     get_joint_addr_from_name,
@@ -239,6 +239,7 @@ class MujocoBackend(Backend):
                             self.target_head_pose, self.target_body_yaw
                         )
                     except ValueError as e:
+                        self.ik_status = IKStatus.UNREACHABLE
                         log_throttling.by_time(self.logger, interval=0.5).warning(
                             f"IK error: {e}"
                         )

--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -22,7 +22,7 @@ from reachy_mini_motor_controller import ReachyMiniPyControlLoop
 
 from reachy_mini.utils.hardware_config.parser import parse_yaml_config
 
-from ..abstract import Backend, MotorControlMode
+from ..abstract import Backend, IKStatus, MotorControlMode
 
 
 class RobotBackend(Backend):
@@ -236,6 +236,7 @@ class RobotBackend(Backend):
                             self.target_head_pose, self.target_body_yaw
                         )
                     except ValueError as e:
+                        self.ik_status = IKStatus.UNREACHABLE
                         log_throttling.by_time(self.logger, interval=0.5).warning(
                             f"IK error: {e}"
                         )

--- a/src/reachy_mini/kinematics/analytical_kinematics.py
+++ b/src/reachy_mini/kinematics/analytical_kinematics.py
@@ -85,7 +85,7 @@ class AnalyticalKinematics:
             reachy_joints = self.kin.inverse_kinematics_safe(
                 _pose,
                 body_yaw=body_yaw,
-                max_relative_yaw=np.deg2rad(65),
+                max_relative_yaw=np.deg2rad(55),
                 max_body_yaw=np.deg2rad(160),
             )
         else:

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -10,11 +10,12 @@ import asyncio
 import json
 import logging
 import time
-from typing import Dict, List, Literal, Optional, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 import cv2
 import numpy as np
 import numpy.typing as npt
+import requests
 import zenoh
 from asgiref.sync import async_to_sync
 from scipy.spatial.transform import Rotation as R
@@ -51,6 +52,13 @@ SLEEP_HEAD_POSE = np.array(
 )
 
 ConnectionMode = Literal["auto", "localhost_only", "network"]
+DEFAULT_DAEMON_API_BASE_URL = "http://localhost:8000"
+DEFAULT_LIMITS: Dict[str, Any] = {
+    "head_cone_angle_deg": 35.0,
+    "head_yaw_deg": {"min": -179.0, "max": 179.0},
+    "body_yaw_deg": {"min": -160.0, "max": 160.0},
+    "yaw_delta_max_deg": 55.0,
+}
 
 
 class ReachyMini:
@@ -125,6 +133,58 @@ class ReachyMini:
         )
 
         self.media_manager = self._configure_mediamanager(media_backend, log_level)
+
+    @property
+    def limits(self) -> Dict[str, Any]:
+        """Task-space motion limits.
+
+        The value is fetched from the connected daemon REST API and cached.
+        Falls back to SDK defaults if the REST API is unavailable.
+        """
+        if not hasattr(self, "_limits_cache"):
+            last_error: Exception | None = None
+            for daemon_base_url in self._daemon_api_base_urls():
+                url = f"{daemon_base_url}/api/kinematics/limits"
+                try:
+                    response = requests.get(url, timeout=5.0)
+                    response.raise_for_status()
+                    limits = response.json()["limits"]
+                    if not isinstance(limits, dict):
+                        raise ValueError(
+                            f"Expected 'limits' dict in response, got {type(limits)}."
+                        )
+                    self._limits_cache = dict(limits)
+                    break
+                except (requests.RequestException, KeyError, TypeError, ValueError) as e:
+                    last_error = e
+
+            if not hasattr(self, "_limits_cache"):
+                if not hasattr(self, "_limits_fallback_warned"):
+                    self.logger.warning(
+                        "Could not fetch limits from daemon (%s). Using SDK defaults.",
+                        last_error,
+                    )
+                    self._limits_fallback_warned = True
+                return dict(DEFAULT_LIMITS)
+
+        return dict(self._limits_cache)
+
+    def _daemon_api_base_urls(self, base_url: Optional[str] = None) -> List[str]:
+        """Return candidate daemon API base URLs to try, in priority order."""
+        if base_url is not None:
+            normalized = base_url.rstrip("/")
+            if normalized == "":
+                raise ValueError("base_url must not be empty.")
+            return [normalized]
+
+        urls: List[str] = []
+        status = self.client.get_status(wait=False)
+        wlan_ip = status.get("wlan_ip")
+        if self.connection_mode == "network" and isinstance(wlan_ip, str) and wlan_ip:
+            urls.append(f"http://{wlan_ip}:8000")
+
+        urls.append(DEFAULT_DAEMON_API_BASE_URL)
+        return list(dict.fromkeys(urls))
 
     def __del__(self) -> None:
         """Destroy the Reachy Mini instance.
@@ -852,6 +912,62 @@ class ReachyMini:
 
         """
         self.client.send_command(json.dumps({"automatic_body_yaw": body_yaw}))
+
+    def is_reachable(
+        self,
+        head: npt.NDArray[np.float64],
+        body_yaw: float = 0.0,
+        base_url: Optional[str] = None,
+    ) -> bool:
+        """Check if a head pose is reachable given body yaw.
+
+        Calls the daemon REST API. If `base_url` is not provided, the SDK tries the
+        currently connected daemon first (network mode) and falls back to localhost.
+
+        Args:
+            head: 4x4 head pose matrix.
+            body_yaw: Body yaw in radians (default 0.0).
+            base_url: Optional daemon API base URL override.
+
+        Returns:
+            True if the pose is within the reachable workspace.
+
+        Raises:
+            ConnectionError: If the daemon REST API cannot be reached.
+            RuntimeError: If the daemon response payload is invalid.
+
+        """
+        if head.shape != (4, 4):
+            raise ValueError(f"Head pose must be a 4x4 matrix, got shape {head.shape}.")
+
+        payload = {
+            "target_head_pose": {"m": head.flatten().tolist()},
+            "target_body_yaw": body_yaw,
+        }
+
+        errors: List[str] = []
+        for daemon_base_url in self._daemon_api_base_urls(base_url):
+            url = f"{daemon_base_url}/api/kinematics/is_reachable"
+            try:
+                response = requests.post(url, json=payload, timeout=5.0)
+                response.raise_for_status()
+                reachable = response.json()["reachable"]
+                if not isinstance(reachable, bool):
+                    raise RuntimeError(
+                        f"Invalid 'reachable' payload from daemon at {url}: {reachable!r}"
+                    )
+                return reachable
+            except requests.RequestException as e:
+                errors.append(f"{url}: {e}")
+            except (KeyError, TypeError) as e:
+                raise RuntimeError(
+                    f"Invalid response from daemon at {url}: missing or malformed 'reachable'."
+                ) from e
+
+        raise ConnectionError(
+            "Failed to query daemon reachability endpoint. Tried: "
+            + "; ".join(errors)
+        )
 
     async def async_play_move(
         self,


### PR DESCRIPTION
# Expose kinematics limits and IK feedback to app developers

## Problem statement

When using additive expressions (e.g. incremental head poses), the robot sometimes gets pushed past physical extremes. In that case the robot effectively says “I’ll stay here until I get another signal within limits” and holds the last valid pose. There is no way for the app to:

1. **Know the limits**: They are documented (e.g. in Core Concepts) but not exposed programmatically
2. **Know when a command rejected**: The daemon logs an IK error and keeps the previous target; the client gets no feedback (no “clamped” flag, no achieved-vs-requested).

So the physical envelope exists in the SDK/daemon but is not communicated to apps.

## Proposed solution

1. **Expose limits via SDK and REST API**
   - `mini.limits` (property) and `GET /api/kinematics/limits` returning the task-space limits (head cone, head yaw, body yaw, yaw delta).
   - No probing needed; use the same values the IK uses.

2. **Feedback when poses are clamped or unreachable**
   - Track IK status in the backend: `ok`, `clamped`, `unreachable`.
   - Expose it in the state stream (e.g. `GET /api/state/full?with_ik_status=true` and WebSocket) so apps can react instead of wondering why the robot stopped moving.

3. **Reachability check**
   - `mini.is_reachable(head_pose, body_yaw)` and `POST /api/kinematics/is_reachable` so apps can pre-check or clamp on their side before sending commands.

## Context

- Limits are already enforced inside the kinematics engines (Placo constraints, Analytical `inverse_kinematics_safe`, URDF joint limits).
- When Inverse kinematics fails, the daemon catches the error and keeps the last valid `target_head_joint_positions`; only a throttled log is emitted.

## Acceptance criteria

- [x] App can read task-space limits without probing (SDK property and REST).
- [x] App can check if a pose is reachable before sending (SDK method and REST).
- [x] App can observe Inverse kinematics status (ok / clamped / unreachable) via state API when requested.
- [x] Docs (Core Concepts, Troubleshooting, Python SDK) mention `mini.limits` and `mini.is_reachable()` and the corrected limit values.
- [ ] Still needs to be tested on the Reachy mini
