### PR TITLE
Prevent hardware error check from blocking backend control loop

### DIFF
--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -119,8 +119,8 @@ class RobotBackend(Backend):
         self.hardware_error_check_period = (
             1.0 / hardware_error_check_frequency
         )  # seconds
-        self._hw_error_check_in_progress = False
-        self._hw_error_check_thread: threading.Thread | None = None
+        self._hw_error_check_requested = threading.Event()
+        self._hw_error_check_busy = False
 
         # Install a no-op SIGUSR1 handler so we can use pthread_kill to
         # interrupt threads stuck in blocking serial reads without terminating
@@ -128,6 +128,14 @@ class RobotBackend(Backend):
         # signal.signal() must be called from the main thread.
         if threading.current_thread() is threading.main_thread():
             signal.signal(signal.SIGUSR1, lambda *_: None)
+
+        # Start a persistent worker thread for hardware error checks.
+        # Must be started here (before any Rust thread can hold the GIL)
+        # because Thread.start() needs the new thread to acquire the GIL.
+        self._hw_error_check_thread = threading.Thread(
+            target=self._hw_error_check_loop, daemon=True, name="hw-error-check"
+        )
+        self._hw_error_check_thread.start()
 
         # Initialize IMU for wireless version
         if wireless_version:
@@ -316,12 +324,8 @@ class RobotBackend(Backend):
                 time.time() - self.last_hardware_error_check_time
                 > self.hardware_error_check_period
             ):
-                if not self._hw_error_check_in_progress:
-                    self._hw_error_check_in_progress = True
-                    self._hw_error_check_thread = threading.Thread(
-                        target=self._do_hardware_error_check, daemon=True
-                    )
-                    self._hw_error_check_thread.start()
+                if not self._hw_error_check_busy:
+                    self._hw_error_check_requested.set()
                 else:
                     # Previous check is stuck in a blocking serial read.
                     # Send SIGUSR1 to interrupt the syscall (causes EINTR).
@@ -638,20 +642,25 @@ class RobotBackend(Backend):
             except (OSError, ProcessLookupError):
                 pass
 
-    def _do_hardware_error_check(self) -> None:
-        """Run hardware error check in a background thread. Logs results directly."""
-        try:
-            hardware_errors = self.read_hardware_errors()
-            if hardware_errors:
-                for motor_name, errors in hardware_errors.items():
-                    self.logger.error(
-                        f"Motor '{motor_name}' hardware errors: {errors}"
-                    )
-        except Exception as e:
-            self.logger.warning(f"Hardware error check failed: {e}. Skipping.")
-        finally:
-            self._hw_error_check_in_progress = False
-            self._hw_error_check_thread = None
+    def _hw_error_check_loop(self) -> None:
+        """Persistent worker loop for hardware error checks."""
+        while not self.should_stop.is_set():
+            triggered = self._hw_error_check_requested.wait(timeout=5.0)
+            if not triggered:
+                continue  # Timeout — just re-check should_stop
+            self._hw_error_check_requested.clear()
+            self._hw_error_check_busy = True
+            try:
+                hardware_errors = self.read_hardware_errors()
+                if hardware_errors:
+                    for motor_name, errors in hardware_errors.items():
+                        self.logger.error(
+                            f"Motor '{motor_name}' hardware errors: {errors}"
+                        )
+            except Exception as e:
+                self.logger.warning(f"Hardware error check failed: {e}. Skipping.")
+            finally:
+                self._hw_error_check_busy = False
 
     def read_hardware_errors(self) -> dict[str, list[str]]:
         """Read hardware errors from the motor controller."""


### PR DESCRIPTION
This PR fixes a deadlock problem that occurs randomly after running the daemon for a long time (for e.g. more than 6 hours). All threads are running but they are waiting on GIL.

I've marked in the py-spy output where the GIL is stuck:

```
Process 114254: python -u -m reachy_mini.daemon.app.main --wireless-version --autostart
Python v3.12.12 (/home/pollen/.local/share/uv/python/cpython-3.12.12-linux-aarch64-gnu/bin/python3.12)

Thread 114254 (idle): "MainThread"
    select (selectors.py:468)
    _run_once (asyncio/base_events.py:1961)
    run_forever (asyncio/base_events.py:645)
    run_until_complete (asyncio/base_events.py:678)
    run (asyncio/runners.py:118)
    run (asyncio/runners.py:195)
    run_app (reachy_mini/daemon/app/main.py:373)
    main (reachy_mini/daemon/app/main.py:614)
    <module> (reachy_mini/daemon/app/main.py:618)
    _run_code (<frozen runpy>:88)
    _run_module_as_main (<frozen runpy>:198)
Thread 114265 (idle): "Thread-1 (<lambda>)"
    run (gi/overrides/GLib.py:497)
    <lambda> (reachy_mini/media/webrtc_daemon.py:99)
    run (threading.py:1012)
    _bootstrap_inner (threading.py:1075)
    _bootstrap (threading.py:1032)
Thread 114305 (idle): "Thread-2 (<lambda>)"
    run (gi/overrides/GLib.py:497)
    <lambda> (reachy_mini/media/audio_gstreamer.py:83)
    run (threading.py:1012)
    _bootstrap_inner (threading.py:1075)
    _bootstrap (threading.py:1032)
Thread 114315 (idle): "Thread-3 (pyo3-closure)"
    run (threading.py:1012)
    _bootstrap_inner (threading.py:1075)
    _bootstrap (threading.py:1032)
Thread 114316 (idle): "Thread-4 (pyo3-closure)"
    run (threading.py:1012)
    _bootstrap_inner (threading.py:1075)
    _bootstrap (threading.py:1032)
Thread 114317 (idle): "Thread-5 (_publish_status)"
    _publish_status (reachy_mini/daemon/daemon.py:458)
    run (threading.py:1012)
    _bootstrap_inner (threading.py:1075)
    _bootstrap (threading.py:1032)
Thread 114318 (idle): "Thread-6 (backend_wrapped_run)"
    voltage_ok (reachy_mini/daemon/backend/robot/backend.py:638) # <- GIL is stuck here
    read_hardware_errors (reachy_mini/daemon/backend/robot/backend.py:652)
    _update (reachy_mini/daemon/backend/robot/backend.py:308)
    run (reachy_mini/daemon/backend/robot/backend.py:169)
    wrapped_run (reachy_mini/daemon/backend/abstract.py:200)
    backend_wrapped_run (reachy_mini/daemon/daemon.py:237)
    run (threading.py:1012)
    _bootstrap_inner (threading.py:1075)
    _bootstrap (threading.py:1032)
Thread 114392 (idle): "AnyIO worker thread"
    wait (threading.py:355)
    get (queue.py:171)
    run (anyio/_backends/_asyncio.py:975)
    _bootstrap_inner (threading.py:1075)
    _bootstrap (threading.py:1032)
Thread 114307 (idle): "Dummy-7"
```

voltage_ok() is infinitely blocked by async_read_raw_bytes() because the motor is never going to respond.

When this happens:

- uvicorn api server does not respond (waiting forever)
- no zenoh topics are published so nothing can be read
- no errors are logged so very hard to debug

# Fix

The Rust async_read_raw_bytes holds the Python GIL while blocked on the serial read, which rules out simple timeout-based solutions (concurrent.futures.Future.result(timeout=...) can't complete because it needs the GIL to raise TimeoutError).

Instead, the fix uses a fire-and-forget pattern with signal-based interruption:

1. Non-blocking dispatch: Hardware error checks run in a daemon thread. The control loop never waits for the result — errors are logged directly from the worker thread.
2. No thread pile-up: A flag prevents spawning a new check while the previous one is still running.
3. Signal-based interruption: When a stuck check is detected on the next cycle, signal.pthread_kill(thread, SIGUSR1) interrupts the blocking read() syscall with EINTR, which propagates as an exception and terminates the thread cleanly.
4. Safe signal setup: A no-op SIGUSR1 handler is installed at init (from the main thread) so the signal doesn't terminate the process.