### PR TITLE
Fix mujoco sim crash on macos

### DIFF
--- a/src/reachy_mini/daemon/backend/mujoco/backend.py
+++ b/src/reachy_mini/daemon/backend/mujoco/backend.py
@@ -7,6 +7,7 @@ It includes methods for running the simulation, getting joint positions, and con
 """
 
 import json
+import platform
 import time
 from dataclasses import dataclass
 from importlib.resources import files
@@ -31,7 +32,24 @@ from .video_udp import UDPJPEGFrameSender
 
 CAMERA_REACHY = "eye_camera"
 CAMERA_STUDIO_CLOSE = "studio_close"
-CAMERA_SIZES = {CAMERA_REACHY: (640, 360), CAMERA_STUDIO_CLOSE: (640, 640)}
+
+
+def _get_udp_max_dgram() -> int:
+    """Get the default maximum UDP datagram size for the current platform.
+
+    macOS defaults to 9216 bytes, while Linux and Windows default to 65535 bytes.
+    """
+    if platform.system() == "Darwin":
+        return 9216
+    return 65535
+
+
+UDP_MAX_DGRAM = _get_udp_max_dgram()
+
+CAMERA_SIZES = {
+    CAMERA_REACHY: (1280, 720) if UDP_MAX_DGRAM > 9216 else (640, 360),
+    CAMERA_STUDIO_CLOSE: (640, 640),
+}
 
 
 class MujocoBackend(Backend):

--- a/src/reachy_mini/daemon/backend/mujoco/video_udp.py
+++ b/src/reachy_mini/daemon/backend/mujoco/video_udp.py
@@ -1,6 +1,7 @@
 """UDP JPEG Frame Sender.
 
-This module provides a class to send JPEG frames over UDP. It encodes the frames as JPEG images and splits them into chunks to fit within the maximum packet size for UDP transmission.
+This module provides a class to send JPEG frames over UDP. It encodes the frames as JPEG images
+and automatically reduces quality to fit within the maximum packet size for UDP transmission.
 """
 
 import socket
@@ -43,11 +44,20 @@ class UDPJPEGFrameSender:
         self.jpeg_quality = jpeg_quality
         self.min_jpeg_quality = min_jpeg_quality
 
-    def send_frame(self, frame: npt.NDArray[np.uint8], min_quality: int = 10) -> None:
-        frame_cvt = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
-        quality = 80
+    def send_frame(self, frame: npt.NDArray[np.uint8]) -> None:
+        """Send a frame as a JPEG image over UDP.
 
-        while quality >= min_quality:
+        Automatically reduces JPEG quality until the encoded frame fits
+        within max_packet_size.
+
+        Args:
+            frame (np.ndarray): The frame to be sent, in RGB format.
+
+        """
+        frame_cvt = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+        quality = self.jpeg_quality
+
+        while quality >= self.min_jpeg_quality:
             ret, jpeg_bytes = cv2.imencode(
                 ".jpg", frame_cvt, [int(cv2.IMWRITE_JPEG_QUALITY), quality]
             )


### PR DESCRIPTION
Fixes issue https://github.com/pollen-robotics/reachy_mini/issues/878.

macos limits udp datagrams to 9216 bytes by default, causing `OSError: [Errno 40] Message too long` when streaming camera frames from the mujoco sim.

Changes:
- `backend.py:` detect platform and use 640×360 on macos, 1280×720 on linux/windows
- `video_udp.py`: default `max_packet_size` to 8192, auto-reduce jpeg quality to fit

Let's test if it works and makes sense