### PR TITLE
Fix SSH hostname in quickstart docs

### DIFF
--- a/docs/source/SDK/quickstart.md
+++ b/docs/source/SDK/quickstart.md
@@ -18,7 +18,7 @@ If you want to run the SDK directly on your wireless Reachy Mini instead of remo
 Open a terminal and run:
 
 ```bash
-ssh pollen@reachy-mini
+ssh pollen@reachy-mini.local
 ```
 
 When prompted, use these **default credentials**:


### PR DESCRIPTION
## Summary

- Append `.local` suffix to SSH hostname in quickstart docs (`reachy-mini` → `reachy-mini.local`)

The Reachy Mini is discovered via mDNS, so the `.local` suffix is required for name resolution. Without it, `ssh pollen@reachy-mini` fails with `Could not resolve hostname`.

## Test plan

- [ ] Verify `ssh pollen@reachy-mini.local` resolves and connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)