### PR TITLE
Fix/volume control wireless

### DIFF
--- a/src/reachy_mini/daemon/app/routers/volume.py
+++ b/src/reachy_mini/daemon/app/routers/volume.py
@@ -10,7 +10,7 @@ This exposes:
 import logging
 from collections.abc import Callable
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from reachy_mini.daemon.app.dependencies import get_backend
@@ -86,14 +86,15 @@ async def get_volume() -> VolumeResponse:
 @router.post("/set")
 async def set_volume(
     volume_req: VolumeRequest,
-    backend: Backend = Depends(get_backend),
+    request: Request,
 ) -> VolumeResponse:
     """Set the output volume level and play a test sound."""
     vc = _get_volume_control()
     response = _write_volume(vc.set_output_volume, volume_req.volume, vc, vc.output_device.name, "Failed to set volume")
 
-    # Play test sound
-    if backend.audio:
+    daemon = getattr(request.app.state, "daemon", None)
+    backend: Backend | None = daemon.backend if daemon is not None else None
+    if backend is not None and backend.ready.is_set() and backend.audio:
         try:
             backend.audio.play_sound("impatient1.wav")
         except Exception as e:

--- a/src/reachy_mini/daemon/app/routers/volume_control_linux.py
+++ b/src/reachy_mini/daemon/app/routers/volume_control_linux.py
@@ -16,8 +16,10 @@ logger = logging.getLogger(__name__)
 
 try:
     import pulsectl
+    with pulsectl.Pulse("dummy"):
+        pass
     _PULSECTL_AVAILABLE = True
-except (ImportError, OSError):
+except (ImportError, OSError, pulsectl.PulseError):
     _PULSECTL_AVAILABLE = False
 
 # Constants
@@ -294,6 +296,7 @@ class VolumeControlLinux(VolumeControl):
                 text=True,
                 timeout=AUDIO_COMMAND_TIMEOUT,
                 check=True,
+                shell=True,
             )
         except (subprocess.TimeoutExpired, FileNotFoundError, subprocess.CalledProcessError) as e:
             logger.warning(f"Failed to initialize {device.id} device, amixer failed with error: {e}")
@@ -352,7 +355,7 @@ class VolumeControlLinux(VolumeControl):
         device: AudioDevice,
         controls: list[str] | None = None,
         index: int = 0,
-    ) -> list[str]:
+    ) -> str:
         """Build the amixer command to get the volume of a specific device and control.
 
         Args:
@@ -375,7 +378,7 @@ class VolumeControlLinux(VolumeControl):
             sub_commands.append(cmd)
 
         full_command = " || ".join(sub_commands)
-        return full_command.split(" ")
+        return full_command
 
     def _build_amixer_set_command(
         self,
@@ -383,7 +386,7 @@ class VolumeControlLinux(VolumeControl):
         volume: int,
         controls: list[str] | None = None,
         index: int = 0,
-    ) -> list[str]:
+    ) -> str:
         """Build the amixer command to set the volume of a specific device and control.
 
         Args:
@@ -409,7 +412,7 @@ class VolumeControlLinux(VolumeControl):
             sub_commands.append(cmd)
 
         full_command = " || ".join(sub_commands)
-        return full_command.split(" ")
+        return full_command
 
     def _alsa_get_device_volume(self, device: AudioDevice) -> int:
         """Get the volume of an audio device via amixer.
@@ -428,6 +431,7 @@ class VolumeControlLinux(VolumeControl):
                 text=True,
                 timeout=AUDIO_COMMAND_TIMEOUT,
                 check=True,
+                shell=True,
             )
             for line in result.stdout.splitlines():
                 # TODO: add support for other channels ?
@@ -461,6 +465,7 @@ class VolumeControlLinux(VolumeControl):
                 text=True,
                 timeout=AUDIO_COMMAND_TIMEOUT,
                 check=True,
+                shell=True,
             )
             return True
 


### PR DESCRIPTION
This PR fixes issues with audio volume control on the Wireless version :
- Defaults to `ALSA` instead of `pulsectl` when the import of `pulsectl` succeeds but the instantiation of a `Pulse` fails (happens when the daemon is run with `sudo`)
- Extend output volume control to the case when the daemon is off and no media backend is available (no sound is played)