### PR TITLE
Skip PulseAudio monitor sources in GStreamer audio device detection

### DIFF
--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -442,6 +442,10 @@ class GStreamerAudio(AudioBase):
                 device_props = device.get_properties()
 
                 if snd_card_name in name:
+                    # Skip monitor/loopback sources (e.g. "Monitor of Reachy Mini Audio")
+                    if device_props and device_props.has_field("device.class"):
+                        if device_props.get_string("device.class") == "monitor":
+                            continue
                     if device_props and device_props.has_field("node.name"):
                         node_name = device_props.get_string("node.name")
                         self.logger.debug(


### PR DESCRIPTION
## Root cause                                                                                                                                                                                      
GStreamerAudio._get_audio_device("Source") iterates through GStreamer's device monitor looking for
 a device whose display name contains "Reachy Mini Audio". On PulseAudio systems, there are two
matching source devices:                                                                          
                                                                                                  
1. "Monitor of Reachy Mini Audio Analog Stereo" -- a PulseAudio loopback/monitor source (captures
what the speaker plays, not the mic)                                                              
2. "Reachy Mini Audio Analog Stereo" -- the actual microphone                                     
                                                                                                  
The monitor device appears first in the list. It matches the name check at line 444, then falls   
through the detection logic:                                                                      
- No node.name field (PipeWire path fails)                                                        
- Not Windows, not macOS                                                                          
- Linux path: has udev.id but no device.profile.name, so the PulseAudio name construction at line 
482 (if udev_id and profile:) is skipped                                                          
- Falls to the final device.string fallback at line 491, which returns "3" (the bare ALSA card    
number)                                                                                           
                                                                                                  
The pipeline then does pulsesrc device="3", which is not a valid PulseAudio source identifier.    
PulseAudio accepts it silently but produces all-zero samples.                                     
                                                                                                  
The real mic device (second in the list) is never reached because the loop returns on the first   
match.                                                                                            
                                                                                                    
## Fix                                                                                               
Added a check at the top of the name-match block to skip devices with device.class == "monitor".           
