### PR TITLE
938 apps venv sync fails due to git lfs and uv

### DIFF
--- a/src/reachy_mini/utils/wireless_version/utils.py
+++ b/src/reachy_mini/utils/wireless_version/utils.py
@@ -90,7 +90,7 @@ def build_install_command(
         step3 = shlex.join(step3_args)
         cmd = f"{step1} && {step2} || {step3}"
         logger.info(f"Git ref install: {cmd}")
-        extra_env: dict[str, str] = {}
+        extra_env: dict[str, str] = {"GIT_LFS_SKIP_SMUDGE": "1"}
         return cmd, extra_env
 
     logger.info(f"Installing from PyPI: {version if version else 'latest pre-release' if pre_release else 'latest stable'}")


### PR DESCRIPTION
## Fix apps_venv sync failure on boot

The `check_and_sync_apps_venv_sdk()` startup check was silently failing, leaving apps_venv stuck on old reachy_mini versions (e.g. 1.2.10 with ZenohClient while daemon runs 1.5.0).

Two bugs in `build_install_command`:

**1. Git LFS blocks `uv pip install` from git refs**

`uv`'s internal git runner runs `git reset --hard` which triggers the LFS smudge filter. If any LFS object is missing or inaccessible on the remote, the entire install fails. Fix: set `GIT_LFS_SKIP_SMUDGE=1` since LFS files (mostly docs images) are not needed for pip installs.

Note: I also recovered and re-pushed the missing LFS blob (`docs/assets/all_motors_found.png`), but uv still fails to fetch it in my tests (note that AnneCha now reports that it works on her end after the LFS push, so I'm afraid there might be an obscure cache messing with me somewhere?).

**2. `--upgrade-strategy` is pip-only, not supported by `uv`**

Step 3 of the install chain (dependency upgrade fallback) used `--upgrade-strategy only-if-needed`, which `uv` rejects. This was a latent bug, step 3 only runs when step 1 fails. Fix: conditionally include the flag only when using pip, keeping the smarter upgrade behavior available for pip-based setups (we could also just drop the flag entirely but I choose to keep backwards compatibility for now)