### PR TITLE
Update doc to refer to Reachy Mini Control instead of dashboard

### DIFF
--- a/docs/assets/control-app-controller.png
+++ b/docs/assets/control-app-controller.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76e302b64607aefb3d57fe479ee8460dbad846a7ac07ed287c74766a8272748f
+size 646889

--- a/docs/assets/control-app-dashboard.png
+++ b/docs/assets/control-app-dashboard.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c318b6ce9a18d2a38ca9f0abdeb3d9662c6afd27cb42adc9e4facd0a0e08743
+size 811592

--- a/docs/assets/control-app-expressions.png
+++ b/docs/assets/control-app-expressions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1f79318cc6c13bd7ce7f5f194ba840a2346e67b8297f49ef77e608eb07bb412
+size 777238

--- a/docs/assets/control-app-external-daemon.png
+++ b/docs/assets/control-app-external-daemon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98dc7bf3fbed3ce104f58ed83943fdb91d4d44b753187aa89e02087b2a4a7815
+size 426593

--- a/docs/assets/control-app-settings.png
+++ b/docs/assets/control-app-settings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:014c0bde32a10e7a4714e8327cf8e75ac8daada8ddaf2037c0f4f88ba2bcd92b
+size 759276

--- a/docs/assets/control-app-testbench.png
+++ b/docs/assets/control-app-testbench.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6f8e49e01f5eaf5f41423c3092c35631259c8862e934a2da8828aa6917351a6
+size 578094

--- a/docs/assets/control-app-update.png
+++ b/docs/assets/control-app-update.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b54d0a5c7aeeb0aa711d9ed665205e6d28950c25c5d593735a870fd17439c0d7
+size 517656

--- a/docs/assets/first-setup-wifi-1.png
+++ b/docs/assets/first-setup-wifi-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68dae823e606b7a097324b169169162b54f7f4c9249064c3e2d25ec998197e95
+size 397869

--- a/docs/assets/first-setup-wifi-2.png
+++ b/docs/assets/first-setup-wifi-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a17f0022274045e5647111320b860a2d64929c05fc6829872d2ebdb4f474c012
+size 409568

--- a/docs/notebooks/0-First-Connection-and-Movement.ipynb
+++ b/docs/notebooks/0-First-Connection-and-Movement.ipynb
@@ -64,21 +64,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 2. Verify Connection\n",
-    "\n",
-    "Before running code, let's verify the robot is up and running.\n",
-    "\n",
-    "You should be able to access Reachy Mini's dashboard via a web browser. The dashboard is a web interface allowing you to run apps on the robot, turn it on /off, play emotions and manage its sound system. Depending on your version, you can access the dashboard at *http://reachy-mini.local:8000/* for the wireless version and *http://localhost:8000/* for the lite version. For the lite, if you're connecting remotely, replace `localhost` with the machine running the daemon's IP address.\n",
-    "\n",
-    "Once on the dashboard, you can check that the robot is ON with the on / off toggle button in the top right corner.\n",
-    "\n",
-    "**Make sure the robot is ON before proceeding! Especially with the wireless version, the dashboard is active at boot but the robot's code is OFF by default when the robot is powered on.**\n",
-    "\n",
-    "Refer to the [Connection and Dashboard section](https://huggingface.co/docs/reachy_mini/troubleshooting#-connection--dashboard) of the documentation for troubleshooting if you don't see the interface."
-   ]
+   "source": "---\n\n## 2. Verify Connection\n\nBefore running code, let's verify the robot is up and running.\n\nYou should use **Reachy Mini Control** to check that your robot is connected and ready. Reachy Mini Control is a desktop app that lets you manage your robot, run apps, play expressions, and control its sound system. Download it from the [official website](https://hf.co/reachy-mini/#/download) if you haven't already.\n\nOnce connected in Reachy Mini Control, make sure the robot is **ON**.\n\n**Make sure the robot is ON before proceeding! Especially with the wireless version, the robot's code is OFF by default when the robot is powered on.**\n\nRefer to the [Connection & Reachy Mini Control section](https://huggingface.co/docs/reachy_mini/troubleshooting#-connection--reachy-mini-control) of the documentation for troubleshooting."
   },
   {
    "cell_type": "markdown",

--- a/docs/notebooks/1-Basic-Media-Camera-and-Audio.ipynb
+++ b/docs/notebooks/1-Basic-Media-Camera-and-Audio.ipynb
@@ -553,20 +553,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "**Available volume endpoints:**\n",
-    "\n",
-    "| Endpoint | Method | Description |\n",
-    "|---|---|---|\n",
-    "| `/api/volume/current` | GET | Get current speaker volume (0-100) |\n",
-    "| `/api/volume/set` | POST | Set speaker volume (`{\"volume\": 75}`) |\n",
-    "| `/api/volume/microphone/current` | GET | Get current microphone volume |\n",
-    "| `/api/volume/microphone/set` | POST | Set microphone volume |\n",
-    "\n",
-    "You can also access these controls from the **dashboard** (the web interface at the same URL) using the volume slider.\n",
-    "\n",
-    "**Tip:** You can also explore all available API endpoints interactively at `http://{daemon-url}:8000/docs`."
-   ]
+   "source": "**Available volume endpoints:**\n\n| Endpoint | Method | Description |\n|---|---|---|\n| `/api/volume/current` | GET | Get current speaker volume (0-100) |\n| `/api/volume/set` | POST | Set speaker volume (`{\"volume\": 75}`) |\n| `/api/volume/microphone/current` | GET | Get current microphone volume |\n| `/api/volume/microphone/set` | POST | Set microphone volume |\n\nYou can also adjust the volume from **Reachy Mini Control**.\n\n**Tip:** You can also explore all available API endpoints interactively at `http://{daemon-url}:8000/docs`."
   },
   {
    "cell_type": "markdown",

--- a/docs/notebooks/README.md
+++ b/docs/notebooks/README.md
@@ -18,7 +18,8 @@ To run the notebooks, make sure that you have a python environment with Reachy M
 pip install notebook
 ```
 
-Also, you'll need to have Reachy Mini daemon's up and running by checking the [dashboard](https://huggingface.co/docs/reachy_mini/platforms/reachy_mini/usage#1-the-dashboard-), the robot is considered ready when the toggle in the top right corner is on.
+Also, you'll need to have Reachy Mini daemon's up and running by using Reachy Mini Control. Please refer to the [installation guide](https://huggingface.co/docs/reachy_mini/platforms/reachy_mini/usage#2-installation).
+
 
 <details>
 <summary><strong>In case <code>ipykernel</code> is asked to be installed</strong></summary>

--- a/docs/source/SDK/media-architecture.md
+++ b/docs/source/SDK/media-architecture.md
@@ -20,9 +20,9 @@ Thanks to webrtc, the audio and video streams can also be accessed directly from
 
 ## Reachy Mini Lite
 
-In the case of Reachy Mini Lite, the Daemon doesn't manage the camera, microphone, and speaker. It only plays a sound during startup and exit or if moves are triggered from the dashboard.
+In the case of Reachy Mini Lite, the Daemon doesn't manage the camera, microphone, and speaker. It only plays a sound during startup and exit or if moves are triggered from Reachy Mini Control.
 
-> **Note:** Sounddevice locks the audio card when playing a sound. Keep this in mind when you use the sound from the SDK and trigger a move from the dashboard.
+> **Note:** Sounddevice locks the audio card when playing a sound. Keep this in mind when you use the sound from the SDK and trigger a move from Reachy Mini Control.
 
 [![Reachy Mini Media Daemon](https://github.com/pollen-robotics/reachy_mini/raw/develop/docs/assets/reachyminilite_media_daemon.png)]()
 

--- a/docs/source/SDK/quickstart.md
+++ b/docs/source/SDK/quickstart.md
@@ -75,7 +75,7 @@ The **Daemon** is a background service that handles the low-level communication 
       ```
       > **⚠️ macOS Users:** `uv` may have compatibility issues with MuJoCo on macOS. If you encounter installation or runtime problems, it's recommended to use `pip` directly instead of `uv` for MuJoCo-related packages.
 
-✅ **Verification:** Open [http://localhost:8000](http://localhost:8000) in your browser. If you see the Reachy Dashboard, you are ready!
+✅ **Verification:** Open [http://localhost:8000/docs](http://localhost:8000/docs) in your browser. If you see the Reachy SDK API documentation, you are ready!
 
 ## 3. Your First Script
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -22,7 +22,7 @@
 
 ## 📱 Apps & Ecosystem
 
-Reachy Mini comes with an app store powered by Hugging Face Spaces. You can install these apps directly from your robot's dashboard with one click!
+Reachy Mini comes with an app store powered by Hugging Face Spaces. You can install these apps directly from Reachy Mini Control with one click!
 
 * **🗣️ [Conversation App](https://huggingface.co/spaces/pollen-robotics/reachy_mini_conversation_app):** Talk naturally with Reachy Mini (powered by LLMs).
 * **📻 [Radio](https://huggingface.co/spaces/pollen-robotics/reachy_mini_radio):** Listen to the radio with Reachy Mini !

--- a/docs/source/platforms/reachy_mini/development_workflow.md
+++ b/docs/source/platforms/reachy_mini/development_workflow.md
@@ -6,7 +6,7 @@ This guide covers efficient workflows for developing and testing code on the Wir
 
 - SSH access to your robot (`ssh pollen@reachy-mini.local`, password: `root`)
 - SSHFS installed on your computer (`sudo apt install sshfs` on Ubuntu/Debian)
-- Your robot's IP address (find it in the dashboard, router, or run `ifconfig` after SSH)
+- Your robot's IP address (find it in Reachy Mini Control, router, or run `ifconfig` after SSH)
 
 ## Quick Cross-Platform Options
 
@@ -81,7 +81,7 @@ fusermount -u ~/wireless_dev
 
 ## Approach B: Override Installed App Sources
 
-If you already installed an app via the dashboard and want to modify its source code directly by mounting your local files onto the robot.
+If you already installed an app via Reachy Mini Control and want to modify its source code directly by mounting your local files onto the robot.
 
 ### Step 1: Locate the installed app on the robot
 
@@ -109,7 +109,7 @@ Now edit files on your PC. Changes apply immediately when you restart the app.
 
 ## Approach C: Mount Local Source and Run Directly
 
-Similar to Approach B, but without using pip install or the dashboard. You mount your local source onto the robot and run the app directly.
+Similar to Approach B, but without using pip install or Reachy Mini Control. You mount your local source onto the robot and run the app directly.
 
 ### Step 1: Mount your local source onto the robot
 
@@ -130,7 +130,7 @@ cd /home/pollen/my_app_mount
 /venvs/apps_venv/bin/python main.py
 ```
 
-This approach is fast for testing, but you won't have the app registered in the dashboard.
+This approach is fast for testing, but you won't have the app registered in Reachy Mini Control.
 
 ## Installing a Specific Branch or Version
 

--- a/docs/source/platforms/reachy_mini/get_started.md
+++ b/docs/source/platforms/reachy_mini/get_started.md
@@ -22,24 +22,22 @@ Reachy Mini comes as a kit. Building it is the first step of your journey!
 Once assembled, you need to connect the robot to your Wi-Fi network.
 
 1.  **Power On:** Turn on your Reachy Mini.
-2.  **Connect to Reachy:** Wait a few moments. The robot will create a Wi-Fi network named **`reachy-mini-ap`**.
-    * **Password:** `reachy-mini`
-    * *Or scan the QR Code:*
-    
-    ![QR-Code reachy-mini-ap](https://github.com/pollen-robotics/reachy_mini/raw/develop/docs/assets/qrcode-ap.png)
-
-3.  **Configure Wi-Fi:**
-    * Open your browser and go to: **[http://reachy-mini.local:8000/settings](http://reachy-mini.local:8000/settings)**.
-    * Enter your local Wi-Fi credentials (SSID & Password) and click **"Connect"**.
-    * Wait a few moments for Reachy Mini to connect to your Wi-Fi network. The access point will disappear once connected. If the connection fails, Reachy Mini will restart the access point, and you can try again.
+2. **Download Reachy Mini Control:** If you haven't already, download and install the **Reachy Mini Control** app from the [official website](https://hf.co/reachy-mini/#/download).
+3. **Run the App:** Open **Reachy Mini Control** and click on the bottom link **"First time connecting..."**.
+![First time connecting](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/first-setup-wifi-1.png)
+4. **Follow the Instructions:** The app will guide you through the connection process. It will ask you to connect to the robot's Wi-Fi AP and then configure your Wi-Fi.
+![Configuring your WiFi](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/first-setup-wifi-2.png)
 
 ## 3. 🔄 Update System
 
 Before going further, it is highly recommended to update your robot to the latest version.
 
-1.  **Open Settings:** Go to **[http://reachy-mini.local:8000/settings](http://reachy-mini.local:8000/settings)**.
-2.  **Check for Updates:** Click the **"Check for updates"** button.
-3.  **Install:** If a new version is available, follow the on-screen instructions to install it.
+1. Connect to your robot using **Reachy Mini Control**.
+2. Once connected, click on the **"⚙️"** settings tab.
+![Settings Tab](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/control-app-settings.png)
+3. Go to the **System Updates** section.
+![System Update Section](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/control-app-update.png)
+4.  **Install:** If a new version is available, follow the on-screen instructions to install it.
 
 
 ## 4. 🕹️ Next Step: Using the Robot
@@ -47,7 +45,7 @@ Before going further, it is highly recommended to update your robot to the lates
 Now that your robot is online and up to date, you can start controlling it!
 
 👉 **[Go to the Usage Guide](usage.md)** to learn how to:
-* Access the **Dashboard**.
+* Use the **Reachy Mini Control**.
 * Install and run **Apps** (like Conversation or Games).
 * Program your Reachy with **Python**.
 

--- a/docs/source/platforms/reachy_mini/install_daemon_from_branch.md
+++ b/docs/source/platforms/reachy_mini/install_daemon_from_branch.md
@@ -5,8 +5,6 @@
 >
 > This guide explains how to install the Reachy Mini daemon from a specific GitHub branch before it is officially released. Use this for testing new features or bug fixes.
 
-> [!TIP]
-> Starting from v1.3.0, you can install a branch directly from _Settings → Reachy Mini Update_ in the web dashboard.
 
 ## Prerequisites
 

--- a/docs/source/platforms/reachy_mini/install_daemon_from_branch.md
+++ b/docs/source/platforms/reachy_mini/install_daemon_from_branch.md
@@ -16,7 +16,7 @@
 > [!NOTE]
 > This option is intended for active development and fast debugging cycles. It allows you to safely test changes without affecting the system-wide installation.
 >
-> ⚠️ Avoid installing dashboard apps with this option—any changes made to the local `reachy_mini` version won’t be propagated correctly.
+> ⚠️ Avoid installing apps with this option as any changes made to the local `reachy_mini` version won’t be propagated correctly.
 
 ### Steps:
 
@@ -57,7 +57,7 @@ Now you can modify the code in `~/reachy_mini` and test your changes without aff
 ## Option B: System-Wide Custom Installation
 
 > [!NOTE]
-> This option installs a branch build of reachy-mini as the system-wide daemon. It's better suited for thorough, end-to-end testing and supports seamless app installation from the dashboard.
+> This option installs a branch build of reachy-mini as the system-wide daemon. It's better suited for thorough, end-to-end testing and supports seamless app installation from Reachy Mini Control.
 
 ### Steps:
 

--- a/docs/source/platforms/reachy_mini/usage.md
+++ b/docs/source/platforms/reachy_mini/usage.md
@@ -1,27 +1,40 @@
 # Using Reachy Mini
 
-Now that your robot is connected, here is how to interact with it. You can control it visually using the **Dashboard** or programmatically using **Python**.
+Now that your robot is connected, here is how to interact with it. You can control it visually using **Reachy Mini Control** or programmatically using **Python**.
 
-## 1. The Dashboard 🕹️
+## 1. Reachy Mini Control 🕹️
 
-The Dashboard is the web interface running inside your robot. It allows you to check the robot's status, update the system, and manage applications.
+**Reachy Mini Control** is the desktop app for your robot. It allows you to check the robot's status, update the system, and manage applications.
 
-**Access:** Open [http://reachy-mini.local:8000/](http://reachy-mini.local:8000/) in your browser.
+**Download:** Get the latest version of **Reachy Mini Control** from the [official website](https://hf.co/reachy-mini/#/download).
+
+**Open Reachy Mini Control** and connect to your robot. Once connected, you will see real-time information about your robot.
+
+![Reachy Mini Control](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/control-app-dashboard.png)
 
 ### Features
-* **System Updates:** Always keep your robot up to date. Go to the *Settings* tab and click "Check for updates".
-* **Hardware Monitor:** Check battery level, motor temperatures, and disk usage.
-* **Network:** Configure Wi-Fi connections.
+
+* Control the **Head** and **Antennas** using the *Controller* tab.
+
+![Controller Tab](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/control-app-controller.png)
+
+* Play with **Expressions**: Make your robot happy, sad, angry, and more with the built-in expressions.
+
+![Expressions Tab](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/control-app-expressions.png)
+
+* In the *⚙️* tab, you can:
+    * **System Updates:** Always keep your robot up to date.
+    * **Network:** Configure Wi-Fi connections.
 
 ## 2. Applications 📱
 
 Reachy Mini can run "Apps" — autonomous behaviors packaged for the robot (like a Conversation demo, a Game, or a Dance).
 
 ### How to use Apps
-1.  **Browse:** Go to the *Apps* tab on the Dashboard.
-2.  **Install:** Click on the "Store" button to browse the [Hugging Face Spaces](https://huggingface.co/spaces?q=reachy_mini) ecosystem. You can install any compatible app with one click.
-3.  **Launch:** Click the "Play" ▶️ button on an installed app. The robot will start the behavior immediately.
-4.  **Stop:** Click the "Stop" ⏹️ button to kill the application.
+1.  **Browse:** Go to the *Applications* tab on Reachy Mini Control and click on "Discover Apps". This will open the Hugging Face Spaces ecosystem, where you can find compatible apps for your robot.
+2.  **Install:** Click on the "Install" button on an app to add it to your robot.
+3.  **Launch:** Click the "Start ▶️" button on an installed app. The robot will start the behavior immediately.
+4.  **Stop:** Click the "Stop" ⏹️ button to stop the application.
 
 > **Note:** When an App is running, it takes control of the robot. You cannot run Python scripts while an App is active.
 

--- a/docs/source/platforms/reachy_mini_lite/get_started.md
+++ b/docs/source/platforms/reachy_mini_lite/get_started.md
@@ -24,16 +24,15 @@ Reachy Mini comes as a kit. Building it is the first step of your journey!
 ## 3. 📥 Download Reachy Mini Control
 
 > [!WARNING]
-> **⚠️ Desktop App Compatibility:**
-> - **Windows users:** The Reachy Mini Control app for Windows is currently being finalized and will be available in a few days.
-> - **ARM64 systems (DGX, Jetson, etc.) and unusual Linux distributions:** The desktop app may not work on your system.
+> **⚠️ Reachy Mini Control Compatibility:**
+> - **ARM64 systems (DGX, Jetson, Surface etc.) and unusual Linux distributions:** The desktop app may not work on your system.
 >
 > **Alternative:** If the desktop app doesn't work on your setup, you can install and use the [Python SDK](../../SDK/readme.md) directly - it's a fully supported and valid way to control your robot!
 
-The **Reachy Mini Control** desktop app is the command center for your robot. It includes the dashboard, visualization tools, and app launcher—no command line required.
+The **Reachy Mini Control** desktop app is the command center for your robot. It includes visualization tools, an app launcher, and system settings—no command line required.
 
 <div align="center">
-  <a href="http://hf.co/reachy-mini/#/download">
+  <a href="https://hf.co/reachy-mini/#/download">
     <img src="https://huggingface.co/spaces/pollen-robotics/Reachy_Mini/resolve/main/public/assets/desktop-app-screenshot--white.png" width="600" alt="Reachy Mini Control App">
   </a>
 </div>
@@ -41,7 +40,7 @@ The **Reachy Mini Control** desktop app is the command center for your robot. It
 
 **Get the App:**
 
-* **👉 [Download from Official Website](http://hf.co/reachy-mini/#/download)** (Recommended for Windows, macOS, Linux)
+* **👉 [Download from Official Website](https://hf.co/reachy-mini/#/download)** (Recommended for Windows, macOS, Linux)
 * *Alternative:* [GitHub Releases](https://github.com/pollen-robotics/reachy-mini-desktop-app/releases) (For specific versions)
 
 > **✨ Auto-Update:** Once installed, simply open the app. It will automatically check for and install the latest updates for both the App and the Robot's internal software.

--- a/docs/source/platforms/reachy_mini_lite/usage.md
+++ b/docs/source/platforms/reachy_mini_lite/usage.md
@@ -1,12 +1,14 @@
 # Using Reachy Mini Lite
 
-The Lite version relies on your computer to run its intelligence. The central hub for this is the **Reachy Mini Control** application.
+Now that your robot is connected, here is how to interact with it. You can control it visually using **Reachy Mini Control** or programmatically using **Python**.
 
-Check [this guide](./get_started.md) if you have not installed it yet.
+Check [this guide](./get_started.md) if you have not installed the app yet.
 
-## 1. Reachy Mini Control (Dashboard) 🖥️
+## 1. Reachy Mini Control 🖥️
 
-When you open the application, you access the complete control panel for your robot.
+**Reachy Mini Control** is the desktop app for your robot. It allows you to check the robot's status, update the system, and manage applications.
+
+Open **Reachy Mini Control** and connect your robot via USB. Once connected, you will see real-time information about your robot.
 
 * **Status & Visualizer (Left Panel):**
     * **3D View:** Shows the real-time position of the robot.
@@ -14,24 +16,29 @@ When you open the application, you access the complete control panel for your ro
     * **Sensors:** Monitor the microphone input and speaker volume.
     * **Logs:** See technical details and connection events at the bottom.
 
-## 2. Applications & Demos 📱
+### Features
 
-You don't need to code to start having fun. The app comes with an integrated ecosystem.
+* Control the **Head** and **Antennas** using the *Controller* tab.
 
-### Quick Actions
-Located at the bottom right, these are built-in demos ready to launch instantly:
-* **Expressions:** Make Reachy express emotions (Happy, Sad, Angry, etc.).
-* **Controller:** Teleoperate the robot using a game controller or sliders. 
+![Controller Tab](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/control-app-controller.png)
 
-### Installing New Apps
-To extend Reachy's capabilities with community-created behaviors:
-1.  **Discover:** Click the **"Discover apps"** button. This opens the Hugging Face Spaces store.
-2.  **Install:** Select an app (like a Game or a Conversation demo) and click "Install".
-3.  **Play:** Once installed, the app will appear in your "Applications" list. Simply click **"Play"** to start it.
+* Play with **Expressions**: Make your robot happy, sad, angry, and more with the built-in expressions.
 
-> **Note:** When an App is running, it controls the robot. Stop the app before trying to run your own Python scripts.
+![Expressions Tab](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/control-app-expressions.png)
 
-## 3. Coding with Python 🐍
+## 2. Applications 📱
+
+Reachy Mini can run "Apps" — autonomous behaviors packaged for the robot (like a Conversation demo, a Game, or a Dance).
+
+### How to use Apps
+1.  **Browse:** Go to the *Applications* tab on Reachy Mini Control and click on "Discover Apps". This will open the Hugging Face Spaces ecosystem, where you can find compatible apps for your robot.
+2.  **Install:** Click on the "Install" button on an app to add it to your robot.
+3.  **Launch:** Click the "Start ▶️" button on an installed app. The robot will start the behavior immediately.
+4.  **Stop:** Click the "Stop" ⏹️ button to stop the application.
+
+> **Note:** When an App is running, it takes control of the robot. You cannot run Python scripts while an App is active.
+
+## 3. Coding Quickstart 🐍
 
 Ready to write your own logic? Reachy Mini is controlled via a simple Python SDK.
 

--- a/docs/source/platforms/simulation/get_started.md
+++ b/docs/source/platforms/simulation/get_started.md
@@ -38,9 +38,11 @@ mjpython -m reachy_mini.daemon.app.main --sim
 
 > **⚠️ macOS Users:** `uv` may have compatibility issues with MuJoCo on macOS. If you encounter installation or runtime problems, it's recommended to use `pip` directly instead of `uv` for MuJoCo-related packages.
 
-## 3. Dashboard and Apps
+## 3. Reachy Mini Control and Apps
 
-You can access the Dashboard at **[http://localhost:8000](http://localhost:8000)**.
+You can use **Reachy Mini Control** to interact with the simulated robot. Simply open the app and connect to the local simulation.
+
+![Control App with local daemon](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/control-app-external-daemon.png)
 
 * **Apps:** You can install and run Apps! They will execute inside the simulation (e.g., the robot will move in the 3D viewer).
 

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -14,15 +14,12 @@ To restart your robot, press OFF, wait 5 seconds, then press ON. This simple pro
 
 **How to update the software:**
 
-- **If you are using the dashboard in a web browser**  
-  Open `Settings`, then click **Check for updates**.  
-  ![Update](https://github.com/pollen-robotics/reachy_mini/raw/develop/docs/assets/update.png)
-- **If you are using the new dashboard/app**  
-  Since 0.8.5 of the app, 
+- **If you are using Reachy Mini Control**
+  From the "⚙️" settings tab, "Check for updates". If an update is available, click on "Update now".
 - **If you are using a cloned repository**  
   Make sure you are either:
   - On the latest tagged release, or
-  - Up to date with the `develop` branch (`git pull`).
+  - Up to date with the `main` branch (`git pull`).
 
 **Wireless Reachy Mini**: run `reachyminios_check` to make sure everything is fine (see [Get Started](./platforms/reachy_mini/get_started.md))  
 
@@ -171,7 +168,7 @@ Wireless units do not expose the robot over USB the way the Lite version does, s
 Instead:
 
 - Join the robot to your Wi-Fi network and use the SDK client on your laptop to control it remotely.
-- If you want to run code directly on the embedded Raspberry Pi, SSH in and execute your scripts there (this is what the Dashboard does after you publish/install an app).
+- If you want to run code directly on the embedded Raspberry Pi, SSH in and execute your scripts there (this is what Reachy Mini Control does after you publish/install an app).
 - For a tethered link, use a USB-C-to-Ethernet adapter plus an Ethernet cable—this simply replaces Wi-Fi with wired Ethernet.
 
 </details>
@@ -238,7 +235,7 @@ You do not need to install them.
 
 
 
-## 🔌 Connection & Dashboard
+## 🔌 Connection & Reachy Mini Control
 
 <details>
 <summary><strong>How do I connect the robot to Wi-Fi?</strong></summary>
@@ -251,33 +248,6 @@ See the [Reachy Mini Wireless guide](./platforms/reachy_mini/get_started.md) for
 <summary><strong>How do I reset the Wi-Fi hotspot?</strong></summary>
 
 If you need to reset the robot's Wi-Fi hotspot (for example, if you can't connect or want to change the network), follow the instructions in the [Wi-Fi Reset Guide](./platforms/reachy_mini/reset.md).
-
-</details>
-
-<details>
-<summary><strong>The dashboard at http://localhost:8000 doesn't work.</strong></summary>
-
-1. **Check browser permissions**: Ensure your browser can access local networks.  On _macOS_, these permissions are found in System Settings → Privacy & Security → Local Network.
-
-2. **For Wireless Reachy Mini**: Ensure both your computer and the robot are connected to the **same network**, then verify connectivity by running the following command in your terminal:
-```bash
-ping reachy-mini
-```
-
-3. **For Lite Reachy Mini**: Perform these checks.
-- _Virtual Environment:_ Ensure you are running inside your virtual environment (`.venv`, `reachy_mini_env`,...).
-- _SDK Update:_ Ensure you have the latest version.
-
-With `pip`, run :
-```bash
-pip install -U reachy-mini
-```
-With `uv`, run :
-```bash
-uv pip install -U reachy-mini
-```
-
-- _Daemon:_ Make sure the daemon `reachy-mini-daemon` is running in a terminal.
 
 </details>
 
@@ -512,9 +482,9 @@ Check the [Hugging Face Tutorial](https://huggingface.co/blog/pollen-robotics/ma
 
 </details>
 
-<details><summary><strong>Is installing apps directly from the dashboard supported?</strong></summary>
+<details><summary><strong>Is installing apps directly from Reachy Mini Control supported?</strong></summary>
 
-Sure! You can install apps directly from your Dashboard if they’re native, or add them to your favourites if they’re web-based.
+Sure! You can install apps directly from Reachy Mini Control if they’re native, or add them to your favourites if they’re web-based.
 
 </details>
 
@@ -551,7 +521,7 @@ Yes, via MuJoCo. It is still a work in progress, but you can run code with the `
 <details>
 <summary><strong>How do I debug an app on the Wireless?</strong></summary>
 
-SSH into the embedded computer, clone (or copy) your app, and run it manually. This reproduces what the dashboard does when launching your app.
+SSH into the embedded computer, clone (or copy) your app, and run it manually. This reproduces what Reachy Mini Control does when launching your app.
 
 ```bash
 ssh pollen@reachy-mini.local
@@ -620,7 +590,7 @@ You can check that the motor control loop runs correctly by checking the daemon 
 mini = ReachyMini()
 print(mini.client.get_status())
 ```
-- via the dashboard API at `http://localhost:8000/docs` on a lite and `http://reachy-mini.local:8000/docs` for the wireless (look for `/api/daemon/status` endpoint)
+- via the REST API at `http://localhost:8000/docs` on a Lite and `http://reachy-mini.local:8000/docs` for the Wireless (look for `/api/daemon/status` endpoint)
 
 You should see values around 50Hz (~20ms period): 
 ```python

--- a/docs/source/troubleshooting/motors_diagnosis.md
+++ b/docs/source/troubleshooting/motors_diagnosis.md
@@ -4,27 +4,10 @@ This document provides a guide to diagnose and troubleshoot common issues relate
 
 ## Reachy Mini Testbench app
 To help diagnose motor issues, we have developed the [Reachy Mini Testbench app](https://huggingface.co/spaces/pollen-robotics/reachy_mini_testbench). This app allows you to test individual motors, check their status, and identify potential problems.
-You need to install this app on the robot before using it. If you have a lite version, you will need to run the daemon without autostart in a terminal and access the dashboard, as explained below:
-<details>
-<summary>Instructions for Lite version</summary>
 
-- _Virtual Environment:_ Ensure you are running inside your virtual environment (`.venv`, `reachy_mini_env`,...).
-- _SDK Update:_ Ensure you have the latest version.
-    With `pip`, run :
-    ```bash
-    pip install -U reachy-mini
-    ```
-    With `uv`, run :
-    ```bash
-    uv pip install -U reachy-mini
-    ```
+You need to install this app using Reachy Mini Control before using it (refer to the [installation guide](https://huggingface.co/docs/reachy_mini/platforms/reachy_mini/usage#2-installation)).
 
-- _Daemon:_ Run the daemon `reachy-mini-daemon --no-autostart`
-- _Access Dashboard:_ Open your web browser and go to `http://localhost:8000/`.  
-There, you can find the Testbench app in the "Apps" section, install it then run it.
-
-
-</details>
+![Reachy Mini Testbench app](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/control-app-testbench.png)
 
 ## Motors typical troubleshooting process
 If you have any of the following symptoms, please follow the diagnosis steps below.


### PR DESCRIPTION
Note for reviewers, links to images are broken until merged in main.