### PR TITLE
Offset default antenna position by 10° to reduce shaking

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -713,6 +713,7 @@ class Backend:
         1.0032234352772091,
     ]
 
+    INIT_ANTENNAS_JOINT_POSITIONS = np.array((-0.1745, 0.1745))  # ~10° offset to reduce shaking at vertical
     SLEEP_ANTENNAS_JOINT_POSITIONS = np.array((-3.05, 3.05))
     SLEEP_HEAD_POSE = np.array(
         [
@@ -733,7 +734,7 @@ class Backend:
 
         await self.goto_target(
             self.INIT_HEAD_POSE,
-            antennas=np.array((0.0, 0.0)),
+            antennas=self.INIT_ANTENNAS_JOINT_POSITIONS,
             duration=magic_distance * 20 / 1000,  # ms_per_magic_mm = 10
         )
         await asyncio.sleep(0.1)
@@ -773,7 +774,7 @@ class Backend:
             if dist_to_init_pose > 30:
                 # Move to the initial position
                 await self.goto_target(
-                    self.INIT_HEAD_POSE, antennas=np.array((0.0, 0.0)), duration=1
+                    self.INIT_HEAD_POSE, antennas=self.INIT_ANTENNAS_JOINT_POSITIONS, duration=1
                 )
                 await asyncio.sleep(0.2)
 

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -50,6 +50,7 @@ SLEEP_HEAD_JOINT_POSITIONS = [
 ]
 
 
+INIT_ANTENNAS_JOINT_POSITIONS = [-0.1745, 0.1745]  # ~10° offset to reduce shaking at vertical
 SLEEP_ANTENNAS_JOINT_POSITIONS = [-3.05, 3.05]
 SLEEP_HEAD_POSE = np.array(
     [
@@ -471,7 +472,7 @@ class ReachyMini:
 
     def wake_up(self) -> None:
         """Wake up the robot - go to the initial head position and play the wake up emote and sound."""
-        self.goto_target(INIT_HEAD_POSE, antennas=[0.0, 0.0], duration=2)
+        self.goto_target(INIT_HEAD_POSE, antennas=INIT_ANTENNAS_JOINT_POSITIONS, duration=2)
         time.sleep(0.1)
 
         # Toudoum
@@ -503,7 +504,7 @@ class ReachyMini:
         ]
         dist = np.linalg.norm(np.array(current_positions) - np.array(init_positions))
         if dist > 0.2:
-            self.goto_target(INIT_HEAD_POSE, antennas=[0.0, 0.0], duration=1)
+            self.goto_target(INIT_HEAD_POSE, antennas=INIT_ANTENNAS_JOINT_POSITIONS, duration=1)
             time.sleep(0.2)
 
         # Pfiou


### PR DESCRIPTION
Problem:
Antennas at 0° sit in an unstable equilibrum position (think inverted pendulum).
This + gearbox backlash causes oscillation. 

Solution:
We've not been able to find PID values that work for all robots, as tiny friction differences between units are enough to make the vibration appear or not.

Instead, shifting rest position to ±10° lets gravity bias the gears and dampen shaking. Also it's cuter like this imo :)