### PR TITLE
fix: keep bus watch active on transient errors, and add startup wait

### DIFF
--- a/src/reachy_mini/media/camera_gstreamer.py
+++ b/src/reachy_mini/media/camera_gstreamer.py
@@ -213,8 +213,14 @@ class GStreamerCamera(CameraBase):
 
         elif t == Gst.MessageType.ERROR:
             err, debug = msg.parse_error()
-            self.logger.error(f"Error: {err} {debug}")
-            return False
+            self.logger.warning(
+                f"GStreamer pipeline error (domain={err.domain}, code={err.code}): {err.message}"
+            )
+            self.logger.debug(f"GStreamer error debug info: {debug}")
+            # Keep the bus watch active — some errors are transient and the pipeline
+            # will self-recover. Fatal errors should be handled by inspecting
+            # err.domain and err.code.
+            return True
 
         return True
 
@@ -257,7 +263,15 @@ class GStreamerCamera(CameraBase):
         self._thread_bus_calls = Thread(target=self._handle_bus_calls, daemon=True)
         self._thread_bus_calls.start()
         GLib.timeout_add_seconds(5, self._dump_latency)
-        # TODO: Add a small loop to wait for the frames to be ready after restarting the pipeline
+        # Best-effort wait for the first frame before returning, so callers can
+        # read immediately without getting None.
+        deadline = time.monotonic() + 2.0
+        try:
+            while time.monotonic() < deadline:
+                if self._appsink_video.emit("try-pull-sample", 100_000_000) is not None:
+                    break
+        except Exception:
+            pass
 
     def _get_sample(self, appsink: GstApp.AppSink) -> Optional[bytes]:
         sample = appsink.try_pull_sample(20_000_000)


### PR DESCRIPTION
### Summary
Two small improvements to GStreamerCamera in camera_gstreamer.py:

#### Change 1. Bus watch now survives transient pipeline errors
GStreamer expects a continuous message channel for the lifetime of the pipeline. An ERROR message does not automatically mean “stop listening”. It just means “something went wrong” and the application is expected to decide what to do.  

**PROBLEM: `_on_bus_message` previously returned False on _any_ ERROR message**, 
permanently removing the bus watch after first error. Transient errors (e.g. buffer allocation failure during v4l2src startup) self-recover without intervention, but the bus watch was being torn down before recovery could happen, silently dropping all subsequent bus events including EOS and future errors.  

**SOLUTION: Return True on ERROR, keeping the bus watch active for the pipeline lifetime.**   
Error logging is improved to include domain and code for easier triage. Additional error details can be identified by inspecting these fields.

#### Change 2. open() waits for first frame before returning
Bonus: Replaced the existing TODO comment with a best-effort 2-second wait for the first frame after setting the pipeline to PLAYING. This ensures callers can read frames immediately without receiving None on the first call. 
Non-blocking; if no frame arrives within 2 seconds, open() returns normally.

**Changes were tested against v1.5.1 and conversation app**  
The transient buffer allocation error that previously triggered bus watch teardown is now handled gracefully.