### PR TITLE
Expose authenticated private Hugging Face Spaces in the daemon catalog

### DIFF
--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -49,16 +49,9 @@ class RunningApp:
 
 
 def _get_catalog_app_key(app: AppInfo) -> str:
-    """Build a stable key for deduplicating catalog entries."""
-    for key in ("id", "repo_id", "repoId", "space_id", "spaceId", "app_id", "appId"):
-        value = app.extra.get(key)
-        if isinstance(value, str) and value:
-            return value
-
-    if app.url:
-        return app.url
-
-    return app.name
+    """Return the Hugging Face space id used to deduplicate catalog entries."""
+    value = app.extra.get("id")
+    return value if isinstance(value, str) else ""
 
 
 class AppManager:
@@ -338,8 +331,11 @@ class AppManager:
         catalog_apps: list[AppInfo] = []
         seen_catalog_apps: set[str] = set()
 
-        for app in [*hf_space_apps, *dashboard_selection_apps]:
+        for app in [*dashboard_selection_apps, *hf_space_apps]:
             app_key = _get_catalog_app_key(app)
+            if not app_key:
+                catalog_apps.append(app)
+                continue
             if app_key in seen_catalog_apps:
                 continue
             seen_catalog_apps.add(app_key)

--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -48,6 +48,19 @@ class RunningApp:
     status: AppStatus
 
 
+def _get_catalog_app_key(app: AppInfo) -> str:
+    """Build a stable key for deduplicating catalog entries."""
+    for key in ("id", "repo_id", "repoId", "space_id", "spaceId", "app_id", "appId"):
+        value = app.extra.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    if app.url:
+        return app.url
+
+    return app.name
+
+
 class AppManager:
     """Manager for Reachy Mini apps."""
 
@@ -284,11 +297,25 @@ class AppManager:
 
     # Apps management interface
     async def list_all_available_apps(self) -> list[AppInfo]:
-        """List available apps (parallel async)."""
+        """List available apps while preserving curated-only entries."""
         results = await asyncio.gather(
-            *[self.list_available_apps(kind) for kind in SourceKind]
+            self.list_available_apps(SourceKind.HF_SPACE),
+            self.list_available_apps(SourceKind.DASHBOARD_SELECTION),
+            self.list_available_apps(SourceKind.LOCAL),
+            self.list_available_apps(SourceKind.INSTALLED),
         )
-        return sum(results, [])
+
+        catalog_apps: list[AppInfo] = []
+        seen_catalog_apps: set[str] = set()
+
+        for app in [*results[0], *results[1]]:
+            app_key = _get_catalog_app_key(app)
+            if app_key in seen_catalog_apps:
+                continue
+            seen_catalog_apps.add(app_key)
+            catalog_apps.append(app)
+
+        return [*catalog_apps, *results[2], *results[3]]
 
     async def list_available_apps(self, source: SourceKind) -> list[AppInfo]:
         """List available apps for given source kind."""

--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -334,7 +334,6 @@ class AppManager:
         for app in [*dashboard_selection_apps, *hf_space_apps]:
             app_key = _get_catalog_app_key(app)
             if not app_key:
-                catalog_apps.append(app)
                 continue
             if app_key in seen_catalog_apps:
                 continue

--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -298,7 +298,12 @@ class AppManager:
     # Apps management interface
     async def list_all_available_apps(self) -> list[AppInfo]:
         """List available apps while preserving curated-only entries."""
-        results = await asyncio.gather(
+        (
+            hf_space_apps,
+            dashboard_selection_apps,
+            local_apps,
+            installed_apps,
+        ) = await asyncio.gather(
             self.list_available_apps(SourceKind.HF_SPACE),
             self.list_available_apps(SourceKind.DASHBOARD_SELECTION),
             self.list_available_apps(SourceKind.LOCAL),
@@ -308,14 +313,14 @@ class AppManager:
         catalog_apps: list[AppInfo] = []
         seen_catalog_apps: set[str] = set()
 
-        for app in [*results[0], *results[1]]:
+        for app in [*hf_space_apps, *dashboard_selection_apps]:
             app_key = _get_catalog_app_key(app)
             if app_key in seen_catalog_apps:
                 continue
             seen_catalog_apps.add(app_key)
             catalog_apps.append(app)
 
-        return [*catalog_apps, *results[2], *results[3]]
+        return [*catalog_apps, *local_apps, *installed_apps]
 
     async def list_available_apps(self, source: SourceKind) -> list[AppInfo]:
         """List available apps for given source kind."""

--- a/src/reachy_mini/apps/sources/hf_space.py
+++ b/src/reachy_mini/apps/sources/hf_space.py
@@ -2,18 +2,76 @@
 
 import asyncio
 import json
+import logging
 from typing import Any, Dict
 
 import aiohttp
+from huggingface_hub import HfApi
 
 from .. import AppInfo, SourceKind
+from . import hf_auth
 
 # Constants
 AUTHORIZED_APP_LIST_URL = "https://huggingface.co/datasets/pollen-robotics/reachy-mini-official-app-store/raw/main/app-list.json"
 HF_SPACES_API_URL = "https://huggingface.co/api/spaces"
 # TODO look for js apps too (reachy_mini_js_app)
-HF_SPACES_FILTER_URL = "https://huggingface.co/api/spaces?filter=reachy_mini_python_app&sort=likes&direction=-1&limit=500&full=true"
+HF_SPACES_FILTER = "reachy_mini_python_app"
+HF_SPACES_FILTER_URL = f"https://huggingface.co/api/spaces?filter={HF_SPACES_FILTER}&sort=likes&direction=-1&limit=500&full=true"
+HF_SPACES_LIMIT = 500
 REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30)
+logger = logging.getLogger("reachy_mini.apps.sources.hf_space")
+
+
+def _normalize_space_data(space_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize HF API responses to the shape used by the app store."""
+    normalized = dict(space_data)
+
+    created_at = normalized.get("createdAt") or normalized.get("created_at")
+    if created_at is not None:
+        normalized["createdAt"] = created_at
+
+    last_modified = normalized.get("lastModified") or normalized.get("last_modified")
+    if last_modified is not None:
+        normalized["lastModified"] = last_modified
+
+    card_data = normalized.get("cardData") or normalized.get("card_data")
+    if card_data is not None:
+        normalized["cardData"] = card_data
+
+    return normalized
+
+
+def _build_app_info(item: Dict[str, Any]) -> AppInfo | None:
+    """Build AppInfo from a normalized Hugging Face Space payload."""
+    if item is None or "id" not in item:
+        return None
+
+    item = _normalize_space_data(item)
+
+    return AppInfo(
+        name=item["id"].split("/")[-1],
+        description=item.get("cardData", {}).get("short_description", ""),
+        url=f"https://huggingface.co/spaces/{item['id']}",
+        source_kind=SourceKind.HF_SPACE,
+        extra=item,
+    )
+
+
+def _list_all_spaces_with_hf_api(token: str) -> list[Dict[str, Any]]:
+    """List spaces with Hugging Face Hub API using the stored token."""
+    api = HfApi(token=token)
+    spaces = api.list_spaces(
+        filter=HF_SPACES_FILTER,
+        sort="likes",
+        limit=HF_SPACES_LIMIT,
+        full=True,
+        token=token,
+    )
+    return [
+        _normalize_space_data(space.__dict__)
+        for space in spaces
+        if getattr(space, "id", None)
+    ]
 
 
 async def _fetch_space_data(
@@ -59,24 +117,28 @@ async def list_available_apps() -> list[AppInfo]:
         # Build AppInfo list from fetched data
         apps = []
         for item in spaces_data:
-            if item is None or "id" not in item:
-                continue
-
-            apps.append(
-                AppInfo(
-                    name=item["id"].split("/")[-1],
-                    description=item.get("cardData", {}).get("short_description", ""),
-                    url=f"https://huggingface.co/spaces/{item['id']}",
-                    source_kind=SourceKind.HF_SPACE,
-                    extra=item,
-                )
-            )
+            app_info = _build_app_info(item)
+            if app_info is not None:
+                apps.append(app_info)
 
         return apps
 
 
 async def list_all_apps() -> list[AppInfo]:
-    """List all apps available on Hugging Face Spaces (including unofficial ones)."""
+    """List all apps available on Hugging Face Spaces (including private ones when authenticated)."""
+    token = hf_auth.get_hf_token()
+    if token:
+        try:
+            data = await asyncio.to_thread(_list_all_spaces_with_hf_api, token)
+            apps = []
+            for item in data:
+                app_info = _build_app_info(item)
+                if app_info is not None:
+                    apps.append(app_info)
+            return apps
+        except Exception as exc:
+            logger.warning("Falling back to the public HF catalog: %s", exc)
+
     async with aiohttp.ClientSession(timeout=REQUEST_TIMEOUT) as session:
         try:
             async with session.get(HF_SPACES_FILTER_URL) as response:
@@ -90,17 +152,8 @@ async def list_all_apps() -> list[AppInfo]:
 
         apps = []
         for item in data:
-            if item is None or "id" not in item:
-                continue
-
-            apps.append(
-                AppInfo(
-                    name=item["id"].split("/")[-1],
-                    description=item.get("cardData", {}).get("short_description", ""),
-                    url=f"https://huggingface.co/spaces/{item['id']}",
-                    source_kind=SourceKind.HF_SPACE,
-                    extra=item,
-                )
-            )
+            app_info = _build_app_info(item)
+            if app_info is not None:
+                apps.append(app_info)
 
         return apps

--- a/src/reachy_mini/apps/sources/hf_space.py
+++ b/src/reachy_mini/apps/sources/hf_space.py
@@ -3,7 +3,6 @@
 import asyncio
 import json
 import logging
-from typing import Any, Dict
 
 import aiohttp
 from huggingface_hub import HfApi
@@ -20,9 +19,42 @@ HF_SPACES_FILTER_URL = f"https://huggingface.co/api/spaces?filter={HF_SPACES_FIL
 HF_SPACES_LIMIT = 500
 REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30)
 logger = logging.getLogger("reachy_mini.apps.sources.hf_space")
+SpaceData = dict[str, object]
 
 
-def _normalize_space_data(space_data: Dict[str, Any]) -> Dict[str, Any]:
+def _coerce_space_data(value: object) -> SpaceData | None:
+    """Return a string-keyed dict for space payloads."""
+    if not isinstance(value, dict):
+        return None
+    return {str(key): item for key, item in value.items()}
+
+
+def _coerce_space_list(value: object) -> list[SpaceData]:
+    """Return only dict-shaped items from a raw HF payload."""
+    if not isinstance(value, list):
+        return []
+
+    spaces: list[SpaceData] = []
+    for item in value:
+        space_data = _coerce_space_data(item)
+        if space_data is not None:
+            spaces.append(space_data)
+    return spaces
+
+
+def _get_string(item: SpaceData, key: str) -> str | None:
+    """Read a string field from a space payload."""
+    value = item.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _get_card_data(item: SpaceData) -> SpaceData:
+    """Read card data from a space payload."""
+    card_data = item.get("cardData")
+    return card_data if isinstance(card_data, dict) else {}
+
+
+def _normalize_space_data(space_data: SpaceData) -> SpaceData:
     """Normalize HF API responses to the shape used by the app store."""
     normalized = dict(space_data)
 
@@ -41,23 +73,28 @@ def _normalize_space_data(space_data: Dict[str, Any]) -> Dict[str, Any]:
     return normalized
 
 
-def _build_app_info(item: Dict[str, Any]) -> AppInfo | None:
+def _build_app_info(item: SpaceData | None) -> AppInfo | None:
     """Build AppInfo from a normalized Hugging Face Space payload."""
-    if item is None or "id" not in item:
+    if item is None:
         return None
 
     item = _normalize_space_data(item)
+    space_id = _get_string(item, "id")
+    if space_id is None:
+        return None
+    card_data = _get_card_data(item)
+    short_description = _get_string(card_data, "short_description") or ""
 
     return AppInfo(
-        name=item["id"].split("/")[-1],
-        description=item.get("cardData", {}).get("short_description", ""),
-        url=f"https://huggingface.co/spaces/{item['id']}",
+        name=space_id.split("/")[-1],
+        description=short_description,
+        url=f"https://huggingface.co/spaces/{space_id}",
         source_kind=SourceKind.HF_SPACE,
         extra=item,
     )
 
 
-def _list_all_spaces_with_hf_api(token: str) -> list[Dict[str, Any]]:
+def _list_all_spaces_with_hf_api(token: str) -> list[SpaceData]:
     """List spaces with Hugging Face Hub API using the stored token."""
     api = HfApi(token=token)
     spaces = api.list_spaces(
@@ -67,23 +104,24 @@ def _list_all_spaces_with_hf_api(token: str) -> list[Dict[str, Any]]:
         full=True,
         token=token,
     )
-    return [
-        _normalize_space_data(space.__dict__)
-        for space in spaces
-        if getattr(space, "id", None)
-    ]
+    payloads: list[SpaceData] = []
+    for space in spaces:
+        space_data = _coerce_space_data(space.__dict__)
+        if space_data is None or _get_string(space_data, "id") is None:
+            continue
+        payloads.append(_normalize_space_data(space_data))
+    return payloads
 
 
 async def _fetch_space_data(
     session: aiohttp.ClientSession, space_id: str
-) -> Dict[str, Any] | None:
+) -> SpaceData | None:
     """Fetch data for a single space from Hugging Face API."""
     url = f"{HF_SPACES_API_URL}/{space_id}"
     try:
         async with session.get(url, timeout=REQUEST_TIMEOUT) as response:
             if response.status == 200:
-                data: Dict[str, Any] = await response.json()
-                return data
+                return _coerce_space_data(await response.json())
             else:
                 return None
     except (aiohttp.ClientError, asyncio.TimeoutError):
@@ -143,15 +181,12 @@ async def list_all_apps() -> list[AppInfo]:
         try:
             async with session.get(HF_SPACES_FILTER_URL) as response:
                 response.raise_for_status()
-                data: list[Dict[str, Any]] = await response.json()
+                public_data = _coerce_space_list(await response.json())
         except (aiohttp.ClientError, json.JSONDecodeError, asyncio.TimeoutError):
             return []
 
-        if not isinstance(data, list):
-            return []
-
         apps = []
-        for item in data:
+        for item in public_data:
             app_info = _build_app_info(item)
             if app_info is not None:
                 apps.append(app_info)

--- a/src/reachy_mini/apps/sources/hf_space.py
+++ b/src/reachy_mini/apps/sources/hf_space.py
@@ -15,7 +15,6 @@ AUTHORIZED_APP_LIST_URL = "https://huggingface.co/datasets/pollen-robotics/reach
 HF_SPACES_API_URL = "https://huggingface.co/api/spaces"
 # TODO look for js apps too (reachy_mini_js_app)
 HF_SPACES_FILTER = "reachy_mini_python_app"
-HF_SPACES_FILTER_URL = f"https://huggingface.co/api/spaces?filter={HF_SPACES_FILTER}&sort=likes&direction=-1&limit=500&full=true"
 HF_SPACES_LIMIT = 500
 REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30)
 logger = logging.getLogger("reachy_mini.apps.sources.hf_space")
@@ -58,16 +57,16 @@ def _normalize_space_data(space_data: SpaceData) -> SpaceData:
     """Normalize HF API responses to the shape used by the app store."""
     normalized = dict(space_data)
 
-    created_at = normalized.get("createdAt") or normalized.get("created_at")
-    if created_at is not None:
+    created_at = normalized.pop("created_at", None)
+    if not normalized.get("createdAt") and created_at is not None:
         normalized["createdAt"] = created_at
 
-    last_modified = normalized.get("lastModified") or normalized.get("last_modified")
-    if last_modified is not None:
+    last_modified = normalized.pop("last_modified", None)
+    if not normalized.get("lastModified") and last_modified is not None:
         normalized["lastModified"] = last_modified
 
-    card_data = normalized.get("cardData") or normalized.get("card_data")
-    if card_data is not None:
+    card_data = normalized.pop("card_data", None)
+    if not normalized.get("cardData") and card_data is not None:
         normalized["cardData"] = card_data
 
     return normalized
@@ -94,9 +93,9 @@ def _build_app_info(item: SpaceData | None) -> AppInfo | None:
     )
 
 
-def _list_all_spaces_with_hf_api(token: str) -> list[SpaceData]:
-    """List spaces with Hugging Face Hub API using the stored token."""
-    api = HfApi(token=token)
+def _list_all_spaces_with_hf_api(token: str | None) -> list[SpaceData]:
+    """List spaces with Hugging Face Hub API using an optional token."""
+    api = HfApi()
     spaces = api.list_spaces(
         filter=HF_SPACES_FILTER,
         sort="likes",
@@ -165,30 +164,16 @@ async def list_available_apps() -> list[AppInfo]:
 async def list_all_apps() -> list[AppInfo]:
     """List all apps available on Hugging Face Spaces (including private ones when authenticated)."""
     token = hf_auth.get_hf_token()
-    if token:
-        try:
-            data = await asyncio.to_thread(_list_all_spaces_with_hf_api, token)
-            apps = []
-            for item in data:
-                app_info = _build_app_info(item)
-                if app_info is not None:
-                    apps.append(app_info)
-            return apps
-        except Exception as exc:
-            logger.warning("Falling back to the public HF catalog: %s", exc)
+    try:
+        data = await asyncio.to_thread(_list_all_spaces_with_hf_api, token)
+    except Exception as exc:
+        logger.warning("Could not list HF Spaces: %s", exc)
+        return []
 
-    async with aiohttp.ClientSession(timeout=REQUEST_TIMEOUT) as session:
-        try:
-            async with session.get(HF_SPACES_FILTER_URL) as response:
-                response.raise_for_status()
-                public_data = _coerce_space_list(await response.json())
-        except (aiohttp.ClientError, json.JSONDecodeError, asyncio.TimeoutError):
-            return []
+    apps = []
+    for item in data:
+        app_info = _build_app_info(item)
+        if app_info is not None:
+            apps.append(app_info)
 
-        apps = []
-        for item in public_data:
-            app_info = _build_app_info(item)
-            if app_info is not None:
-                apps.append(app_info)
-
-        return apps
+    return apps


### PR DESCRIPTION
Solves https://github.com/pollen-robotics/reachy_mini/issues/991. This updates the daemon catalog so `/api/apps/list-available` can return private Hugging Face Spaces accessible through the stored user token. It adds token-backed Space discovery, keeps the curated dashboard selection in the aggregate catalog, deduplicates catalog entries by stable repo identity, preserves curated-only apps, and logs when authenticated discovery falls back to the public API. This makes private preview Spaces discoverable from the desktop app without regressing the curated catalog behavior.