### PR TITLE
documentation #969: update gstreamer installation section

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,9 @@
 # Contributing
 
+## Requirements
+
+Follow the [instructions](https://huggingface.co/docs/reachy_mini/SDK/installation) to install the SDK. Please note that the Linux users have to [manually install gstreamer](https://huggingface.co/docs/reachy_mini/SDK/gstreamer-installation).
+
 ## Code quality
 
 The quality of code is insured by ruff and mypy. Please make sure to run them before pushing your code.
@@ -38,7 +42,7 @@ Please note that mpy results depend on the installed package. The [CI](../.githu
 uv sync --all-extras --group dev
 ```
 
-## Code testing
+## Code testing
 
 The code is tested with pytest. You can run the tests with the following command:
 

--- a/docs/source/SDK/gstreamer-installation.md
+++ b/docs/source/SDK/gstreamer-installation.md
@@ -12,10 +12,7 @@ Python wheels are available for the Windows and macOS platforms and are included
 
 </div>
 
-## 🔧 Install GStreamer
-
-<hfoptions id="gstreamer-install">
-<hfoption id="Linux">
+## 🔧 Install GStreamer and webrtc plugins
 
 ### Step 1: Install GStreamer
 
@@ -25,7 +22,7 @@ In your terminal, run:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y \
+sudo apt-get install \
     libgstreamer-plugins-bad1.0-dev \
     libgstreamer-plugins-base1.0-dev \
     libgstreamer1.0-dev \
@@ -40,7 +37,7 @@ sudo apt-get install -y \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-nice \
     python3-gi \
-    python3-gi-cairo
+    python3-gi-cairo    
 ```
 
 **For Ubuntu 22.04 only:** The default GStreamer version is too old. Gstreamer >=1.22 is required. You need to add a PPA to get GStreamer 1.24.x:
@@ -98,50 +95,16 @@ source ~/.bashrc
 > **💡 Note:** For ARM64 systems (like Raspberry Pi), replace `x86_64-linux-gnu` with `aarch64-linux-gnu` in the export command.
 
 
-</hfoption>
-<hfoption id="macOS">
-
-It is not necessary to install GStreamer manually since the wheels are provided. However, it is still possible to avoid using the wheels and rely on the system installation.
-
-### Using Homebrew
-
-```bash
-brew install gstreamer libnice-gstreamer
-```
-
-The WebRTC plugin is enabled by default in the Homebrew package.
-
-
-</hfoption>
-<hfoption id="Windows">
-
-It is not necessary to install GStreamer manually since the wheels are provided. However, it is still possible to avoid using the wheels and rely on the system installation.
-
-### Step 1: Install GStreamer using the official installer
-
-<div align="center">
-
-[![Download GStreamer for Windows](https://img.shields.io/badge/Download-GStreamer%20for%20Windows-blue?style=for-the-badge&logo=windows&logoColor=white)](https://gstreamer.freedesktop.org/download/)
-
-</div>
-
-1. Download the **runtime** installer (MSVC version)
-2. Install with the **Complete** installation option
-3. Edit the environment variables and add to system PATH: `C:\Program Files\gstreamer\1.0\msvc_x86_64\bin`
-4. Add to PYTHONPATH: `C:\Program Files\gstreamer\1.0\msvc_x86_64\lib\site-packages`
-
-> **💡 Important:** Replace `C:\Program Files\gstreamer` with your actual GStreamer installation folder if you installed it in a different location.
-
-</hfoption>
-</hfoptions>
-
 ## ✅ Verify Installation
 
 Finally, you can test your GStreamer installation as follows:
 
 ```bash
+# install the optional tools
+sudo apt install gstreamer1.0-tools
+
 # Check version
-gst-launch-1.0(.exe) --version
+gst-launch-1.0 --version
 
 # Test basic functionalities
 gst-launch-1.0 videotestsrc ! autovideosink

--- a/docs/source/SDK/installation.md
+++ b/docs/source/SDK/installation.md
@@ -204,20 +204,10 @@ reachy_mini_env\Scripts\activate
 
 Choose your installation method:
 
-<div align="center">
+<hfoptions id="install-method">
+<hfoption id="📦 Option A: PyPI">
 
-| 📦 **PyPI Installation** | 🔧 **Source Installation** |
-|:---:|:---:|
-| **For Everyone** | **For Developers** |
-| Ready to use | Modify the code |
-
-</div>
-
-### 📦 Option A: Install from PyPI
 > **Recommended for most users** - Just want to control your robot? This is for you!
-
-<hfoptions id="install-pypi">
-<hfoption id="Linux / macOS / Windows">
 
 In your terminal, run:
 ```bash
@@ -232,15 +222,10 @@ uv pip install "reachy-mini[mujoco]"
 > [!TIP]
 > The post installation of gstreamer is due to an [issue](https://github.com/pypi/support/issues/8847#issuecomment-3899714506) with PyPi and should be solved in the future.
 
-</hfoption>
-<hfoption id="Linux (additional steps)">
+<details>
+<summary>🐧 <strong>Linux users: additional steps required</strong></summary>
 
-In your terminal, run:
-```bash
-uv pip install "reachy-mini"
-```
-
-**🐧 Linux users also need to install GStreamer manually.** Media management is performed by the GStreamer library, which requires a system-level installation on Linux:
+**GStreamer** must be installed manually on Linux:
 
 <div align="center">
 
@@ -248,10 +233,7 @@ uv pip install "reachy-mini"
 
 </div>
 
-<details>
-<summary>🐧 <strong>Linux users also need to set up USB permissions</strong></summary>
-
-Run these commands in your terminal:
+**USB permissions** — needed for the USB connection to Reachy Mini:
 
 ```bash
 echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d3", MODE="0666", GROUP="dialout"
@@ -261,16 +243,16 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="38fb", ATTRS{idProduct}=="1001", MODE="0666"
 sudo udevadm control --reload-rules && sudo udevadm trigger
 sudo usermod -aG dialout $USER
 ```
+
+> [!WARNING]
+> Log out and log back in for the changes to take effect!
+
 </details>
 
 </hfoption>
-</hfoptions>
+<hfoption id="🔧 Option B: Source">
 
-### 🔧 Option B: Install from Source
 > **For developers** - Want to modify the SDK or contribute? Choose this option!
-
-<hfoptions id="install-source">
-<hfoption id="Linux / macOS / Windows">
 
 In your terminal, run:
 ```bash
@@ -283,16 +265,10 @@ If you want to use the simulation mode, you need to add the `mujoco` extra:
 uv sync --extra mujoco
 ```
 
-</hfoption>
-<hfoption id="Linux (additional steps)">
+<details>
+<summary>🐧 <strong>Linux users: additional steps required</strong></summary>
 
-In your terminal, run:
-```bash
-git clone https://github.com/pollen-robotics/reachy_mini && cd reachy_mini
-uv sync
-```
-
-**🐧 Linux users also need to install GStreamer manually.** Media management is performed by the GStreamer library, which requires a system-level installation on Linux:
+**GStreamer** must be installed manually on Linux:
 
 <div align="center">
 
@@ -300,11 +276,7 @@ uv sync
 
 </div>
 
-<details>
-<summary>🐧 <strong>Linux users also need to set up USB permissions</strong></summary>
-
-
-Run these commands in your terminal:
+**USB permissions** — needed for the USB connection to Reachy Mini:
 
 ```bash
 echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d3", MODE="0666", GROUP="dialout"
@@ -314,6 +286,10 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="38fb", ATTRS{idProduct}=="1001", MODE="0666"
 sudo udevadm control --reload-rules && sudo udevadm trigger
 sudo usermod -aG dialout $USER
 ```
+
+> [!WARNING]
+> Log out and log back in for the changes to take effect!
+
 </details>
 
 </hfoption>

--- a/docs/source/SDK/installation.md
+++ b/docs/source/SDK/installation.md
@@ -216,6 +216,9 @@ Choose your installation method:
 ### 📦 Option A: Install from PyPI
 > **Recommended for most users** - Just want to control your robot? This is for you!
 
+<hfoptions id="install-pypi">
+<hfoption id="Linux / macOS / Windows">
+
 In your terminal, run:
 ```bash
 uv pip install "reachy-mini"
@@ -229,26 +232,24 @@ uv pip install "reachy-mini[mujoco]"
 > [!TIP]
 > The post installation of gstreamer is due to an [issue](https://github.com/pypi/support/issues/8847#issuecomment-3899714506) with PyPi and should be solved in the future.
 
-
-### 🔧 Option B: Install from Source  
-> **For developers** - Want to modify the SDK or contribute? Choose this option!
+</hfoption>
+<hfoption id="Linux (additional steps)">
 
 In your terminal, run:
 ```bash
-git clone https://github.com/pollen-robotics/reachy_mini && cd reachy_mini
-uv sync
+uv pip install "reachy-mini"
 ```
 
-If you want to use the simulation mode, you need to add the `mujoco` extra:
-```bash
-uv sync --extra mujoco
-```
-### 🐧 Linux Users
+**🐧 Linux users also need to install GStreamer manually.** Media management is performed by the GStreamer library, which requires a system-level installation on Linux:
 
-> **Linux + USB connection?** You need to grant access to Reachy Mini's serial port.
+<div align="center">
+
+[![GStreamer Installation Guide](https://img.shields.io/badge/📖-GStreamer%20Installation%20Guide-blue?style=for-the-badge)](gstreamer-installation)
+
+</div>
 
 <details>
-<summary>🔧 <strong>Click here to set up USB permissions</strong></summary>
+<summary>🐧 <strong>Linux users also need to set up USB permissions</strong></summary>
 
 Run these commands in your terminal:
 
@@ -260,37 +261,65 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="38fb", ATTRS{idProduct}=="1001", MODE="0666"
 sudo udevadm control --reload-rules && sudo udevadm trigger
 sudo usermod -aG dialout $USER
 ```
-
-> [!WARNING]
-> Log out and log back in for the changes to take effect!
-
 </details>
 
-<br />
+</hfoption>
+</hfoptions>
 
-> **PortAudio** Make sure that portaudio is installed on your system to enable audio features with the default backend.
+### 🔧 Option B: Install from Source
+> **For developers** - Want to modify the SDK or contribute? Choose this option!
 
-<details>
-<summary>🔧 <strong>Installing PortAudio</strong></summary>
+<hfoptions id="install-source">
+<hfoption id="Linux / macOS / Windows">
 
-Run this command in your terminal:
-
+In your terminal, run:
 ```bash
-sudo apt-get install libportaudio2
+git clone https://github.com/pollen-robotics/reachy_mini && cd reachy_mini
+uv sync
 ```
 
-</details>
+If you want to use the simulation mode, you need to add the `mujoco` extra:
+```bash
+uv sync --extra mujoco
+```
 
-#### Gstreamer
+</hfoption>
+<hfoption id="Linux (additional steps)">
 
-Media management is performed by the GStreamer library. It is installed with all the dependencies for Mac and Windows users.
-Linux users have extra steps to follow:
+In your terminal, run:
+```bash
+git clone https://github.com/pollen-robotics/reachy_mini && cd reachy_mini
+uv sync
+```
+
+**🐧 Linux users also need to install GStreamer manually.** Media management is performed by the GStreamer library, which requires a system-level installation on Linux:
 
 <div align="center">
 
 [![GStreamer Installation Guide](https://img.shields.io/badge/📖-GStreamer%20Installation%20Guide-blue?style=for-the-badge)](gstreamer-installation)
 
 </div>
+
+<details>
+<summary>🐧 <strong>Linux users also need to set up USB permissions</strong></summary>
+
+
+Run these commands in your terminal:
+
+```bash
+echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d3", MODE="0666", GROUP="dialout"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="38fb", ATTRS{idProduct}=="1001", MODE="0666", GROUP="dialout"' \
+| sudo tee /etc/udev/rules.d/99-reachy-mini.rules
+
+sudo udevadm control --reload-rules && sudo udevadm trigger
+sudo usermod -aG dialout $USER
+```
+</details>
+
+</hfoption>
+</hfoptions>
+
+
 
 ## 🎉 Congratulations!
 


### PR DESCRIPTION
Address this issue https://github.com/pollen-robotics/reachy_mini/issues/969

@brainwavecoder9 I've made more explicit that linux users must install gstreamer. It's not just about contributing. Wdyt?