### PR TITLE
Prepare release 1.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reachy_mini"
-version = "1.6.1"
+version = "1.6.2"
 authors = [{ name = "Pollen Robotics", email = "contact@pollen-robotics.com" }]
 description = ""
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -3400,7 +3400,7 @@ wheels = [
 
 [[package]]
 name = "reachy-mini"
-version = "1.6.1"
+version = "1.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Change 1.6.1 --> 1.6.2

  - [x] macOS audio pipeline fix: Added a queue and audiorate element between audiosrc and webrtcsink on macOS to decouple clocking. This will allow the desktop app preview to work.
  - [x] OAuth localhost redirect support: Added a use_localhost parameter to the OAuth flow, allowing desktop apps to proxy localhost:8000 callbacks to the robot. This enables HuggingFace authentication when connecting through a desktop app rather than directly to the robot's IP (useful when working with multiple wireless robots).
