### PR TITLE
Prepare release 1.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reachy_mini"
-version = "1.6.2"
+version = "1.6.3"
 authors = [{ name = "Pollen Robotics", email = "contact@pollen-robotics.com" }]
 description = ""
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -3400,7 +3400,7 @@ wheels = [
 
 [[package]]
 name = "reachy-mini"
-version = "1.6.2"
+version = "1.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
- macOS WebRTC audio fix (desktop app): Reverted the queue/audiorate workaround added in 1.6.2 for macOS audio and instead fixed the root cause — osxaudiosrc now keeps its default clock behaviour