### PR TITLE
bug #1017: set the appsrc as not live to avoid drop of first samples

### DIFF
--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -177,7 +177,6 @@ class GStreamerAudio(AudioBase):
     def _init_pipeline_playback(self, pipeline: Gst.Pipeline) -> None:
         self._appsrc = Gst.ElementFactory.make("appsrc")
         self._appsrc.set_property("format", Gst.Format.TIME)
-        self._appsrc.set_property("is-live", True)
         caps = Gst.Caps.from_string(
             f"audio/x-raw,format=F32LE,channels={self.CHANNELS},rate={self.SAMPLE_RATE},layout=interleaved"
         )


### PR DESCRIPTION
This should fix the issue with the first words not being playback. It seems that it happened only with the lite.
I've double checked with oss conv app, the openai conv app and `python examples/sound_play.py --live`. 