### PR TITLE
feat(media): add SimulationMode enum and mockup sim video support

### DIFF
--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -39,6 +39,7 @@ from reachy_mini.daemon.app.routers import (
     volume,
 )
 from reachy_mini.daemon.daemon import Daemon
+from reachy_mini.daemon.utils import SimulationMode
 from reachy_mini.media.audio_utils import (
     check_reachymini_asoundrc,
     write_asoundrc_to_home,
@@ -200,13 +201,20 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
     )
 
     app.state.args = args
+    sim_mode = (
+        SimulationMode.MUJOCO
+        if args.sim
+        else SimulationMode.MOCKUP
+        if args.mockup_sim
+        else SimulationMode.NONE
+    )
     app.state.daemon = Daemon(
         robot_name=args.robot_name,
         wireless_version=args.wireless_version,
         desktop_app_daemon=args.desktop_app_daemon,
         log_level=args.log_level,
         no_media=args.no_media,
-        use_sim=args.sim,
+        sim_mode=sim_mode,
     )
     app.state.app_manager = AppManager(
         wireless_version=args.wireless_version,
@@ -291,9 +299,7 @@ def run_app(args: Args) -> None:
     # Create handler that writes to stderr with immediate flush
     handler = logging.StreamHandler(sys.stderr)
     handler.setLevel(args.log_level)
-    handler.setFormatter(
-        logging.Formatter("%(name)s - %(levelname)s - %(message)s")
-    )
+    handler.setFormatter(logging.Formatter("%(name)s - %(levelname)s - %(message)s"))
     root_logger.handlers.clear()
     root_logger.addHandler(handler)
 

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -13,6 +13,7 @@ from threading import Event, Thread
 from typing import Any, Optional
 
 from reachy_mini.daemon.utils import (
+    SimulationMode,
     find_serial_port,
     get_ip_address,
 )
@@ -41,7 +42,7 @@ class Daemon:
         wireless_version: bool = False,
         desktop_app_daemon: bool = False,
         no_media: bool = False,
-        use_sim: bool = False,
+        sim_mode: SimulationMode = SimulationMode.NONE,
     ) -> None:
         """Initialize the Reachy Mini daemon."""
         self.log_level = log_level
@@ -88,7 +89,7 @@ class Daemon:
             from reachy_mini.media.media_server import GstMediaServer
 
             try:
-                self._media_server = GstMediaServer(log_level, use_sim=use_sim)
+                self._media_server = GstMediaServer(log_level, sim_mode=sim_mode)
                 self._status.camera_specs_name = self._media_server.camera_specs.name
             except Exception as e:
                 self.logger.error(f"Failed to initialize media server: {e}")

--- a/src/reachy_mini/daemon/utils.py
+++ b/src/reachy_mini/daemon/utils.py
@@ -4,9 +4,19 @@ import os
 import struct
 import subprocess
 import time
+from enum import Enum
 
 import psutil
 import serial.tools.list_ports
+
+
+class SimulationMode(Enum):
+    """Simulation mode for the Reachy Mini daemon."""
+
+    NONE = "none"
+    MUJOCO = "mujoco"
+    MOCKUP = "mockup"
+
 
 # Path to the unix socket created by WebRTC daemon for local camera access (Linux/macOS)
 CAMERA_SOCKET_PATH = "/tmp/reachymini_camera_socket"

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -33,11 +33,13 @@ import gi
 from reachy_mini.daemon.utils import (
     CAMERA_PIPE_NAME,
     CAMERA_SOCKET_PATH,
+    SimulationMode,
     is_local_camera_available,
 )
 from reachy_mini.media.audio_utils import has_reachymini_asoundrc
 from reachy_mini.media.camera_constants import (
     CameraSpecs,
+    GenericWebcamSpecs,
     MujocoCameraSpecs,
     ReachyMiniLiteCamSpecs,
 )
@@ -70,40 +72,46 @@ class GstMediaServer:
     def __init__(
         self,
         log_level: str = "INFO",
-        use_sim: bool = False,
+        sim_mode: SimulationMode = SimulationMode.NONE,
     ) -> None:
         """Initialize the GStreamer WebRTC pipeline.
 
         Args:
             log_level: Logging level for WebRTC daemon operations.
-            use_sim: If True, receive video from MuJoCo simulation via UDP
-                instead of a physical camera.
+            sim_mode: Simulation mode. MUJOCO receives video via UDP,
+                MOCKUP uses autovideosrc, NONE detects a physical camera.
 
         Raises:
-            RuntimeError: If no camera is detected (unless use_sim is True)
+            RuntimeError: If no camera is detected (unless in simulation mode)
                 or camera specifications cannot be determined.
 
         """
         self._logger = logging.getLogger(__name__)
         self._logger.setLevel(log_level)
         self._log_level = log_level
-        self._use_sim = use_sim
+        self._sim_mode = sim_mode
 
         Gst.init([])
         self._loop = GLib.MainLoop()
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()
 
-        if use_sim:
-            cam_path = "use_sim"
-            self.camera_specs: CameraSpecs = MujocoCameraSpecs()
-        else:
-            cam_path, detected_specs = get_video_device()
-            if detected_specs is None:
-                self._logger.warning("No camera found. Video will not be available.")
-                self.camera_specs = ReachyMiniLiteCamSpecs()
-            else:
-                self.camera_specs = detected_specs
+        match sim_mode:
+            case SimulationMode.MUJOCO:
+                cam_path = "use_sim"
+                self.camera_specs: CameraSpecs = MujocoCameraSpecs()
+            case SimulationMode.MOCKUP:
+                cam_path = "use_mockup_sim"
+                self.camera_specs = GenericWebcamSpecs()
+            case SimulationMode.NONE:
+                cam_path, detected_specs = get_video_device()
+                if detected_specs is None:
+                    self._logger.warning(
+                        "No camera found. Video will not be available."
+                    )
+                    self.camera_specs = ReachyMiniLiteCamSpecs()
+                else:
+                    self.camera_specs = detected_specs
 
         self._resolution = self.camera_specs.default_resolution
         self.resized_K = self.camera_specs.K
@@ -397,6 +405,9 @@ class GstMediaServer:
             # instead of UDP loopback.
             source_elements = self._build_sim_source()
 
+        elif cam_path == "use_mockup_sim":
+            source_elements = self._build_autovideo_source()
+
         elif cam_path == "imx708":
             # Raspberry Pi CSI camera (libcamerasrc)
             source_elements = self._build_libcamera_source()
@@ -483,6 +494,29 @@ class GstMediaServer:
         elements = [udpsrc, queue, rtpvrawdepay, videoconvert, videorate]
         if not all(elements):
             raise RuntimeError("Failed to create simulation video source elements")
+        return elements
+
+    def _build_autovideo_source(self) -> list[Gst.Element]:
+        """Build source chain using autovideosrc (auto-detect system camera).
+
+        Used by mockup simulation to grab video from whatever camera is
+        available on the host system.
+        """
+        camsrc = Gst.ElementFactory.make("autovideosrc")
+        videoconvert = Gst.ElementFactory.make("videoconvert")
+        videorate = Gst.ElementFactory.make("videorate")
+
+        caps_raw = Gst.Caps.from_string(
+            f"video/x-raw,width={self.resolution[0]},"
+            f"height={self.resolution[1]},"
+            f"framerate={self.framerate}/1"
+        )
+        capsfilter = Gst.ElementFactory.make("capsfilter")
+        capsfilter.set_property("caps", caps_raw)
+
+        elements = [camsrc, videoconvert, videorate, capsfilter]
+        if not all(elements):
+            raise RuntimeError("Failed to create autovideo source elements")
         return elements
 
     def _build_libcamera_source(self) -> list[Gst.Element]:
@@ -749,8 +783,11 @@ class GstMediaServer:
                 f"{factory_name} — keeping default provide-clock behaviour."
             )
 
+        queue = Gst.ElementFactory.make("queue", "queue_audiosrc")
         pipeline.add(audiosrc)
-        audiosrc.link(webrtcsink)
+        pipeline.add(queue)
+        audiosrc.link(queue)
+        queue.link(webrtcsink)
 
     def _build_audio_source(self) -> Optional[Gst.Element]:
         """Build a platform-aware audio source element.


### PR DESCRIPTION
## Summary

- Introduce `SimulationMode` enum (`NONE`, `MUJOCO`, `MOCKUP`) replacing the `use_sim: bool` flag, so the media server can distinguish between mujoco and mockup simulation
- Add `autovideosrc`-based video pipeline for mockup sim, using `GenericWebcamSpecs` (720p@30fps, approximate intrinsics)
- Mockup sim now streams video from whatever system webcam is available, instead of having no video at all

## Test plan

- [ ] Run daemon with `--mockup-sim` — verify video pipeline starts with autovideosrc and streams from system webcam
- [ ] Run daemon with `--sim` — verify mujoco UDP pipeline still works as before
- [ ] Run daemon without sim flags — verify physical camera detection is unchanged