### PR TITLE
Reduce local GStreamer playback latency

### DIFF
--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -77,6 +77,10 @@ gi.require_version("GstApp", "1.0")
 
 from gi.repository import GLib, Gst  # noqa: E402
 
+_PLAYBACK_GAP_RESET_NS = 200 * Gst.MSECOND
+_PLAYBACK_SINK_BUFFER_TIME_US = 50_000
+_PLAYBACK_SINK_LATENCY_TIME_US = 5_000
+
 
 class GStreamerAudio(AudioBase):
     """Audio implementation using GStreamer.
@@ -115,11 +119,28 @@ class GStreamerAudio(AudioBase):
 
         self._playbin: Optional[Gst.Element] = None
         self._pipeline_playback = Gst.Pipeline.new("audio_player")
+        self._playback_next_pts_ns: int | None = None
         self._init_pipeline_playback(self._pipeline_playback)
         self._bus_playback = self._pipeline_playback.get_bus()
         self._bus_playback.add_watch(
             GLib.PRIORITY_DEFAULT, self._on_bus_message, self._loop
         )
+
+    def _compute_playback_buffer_timing(
+        self,
+        num_samples: int,
+        sample_rate: int,
+        running_time_ns: int,
+        next_pts_ns: int | None,
+        gap_reset_ns: int = _PLAYBACK_GAP_RESET_NS,
+    ) -> tuple[int, int, int]:
+        """Return ``(pts_ns, duration_ns, next_pts_ns)`` for a playback buffer."""
+        duration_ns = (num_samples * Gst.SECOND) // sample_rate
+        if next_pts_ns is None or running_time_ns > next_pts_ns + gap_reset_ns:
+            pts_ns = running_time_ns
+        else:
+            pts_ns = next_pts_ns
+        return pts_ns, duration_ns, pts_ns + duration_ns
 
     def _init_pipeline_record(self, pipeline: Gst.Pipeline) -> None:
         self._appsink_audio = Gst.ElementFactory.make("appsink")
@@ -176,6 +197,7 @@ class GStreamerAudio(AudioBase):
 
     def _init_pipeline_playback(self, pipeline: Gst.Pipeline) -> None:
         self._appsrc = Gst.ElementFactory.make("appsrc")
+        self._appsrc.set_property("do-timestamp", False)
         self._appsrc.set_property("format", Gst.Format.TIME)
         self._appsrc.set_property("is-live", True)
         caps = Gst.Caps.from_string(
@@ -214,6 +236,12 @@ class GStreamerAudio(AudioBase):
                 audiosink = Gst.ElementFactory.make("pulsesink")
                 audiosink.set_property("device", f"{id_audio_card}")
 
+        if audiosink is not None:
+            if audiosink.find_property("buffer-time") is not None:
+                audiosink.set_property("buffer-time", _PLAYBACK_SINK_BUFFER_TIME_US)
+            if audiosink.find_property("latency-time") is not None:
+                audiosink.set_property("latency-time", _PLAYBACK_SINK_LATENCY_TIME_US)
+
         queue = Gst.ElementFactory.make("queue")
 
         pipeline.add(audiosink)
@@ -245,6 +273,13 @@ class GStreamerAudio(AudioBase):
         self._pipeline_playback.query(query)
         self.logger.info(f"Audio pipeline latency {query.parse_latency()}")
 
+    def _get_playback_running_time_ns(self) -> int:
+        """Return the current playback running time in nanoseconds."""
+        clock = self._pipeline_playback.get_clock()
+        if clock is None:
+            return 0
+        return int(max(0, clock.get_time() - self._pipeline_playback.get_base_time()))
+
     def start_recording(self) -> None:
         """Start capturing audio from the microphone."""
         self._pipeline_record.set_state(Gst.State.PLAYING)
@@ -255,6 +290,7 @@ class GStreamerAudio(AudioBase):
 
     def start_playing(self) -> None:
         """Start the playback pipeline so ``push_audio_sample`` can feed data."""
+        self._playback_next_pts_ns = None
         self._pipeline_playback.set_state(Gst.State.PLAYING)
         GLib.timeout_add_seconds(5, self._dump_latency)
 
@@ -268,7 +304,17 @@ class GStreamerAudio(AudioBase):
 
         """
         if self._appsrc is not None:
+            pts_ns, duration_ns, self._playback_next_pts_ns = (
+                self._compute_playback_buffer_timing(
+                    int(data.shape[0]),
+                    self.SAMPLE_RATE,
+                    self._get_playback_running_time_ns(),
+                    self._playback_next_pts_ns,
+                )
+            )
             buf = Gst.Buffer.new_wrapped(data.tobytes())
+            buf.pts = pts_ns
+            buf.duration = duration_ns
             self._appsrc.push_buffer(buf)
         else:
             self.logger.warning(
@@ -277,6 +323,7 @@ class GStreamerAudio(AudioBase):
 
     def stop_playing(self) -> None:
         """Stop the playback pipeline."""
+        self._playback_next_pts_ns = None
         self._pipeline_playback.set_state(Gst.State.NULL)
         if self._playbin is not None:
             self._playbin.set_state(Gst.State.NULL)
@@ -294,6 +341,7 @@ class GStreamerAudio(AudioBase):
     def clear_player(self) -> None:
         """Flush the player's appsrc to drop any queued audio immediately."""
         if self._appsrc is not None:
+            self._playback_next_pts_ns = None
             self._pipeline_playback.set_state(Gst.State.PAUSED)
             self._appsrc.send_event(Gst.Event.new_flush_start())
             self._appsrc.send_event(Gst.Event.new_flush_stop(reset_time=True))

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -77,10 +77,6 @@ gi.require_version("GstApp", "1.0")
 
 from gi.repository import GLib, Gst  # noqa: E402
 
-_PLAYBACK_GAP_RESET_NS = 200 * Gst.MSECOND
-_PLAYBACK_SINK_BUFFER_TIME_US = 50_000
-_PLAYBACK_SINK_LATENCY_TIME_US = 5_000
-
 
 class GStreamerAudio(AudioBase):
     """Audio implementation using GStreamer.
@@ -93,6 +89,10 @@ class GStreamerAudio(AudioBase):
       flush events, dropping any queued audio.
 
     """
+
+    PLAYBACK_GAP_RESET_NS = 200 * Gst.MSECOND
+    PLAYBACK_SINK_BUFFER_TIME_US = 50_000
+    PLAYBACK_SINK_LATENCY_TIME_US = 5_000
 
     def __init__(self, log_level: str = "INFO") -> None:
         """Initialize recording and playback pipelines.
@@ -132,9 +132,11 @@ class GStreamerAudio(AudioBase):
         sample_rate: int,
         running_time_ns: int,
         next_pts_ns: int | None,
-        gap_reset_ns: int = _PLAYBACK_GAP_RESET_NS,
+        gap_reset_ns: int | None = None,
     ) -> tuple[int, int, int]:
         """Return ``(pts_ns, duration_ns, next_pts_ns)`` for a playback buffer."""
+        if gap_reset_ns is None:
+            gap_reset_ns = self.PLAYBACK_GAP_RESET_NS
         duration_ns = (num_samples * Gst.SECOND) // sample_rate
         if next_pts_ns is None or running_time_ns > next_pts_ns + gap_reset_ns:
             pts_ns = running_time_ns
@@ -238,9 +240,9 @@ class GStreamerAudio(AudioBase):
 
         if audiosink is not None:
             if audiosink.find_property("buffer-time") is not None:
-                audiosink.set_property("buffer-time", _PLAYBACK_SINK_BUFFER_TIME_US)
+                audiosink.set_property("buffer-time", self.PLAYBACK_SINK_BUFFER_TIME_US)
             if audiosink.find_property("latency-time") is not None:
-                audiosink.set_property("latency-time", _PLAYBACK_SINK_LATENCY_TIME_US)
+                audiosink.set_property("latency-time", self.PLAYBACK_SINK_LATENCY_TIME_US)
 
         queue = Gst.ElementFactory.make("queue")
 

--- a/tests/unit_tests/test_audio_gstreamer.py
+++ b/tests/unit_tests/test_audio_gstreamer.py
@@ -1,0 +1,50 @@
+"""Unit tests for GStreamer audio playback timestamp helpers."""
+
+from typing import cast
+
+from reachy_mini.media.audio_gstreamer import GStreamerAudio
+
+
+def test_compute_playback_buffer_timing_starts_at_running_time() -> None:
+    """Start the first buffer at the current playback running time."""
+    pts_ns, duration_ns, next_pts_ns = GStreamerAudio._compute_playback_buffer_timing(
+        cast(GStreamerAudio, object()),
+        1600,
+        16000,
+        2_000_000_000,
+        None,
+    )
+
+    assert pts_ns == 2_000_000_000
+    assert duration_ns == 100_000_000
+    assert next_pts_ns == 2_100_000_000
+
+
+def test_compute_playback_buffer_timing_continues_without_gap() -> None:
+    """Keep appending buffers when the running time has not drifted ahead."""
+    pts_ns, duration_ns, next_pts_ns = GStreamerAudio._compute_playback_buffer_timing(
+        cast(GStreamerAudio, object()),
+        800,
+        16000,
+        1_050_000_000,
+        1_100_000_000,
+    )
+
+    assert pts_ns == 1_100_000_000
+    assert duration_ns == 50_000_000
+    assert next_pts_ns == 1_150_000_000
+
+
+def test_compute_playback_buffer_timing_resets_after_large_gap() -> None:
+    """Realign buffer timing after a long idle gap in sparse realtime audio."""
+    pts_ns, duration_ns, next_pts_ns = GStreamerAudio._compute_playback_buffer_timing(
+        cast(GStreamerAudio, object()),
+        800,
+        16000,
+        1_400_000_000,
+        1_100_000_000,
+    )
+
+    assert pts_ns == 1_400_000_000
+    assert duration_ns == 50_000_000
+    assert next_pts_ns == 1_450_000_000

--- a/tests/unit_tests/test_audio_gstreamer.py
+++ b/tests/unit_tests/test_audio_gstreamer.py
@@ -13,6 +13,7 @@ def test_compute_playback_buffer_timing_starts_at_running_time() -> None:
         16000,
         2_000_000_000,
         None,
+        GStreamerAudio.PLAYBACK_GAP_RESET_NS,
     )
 
     assert pts_ns == 2_000_000_000
@@ -28,6 +29,7 @@ def test_compute_playback_buffer_timing_continues_without_gap() -> None:
         16000,
         1_050_000_000,
         1_100_000_000,
+        GStreamerAudio.PLAYBACK_GAP_RESET_NS,
     )
 
     assert pts_ns == 1_100_000_000
@@ -43,6 +45,7 @@ def test_compute_playback_buffer_timing_resets_after_large_gap() -> None:
         16000,
         1_400_000_000,
         1_100_000_000,
+        GStreamerAudio.PLAYBACK_GAP_RESET_NS,
     )
 
     assert pts_ns == 1_400_000_000


### PR DESCRIPTION
## Summary
This reduces perceived latency on the local GStreamer playback path used by `GStreamerAudio`.

The patch is intentionally narrow:
- disable `appsrc` auto-timestamping for local playback
- assign explicit `pts` and `duration` to pushed playback buffers
- keep a playback timeline across consecutive buffers
- reset that timeline after `start_playing()`, `stop_playing()`, `clear_player()`, and after sufficiently large idle gaps
- lower sink buffering when the selected sink exposes `buffer-time` / `latency-time`
- add unit coverage for the playback timing helper

## Why
On the local playback path, sparse realtime TTS audio arrives in bursts rather than as a perfectly continuous stream.

In practice, two things were hurting responsiveness:
- the default sink buffering was large enough to report about `220 ms` minimum playback latency
- pushed buffers did not carry explicit playback timestamps, which made the first chunk after an idle gap or flush more likely to start late or get shaved

Together, that made local realtime speech feel less snappy than it should and could cut the start of a reply.

## Scope
This PR only affects the local GStreamer playback path in `GStreamerAudio`.

It does not change:
- recording
- `play_sound()`
- WebRTC audio

## Compatibility Notes
There is an explicit tradeoff here:
- lower buffering can increase underrun risk on slower systems or with burstier producers
- sink latency tuning only applies when the selected sink exposes `buffer-time` / `latency-time`
- sinks that do not expose those properties still benefit from explicit playback timestamps and reset-on-flush behavior

The playback timeline reset after a sufficiently large gap is intentional for sparse conversational audio. If we later use this same path for workloads that depend on preserving a single uninterrupted playback clock across long silences, this policy may need to be revisited.

## Validation
- `./.venv/bin/ruff check src/reachy_mini/media/audio_gstreamer.py tests/unit_tests/test_audio_gstreamer.py`
- `./.venv/bin/mypy src/reachy_mini/media/audio_gstreamer.py tests/unit_tests/test_audio_gstreamer.py`
- `./.venv/bin/pytest tests/unit_tests/test_audio_gstreamer.py -q`
