### PR TITLE
enhancement #1025: bump gstreamer to 1.28.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "tornado>=6.5.5", # fix security issue of this subdependency
     "requests>=2.33.0", # fix security issue of this subdependency
 
-    "gstreamer-bundle==1.28.1; sys_platform != 'linux'",
+    "gstreamer-bundle==1.28.2; sys_platform != 'linux'",
     # OS-specific: use PyGObject for Linux
     "PyGObject>=3.42.2,<=3.46.0; sys_platform == 'linux'",
 ]
@@ -89,12 +89,6 @@ reachy-mini-daemon = "reachy_mini.daemon.app.main:main"
 reachy-mini-app-assistant = "reachy_mini.apps.app:main"
 reachy-mini-reflash-motors = "reachy_mini.tools.reflash_motors:main"
 
-[tool.uv]
-dependency-metadata = [
-    # Upstream metadata currently marks `gstreamer-msvc-runtime` as unconditional.
-    # It should only be required on Windows.
-    { name = "gstreamer-libs", version = "1.28.1", requires-dist = ["gstreamer-msvc-runtime; sys_platform == 'win32'", "setuptools"] },
-]
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/uv.lock
+++ b/uv.lock
@@ -6,13 +6,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[manifest]
-
-[[manifest.dependency-metadata]]
-name = "gstreamer-libs"
-version = "1.28.1"
-requires-dist = ["gstreamer-msvc-runtime ; sys_platform == 'win32'", "setuptools"]
-
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -1072,7 +1065,7 @@ wheels = [
 
 [[package]]
 name = "gstreamer-bundle"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gstreamer-cli" },
@@ -1085,180 +1078,180 @@ dependencies = [
     { name = "gstreamer-python" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/81/45d9a7f25ae0ddc3afbfecab658163124cc46384844f05cfca30c4c23f15/gstreamer_bundle-1.28.1-py3-none-any.whl", hash = "sha256:ef40bcf15a5894d3f06b242fe9a24480dedf8a038c702a60b6396f81af722ca6", size = 2574, upload-time = "2026-03-03T10:46:10.358Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/09/f5b25a3bb6a0c66b1bd1864fdb7d1a3adfd20895f8300bf32dc7bfe1807d/gstreamer_bundle-1.28.2-py3-none-any.whl", hash = "sha256:c2f743b5be35e67f049c6f8764290dc14badd3669985b9ae716f09b72df094ae", size = 2573, upload-time = "2026-04-08T21:21:21.18Z" },
 ]
 
 [[package]]
 name = "gstreamer-cli"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gstreamer-libs" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/3a/c4a32dc1ae1a846d6dacbcb4ed7e51ccce177b8f86977d401f4465a905cc/gstreamer_cli-1.28.1-cp313-cp313t-win32.whl", hash = "sha256:ee8c5a92ae082871a1747bd67d53fd6adbb2ba6e037c444543fb1914ab7d74c6", size = 5652960, upload-time = "2026-02-26T21:12:08.043Z" },
-    { url = "https://files.pythonhosted.org/packages/89/b9/0093c37fb1b807c0dc81ee2194081ae6b2b92ab9a7113c305564c7be15a9/gstreamer_cli-1.28.1-cp313-cp313t-win_amd64.whl", hash = "sha256:90c11da93d82adc34b94c898ce568a3f2300d88ec6159f448eae38fe34eaecfc", size = 6342641, upload-time = "2026-02-26T21:12:11.6Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/6f/37b932ad1a93eac430476a44447641a8434db3b54a9d9a8389c3dbf442b6/gstreamer_cli-1.28.1-cp314-cp314t-win32.whl", hash = "sha256:ad07e85cd588b83106d2b4f866bfa667d28f3dfd2992ca02773c866232623971", size = 5760743, upload-time = "2026-02-26T21:12:14.051Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a8/e4e09058cc6283602444810a47a14b0c0ff6381280902a59951eb5833c6f/gstreamer_cli-1.28.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ea9800a187e688098a1e2ac7bb77c47d377982702d9d7c68e6c2be35ed8489e6", size = 6596793, upload-time = "2026-02-26T21:12:16.022Z" },
-    { url = "https://files.pythonhosted.org/packages/81/f8/0093779a9694e723a393c33561295e8ea4157084f2a135d2821d7efef561/gstreamer_cli-1.28.1-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:35f029d28e1eef856dfb332bcb9753b6bdbe61c2bf31799370e4e0c1b4f3a5f3", size = 15838524, upload-time = "2026-02-26T21:03:42.731Z" },
-    { url = "https://files.pythonhosted.org/packages/10/15/e8e5848affb075ab2b42f06b54e55bbdcad318a93e0bbd4276d5d84d0a74/gstreamer_cli-1.28.1-cp39-abi3-win32.whl", hash = "sha256:2605d356ea8047c6560fe0ee6216ae80dd9436457590d67fe410183df2aa67cb", size = 5652959, upload-time = "2026-02-26T21:03:47.205Z" },
-    { url = "https://files.pythonhosted.org/packages/76/f4/29a15ff600d85cfecb755e69fdc9b4f7b6058d66998417476248e9c77be2/gstreamer_cli-1.28.1-cp39-abi3-win_amd64.whl", hash = "sha256:a118663496603c710ca86e9ba370183e4a2c6016fac4b7091fdfa7b884cf6bd7", size = 6342642, upload-time = "2026-02-26T21:03:51.092Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3a/cc1c7e23c29a44976f77c5623adae943479dbed9fb4336a4def44ab57cbf/gstreamer_cli-1.28.2-cp313-cp313t-win32.whl", hash = "sha256:4b1f7517ecd985583693760fbc281d43b966154a9491c20bcde0d9d5ac5af6ee", size = 5651730, upload-time = "2026-04-08T21:21:25.493Z" },
+    { url = "https://files.pythonhosted.org/packages/84/6c/d8a868fc36fbf095e56545c24259b0927ed9a4dec7934b002d1eca2598b7/gstreamer_cli-1.28.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ba109f9c4762280763ba25d4eacf6c0565f49bfbc2ca1d98b753c06410ffc6a7", size = 6339254, upload-time = "2026-04-08T21:21:28.715Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0f/57b7a683b2331b93aaeb43d52823222e41aa230cbe007b417e9fb5048601/gstreamer_cli-1.28.2-cp314-cp314t-win32.whl", hash = "sha256:d740cb92bd95b8768de677f73a247ce466c9110c9794ecbb8a8de0816431a390", size = 5759032, upload-time = "2026-04-08T21:21:31.953Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/69/681522da21ccb40843e913b052b879b2dfdd407d10fd78448861980402d3/gstreamer_cli-1.28.2-cp314-cp314t-win_amd64.whl", hash = "sha256:edf670476fa55381595cf2e04d2d94e80dfc0655a6a0a78b196c0b7d597b1d33", size = 6592346, upload-time = "2026-04-08T21:21:35.492Z" },
+    { url = "https://files.pythonhosted.org/packages/28/31/3460ecf0d81accffbe6ee2d1e513c92d2aa9fb122788d89f2ebde8f1d30c/gstreamer_cli-1.28.2-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:bbcde5e0cff3c33d55ab5f9e8937b0311e16f9d8450d53af60f0ccc3fd739be1", size = 15823020, upload-time = "2026-04-08T21:15:08.846Z" },
+    { url = "https://files.pythonhosted.org/packages/63/63/60a7fbfd9b47336399d1b611ad10611c32a0c729e6ba2bb58adb57448359/gstreamer_cli-1.28.2-cp39-abi3-win32.whl", hash = "sha256:f38d3894748f787f4b6e7e3f0e8f309f9b2656e066b00affa1a3c1534f22df8b", size = 5651732, upload-time = "2026-04-08T21:15:12.397Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7b/41a34715a2aeab8ce17221c247bbb49dcb8456185694ed95559574d49521/gstreamer_cli-1.28.2-cp39-abi3-win_amd64.whl", hash = "sha256:00c8eb8f64dee37b7ce736470f9e9c9f163aee0f5f1158809d10bd7f9ce44b53", size = 6339253, upload-time = "2026-04-08T21:15:15.073Z" },
 ]
 
 [[package]]
 name = "gstreamer-gtk"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/a6/ffc8803db0d11f835e837e54c3c0c0904f2d114e84f05c209306da447ef4/gstreamer_gtk-1.28.1-cp313-cp313t-win32.whl", hash = "sha256:ea0caed6450984aa0ae073e5c0e7bcf4cee15118d9b527312e0865c3df35f572", size = 4860466, upload-time = "2026-02-26T21:12:18.283Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/e8/6cf412933e2bd41b50ce6025aa8235b713b6eb0c253ba67307f3cef354ca/gstreamer_gtk-1.28.1-cp313-cp313t-win_amd64.whl", hash = "sha256:9439f6f64a6f729f6f60d13559b577e1987d6486b897d0d25100a582f86922ad", size = 5879984, upload-time = "2026-02-26T21:12:20.852Z" },
-    { url = "https://files.pythonhosted.org/packages/85/75/42e0276c06e083e9a6ccc496cc4684667161f972eb626b3da4b9e9be1805/gstreamer_gtk-1.28.1-cp314-cp314t-win32.whl", hash = "sha256:c931429b37c836a5b73989b81ee27b420efdde2b0b69ab0a37672e3b5e87884a", size = 4979348, upload-time = "2026-02-26T21:12:23.254Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/11/16f611905791d683980615932c1ff304401eba2d18decafa5e1572ee0e6b/gstreamer_gtk-1.28.1-cp314-cp314t-win_amd64.whl", hash = "sha256:1cbbdaf97e88e90febe23e694c77b3dbd089d8ae7cd5106085f1bba9cd716cf3", size = 6133672, upload-time = "2026-02-26T21:12:25.492Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/19/f9ec3383dd27f8903332e2ece66dff4404a6f08080c2f6477a0fd350e69d/gstreamer_gtk-1.28.1-cp39-abi3-macosx_10_15_universal2.whl", hash = "sha256:553483771017daa1685412a3ad396bcaab2e20842f1199e7d16228e9dcb167d6", size = 20437250, upload-time = "2026-02-26T21:09:15.801Z" },
-    { url = "https://files.pythonhosted.org/packages/53/6e/97e915dc603fcca897e7e5758f9c65e0e4d8ad5fa36cc1631e9786724666/gstreamer_gtk-1.28.1-cp39-abi3-win32.whl", hash = "sha256:0e18b8b821226ee4384d2260a6bb90492260fda52d9e76660a04ff11434fcce0", size = 4860460, upload-time = "2026-02-26T21:09:18.593Z" },
-    { url = "https://files.pythonhosted.org/packages/27/04/6fcf0e6129a231bc3ba35ee737c0cf0030e26ecffb75fb8e600c861c8615/gstreamer_gtk-1.28.1-cp39-abi3-win_amd64.whl", hash = "sha256:267b0e313be24563a77164b115ffd166e6281d088540564fe251e371675fdbf9", size = 5879980, upload-time = "2026-02-26T21:09:20.952Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ae/53d1fc991d8cd19cf176a9a14cfad6ff95139f5b98eeeebe8d3abffb9040/gstreamer_gtk-1.28.2-cp313-cp313t-win32.whl", hash = "sha256:e4ab2f998108ecac5b9517132df50ae2a5120e69dd239eb6430be7f22cfcc009", size = 4863883, upload-time = "2026-04-08T21:21:38.387Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/26/2f6457398c8ce74eb393b73834605a22917029580cf8aa9adf76f5a9cd71/gstreamer_gtk-1.28.2-cp313-cp313t-win_amd64.whl", hash = "sha256:2f9bcfc0792ea2d0f3b63feb9f4fdd461ff9c94c17d2b8fe22b193168e63e2e9", size = 5885927, upload-time = "2026-04-08T21:22:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f0/033e7bcf49b019cccc8eff22cfd088ce8e1e37060aa1157c3230144b5483/gstreamer_gtk-1.28.2-cp314-cp314t-win32.whl", hash = "sha256:c190e86b31d7a3ddbcecb68237d66aeea0411390336b61d7f5c5a58ea6251bed", size = 4982211, upload-time = "2026-04-08T21:22:06.08Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/1f/5929a36a2a9b39582a58d00ad74db575bf5cdb34571d20d4be87ba373acb/gstreamer_gtk-1.28.2-cp314-cp314t-win_amd64.whl", hash = "sha256:ec7163fe3c4513f33f3fc946f4bb27480e3a02abd61ad0d59b1e86ab98da5386", size = 6139580, upload-time = "2026-04-08T21:22:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b2/28687cd4c9201e05dc72a5fe8d269b5983be4c9ab63ba31f606490b7e730/gstreamer_gtk-1.28.2-cp39-abi3-macosx_10_15_universal2.whl", hash = "sha256:46d3deecd610c3f30d6bbea509a2017057160d6258f1ccd467f52f6251d66ebc", size = 20436719, upload-time = "2026-04-08T21:15:28.808Z" },
+    { url = "https://files.pythonhosted.org/packages/39/69/8bb74d8fd5065936009c5e3843cc6a9473246294ca2fb1908f1bff0e2ba0/gstreamer_gtk-1.28.2-cp39-abi3-win32.whl", hash = "sha256:6fcebe63fcba301d05f60f2bb2e4119ce0d134f68b0cb884bb915fd95e0b8e42", size = 4863880, upload-time = "2026-04-08T21:15:32.323Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ed/eddc88a03fe63aab190a9f840eb436c4eb6b5a6b606e792cabb06cebd57a/gstreamer_gtk-1.28.2-cp39-abi3-win_amd64.whl", hash = "sha256:63c61e7866f724a54599acd8e850c73eb88490eb047ac5393c1745e53241cd57", size = 5885925, upload-time = "2026-04-08T21:15:34.828Z" },
 ]
 
 [[package]]
 name = "gstreamer-libs"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "gstreamer-msvc-runtime", marker = "sys_platform == 'win32'" },
+    { name = "gstreamer-msvc-runtime" },
     { name = "setuptools" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/df/663c1e022dc9b03367fdeb1abb2a65a6f284bb7a8fe8a95678d5e8447d76/gstreamer_libs-1.28.1-cp313-cp313t-win32.whl", hash = "sha256:02cb213f23dcf39cd2c91d58956aff1513aaf6603aab83ce3382bb431061271a", size = 29122870, upload-time = "2026-02-26T21:12:30.075Z" },
-    { url = "https://files.pythonhosted.org/packages/86/77/b553a002fb0c6d9be9e105e0478b65f029f10883af451e2c40d9ac5eee78/gstreamer_libs-1.28.1-cp313-cp313t-win_amd64.whl", hash = "sha256:822fc751625be19a713811e4aa4aa7110d862c6694a92e8fc3f37467c404c442", size = 33028433, upload-time = "2026-02-26T21:12:36.001Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/db/c34fe5566fa385b5d8934579d70f5e5fc84f225671f9cef4c5dd8cf1bec7/gstreamer_libs-1.28.1-cp314-cp314t-win32.whl", hash = "sha256:647187198f1384281d0a396a84f5930f6eac67d58d10aeef28177975e68398c1", size = 29932834, upload-time = "2026-02-26T21:12:41.611Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/82/3fdd5e44112e69e9cd4e3f1b327c4fbac44a446337cbf21f88eda4f8161c/gstreamer_libs-1.28.1-cp314-cp314t-win_amd64.whl", hash = "sha256:33fd0e9e074a580987c19d909cc5f692a167f6c0377d0bca47efce493bc00aef", size = 34118760, upload-time = "2026-02-26T21:12:47.691Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/a0/3754ae28c50e12d87bd70af3e7441da6921e09c30a76e308ddc58fc305bc/gstreamer_libs-1.28.1-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:928dfbd0660571cdf4be7f0397f0c3cda5876744dc9389b7cc4008a8cdbe60df", size = 95892243, upload-time = "2026-02-26T21:09:30.957Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/21/0a4b14b623de87d60664a6237cb8b7214989d606a15d204967540fec6813/gstreamer_libs-1.28.1-cp39-abi3-win32.whl", hash = "sha256:671bf425383ffbfcb8838acf301f63765f1c19ff94c1610a4516669f45d6fd45", size = 29122869, upload-time = "2026-02-26T21:09:39.295Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/fc/d1f67da1a1267fa2db072abe105f7a44a32ac66a200e6c5484397f1e708a/gstreamer_libs-1.28.1-cp39-abi3-win_amd64.whl", hash = "sha256:99c7c4482a91209b15c51bcaee872dade7c6a2da446dad84f04f189baf4f016b", size = 33028432, upload-time = "2026-02-26T21:09:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a0/fb6bb2c583c881d7c038bd4472f60059046e02492ed9208de69844f669ed/gstreamer_libs-1.28.2-cp313-cp313t-win32.whl", hash = "sha256:2dced95ab6cc6e8b8b7786bf17cec61b07f3006c20f236183e0a613bc56aaf5d", size = 29127356, upload-time = "2026-04-08T21:22:14.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/26/ca46ac6f72d93c2e6cde8198222ad76dbd9e0ac93a1d1ddf52efcbcc51db/gstreamer_libs-1.28.2-cp313-cp313t-win_amd64.whl", hash = "sha256:09c4652d134f811d2412ca1daae30f1fba36612e19e8a897c11efcf1dcd79864", size = 33028775, upload-time = "2026-04-08T21:22:22.329Z" },
+    { url = "https://files.pythonhosted.org/packages/31/eb/a94e9d90ee15347727db1684b3cd50512fa1fbcac0ca259afdec611b19bc/gstreamer_libs-1.28.2-cp314-cp314t-win32.whl", hash = "sha256:b8d75f5e56da6724da8ba77af7afc013497d4976b9b35c7c3668cb591492e86e", size = 29938863, upload-time = "2026-04-08T21:22:30.008Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d4/976ce1ed650ad201dee618cfa58f06c4f904a4f40946242916698f2304d6/gstreamer_libs-1.28.2-cp314-cp314t-win_amd64.whl", hash = "sha256:cb3a5205a3673924d3427a42031f8fd9aec75842a034f8f57519e781231890d1", size = 34117075, upload-time = "2026-04-08T21:22:36.529Z" },
+    { url = "https://files.pythonhosted.org/packages/32/05/d2a63d60569442665f9eff524f1145af30546562b948c3813e9fa8f5d47a/gstreamer_libs-1.28.2-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:9d6825422fda9beb98e799bf8c6a634ffea67928b9d0b1b39cc8c61aa70d3ffb", size = 95896602, upload-time = "2026-04-08T21:15:46.011Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ff/46f4c0ba365cddb519bb37745c6961d8cd1f1f83f4e338197feffd276038/gstreamer_libs-1.28.2-cp39-abi3-win32.whl", hash = "sha256:73c7567ab4aacce57b66d15d0a44a5c100706e0abda7372cc68242af03af84f8", size = 29127354, upload-time = "2026-04-08T21:15:55.582Z" },
+    { url = "https://files.pythonhosted.org/packages/28/a8/376e470622fba2b23ae5c919f51a3408e2c7a758b9ced46f26c0d84e0e6a/gstreamer_libs-1.28.2-cp39-abi3-win_amd64.whl", hash = "sha256:f3c13962e6a7a1b51b5211fe3a040e2a9a7ee8e53b897a6e16032004a7f1069d", size = 33028773, upload-time = "2026-04-08T21:16:02.038Z" },
 ]
 
 [[package]]
 name = "gstreamer-msvc-runtime"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/85/1d358cc27394bc5e946d4eeb00f72ddc6cc500b2121b4b45554a8a4ee2bf/gstreamer_msvc_runtime-1.28.1-cp313-cp313t-win32.whl", hash = "sha256:15ee719b6b4efc1b7f0e1b649f196b9accac75d107a27ebf45dc073c0d78bb26", size = 871800, upload-time = "2026-02-26T21:12:52.098Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9c/316dd8d6a66b93779e77fd9957b0a220306b2bbf676788a27d7d887e7eb2/gstreamer_msvc_runtime-1.28.1-cp313-cp313t-win_amd64.whl", hash = "sha256:da0ccf967c1a178955b2d8e6bb22ebb02e1ca4c6134a4eadf313ab4bbc0d0539", size = 1004137, upload-time = "2026-02-26T21:12:55.034Z" },
-    { url = "https://files.pythonhosted.org/packages/72/74/97c3841b78253ff783367444e2551b976d263990709363bc175c24692faf/gstreamer_msvc_runtime-1.28.1-cp314-cp314t-win32.whl", hash = "sha256:c1027a34ab55bb5686120aa48b42779338570c4412ab225ecb885e374481dd18", size = 895016, upload-time = "2026-02-26T21:12:56.683Z" },
-    { url = "https://files.pythonhosted.org/packages/05/4d/610a7bf09a1e462cfe621f54c222cdea92efc61db517522af364c68862b0/gstreamer_msvc_runtime-1.28.1-cp314-cp314t-win_amd64.whl", hash = "sha256:b93410a59b02bbf4cbc42a41ba060f8160d026e3dac9af4ca28c19ed336e00cc", size = 1032546, upload-time = "2026-02-26T21:12:58.836Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/85/676d95c0b7074c8cb28faf0744b6661bd3e58f89ca96d4fc1a4250b49bc7/gstreamer_msvc_runtime-1.28.1-cp39-abi3-win32.whl", hash = "sha256:1a2fc1193f896063e65be8ae783e00fb0dfe6905a8381a05173bca1ff3352ebe", size = 871802, upload-time = "2026-02-26T21:09:47.516Z" },
-    { url = "https://files.pythonhosted.org/packages/86/9d/3e7709400ef91b098f79186392d056ff0eb807dac90065f275d86a1834a3/gstreamer_msvc_runtime-1.28.1-cp39-abi3-win_amd64.whl", hash = "sha256:7af9f11b1c22c2278f0668ad63ea901d4fb88b6b7d2612c8cc3ff99ead24f56e", size = 1004135, upload-time = "2026-02-26T21:09:49.306Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4f/17e8c6fee297b346ef03d30822eead444d6dbd012342facfce092117cb21/gstreamer_msvc_runtime-1.28.2-cp313-cp313t-win32.whl", hash = "sha256:d4bffedbe30fe2d688897eacb47b5ec2f28d8385dcc8a56272d67e2227db63e6", size = 871800, upload-time = "2026-04-08T21:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/21/80/5e7c476e6e09e093175770a0991afa385f8fd2b74df76b748696f3c6dbd3/gstreamer_msvc_runtime-1.28.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9f44e2d6be8a9f44f96a0a852d630b0959729caca58712d93b19b42393edb5f9", size = 1004140, upload-time = "2026-04-08T21:22:42.312Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/c8/ae92937db54b57505889f0cbe3627943ed4977a6ad9f8bd8435a52cfa09c/gstreamer_msvc_runtime-1.28.2-cp314-cp314t-win32.whl", hash = "sha256:592211e4148ffce575847a56c552472621793738cce55c499470691387905172", size = 895018, upload-time = "2026-04-08T21:22:44.01Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/e789be00e706e00043ece8781a14f930edfd6d7213de88dda00ebe8425a9/gstreamer_msvc_runtime-1.28.2-cp314-cp314t-win_amd64.whl", hash = "sha256:db5b1463639eda157a72f93ecc07b9d4b10fb327382f90df793068fff03e80c9", size = 1032546, upload-time = "2026-04-08T21:22:46.09Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/b4/c12f28173fd843c92b7b554a71510e066d62eaeb470ff7b7ab247833ce8e/gstreamer_msvc_runtime-1.28.2-cp39-abi3-win32.whl", hash = "sha256:3e544f6aa0e6f8d98a3c2ba0bf6a93b23f5e7a585ed84394bdc4ab6d538e247b", size = 871802, upload-time = "2026-04-08T21:16:04.969Z" },
+    { url = "https://files.pythonhosted.org/packages/11/e8/b76fbff62d6c41f604c68f27dc492d700b03f359a7a88f147a3566038ccf/gstreamer_msvc_runtime-1.28.2-cp39-abi3-win_amd64.whl", hash = "sha256:8eebafe2bb694a398516bbab410282d0c857dba05b69ba19f02b2b06932afbfa", size = 1004137, upload-time = "2026-04-08T21:16:07.023Z" },
 ]
 
 [[package]]
 name = "gstreamer-plugins"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gstreamer-plugins-libs" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/63/ed51317953aa6aa45d80e599243ae5788d70e03c09550e137e1993aeac46/gstreamer_plugins-1.28.1-cp313-cp313t-win32.whl", hash = "sha256:7bfc078428a37f1124f091cdaea4af4ca504be3dfeea8e9f1b90b06cfab8d8de", size = 39436302, upload-time = "2026-02-26T21:13:06.276Z" },
-    { url = "https://files.pythonhosted.org/packages/46/a7/225f45816d23912863e481ec44c4202c36f692b34d2e2c63e2c55f67b664/gstreamer_plugins-1.28.1-cp313-cp313t-win_amd64.whl", hash = "sha256:21114a6c883ec1f220f9906e3ce1402f6f5a83bf350fa3275f0efdf556c1b286", size = 45757982, upload-time = "2026-02-26T21:13:13.468Z" },
-    { url = "https://files.pythonhosted.org/packages/22/50/ea3fd8a41d60ebb17fd4c1c0e7a27b3ede1d078778301bd56d3ac46290e2/gstreamer_plugins-1.28.1-cp314-cp314t-win32.whl", hash = "sha256:c21567f8a8897219b049535331267fb316f7e6dd93829353e3c2202bd7f91a30", size = 40490064, upload-time = "2026-02-26T21:13:20.084Z" },
-    { url = "https://files.pythonhosted.org/packages/df/67/c6e2e1414f6997f699b2f23de7af6ae1d56adbdeca0b8587effec1f99615/gstreamer_plugins-1.28.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ccc796a337bc1a46d1cfed97506254ee9eba64ed089341932b2f9c90fe7f9c2a", size = 47176696, upload-time = "2026-02-26T21:13:27.508Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/6d/9b2325a7a877847db4d4c2d1121ff4342d2841528aa59ab96807436feca3/gstreamer_plugins-1.28.1-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:3caf60c6c4aeaecb1e6c6ee340b59a3014685bd7c82ca9d3168f4151e075b516", size = 99561570, upload-time = "2026-02-26T21:09:59.616Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/35/1d903593c245aba172f73d5f38e07558f2eb87d0662de80367472194405f/gstreamer_plugins-1.28.1-cp39-abi3-win32.whl", hash = "sha256:243da1884c62dbbfdabfc3e8034774a53b5dea1816a36a8c85bfea4fc135400d", size = 39436300, upload-time = "2026-02-26T21:10:07.248Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/8e/c44165f8356289cd531dd0659a829a4716987071f4aa52197a8e2cc886de/gstreamer_plugins-1.28.1-cp39-abi3-win_amd64.whl", hash = "sha256:14f39fd3941af78d58587babff2f3aa3b12c896a9ec39c1d27363eba7010ed69", size = 45757981, upload-time = "2026-02-26T21:10:13.786Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/8f/2b6e93d9d82eedc8e49f8c1d13a7e9437876c99e6d5d5f382f1c9a08cfef/gstreamer_plugins-1.28.2-cp313-cp313t-win32.whl", hash = "sha256:40bd7fd63d4abdcbf968a56cd980d3264635e798be9c03e01a1cf3b78201d03f", size = 39744050, upload-time = "2026-04-08T21:22:52.651Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f3/a1432e3d4cbc8953ed3f099257c51d4f05ab86141d36cfaf1710dece2b4c/gstreamer_plugins-1.28.2-cp313-cp313t-win_amd64.whl", hash = "sha256:83d05182882e14f047916f947041016615be28128d7c3185fc67780ba6cf3feb", size = 46067491, upload-time = "2026-04-08T21:23:01.636Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7a/52d2fcad1fcd754aed9b90bfdf47c20e414ef1528735099edd6e27af1235/gstreamer_plugins-1.28.2-cp314-cp314t-win32.whl", hash = "sha256:3b79e80a9b3f111345251b2c5db165e82707a168f8b9b8986e2c0c9dd4fcf260", size = 40802690, upload-time = "2026-04-08T21:23:09.731Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7b/1a26910e4c941334a987cadbc97f65a36e7e1a3fce8d704acb64bca6a8f9/gstreamer_plugins-1.28.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a1591cab0b0a4412a02d719d5b8e4a77153b3fcae579509a738fb5855dedb8a6", size = 47500601, upload-time = "2026-04-08T21:23:18.938Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c7/0278336fb3b6d594333231a5eb0c15db66f3de2a635758a343ea6d5009df/gstreamer_plugins-1.28.2-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:62884077ccf202466f594f804b46d69fcc172a3186829fa26abb2db1f8fd42c9", size = 100197112, upload-time = "2026-04-08T21:16:19.48Z" },
+    { url = "https://files.pythonhosted.org/packages/67/27/7bc26591575ea050ebc43c1d5f68410e8a290796d012b2c2986a84bafe0b/gstreamer_plugins-1.28.2-cp39-abi3-win32.whl", hash = "sha256:dab30a20700006fa9653ed478ddc309e5ba1160e54cc11cf5c3ccbff90fce0df", size = 39744049, upload-time = "2026-04-08T21:16:29.594Z" },
+    { url = "https://files.pythonhosted.org/packages/39/0a/12d23da6f65a1abef76e66364d8e1956abdca90d260a1a9fa9bf0c2e00b6/gstreamer_plugins-1.28.2-cp39-abi3-win_amd64.whl", hash = "sha256:77884086a7423362b48f985c9676ae92527902c05402342bb39a069209718d61", size = 46067490, upload-time = "2026-04-08T21:16:37.882Z" },
 ]
 
 [[package]]
 name = "gstreamer-plugins-gpl"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gstreamer-plugins-libs" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/7c/fcf55cc2833d5733e53d3288c37320bf498f9fb676c6556438ef9079794c/gstreamer_plugins_gpl-1.28.1-cp313-cp313t-win32.whl", hash = "sha256:c92934d38ba55147706006157a9949067311287c22e7fc6630ee845e42ed81e8", size = 318810, upload-time = "2026-02-26T21:13:40.228Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e9/32d247876a0c7fdc5f60bb37f30ae87f3e8e4ceacc89d04ef1d1e4a7af04/gstreamer_plugins_gpl-1.28.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d28bdadfe015068d50236d6c00c9f5486d083fba1aed7244cdb4bd4d1743da6e", size = 356488, upload-time = "2026-02-26T21:13:42.068Z" },
-    { url = "https://files.pythonhosted.org/packages/52/0e/4a0ebbf7cca7b0ad4a16589af8c145aaa22198d9d28a8425921086ad2982/gstreamer_plugins_gpl-1.28.1-cp314-cp314t-win32.whl", hash = "sha256:d139e1da7c8c9cc01706d9dba2e0d57f2776f97c8447dc6c9a86c66e2bd29cfa", size = 326021, upload-time = "2026-02-26T21:13:43.641Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a4/538756305b09e1b02d42b0f84f28e9ec59d6ed554c9afed8ef059226896f/gstreamer_plugins_gpl-1.28.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a5f48691fc6687bd152edf3de6a35da90f1287e36223180c6d1bbf6b64727554", size = 363944, upload-time = "2026-02-26T21:13:45.172Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/15/bab73b906b13feb971b38a668021180d8f4903c50d4f45095f5810cc4bec/gstreamer_plugins_gpl-1.28.1-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:36fead4cd7834db0ac03216d85e1725df03257197347769fe820a0fe665e6c8a", size = 1045780, upload-time = "2026-02-26T21:10:22.269Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/e7/a3705d059a0e83c002f4590c9a679f6b5a5737d36e69c2fef6afc88ff69f/gstreamer_plugins_gpl-1.28.1-cp39-abi3-win32.whl", hash = "sha256:0aa307c60325d426e2a2d07b44762ed4dd4e84d18c27d01d58d34309cd04a532", size = 318809, upload-time = "2026-02-26T21:10:24.277Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/d0/94b7aad8b8062888159e8bcc84345711025a9010cd495aac851a5a13efd2/gstreamer_plugins_gpl-1.28.1-cp39-abi3-win_amd64.whl", hash = "sha256:8f7b165f28b69104bdac43957263ace40fb0641b71334ee7f0d9f94fc91ef1a5", size = 356488, upload-time = "2026-02-26T21:10:26.256Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cb/2dceff196732171a409ad047bef47bc6de9ff880199f9766cc989f24bfea/gstreamer_plugins_gpl-1.28.2-cp313-cp313t-win32.whl", hash = "sha256:2bc7833b135d7158578e4ad0ecc36b28cabe4061338548bd97b2f5ce235fb1da", size = 318811, upload-time = "2026-04-08T21:23:32.043Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/7f7fa7ebdad55cb330223f345de54ca5d126443cc6f93a78a1dbc10bc631/gstreamer_plugins_gpl-1.28.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9249c74e6c1f5c4402636116d9fed68f63826cc2e47840a8da847c3357fbf570", size = 356490, upload-time = "2026-04-08T21:23:33.624Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/80/01e711acb0276cdab32f03248ec3f56918eab2d8837586815bceaa1be636/gstreamer_plugins_gpl-1.28.2-cp314-cp314t-win32.whl", hash = "sha256:5780399e3556f8451c8e373a065140e1426aaca72a0dc35da7314fbe12aba7e1", size = 326025, upload-time = "2026-04-08T21:23:35.762Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/18/bb3ccb9131940f9904225ce6ce501ad0d19af76d83fcee21980fd1a2db00/gstreamer_plugins_gpl-1.28.2-cp314-cp314t-win_amd64.whl", hash = "sha256:61883b6227af3e8c78335159eab6f3078c681ad5b801b331e0f4ed90c13c7715", size = 363946, upload-time = "2026-04-08T21:23:37.593Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f4/1f9bed35d650e06189f408ab00c04b70cc16cc62d19b84d2991c7ce6d133/gstreamer_plugins_gpl-1.28.2-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:0deace3d0cb385308e52b3061cfce57d0a2bf8469bea90e64c7097c1c10f3d92", size = 1045765, upload-time = "2026-04-08T21:16:48.095Z" },
+    { url = "https://files.pythonhosted.org/packages/91/0f/9ac718d27933102075410d1109a233ab5d06dd45676a727d31a5e6df3d31/gstreamer_plugins_gpl-1.28.2-cp39-abi3-win32.whl", hash = "sha256:387bcaa44fac6d5b59a821f6e8b694190d3d982bb1b3bfc3f4bea54891f58111", size = 318810, upload-time = "2026-04-08T21:16:49.564Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ea/f0ddae86044bc02fc15d3e5842e87f2412df014fa44b7b4e389185b10edb/gstreamer_plugins_gpl-1.28.2-cp39-abi3-win_amd64.whl", hash = "sha256:0e2363092fa0b27896562840824b4afee1c34fdb7cf66add88bf3a2d0a7356a8", size = 356487, upload-time = "2026-04-08T21:16:51.185Z" },
 ]
 
 [[package]]
 name = "gstreamer-plugins-gpl-restricted"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gstreamer-plugins-libs" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/4f/b028dd2d5a0cf847298cf004ae651409acac956a1c3f066b85951f85bf65/gstreamer_plugins_gpl_restricted-1.28.1-cp313-cp313t-win32.whl", hash = "sha256:50052dacdd334caf481dac2be7b44ca8b32f47333ef6a024f7344fa36762a165", size = 2149261, upload-time = "2026-02-26T21:13:47.289Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/f5/7c3979e1e9b6dd6aa47c8419f37c679fdacb5b3a663808431685d4a813ba/gstreamer_plugins_gpl_restricted-1.28.1-cp313-cp313t-win_amd64.whl", hash = "sha256:eeee40261b9221ccab3f0308242c86ae0431d3ebd6980d2c1e88f41005de82b4", size = 3404130, upload-time = "2026-02-26T21:13:49.459Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/c9/d6dba070e0870c2585305092d17c00ec373aec6c02dfdb44e34dc58b1664/gstreamer_plugins_gpl_restricted-1.28.1-cp314-cp314t-win32.whl", hash = "sha256:078fc419e5ef51f8a0e15dfe9c3204c83cd20ba1247ce26e00c8d852211b1c11", size = 2202697, upload-time = "2026-02-26T21:13:50.981Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a4/83b50c06cc89178326dcd0fcab185a68657bafa5006afbe37ad972c91033/gstreamer_plugins_gpl_restricted-1.28.1-cp314-cp314t-win_amd64.whl", hash = "sha256:8c3a42e1e67ad3055ebce58bba5ff42b28690c30c962475b85ccb74abea66b83", size = 3499001, upload-time = "2026-02-26T21:13:52.833Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/83/aa78f47dd00999c63efe0292501652b59a2f544caeb4d2095fd84583fe8d/gstreamer_plugins_gpl_restricted-1.28.1-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:9199e3d6ae0ea81e6a44afa6d277d1336744e470a7991e6d5830c53044a4c807", size = 13315116, upload-time = "2026-02-26T21:10:29.478Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/35/85cfdcf3beb4a70c93447556969cafd1074dfe6ea3da77935b1cfada5c71/gstreamer_plugins_gpl_restricted-1.28.1-cp39-abi3-win32.whl", hash = "sha256:e309c5eeb6a72410b542cbd13819dab3f1c5a95d966da83754a36f1dc5639d43", size = 2149262, upload-time = "2026-02-26T21:10:31.873Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/17/28583e847d9cdc3391f6cdca6ad73b9cb95fecd39e7dba68b431fc1cb995/gstreamer_plugins_gpl_restricted-1.28.1-cp39-abi3-win_amd64.whl", hash = "sha256:85ec578c5453eafb69b56153b0df57f0ce43b78ffc79daf8f7895bbc17eceb65", size = 3404123, upload-time = "2026-02-26T21:10:33.593Z" },
+    { url = "https://files.pythonhosted.org/packages/da/78/c38327e1fc510afd136cb328739d17d71113102067e5e2225a8d800715f1/gstreamer_plugins_gpl_restricted-1.28.2-cp313-cp313t-win32.whl", hash = "sha256:c85c35f842042dc64ee3777016dd45388a07b39583a9c6d9db5d6c3adfc5fb06", size = 2149261, upload-time = "2026-04-08T21:23:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4a/6e694f95d2f1201a454e0659fb74627798f791cb84cfc2aff28d66d4a6de/gstreamer_plugins_gpl_restricted-1.28.2-cp313-cp313t-win_amd64.whl", hash = "sha256:3c1c4c6b0e44e0a174f2741ee5a17647d121f80f3db14322b4b78bc45c57a7b2", size = 3404135, upload-time = "2026-04-08T21:23:43.014Z" },
+    { url = "https://files.pythonhosted.org/packages/57/19/b8be1540e8ae791f5d6cae640d2d3ccc1a72710199958b730801ddfa6077/gstreamer_plugins_gpl_restricted-1.28.2-cp314-cp314t-win32.whl", hash = "sha256:a775717caa1800872da042603c6104ffddb478f2201eec551332e83fc4bdd201", size = 2202697, upload-time = "2026-04-08T21:23:45.222Z" },
+    { url = "https://files.pythonhosted.org/packages/03/63/8aaca747459cd0696c1683b8cf13c7901c1c299dbc61efc97437afa5a0ee/gstreamer_plugins_gpl_restricted-1.28.2-cp314-cp314t-win_amd64.whl", hash = "sha256:90329e5041c0f98a3b6893c6fba63c905b8ed06d9d7fe772cba742d205ce44a1", size = 3499003, upload-time = "2026-04-08T21:23:47.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/05/4af77587e824c7ae6429d35d6de219cf85ba5c4f5c835052ef811b2bbcc9/gstreamer_plugins_gpl_restricted-1.28.2-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:86ab711aa117ed892416c45183d6f72ee5228ed23fa8ad1b18b09aa7d845ef97", size = 13315026, upload-time = "2026-04-08T21:16:54.771Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/af/8b87a5473872f9256ffd3fb9398affe3650dabc31065faaec67857a2ffef/gstreamer_plugins_gpl_restricted-1.28.2-cp39-abi3-win32.whl", hash = "sha256:135e20fda650db02a0525e4502c4d562ab60ea5cd0af0dc9cd379b6e8ea14c32", size = 2149264, upload-time = "2026-04-08T21:16:57.041Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/50/fccaad7c474d2cfd24a2057402233ae0efefc1186572a6eba2586dd309a5/gstreamer_plugins_gpl_restricted-1.28.2-cp39-abi3-win_amd64.whl", hash = "sha256:dac480481b9ef3a6e9765277ed5d681a61b3339391f6be89027a5c2d9693200c", size = 3404127, upload-time = "2026-04-08T21:16:58.968Z" },
 ]
 
 [[package]]
 name = "gstreamer-plugins-libs"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gstreamer-libs" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ad/06118e0b6d018e03d4b1414518151b03a2205b08c94776f8e3b738232e3e/gstreamer_plugins_libs-1.28.1-cp313-cp313t-win32.whl", hash = "sha256:0c244d87f1ba6777a3b434b7d759d1ea885286b195d6573d58cb9bd2923a27c0", size = 16417439, upload-time = "2026-02-26T21:13:56.034Z" },
-    { url = "https://files.pythonhosted.org/packages/85/d6/183a469297f29ee5dd04206875644973815f337d62402bb601b0619a0608/gstreamer_plugins_libs-1.28.1-cp313-cp313t-win_amd64.whl", hash = "sha256:aa430ebefb571a39a8ffe43ac525da3359441b2ef835cb027e6f56334cb0acf4", size = 21187932, upload-time = "2026-02-26T21:14:00.261Z" },
-    { url = "https://files.pythonhosted.org/packages/46/63/98463ffacaffa34da0811dce47ec8edb373628d44088864d8d9f8fc8cdde/gstreamer_plugins_libs-1.28.1-cp314-cp314t-win32.whl", hash = "sha256:466a481af0762ae23d2b9bc6077f124a61f0e9712e2b3ac5be116734153c5c89", size = 16709879, upload-time = "2026-02-26T21:14:04.394Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/15/4816b3cf2f551b5435818d9aa91bf4940a94968b22a836b9739b0b924171/gstreamer_plugins_libs-1.28.1-cp314-cp314t-win_amd64.whl", hash = "sha256:8b5663ba5e4600a5994efd88e10ee08547b66e0de53b3267cef18c7edac507b5", size = 21670454, upload-time = "2026-02-26T21:14:10.189Z" },
-    { url = "https://files.pythonhosted.org/packages/90/f4/17978e002bf158b17739662073b6035d6fa81f02f265877c303e064b0d83/gstreamer_plugins_libs-1.28.1-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:ba05b91d23ebd2316ff16d8d317a39c6f91dec0b092ae4f289536097b4a2ea32", size = 82885943, upload-time = "2026-02-26T21:10:42.598Z" },
-    { url = "https://files.pythonhosted.org/packages/37/6c/105aad9005b631b57383db14a9102ce72e164a6ce16d216550da32378ed4/gstreamer_plugins_libs-1.28.1-cp39-abi3-win32.whl", hash = "sha256:f03875952cff7c26c61ad1dc804a6d9e689b272cf5a912c6b5361220b46972d3", size = 16417435, upload-time = "2026-02-26T21:10:48.349Z" },
-    { url = "https://files.pythonhosted.org/packages/67/2d/71abda97695419fc21be144cea386ff5da7b5c75294ba37e1e21a4431dcf/gstreamer_plugins_libs-1.28.1-cp39-abi3-win_amd64.whl", hash = "sha256:dbcf0e14da94a5f9fc584c419bacf0e096730ef50d5f331f4d5ea3f026a72314", size = 21187934, upload-time = "2026-02-26T21:10:52.405Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2e/f9294e8fea54c2ff9baec57fe121f2275a9568956ba19845d9b6a477da78/gstreamer_plugins_libs-1.28.2-cp313-cp313t-win32.whl", hash = "sha256:ba2e6b63198c1ae32ce068f6ed1f2363d938c10eb84c5a7870de9a58b8f6a764", size = 16367176, upload-time = "2026-04-08T21:23:51.045Z" },
+    { url = "https://files.pythonhosted.org/packages/59/1e/d9c6d573243f07baffd1a43a06993c669fd95bc49d5e6db60810ae982cff/gstreamer_plugins_libs-1.28.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c7903a994932f548b258bc8e7e5afee2b23c7ffd042e25fc8f8cdbcc62dbe95f", size = 21144344, upload-time = "2026-04-08T21:23:55.939Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d2/ee9edb8d6609de31f967e02ed31b472b7827fc762987839e3c6489a52cb1/gstreamer_plugins_libs-1.28.2-cp314-cp314t-win32.whl", hash = "sha256:8061077c13def240112d428fe0b8dc05d55075ce15ad71d9988a270e6f1b9b29", size = 16660160, upload-time = "2026-04-08T21:24:00.366Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b5/1978cb34a32ca37079379cdaaf234d86995879793036187774bda386fd43/gstreamer_plugins_libs-1.28.2-cp314-cp314t-win_amd64.whl", hash = "sha256:ab9df789077e274e1dc4c06757cd39fda73af1053fd7e5484e06aabd62fc2660", size = 21624945, upload-time = "2026-04-08T21:24:05.435Z" },
+    { url = "https://files.pythonhosted.org/packages/df/8f/07a0b16f090360badaa34abee601a4f54cc0253188321b01b0ef4aa89bc3/gstreamer_plugins_libs-1.28.2-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:4398096d33228deee62bb87fe09ef6d3772e00494958254f842d835881d3f53d", size = 82895903, upload-time = "2026-04-08T21:17:09.063Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5f/7e4a16a455c69732d6ec3f1ed690143e239cf1dbd6ddccc3209fa0069145/gstreamer_plugins_libs-1.28.2-cp39-abi3-win32.whl", hash = "sha256:b3706160087aa0e3792fe64c5a6ba2b191e8291cfc139f4c43c52d587bddae66", size = 16367172, upload-time = "2026-04-08T21:17:14.998Z" },
+    { url = "https://files.pythonhosted.org/packages/75/22/b1921ba0ec13f2f19b5343a8d7c5bdda2033d762495b1e44b0452d6fbde9/gstreamer_plugins_libs-1.28.2-cp39-abi3-win_amd64.whl", hash = "sha256:52ff00ee79332f244c2ef858ff0117101a549483670ff2793f58821c3c83ef87", size = 21144342, upload-time = "2026-04-08T21:17:21.368Z" },
 ]
 
 [[package]]
 name = "gstreamer-plugins-restricted"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gstreamer-plugins-libs" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/ee/ded9f9f1bb68141461c53770da07f66f36479948de08647c04717e8dc81c/gstreamer_plugins_restricted-1.28.1-cp313-cp313t-win32.whl", hash = "sha256:9c2ac0ebb5e8d3153b0a49985e1a0f435b5fbb190f9997361fabdc5a793be586", size = 1392966, upload-time = "2026-02-26T21:14:12.591Z" },
-    { url = "https://files.pythonhosted.org/packages/13/77/f4c0efcbe090f86b940f73630a958f160745378e6367b6416d5513bf5f98/gstreamer_plugins_restricted-1.28.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e80fb98322d6544a31223d2b6eb55717f92dcc279f476b31019d6af2d526abc9", size = 1487953, upload-time = "2026-02-26T21:14:14.305Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/df/146e2247f021e93027302060a4a8e152b4f682ab002a6c4b10f859bfd0ee/gstreamer_plugins_restricted-1.28.1-cp314-cp314t-win32.whl", hash = "sha256:e0cfaab8e73c4f15badc133a0c24766b3b7e7aab888158fd5282522eb36cbfcb", size = 1428504, upload-time = "2026-02-26T21:14:16.383Z" },
-    { url = "https://files.pythonhosted.org/packages/00/29/86ef332206c1880dedb5d7aaa96fcd90dc10fd9dadd0a36a4ecbeb76f280/gstreamer_plugins_restricted-1.28.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e11d2519ccfb331e0082b8b243993b51dc5c22fa10de356ab4facf044366a9af", size = 1535114, upload-time = "2026-02-26T21:14:18.709Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/18/bfe6f20308f9cc4d4cf4156323601e064c82974b3cb411b5ac2bb53d3d3d/gstreamer_plugins_restricted-1.28.1-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:04e067a2539d41e0e7ad98f85abe183542f3450282015bcc971f8f49d7237ebf", size = 6013959, upload-time = "2026-02-26T21:10:55.86Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/40/7c52a5bb3782f493a7e2e84a96c6907b8e380e07aeb528a062835de941b3/gstreamer_plugins_restricted-1.28.1-cp39-abi3-win32.whl", hash = "sha256:2fd1672c1bc65cf586865b18766cf33337936faf0daca2ffa378cf207c2a340d", size = 1392964, upload-time = "2026-02-26T21:10:57.713Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/2f/eac30d50e8524e7b21099553ffdd6223c3789814b7219e3f69c632be1f88/gstreamer_plugins_restricted-1.28.1-cp39-abi3-win_amd64.whl", hash = "sha256:12029da1de4025f674cd2724b76f65c61ccc23c369b72918d3ff827da94df2c1", size = 1487947, upload-time = "2026-02-26T21:10:59.176Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6c/5547b54331b3b192ddc57fe934ef9596ec46d3304dcb9684ee96f002d71f/gstreamer_plugins_restricted-1.28.2-cp313-cp313t-win32.whl", hash = "sha256:5d29f18df8917e3aa2d1f7539fb58c3b47743871b8c437d5be00b523193659cf", size = 1392975, upload-time = "2026-04-08T21:24:08.452Z" },
+    { url = "https://files.pythonhosted.org/packages/97/57/abed64ada5fc3e497b42948ee45aecb9753dd1c1b3bd98c31f69c6276089/gstreamer_plugins_restricted-1.28.2-cp313-cp313t-win_amd64.whl", hash = "sha256:f1f8273b72a2e3826de9ba797cff9bc55ca7f02039603c2ed3826765c15bcec9", size = 1487970, upload-time = "2026-04-08T21:24:11.062Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/55/764d90d55bb4629267b0d70f0d3b9348833159948cfb2bb3298d0dab1c87/gstreamer_plugins_restricted-1.28.2-cp314-cp314t-win32.whl", hash = "sha256:ad09f6601933605663f60306c6771acc783faf350f4b03401743c232feb9eaef", size = 1428505, upload-time = "2026-04-08T21:24:13.376Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d4/fb550e804351090772459112d2f31f669cdb2e22ffafb082357b6fcada4e/gstreamer_plugins_restricted-1.28.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a9dff2d91834732d678ed0f7acbf0495d7cb62340a0b2002b35712c557cda3a3", size = 1535126, upload-time = "2026-04-08T21:24:15.368Z" },
+    { url = "https://files.pythonhosted.org/packages/39/11/ea69133e2bb388f33ec2184b195c0ab00bc8653117d97000e7d5d447a284/gstreamer_plugins_restricted-1.28.2-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:9e903a2a9c6f3f431014f0f1547ecb75b032a615384f28bc43c978a5f5081bec", size = 6013897, upload-time = "2026-04-08T21:17:24.847Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/98/1fd8bd46f450eb3e851aeea1dae08f09f4c64fd94e905e0e2b3ac1ea3b74/gstreamer_plugins_restricted-1.28.2-cp39-abi3-win32.whl", hash = "sha256:0d526f68cf6525f7efef09dacb77260240cc598a9ab4ecbdfc160436b6a94ebe", size = 1392976, upload-time = "2026-04-08T21:17:26.812Z" },
+    { url = "https://files.pythonhosted.org/packages/17/70/ea8e0a77ee3e53fa5f823f65171a11d8ed683273483c0bb4a5f3aa457a77/gstreamer_plugins_restricted-1.28.2-cp39-abi3-win_amd64.whl", hash = "sha256:d0f42d44bea52495ec3dbe47a0d75990175b76ef60202b3b99f233d8d65e1bae", size = 1487966, upload-time = "2026-04-08T21:17:29.16Z" },
 ]
 
 [[package]]
 name = "gstreamer-python"
-version = "1.28.1"
+version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/cf/eed77c79ea2211930696d094322c4f240a3b643ef926f7df83f671ce3203/gstreamer_python-1.28.1-cp310-cp310-macosx_10_13_universal2.whl", hash = "sha256:603006a64beff9654c8fb27addaf01d024088718643ad49ebdf1e47471777e9a", size = 1187238, upload-time = "2026-02-26T21:14:20.577Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/02/f274c5c3d8a606771d3d9d9077cb5e5cce97f3b24075e18b46018b4d2a14/gstreamer_python-1.28.1-cp310-cp310-win32.whl", hash = "sha256:ab00d1add3b5333f4013f9f71738f4d480abdd5acd0f459579707b271512ad5d", size = 930471, upload-time = "2026-02-26T21:14:22.81Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/c6/44332775b04a24d3a22286280d89dd003a9545c83ba37e587082457b6b10/gstreamer_python-1.28.1-cp310-cp310-win_amd64.whl", hash = "sha256:b390153a1b56ff43f435c2db23eb5b6dc55d324fef7e4f21cfddd1e573a2e96e", size = 969885, upload-time = "2026-02-26T21:14:24.591Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/67/f1c7892e70f3c821d9ac830280814d3330e17bb20a97fcaafab09ec2f0b3/gstreamer_python-1.28.1-cp311-cp311-macosx_10_13_universal2.whl", hash = "sha256:c1dd1dd1d46b3dd17f1221b4046c25beb32f56fc038f581f13eb835fb2ecd8fa", size = 1187166, upload-time = "2026-02-26T21:14:26.496Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/ff/bde5435f4af19e6ae4538db004f0763e4731200cfa0ce3628c1c906b6772/gstreamer_python-1.28.1-cp311-cp311-win32.whl", hash = "sha256:d06537bd483fce6064e8a7f84223b4b8f89aee63b18ae374d44d86b27c533840", size = 930890, upload-time = "2026-02-26T21:14:28.214Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/da/f70f117ff1ab38a073f6da218586e802151dbfb4900f201bcc6c62d48727/gstreamer_python-1.28.1-cp311-cp311-win_amd64.whl", hash = "sha256:bd8d151184fc0de7eba908893e85dfaeb35078205b60d579fcc2393ab2c6af32", size = 970914, upload-time = "2026-02-26T21:14:29.937Z" },
-    { url = "https://files.pythonhosted.org/packages/de/a3/df628de6c69b499119450b087ebadcdbc17b2029ffa11caccaec4a9f9b21/gstreamer_python-1.28.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cc21fa0f61854462fbf82880733acde586d33411c9c9785a4b9be7a272763547", size = 1194980, upload-time = "2026-02-26T21:14:32.146Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/64/fde015354f9d40be9e83714c769fac0eaf95f106566ff70a50b267ed8cb2/gstreamer_python-1.28.1-cp312-cp312-win32.whl", hash = "sha256:4e02948dc4924c4098afdeb1f4f646826cfff474305ca02500b160da15d18e9c", size = 932980, upload-time = "2026-02-26T21:14:34.373Z" },
-    { url = "https://files.pythonhosted.org/packages/24/7e/7aa3edd47b2032287f431a28eac452438bf8a6ab05bb9a63bdab02d9e5f4/gstreamer_python-1.28.1-cp312-cp312-win_amd64.whl", hash = "sha256:1f72d326cd43107559698d6bddde7af545661a746ab423769ac4d7af2885069b", size = 973663, upload-time = "2026-02-26T21:14:36.145Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/14/8e2fb245de8e72c9e73f57f2a10b0b3380ca021bd8bf8a4d38f24e5b866c/gstreamer_python-1.28.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a317011337c5e7b12cf96ab4f467245e9d29949eacf608ac2f7e91ff16cc9881", size = 1203789, upload-time = "2026-02-26T21:14:37.835Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c5/40093d0a4b0ee3b96fd92afe87ccee63c6604f00f979222d470a6f2caa74/gstreamer_python-1.28.1-cp313-cp313-win32.whl", hash = "sha256:6fa8dc2f536598428623ba1805bef52d9e0868f78213b8f8e8f4061e3aa74dd0", size = 933750, upload-time = "2026-02-26T21:14:43.525Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/b9/774081b6987252ae900abbdd4e4921279f8f25465659f440547a7353f09d/gstreamer_python-1.28.1-cp313-cp313-win_amd64.whl", hash = "sha256:de202b5a276928c9062343e3e90e8849effa5fdb88d7d0655faf6f805fbb9c3b", size = 974799, upload-time = "2026-02-26T21:14:45.246Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/56/e93e17f8fa76476c00740a5e86e4aba1fe6a6199b8541e870e2fc0c8ad36/gstreamer_python-1.28.1-cp313-cp313t-win32.whl", hash = "sha256:fdd8e95794fe92040e7e02c2317cfbbfdeea1014d78ff6cb39050c4941f646c8", size = 947840, upload-time = "2026-02-26T21:14:40.075Z" },
-    { url = "https://files.pythonhosted.org/packages/09/c8/afda085e4de3421a88b6ae9d4d30b81414365b42a4443d0d9d93b76e4000/gstreamer_python-1.28.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e1e73480b4d8951d930cd30a8c7ce4d52b509191ae80449d5613fc25343eb15e", size = 994224, upload-time = "2026-02-26T21:14:41.792Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a1/0b40f2d6135f8252e418b51c4ade3dcfdcf21833279d4b17169bc7f555cb/gstreamer_python-1.28.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a10d01c0e4f6cfe0bfada409547e14c785bd0c4538917dd130d13420556fbf3a", size = 1203798, upload-time = "2026-02-26T21:14:47.092Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/37/63e78619a1f3f3d7a276e9bdb9b9c129464922754eb011ccfd9064bba69e/gstreamer_python-1.28.1-cp314-cp314-win32.whl", hash = "sha256:b13cd51c358f9142912db850f4ae98a6de68f217cbc5f7e54add86ea17637e0a", size = 959220, upload-time = "2026-02-26T21:14:53.402Z" },
-    { url = "https://files.pythonhosted.org/packages/74/29/70cb841fae8ea4c4878f158971ca12db77f8f3dc0c1d2d0e1460f4ddcff7/gstreamer_python-1.28.1-cp314-cp314-win_amd64.whl", hash = "sha256:84c5ded17dcb2515cc3800a5140315edef46bf1d91d35857f685c28f2eeaa6a6", size = 1000668, upload-time = "2026-02-26T21:14:55.209Z" },
-    { url = "https://files.pythonhosted.org/packages/be/c8/0f246365f5fb91356f42e37a743f0293aa183aa462fe2409aa3961585cac/gstreamer_python-1.28.1-cp314-cp314t-win32.whl", hash = "sha256:aa2ab0a970fe862af32e266a8774926675f0ea4e8cc93d36935c83c0e9ddf74e", size = 974554, upload-time = "2026-02-26T21:14:49.276Z" },
-    { url = "https://files.pythonhosted.org/packages/85/f6/ddda0653b981099f43b316002e5cf1bacf6976b27a766695c4cd9e832762/gstreamer_python-1.28.1-cp314-cp314t-win_amd64.whl", hash = "sha256:12fbc7beea0f63486f8a0c9732afe78823cd6bb8356f66e7b1d4d19ee8f8ef0b", size = 1022968, upload-time = "2026-02-26T21:14:51.182Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d3/14bbbd69eae2c4e6e5810118961393e2a9e1db6bbc39429d1c5dfd6b60ee/gstreamer_python-1.28.2-cp310-cp310-macosx_10_13_universal2.whl", hash = "sha256:6450d94c7928776c3812a723e44ac35381871f2133d6012fe76dcd8eadbda0ed", size = 1187432, upload-time = "2026-04-08T21:24:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/ccbe08da34ad7d4c2ff7e89c4abc1d0e7e079cee6c454b7951de77716af8/gstreamer_python-1.28.2-cp310-cp310-win32.whl", hash = "sha256:bf112fa4ddc177b8bc10b7a37e7bf90fd4ee2f551c286976f826e9be59fdc6d0", size = 930755, upload-time = "2026-04-08T21:24:18.558Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e5/3e72fe25925e365620fc49f1e4d4d1db2e4515518b091e50c5b6a474fdc3/gstreamer_python-1.28.2-cp310-cp310-win_amd64.whl", hash = "sha256:c73912242a8f1da29bb6cb579b7a406649e185913012b7f173536e1d6ca80de8", size = 970173, upload-time = "2026-04-08T21:24:20.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/50/845f706262e52bbb5111ffa0570f7569d84b37ab7d3d31b155dc76ee21ca/gstreamer_python-1.28.2-cp311-cp311-macosx_10_13_universal2.whl", hash = "sha256:58bfd8fd8ed23fdf95526eecfaf13c7cd57e7f29433a07bcefbf42948fe923b2", size = 1187440, upload-time = "2026-04-08T21:24:23.68Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d1/d6f57b70952fe17e72ed23c001bbdd6a9d6e5b18949aeb78086c6ad8f204/gstreamer_python-1.28.2-cp311-cp311-win32.whl", hash = "sha256:cd4dcd1e0b6578df4002909d62dc6e459614e53f311e199a84cb2ae4a948dc78", size = 931177, upload-time = "2026-04-08T21:24:25.477Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/fd/b5646bd1501f5886ca24853ff3a6dabf0468a651976da24fa265be2dcc47/gstreamer_python-1.28.2-cp311-cp311-win_amd64.whl", hash = "sha256:81e4c5bd30b56892464c31a4dcf97c570fc2ced0447614ccf858cb688ed5e3e9", size = 971202, upload-time = "2026-04-08T21:24:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/cfd8b4f978fa0ca77d807c607c9670683f6df65e940df20a4e29b1e8a07b/gstreamer_python-1.28.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d41caea97dda2519499d44fd2865b5aab2a7160731c42f6d2481a4e1e0d885f8", size = 1195210, upload-time = "2026-04-08T21:24:29.305Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/68/2e511955548ebc0b1cd42147111a01df7620ad16ebb229ce627504195b38/gstreamer_python-1.28.2-cp312-cp312-win32.whl", hash = "sha256:bcd3e46cc40a8269aa07eff5ac61caf00f1a89b62a465bf3d7171d4313040c48", size = 933272, upload-time = "2026-04-08T21:24:31.467Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/43/6499561f0deb82ebdccdfc0ccbda91851f6bed40b21d58cda4671de159ab/gstreamer_python-1.28.2-cp312-cp312-win_amd64.whl", hash = "sha256:7df2911174115a3409abce0d158ccf12774537a7b7baa27203f8323c35ab2efc", size = 973952, upload-time = "2026-04-08T21:24:33.399Z" },
+    { url = "https://files.pythonhosted.org/packages/de/7f/8c32d7f8c4363e3478cfe70c09d9ab1f7efe78abf6214a4ccf4837be4a15/gstreamer_python-1.28.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dc7ead736545dd644fd370678fff8c120c67420882cc994b3f9a947202343610", size = 1204011, upload-time = "2026-04-08T21:24:35.337Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3c/84cfd116fffb85afc05613ed5b36fff596aef24e2652efa36e54dc350657/gstreamer_python-1.28.2-cp313-cp313-win32.whl", hash = "sha256:5377067243bf171c9af08290269f54e198f3ad32f1422df44d6729d8675357b9", size = 934034, upload-time = "2026-04-08T21:24:41.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7d/ce6819070a509e3d6242672e7e4943975cc965c3fff751d8fe1b5d4d7c7e/gstreamer_python-1.28.2-cp313-cp313-win_amd64.whl", hash = "sha256:b79aadedfeebd704bbe57e6ea598c317fe4c282891f776ad2bfeafd2ad4fc0b8", size = 975096, upload-time = "2026-04-08T21:24:43.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/26/d76e056ed3f667a72a4eb4503521cc64c52decd9d01428ce41335cbdd11d/gstreamer_python-1.28.2-cp313-cp313t-win32.whl", hash = "sha256:ba21dad5b24ce8bcaac0d755ac0767401fa134045a3145aeb2fc531565bf8be7", size = 948133, upload-time = "2026-04-08T21:24:37.629Z" },
+    { url = "https://files.pythonhosted.org/packages/52/aa/ebe0d6c9a8df01b0a7fc492def32a9583e39fac19176effb5e56d63fb3cc/gstreamer_python-1.28.2-cp313-cp313t-win_amd64.whl", hash = "sha256:761aca351437f387e1c9056c93c79ec321f1406eaa3d63b38ffe421c73d31558", size = 994517, upload-time = "2026-04-08T21:24:39.63Z" },
+    { url = "https://files.pythonhosted.org/packages/88/06/a858cafb941baa88b6553a1497a70b8fd63fb0b30a1739b31aeb7a5cb5ce/gstreamer_python-1.28.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:237bbaee74a491ccd1efff1c295b462d28d6376a4523f8e9808044df3bb8d741", size = 1203968, upload-time = "2026-04-08T21:24:45.882Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ab/01aff64f3c2444a1980d75dd87da77443b03cb49d00315500fe30d7fbe5f/gstreamer_python-1.28.2-cp314-cp314-win32.whl", hash = "sha256:1be3fdc21fa91cb79afbb49e39abcb46177e130f671bdfcce73a38dbf51a82e1", size = 959521, upload-time = "2026-04-08T21:24:51.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ff/8cb9c504f86e77f46df231fbcfbe42149784f1299a80278ed08a242f64ca/gstreamer_python-1.28.2-cp314-cp314-win_amd64.whl", hash = "sha256:c0296314eac79cb721d09b7d29073e27e1b9f54d400e0e38132a5f381cb0d850", size = 1000968, upload-time = "2026-04-08T21:24:53.768Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/eb/c359b939ef9b70602898bd11d8f19ceb72e53a2d135c4b30543f5f866f42/gstreamer_python-1.28.2-cp314-cp314t-win32.whl", hash = "sha256:a221cb15349d412fb32d9bf45f58ff12b9c2901485bcd2f4550cdc2fd2264c85", size = 974842, upload-time = "2026-04-08T21:24:47.71Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0f/fc46b0b92721616af252ada19606767f5a66d25310a7efade1aef07916eb/gstreamer_python-1.28.2-cp314-cp314t-win_amd64.whl", hash = "sha256:ada47887f72526650b3222f1864c8149ee27f5b64bd9a3e5f22abbee2952bcb5", size = 1023273, upload-time = "2026-04-08T21:24:49.942Z" },
 ]
 
 [[package]]
@@ -3506,7 +3499,7 @@ requires-dist = [
     { name = "cv2-enumerate-cameras", marker = "extra == 'opencv'", specifier = ">=1.2.1" },
     { name = "fastapi" },
     { name = "gpiozero", marker = "sys_platform == 'linux' and extra == 'wireless-version'", specifier = ">=2.0.0" },
-    { name = "gstreamer-bundle", marker = "sys_platform != 'linux'", specifier = "==1.28.1" },
+    { name = "gstreamer-bundle", marker = "sys_platform != 'linux'", specifier = "==1.28.2" },
     { name = "huggingface-hub", specifier = "==1.3.0" },
     { name = "jinja2" },
     { name = "lgpio", marker = "sys_platform == 'linux' and extra == 'wireless-version'", specifier = ">=0.2.2.0" },


### PR DESCRIPTION
Fixes the need to have the dependency-metadata in the pyproject.toml