### PR TITLE
fix: reject startSession() promise on sessionRejected response

### DIFF
--- a/js/reachy-mini.js
+++ b/js/reachy-mini.js
@@ -453,6 +453,25 @@ export class ReachyMini extends EventTarget {
             };
 
             this._sendToServer({ type: 'startSession', peerId: robotId }).then((r) => {
+                if (r?.type === 'sessionRejected') {
+                    // Central refused the session (e.g. robot busy with another app).
+                    // Fail the pending startSession() promise so callers can react.
+                    const err = new Error(
+                        r.reason === 'robot_busy'
+                            ? `Robot is busy: "${r.activeApp || 'another app'}" is already connected`
+                            : `Session rejected: ${r.reason || 'unknown reason'}`
+                    );
+                    err.reason = r.reason;
+                    err.activeApp = r.activeApp;
+                    this._emit('sessionRejected', { reason: r.reason, activeApp: r.activeApp });
+                    if (this._sessionReject) {
+                        const reject = this._sessionReject;
+                        this._sessionResolve = null;
+                        this._sessionReject = null;
+                        reject(err);
+                    }
+                    return;
+                }
                 if (r?.sessionId) this._sessionId = r.sessionId;
             });
         });


### PR DESCRIPTION
The central server returns { type: "sessionRejected", ... } as the direct POST response to /send for a startSession request — not as a pushed SSE message. The existing handler in _handleSignalingMessage only covered the SSE path, so when the server rejected, the .then() on line 455 silently dropped the response and the promise hung forever (UI stuck on "Starting...").

Now checks the response type and rejects the pending promise with the same shape as the SSE handler (err.reason + err.activeApp), keeping both paths as belt-and-suspenders.