### PR TITLE
fix(media): use host default mic/camera/speaker in simulation modes

### DIFF
--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -43,7 +43,12 @@ from reachy_mini.media.camera_constants import (
     MujocoCameraSpecs,
     ReachyMiniLiteCamSpecs,
 )
-from reachy_mini.media.device_detection import get_audio_device, get_video_device
+from reachy_mini.media.device_detection import (
+    DEFAULT_CAM_NAMES,
+    get_audio_device,
+    get_video_device,
+    gst_monitor_devices,
+)
 from reachy_mini.utils.constants import ASSETS_ROOT_PATH
 
 gi.require_version("Gst", "1.0")
@@ -501,8 +506,23 @@ class GstMediaServer:
 
         Used by mockup simulation to grab video from whatever camera is
         available on the host system.
+
+        When a Reachy Mini USB camera is plugged in, the platform's device
+        enumeration may rank it ahead of the built-in camera (varies per
+        OS and connection order).  In simulation we explicitly want the
+        *host* camera (laptop/desktop webcam), never the robot's camera —
+        so we enumerate the system's video devices, filter out anything
+        matching the known Reachy camera names, and pin the source to the
+        first remaining device.  If no non-Reachy camera is available we
+        fall back to ``autovideosrc`` (which may still pick the Reachy,
+        but there is nothing else to stream from).
         """
-        camsrc = Gst.ElementFactory.make("autovideosrc")
+        camsrc = self._build_non_reachy_video_source()
+        if camsrc is None:
+            self._logger.info(
+                "No non-Reachy camera detected; falling back to autovideosrc."
+            )
+            camsrc = Gst.ElementFactory.make("autovideosrc")
         videoconvert = Gst.ElementFactory.make("videoconvert")
         videorate = Gst.ElementFactory.make("videorate")
 
@@ -518,6 +538,63 @@ class GstMediaServer:
         if not all(elements):
             raise RuntimeError("Failed to create autovideo source elements")
         return elements
+
+    def _build_non_reachy_video_source(self) -> Optional[Gst.Element]:
+        """Return a platform-native video source that is NOT a Reachy camera.
+
+        Enumerates ``Video/Source`` devices via ``Gst.DeviceMonitor`` and
+        picks the first one whose display name does not contain any of
+        the Reachy camera name substrings (``DEFAULT_CAM_NAMES``).  On
+        macOS we use ``avfvideosrc`` pinned to the device's enumeration
+        index; on Windows we use ``mfvideosrc`` pinned to the display
+        name; on Linux (mockup sim on desktop) we fall back to
+        ``autovideosrc`` because v4l2 enumeration isn't consistent enough
+        to hand-pick.
+
+        Returns:
+            A configured GStreamer source element, or ``None`` when no
+            suitable camera is found (caller should fall back to
+            ``autovideosrc``).
+
+        """
+        try:
+            devices = gst_monitor_devices("Video/Source")
+        except Exception:
+            self._logger.exception("Video device enumeration failed")
+            return None
+
+        current_platform = platform.system()
+        for device in devices:
+            name = device.display_name or ""
+            if any(reachy_name in name for reachy_name in DEFAULT_CAM_NAMES):
+                continue
+
+            match current_platform:
+                case "Darwin":
+                    camsrc = Gst.ElementFactory.make("avfvideosrc")
+                    if camsrc is None:
+                        return None
+                    camsrc.set_property("device-index", device.index)
+                    self._logger.info(
+                        "Sim mode: using non-Reachy camera '%s' at index %d",
+                        name,
+                        device.index,
+                    )
+                    return camsrc
+                case "Windows":
+                    camsrc = Gst.ElementFactory.make("mfvideosrc")
+                    if camsrc is None:
+                        return None
+                    camsrc.set_property("device-name", name)
+                    self._logger.info(
+                        "Sim mode: using non-Reachy camera '%s' (Windows)", name
+                    )
+                    return camsrc
+                case _:
+                    # Linux desktop mockup sim: keep autovideosrc fallback.
+                    return None
+
+        return None
 
     def _build_libcamera_source(self) -> list[Gst.Element]:
         """Build source chain for RPi CSI camera (libcamerasrc)."""
@@ -793,19 +870,34 @@ class GstMediaServer:
         """Build a platform-aware audio source element.
 
         Detection order:
-        1. .asoundrc — on the wireless CM4 the ``.asoundrc`` file defines
+        1. Simulation mode short-circuit — when running in MUJOCO or
+           MOCKUP sim we must *never* grab the Reachy Mini microphone
+           (even if a USB robot happens to be plugged in).  We return
+           the host's default audio source (``autoaudiosrc``) so the
+           WebRTC stream carries the laptop/desktop mic instead.
+        2. .asoundrc — on the wireless CM4 the ``.asoundrc`` file defines
            ALSA aliases (``reachymini_audio_src``).  When present we use
            ``alsasrc`` directly, matching the behaviour of the original
            daemon and avoiding PipeWire clock issues.
-        2. GstDeviceMonitor — finds the Reachy Mini Audio card by name and
+        3. GstDeviceMonitor — finds the Reachy Mini Audio card by name and
            returns a platform-native element (pulsesrc, wasapi2src,
            osxaudiosrc).  Used on Lite and desktop platforms.
-        3. autoaudiosrc — last resort when no Reachy Mini card is found.
+        4. autoaudiosrc — last resort when no Reachy Mini card is found.
 
         Returns:
             A GStreamer audio source element, or None if no audio is available.
 
         """
+        # Simulation mode: always use the host's default mic, even if a
+        # Reachy USB robot is plugged in (otherwise the sim pipeline would
+        # capture the robot's microphone instead of the laptop's).
+        if self._sim_mode is not SimulationMode.NONE:
+            self._logger.info(
+                "Simulation mode (%s): using host default audio source (autoaudiosrc).",
+                self._sim_mode.value,
+            )
+            return Gst.ElementFactory.make("autoaudiosrc")
+
         # Wireless CM4: .asoundrc defines reachymini_audio_src alias
         if has_reachymini_asoundrc():
             audiosrc = Gst.ElementFactory.make("alsasrc")
@@ -929,13 +1021,23 @@ class GstMediaServer:
     def _build_audiosink_element(self) -> Optional[Gst.Element]:
         """Build a platform-aware audio sink GStreamer element.
 
-        Same detection order as ``_build_audio_source()``: .asoundrc first
-        (wireless CM4), then DeviceMonitor, then autoaudiosink.
+        Same detection order as ``_build_audio_source()``: sim-mode
+        short-circuit, then .asoundrc (wireless CM4), then DeviceMonitor,
+        then autoaudiosink.
 
         Returns:
             A GStreamer audio sink element, or None to use the default.
 
         """
+        # Simulation mode: always play back through the host's default
+        # speaker, never the Reachy Mini card (even if plugged via USB).
+        if self._sim_mode is not SimulationMode.NONE:
+            self._logger.info(
+                "Simulation mode (%s): using host default audio sink (autoaudiosink).",
+                self._sim_mode.value,
+            )
+            return Gst.ElementFactory.make("autoaudiosink")
+
         # Wireless CM4: .asoundrc defines reachymini_audio_sink alias
         if has_reachymini_asoundrc():
             audiosink = Gst.ElementFactory.make("alsasink")


### PR DESCRIPTION
## Summary

When the daemon is launched with `--mockup-sim` (or MuJoCo sim) while a Reachy Mini is physically plugged via USB, the WebRTC pipeline used to capture **the robot's** microphone — and on platforms where device enumeration ranks the USB webcam first, **the robot's** camera — instead of the host machine's peripherals. Symmetrically, daemon-side sounds played through the robot's speaker even in sim.

Root cause: `GstMediaServer` never consulted `sim_mode` when picking media devices.

- `_build_audio_source()` unconditionally called `get_audio_device(\"Source\")`, which scans `Gst.DeviceMonitor` for any \"Reachy Mini Audio\" card and hands it to `osxaudiosrc` / `pulsesrc` / `wasapi2src`.
- `_build_audiosink_element()` had the symmetric bug for playback.
- `_build_autovideo_source()` used plain `autovideosrc`, leaving device selection to the platform; AVFoundation / Media Foundation can rank a hotplugged USB webcam ahead of the built-in camera.

## Changes

- **Audio source + sink** — short-circuit at the top: when `self._sim_mode is not SimulationMode.NONE`, return `autoaudiosrc` / `autoaudiosink` directly. These respect the OS' default input/output selection and therefore never bind to the Reachy card.
- **Video (mockup sim)** — new `_build_non_reachy_video_source()` helper:
  - enumerates `Video/Source` devices via `Gst.DeviceMonitor`,
  - skips any device whose display name contains a known Reachy camera substring (`DEFAULT_CAM_NAMES` -> `Reachy` / `Arducam_12MP` / `imx708`),
  - pins the resulting source to the first non-Reachy device: `avfvideosrc device-index=N` on macOS, `mfvideosrc device-name=...` on Windows,
  - falls back to `autovideosrc` when no alternative camera is available (e.g. Linux, headless boxes).

No behavioural change for `SimulationMode.NONE` (real-hardware path is untouched).

## Test plan

- [x] Tested on macOS (Apple Silicon, built-in FaceTime HD Camera + Reachy Mini plugged via USB):
  - `--mockup-sim`: WebRTC now streams the Mac's microphone + FaceTime camera, confirmed in both the conversation app and plain browser consumers.
  - Log lines confirm the branch taken:
    - `Simulation mode (mockup): using host default audio source (autoaudiosrc).`
    - `Sim mode: using non-Reachy camera '<cam_name>' at index 0`
    - `Simulation mode (mockup): using host default audio sink (autoaudiosink).`
  - Switching back to USB (no `--mockup-sim`) still picks up the robot's mic/camera/speaker as before.
- [ ] Windows validation (would appreciate a second pair of eyes on the `mfvideosrc device-name=...` branch).
- [ ] Linux desktop validation (falls back to `autovideosrc`; worth checking no regression on the mockup sim path there).

## Notes for reviewers

- The real-hardware path (`SimulationMode.NONE`) is strictly untouched - the sim short-circuit is the *first* check in both audio helpers, so the existing `.asoundrc` / `DeviceMonitor` / `autoaudio*` fallback chain is preserved.
- `_build_non_reachy_video_source()` intentionally returns `None` on Linux so the existing `autovideosrc` fallback remains the behaviour there; if desired I can extend it to `v4l2src` with explicit device-path filtering in a follow-up.

Made with [Cursor](https://cursor.com)