### PR TITLE
fix(media): skip Gst.DeviceMonitor.stop() on macOS to avoid segfault

### DIFF
--- a/src/reachy_mini/media/device_detection.py
+++ b/src/reachy_mini/media/device_detection.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import platform
 import re
+import sys
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, Sequence, Tuple
 
@@ -272,7 +273,23 @@ def gst_monitor_devices(filter_class: str) -> list[DeviceInfo]:
     try:
         return gst_devices_to_device_infos(monitor.get_devices())
     finally:
-        monitor.stop()
+        # Workaround: on macOS (observed on macOS 26 "Tahoe") calling
+        # Gst.DeviceMonitor.stop() can segfault inside
+        # gst_device_provider_stop -> avfdeviceprovider, killing the whole
+        # Python daemon with SIGSEGV before any traceback can be emitted.
+        # The monitor is short-lived (one enumeration at boot) so skipping
+        # the explicit stop is acceptable: the underlying providers are
+        # reclaimed when the Python object is garbage collected and when
+        # the process exits.
+        if sys.platform == "darwin":
+            _logger.debug(
+                "Skipping Gst.DeviceMonitor.stop() on macOS (known crash)",
+            )
+        else:
+            try:
+                monitor.stop()
+            except Exception:  # pragma: no cover - defensive
+                _logger.exception("Gst.DeviceMonitor.stop() failed")
 
 
 def find_audio_device(


### PR DESCRIPTION
## Summary

On macOS 26 (Tahoe) the Python daemon consistently crashes at boot with `SIGSEGV` inside `gst_device_monitor_stop -> gst_device_provider_stop` (`avfdeviceprovider`) when `gst_monitor_devices()` is called for video (and sometimes audio) source enumeration. The crash happens before Python can run `sys.excepthook`, so the daemon just disappears with `exit code 1` and no traceback.

This PR contains a narrow workaround: on `darwin`, we **skip the explicit `Gst.DeviceMonitor.stop()` call**. The monitor is short-lived (one enumeration at boot per source type) and will be reclaimed by Python GC / at process exit, so the leak is effectively nil.

Behavior on Linux and Windows is unchanged, just additionally wrapped in a defensive `try/except` so an unexpected failure in `stop()` is logged instead of propagating.

## Crash report excerpt

```
Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x...
Termination Reason:    Namespace SIGNAL, Code 11 Segmentation fault: 11

Thread 0 (crashed):
  gst_device_provider_stop
  gst_device_monitor_stop              <-- crash here
  ffi_call_SYSV (libffi)
  pygi_invoke_c_callable (PyGObject)
  slot_tp_init (GstMediaServer.__init__)
  slot_tp_init (Daemon.__init__)
  Py_RunMain
```

## How it was reached

Called from both:
- `get_video_device()` -> `gst_monitor_devices("Video/Source")`
- `get_audio_device()` -> `gst_monitor_devices("Audio/...")`

Both happen during `GstMediaServer.__init__` which runs in `Daemon.__init__`.

## Upstream GStreamer root cause (for escalation)

The actual bug is in GStreamer's **`avfdeviceprovider`** (plugin `applemedia`, inside `gst-plugins-bad`). When a `GstDeviceMonitor` is stopped, it iterates its registered providers and calls `gst_device_provider_stop()` on each one; on macOS the AVFoundation-backed provider seems to hit a use-after-free / double-free on an internal `AVCaptureDeviceDiscoverySession` (or the KVO observer it installs) and dereferences a dangling pointer, producing the `EXC_BAD_ACCESS` above.

Exact reproduction environment (what is actually loaded at runtime in the daemon, NOT the system Homebrew GStreamer):

| Layer | Version | Source |
|---|---|---|
| OS | macOS 26.2 "Tahoe" (build 25C56) | - |
| CPU | Apple M1 Pro, arm64 | - |
| GStreamer libs | **1.28.2** | pip wheel `gstreamer_libs==1.28.2` (vendored via `gstreamer_bundle==1.28.1`, pulled in as a direct dep of `reachy_mini`) |
| `applemedia` plugin | **1.28.2** | `.venv/lib/python3.12/site-packages/gstreamer_plugins/lib/gstreamer-1.0/libgstapplemedia.dylib` |
| PyGObject | `3.50.2` | pip (bundled under `gstreamer_python`) |
| Python | `3.12.13` | uv-managed |

`1.28.2` is the **current upstream stable** GStreamer release (not an old packaged one), so this reproduces on a fully up-to-date stack.

Minimal Python reproducer (no `reachy_mini` involved):

```python
import gi
gi.require_version("Gst", "1.0")
from gi.repository import Gst

Gst.init(None)
monitor = Gst.DeviceMonitor()
monitor.add_filter("Video/Source", None)
monitor.start()
devices = monitor.get_devices()
print(f"{len(devices)} device(s) enumerated")
monitor.stop()   # <-- intermittent SIGSEGV here on macOS 26 + GStreamer 1.28.2
```

Or even smaller, in pure C with `gst-device-monitor-1.0`:

```sh
gst-device-monitor-1.0 Video/Source   # crashes on teardown sometimes
```

Where to report:
- GStreamer monorepo issue tracker: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues
- Likely owner area: `subprojects/gst-plugins-bad/sys/applemedia/avfdeviceprovider.m`
- Search terms that *might* already have hits: "avfdeviceprovider segfault", "gst_device_provider_stop crash macOS"

Not yet filed upstream from our side - feel free to open the issue with this PR's crash report if desired.

## Test plan

- [x] Manual USB mode connection on macOS 26.2 (Tahoe, arm64): daemon boots cleanly, no more SIGSEGV, camera + mic pipelines work.
- [x] Manual USB mode connection on macOS 14.x (Sonoma, arm64): no regression.
- [x] `ruff check` + `ruff format` pass via pre-commit hook.
- [ ] Needs validation on Linux / Windows (behavior is unchanged but reviewers may want to confirm).

## Alternatives considered

- **Retry with a small delay before `stop()`**: unreliable, still races.
- **Upstream GStreamer fix in `avfdeviceprovider`**: proper fix but out of scope and much slower to land - see "Upstream GStreamer root cause" section above for everything needed to file the bug.
- **Run the enumeration in a subprocess** so a crash doesn't kill the daemon: overkill for a one-shot device scan.

Made with [Cursor](https://cursor.com)