### PR TITLE
fix(wifi): always fall back to AP mode after forget_all and reboot

### DIFF
--- a/src/reachy_mini/daemon/app/routers/wifi_config.py
+++ b/src/reachy_mini/daemon/app/routers/wifi_config.py
@@ -1,6 +1,7 @@
 """WiFi Configuration Routers."""
 
 import logging
+import subprocess
 from enum import Enum
 from threading import Lock, Thread
 
@@ -10,6 +11,7 @@ from pydantic import BaseModel
 
 HOTSPOT_SSID = "reachy-mini-ap"
 HOTSPOT_PASSWORD = "reachy-mini"
+HOTSPOT_CONNECTION_NAME = "Hotspot"
 
 
 router = APIRouter(
@@ -38,18 +40,27 @@ class WifiStatus(BaseModel):
     connected_network: str | None
 
 
-def get_current_wifi_mode() -> WifiMode:
-    """Get the current WiFi mode."""
-    if busy_lock.locked():
-        return WifiMode.BUSY
+def compute_wifi_mode() -> WifiMode:
+    """Compute the real WiFi mode, ignoring busy state.
 
+    Unlike ``get_current_wifi_mode``, this never returns ``BUSY`` and can be
+    safely called from code that already holds ``busy_lock`` (e.g. worker
+    threads inside ``with busy_lock:``).
+    """
     conn = get_wifi_connections()
-    if check_if_connection_active("Hotspot"):
+    if check_if_connection_active(HOTSPOT_CONNECTION_NAME):
         return WifiMode.HOTSPOT
     elif any(c.device != "--" for c in conn):
         return WifiMode.WLAN
     else:
         return WifiMode.DISCONNECTED
+
+
+def get_current_wifi_mode() -> WifiMode:
+    """Get the current WiFi mode."""
+    if busy_lock.locked():
+        return WifiMode.BUSY
+    return compute_wifi_mode()
 
 
 @router.get("/status")
@@ -58,7 +69,7 @@ def get_wifi_status() -> WifiStatus:
     mode = get_current_wifi_mode()
 
     connections = get_wifi_connections()
-    known_networks = [c.name for c in connections if c.name != "Hotspot"]
+    known_networks = [c.name for c in connections if c.name != HOTSPOT_CONNECTION_NAME]
 
     connected_network = next((c.name for c in connections if c.device != "--"), None)
 
@@ -97,9 +108,17 @@ def setup_hotspot(
 
     def hotspot() -> None:
         with busy_lock:
-            setup_wifi_connection(
-                name="Hotspot", ssid=ssid, password=password, is_hotspot=True
-            )
+            # Use the default hotspot helper when the caller didn't override
+            # credentials so we benefit from the auto-heal behavior.
+            if ssid == HOTSPOT_SSID and password == HOTSPOT_PASSWORD:
+                ensure_hotspot_active()
+            else:
+                setup_wifi_connection(
+                    name=HOTSPOT_CONNECTION_NAME,
+                    ssid=ssid,
+                    password=password,
+                    is_hotspot=True,
+                )
 
     Thread(target=hotspot).start()
     # TODO: wait for it to be really started
@@ -127,12 +146,7 @@ def connect_to_wifi_network(
                 logger.error(f"Failed to connect to WiFi network '{ssid}': {e}")
                 logger.info("Reverting to hotspot...")
                 remove_connection(name=ssid)
-                setup_wifi_connection(
-                    name="Hotspot",
-                    ssid=HOTSPOT_SSID,
-                    password=HOTSPOT_PASSWORD,
-                    is_hotspot=True,
-                )
+                ensure_hotspot_active()
 
     Thread(target=connect).start()
     # TODO: wait for it to be really connected
@@ -152,7 +166,7 @@ def scan_wifi() -> list[str]:
 @router.post("/forget")
 def forget_wifi_network(ssid: str) -> None:
     """Forget a saved WiFi network. Falls back to Hotspot if forgetting the active network."""
-    if ssid == "Hotspot":
+    if ssid == HOTSPOT_CONNECTION_NAME:
         raise HTTPException(status_code=400, detail="Cannot forget Hotspot connection.")
 
     if not check_if_connection_exists(ssid):
@@ -174,12 +188,7 @@ def forget_wifi_network(ssid: str) -> None:
 
                 if was_active:
                     logger.info("Was connected, falling back to hotspot...")
-                    setup_wifi_connection(
-                        name="Hotspot",
-                        ssid=HOTSPOT_SSID,
-                        password=HOTSPOT_PASSWORD,
-                        is_hotspot=True,
-                    )
+                    ensure_hotspot_active()
             except Exception as e:
                 error = e
                 logger.error(f"Failed to forget network '{ssid}': {e}")
@@ -201,22 +210,29 @@ def forget_all_wifi_networks() -> None:
                 connections = get_wifi_connections()
                 forgotten = []
 
+                # Check BEFORE deletion if we were actively connected to a
+                # non-Hotspot network. We cannot rely on the post-delete mode
+                # because deleting the active profile can leave wlan0 in a
+                # transient state where no wifi is "active" yet no error is
+                # raised.
+                was_connected_to_wifi = any(
+                    c.name != HOTSPOT_CONNECTION_NAME and c.device != "--"
+                    for c in connections
+                )
+
                 for conn in connections:
-                    if conn.name != "Hotspot":
+                    if conn.name != HOTSPOT_CONNECTION_NAME:
                         remove_connection(conn.name)
                         forgotten.append(conn.name)
 
                 logger.info(f"Forgotten {len(forgotten)} networks: {forgotten}")
 
-                # Always ensure we have connectivity after forgetting all
-                if get_current_wifi_mode() == WifiMode.DISCONNECTED:
-                    logger.info("No connection left, setting up hotspot...")
-                    setup_wifi_connection(
-                        name="Hotspot",
-                        ssid=HOTSPOT_SSID,
-                        password=HOTSPOT_PASSWORD,
-                        is_hotspot=True,
-                    )
+                # NOTE: ``get_current_wifi_mode()`` would return ``BUSY`` here
+                # because we hold ``busy_lock``. We use ``compute_wifi_mode``
+                # directly so the fallback actually triggers.
+                if was_connected_to_wifi or compute_wifi_mode() != WifiMode.HOTSPOT:
+                    logger.info("Falling back to hotspot after clearing networks...")
+                    ensure_hotspot_active()
             except Exception as e:
                 error = e
                 logger.error(f"Failed to forget networks: {e}")
@@ -277,6 +293,54 @@ def remove_connection(name: str) -> None:
         nmcli.connection.delete(name)
 
 
+def _prepare_wlan0_for_hotspot() -> None:
+    """Best-effort hygiene before (re)starting the hotspot on wlan0.
+
+    Mirrors the behavior of ``bluetooth/commands/HOTSPOT.sh`` so the on-device
+    recovery paths (WiFi API + BLE command) behave identically. Any failure is
+    logged but never raised: we want to keep trying to bring the AP up even if
+    one of these preparation steps is unavailable on the host.
+    """
+    for cmd in (
+        ["nmcli", "device", "disconnect", "wlan0"],
+        ["rfkill", "unblock", "wifi"],
+    ):
+        try:
+            subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        except Exception as exc:  # noqa: BLE001 - best effort
+            logger.debug(f"Preparation step {cmd!r} failed: {exc}")
+
+
+def ensure_hotspot_active() -> None:
+    """Make sure the Hotspot AP is up, auto-healing a broken profile if needed.
+
+    ``nmcli.connection.up("Hotspot")`` can silently fail when the stored
+    profile is stale (e.g. wrong mode, missing ``ipv4.method=shared``) or when
+    wlan0 is in a weird state after a connection was deleted. In that case we
+    drop the profile and re-create it from scratch via ``wifi_hotspot`` so the
+    robot always ends up reachable on ``10.42.0.1``.
+    """
+    _prepare_wlan0_for_hotspot()
+
+    try:
+        setup_wifi_connection(
+            name=HOTSPOT_CONNECTION_NAME,
+            ssid=HOTSPOT_SSID,
+            password=HOTSPOT_PASSWORD,
+            is_hotspot=True,
+        )
+    except Exception as exc:  # noqa: BLE001 - we want to attempt recovery
+        logger.warning(
+            f"Failed to activate existing Hotspot profile ({exc}). "
+            "Recreating it from scratch..."
+        )
+        try:
+            remove_connection(HOTSPOT_CONNECTION_NAME)
+        except Exception as remove_exc:  # noqa: BLE001
+            logger.warning(f"Failed to remove stale Hotspot profile: {remove_exc}")
+        nmcli.device.wifi_hotspot(ssid=HOTSPOT_SSID, password=HOTSPOT_PASSWORD)
+
+
 WIFI_INIT_MAX_RETRIES = 5
 WIFI_INIT_RETRY_DELAY = 3  # seconds
 WIFI_INIT_TIMEOUT = 30  # seconds
@@ -296,15 +360,13 @@ def ensure_wifi_on_startup() -> None:
             # Make sure wlan0 is up and running
             scan_available_wifi()
 
-            # If no WiFi connection is active, set up the default hotspot
-            if get_current_wifi_mode() == WifiMode.DISCONNECTED:
+            # If no WiFi connection is active, set up the default hotspot.
+            # ``compute_wifi_mode`` is used instead of ``get_current_wifi_mode``
+            # for symmetry with ``forget_all`` and to avoid any surprise if a
+            # future refactor schedules this on a thread that holds the lock.
+            if compute_wifi_mode() == WifiMode.DISCONNECTED:
                 logger.info("No WiFi connection active. Setting up hotspot...")
-                setup_wifi_connection(
-                    name="Hotspot",
-                    ssid=HOTSPOT_SSID,
-                    password=HOTSPOT_PASSWORD,
-                    is_hotspot=True,
-                )
+                ensure_hotspot_active()
             return
         except Exception as e:
             logger.warning(

--- a/src/reachy_mini/daemon/app/routers/wifi_config.py
+++ b/src/reachy_mini/daemon/app/routers/wifi_config.py
@@ -294,25 +294,54 @@ def remove_connection(name: str) -> None:
 
 
 def _prepare_wlan0_for_hotspot() -> None:
-    """Best-effort hygiene before (re)starting the hotspot on wlan0.
+    """Best-effort hygiene before transitioning wlan0 into hotspot mode.
 
-    Mirrors the behavior of ``bluetooth/commands/HOTSPOT.sh`` so the on-device
-    recovery paths (WiFi API + BLE command) behave identically. Any failure is
-    logged but never raised: we want to keep trying to bring the AP up even if
-    one of these preparation steps is unavailable on the host.
+    Only called from ``ensure_hotspot_active`` when we actually need to
+    *switch* the interface into AP mode - the caller must have already
+    verified we are NOT currently on the hotspot, otherwise the
+    ``nmcli.device.disconnect`` below would tear down an active AP and kick
+    every associated client (phone during first-time WiFi setup, BLE recovery
+    session, etc.).
+
+    Behavior mirrors ``bluetooth/commands/HOTSPOT.sh`` so the WiFi API and BLE
+    command paths converge to the same state. Both steps are best-effort:
+    failures are logged at debug level and never raised, we still want to try
+    bringing the AP up afterwards.
     """
-    for cmd in (
-        ["nmcli", "device", "disconnect", "wlan0"],
-        ["rfkill", "unblock", "wifi"],
-    ):
-        try:
-            subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        except Exception as exc:  # noqa: BLE001 - best effort
-            logger.debug(f"Preparation step {cmd!r} failed: {exc}")
+    # 1) Drop any lingering client association on wlan0. Uses the nmcli python
+    # binding to stay consistent with the rest of this module (no subprocess
+    # fork, unified error handling).
+    try:
+        nmcli.device.disconnect("wlan0")
+    except Exception as exc:  # noqa: BLE001 - best effort
+        logger.debug(f"nmcli.device.disconnect('wlan0') failed: {exc}")
+
+    # 2) Clear any kernel-level soft-block on the WiFi radio. There is no
+    # Python equivalent in the nmcli lib (``nmcli radio wifi on`` is the
+    # NetworkManager logical switch, not the RF/rfkill one). We still need
+    # this because the CM5's combo WiFi/BT chip can end up soft-blocked after
+    # a firmware hiccup, which is exactly the class of situations leading
+    # users to trigger our recovery paths. Timeout is intentionally short -
+    # rfkill is a near-instant ioctl, anything longer than a couple of
+    # seconds means something is very wrong and we should fail fast.
+    try:
+        subprocess.run(
+            ["rfkill", "unblock", "wifi"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except Exception as exc:  # noqa: BLE001 - best effort
+        logger.debug(f"rfkill unblock wifi failed: {exc}")
 
 
 def ensure_hotspot_active() -> None:
     """Make sure the Hotspot AP is up, auto-healing a broken profile if needed.
+
+    Fast-paths the common case where the hotspot is already live (no wlan0
+    disconnect/reconnect churn, no client kicks) and only runs the wlan0
+    hygiene + profile activation/recreation when we actually need to
+    transition into AP mode.
 
     ``nmcli.connection.up("Hotspot")`` can silently fail when the stored
     profile is stale (e.g. wrong mode, missing ``ipv4.method=shared``) or when
@@ -320,6 +349,14 @@ def ensure_hotspot_active() -> None:
     drop the profile and re-create it from scratch via ``wifi_hotspot`` so the
     robot always ends up reachable on ``10.42.0.1``.
     """
+    # Skip all hygiene / (re)activation work when the AP is already broadcasting.
+    # Addresses review feedback on PR #1039: calling ``_prepare_wlan0_for_hotspot``
+    # unconditionally would ``disconnect wlan0`` and boot any already-associated
+    # client just to bring back the exact same connection.
+    if compute_wifi_mode() == WifiMode.HOTSPOT:
+        logger.debug("Hotspot already active, skipping recovery.")
+        return
+
     _prepare_wlan0_for_hotspot()
 
     try:


### PR DESCRIPTION
## Context

After using **Settings → Clear all networks** in the desktop app (which calls `POST /wifi/forget_all`), the robot stayed unreachable: no WiFi, no AP (`reachy-mini-ap`) broadcast. A reboot did **not** recover it either; only running `HOTSPOT` via Bluetooth (`bluetooth/commands/HOTSPOT.sh`) brought the AP back.

Root-cause analysis on `src/reachy_mini/daemon/app/routers/wifi_config.py` uncovered three stacked issues, all fixed here.

## Issues fixed

### 1. `forget_all` fallback never triggered (the main bug)

```python
def forget_all() -> None:
    with busy_lock:                          # lock is held here
        ...
        if get_current_wifi_mode() == WifiMode.DISCONNECTED:   # always False
            setup_wifi_connection(name="Hotspot", ..., is_hotspot=True)
```

`get_current_wifi_mode()` starts with:

```python
if busy_lock.locked():
    return WifiMode.BUSY
```

Since the worker thread runs inside `with busy_lock:`, the helper returns `BUSY`, never `DISCONNECTED`, so the hotspot is **never** brought back up after clearing all networks.

Fix: introduce `compute_wifi_mode()` (the pure detection logic, ignoring the busy flag) and capture `was_connected_to_wifi` **before** the deletion. The fallback now fires whenever we were on a non-Hotspot wifi OR the post-delete state is not HOTSPOT.

### 2. Stale `Hotspot` profile breaks `connection up` silently

`forget_all` intentionally keeps the `Hotspot` profile. On the next boot, `ensure_wifi_on_startup` calls `setup_wifi_connection`, which for an existing profile only runs `nmcli.connection.up("Hotspot")`. If the stored profile is stale (wrong `mode`, missing `ipv4.method=shared`, autoconnect disabled...) this fails silently and the retry loop just logs warnings.

Fix: new `ensure_hotspot_active()` helper that auto-heals by deleting and recreating the `Hotspot` profile via `nmcli.device.wifi_hotspot` when activation throws.

### 3. wlan0 hygiene missing in the Python paths

`bluetooth/commands/HOTSPOT.sh` does the right prep (`nmcli device disconnect wlan0` + `rfkill unblock wifi`) before the daemon restart. The Python fallbacks (`/setup_hotspot`, startup recovery, `forget_all` fallback) did not. When `wlan0` was in a transient state after a connection deletion, activation could fail for no good reason.

Fix: `_prepare_wlan0_for_hotspot()` mirrors those commands (best-effort, failures logged at debug level) and is run at the start of `ensure_hotspot_active()`.

## Summary of changes

- New `compute_wifi_mode()` pure helper; `get_current_wifi_mode()` now delegates to it.
- New `ensure_hotspot_active()` with `_prepare_wlan0_for_hotspot()` hygiene + profile auto-heal.
- `forget_all` uses `compute_wifi_mode` and a pre-deletion `was_connected_to_wifi` check.
- `/setup_hotspot`, `/connect` recovery, `/forget`, `/forget_all`, `ensure_wifi_on_startup` all route through `ensure_hotspot_active` so the recovery behavior is identical everywhere.
- Hard-coded `"Hotspot"` string replaced with `HOTSPOT_CONNECTION_NAME` constant.

No API change, no new dependency.

## Test plan

- [ ] From the desktop app, open Settings → **Clear all networks** while connected via WiFi. Verify `reachy-mini-ap` reappears within ~10 s without rebooting.
- [ ] Connect the robot to a WiFi, then **reboot**, then `Clear all networks` from the desktop app -> AP should come back.
- [ ] Manually corrupt the Hotspot profile (`nmcli connection modify Hotspot 802-11-wireless.mode infrastructure`) and reboot -> startup recovery should auto-heal the profile and bring the AP up.
- [ ] Existing flow: `POST /wifi/connect` with bad password -> daemon should still revert to hotspot.
- [ ] Bluetooth `CMD_HOTSPOT` keeps working (unchanged, but verifying no regression).

## Related

- Supersedes the earlier partial attempt on `fix/wifi-forget-all-hotspot-fallback` (based on main), which only fixed issue #1.


Made with [Cursor](https://cursor.com)