### PR TITLE
feat(hf-auth): expose /token endpoint for mobile token bridging

### DIFF
--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -18,9 +18,7 @@ router = APIRouter(prefix="/hf-auth")
 # Central signaling server that tracks which robot is currently in use by
 # which remote JS app. We proxy its /api/robot-status endpoint so the
 # desktop frontend never needs to see the raw HF token.
-CENTRAL_ROBOT_STATUS_URL = (
-    "https://cduss-reachy-mini-central.hf.space/api/robot-status"
-)
+CENTRAL_ROBOT_STATUS_URL = "https://cduss-reachy-mini-central.hf.space/api/robot-status"
 CENTRAL_ROBOT_STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 
@@ -63,6 +61,27 @@ async def save_token(request: TokenRequest) -> TokenResponse:
 async def get_auth_status() -> dict[str, Any]:
     """Check if user is authenticated with HuggingFace."""
     return hf_auth.check_token_status()
+
+
+@router.get("/token")
+async def get_token() -> dict[str, Any]:
+    """Return the stored HuggingFace token in plaintext.
+
+    This exists so remote clients (e.g. the mobile app) can bridge the
+    token into a sandboxed iframe that itself cannot go through the HF
+    OAuth flow (hit by ``X-Frame-Options: SAMEORIGIN`` on ``/login``).
+
+    Security note: the daemon's HTTP API is already unauthenticated on
+    the local network, so any client that can reach this endpoint can
+    also start/stop apps at will. Exposing the token here does not
+    meaningfully widen the attack surface, but we deliberately keep the
+    endpoint separate from ``/status`` so the desktop frontend - which
+    never needs the raw token - is not tempted to consume it.
+    """
+    token = hf_auth.get_hf_token()
+    if not token:
+        raise HTTPException(status_code=404, detail="No HF token stored")
+    return {"token": token}
 
 
 @router.get("/relay-status")
@@ -122,7 +141,9 @@ async def get_central_robot_status() -> dict[str, Any]:
         return {"available": False, "robots": [], "reason": "not_authenticated"}
 
     try:
-        async with aiohttp.ClientSession(timeout=CENTRAL_ROBOT_STATUS_TIMEOUT) as session:
+        async with aiohttp.ClientSession(
+            timeout=CENTRAL_ROBOT_STATUS_TIMEOUT
+        ) as session:
             # Token goes in the Authorization header, not the URL —
             # otherwise it leaks into central's access logs and any
             # intermediate proxy's logs. The desktop frontend already
@@ -175,9 +196,7 @@ async def is_oauth_configured() -> dict[str, Any]:
 
 
 @router.get("/oauth/start")
-async def start_oauth(
-    request: Request, use_localhost: bool = False
-) -> dict[str, Any]:
+async def start_oauth(request: Request, use_localhost: bool = False) -> dict[str, Any]:
     """Start a new OAuth authorization session.
 
     Returns the auth_url to redirect the user to HuggingFace.


### PR DESCRIPTION
## Summary

Adds `GET /api/hf-auth/token` so a remote client (mobile app WebView) can retrieve the stored HF OAuth token and seed it into a sandboxed iframe or the ReachyMini JS SDK. Needed because `X-Frame-Options: SAMEORIGIN` on `huggingface.co/login` blocks the browser-side OAuth flow inside any iframe or child WebView, so only the daemon can run the real OAuth flow; this endpoint is the bridge back.

## Motivation

The upcoming Reachy Mini mobile app uses the daemon's own OAuth flow to sign the user in (the daemon is the only place that can legally complete the HF login dance). Several of the mobile app's sub-contexts need the resulting token to skip their own OAuth:

- The embedded ReachyMini JS SDK's `authenticate()` function needs `hf_token + hf_username + hf_token_expires` seeded in sessionStorage before it will hit central.
- HF Space iframes (e.g. the conversation app) expect a token bridged into their URL hash so they can skip `/login`.

Without this endpoint the mobile app would have to duplicate the OAuth flow in its own WebView, which fails because HF's login page refuses framing.

## Security posture

- The daemon's HTTP API is already unauthenticated on the local network, so any client that can reach `/api/hf-auth/token` can also start/stop apps at will via the apps router. Exposing the token does not meaningfully widen the attack surface.
- The endpoint is deliberately kept separate from `/status` so the desktop frontend, which never needs the raw token, is not tempted to consume it.
- Returns 404 (not 401/403) when no token is stored, matching the existing error-shape convention of the router.

## Test plan

- [ ] `GET /api/hf-auth/token` on a logged-in daemon returns `{ "token": "hf_..." }` with HTTP 200.
- [ ] Same call on a logged-out daemon returns HTTP 404 with `{"detail":"No HF token stored"}`.
- [ ] Mobile app can `fetch('/api/hf-auth/token')` and seed the ReachyMini SDK for a successful `authenticate()`.
- [ ] Desktop app behavior unchanged (it does not call this endpoint).

Made with [Cursor](https://cursor.com).