### PR TITLE
[tracking] mobile-app daemon integration (umbrella PR)

### DIFF
--- a/src/reachy_mini/daemon/app/logging_ctx.py
+++ b/src/reachy_mini/daemon/app/logging_ctx.py
@@ -1,0 +1,197 @@
+"""Structured logging context for the Reachy Mini daemon.
+
+Mirrors the mobile app's `src/logger/` layer (PR-A) so that a single
+``X-Trace-Id`` header travels from the phone, through the optional
+WebRTC ``http_proxy`` tunnel, into the daemon's HTTP handlers, and ends
+up tagged on every Python log line emitted while servicing that
+request.
+
+What it provides
+----------------
+* :data:`trace_id_var` - a :class:`contextvars.ContextVar` holding the
+  current trace id (4-char base36 to match the mobile side). Async-safe
+  by design: every coroutine spawned inside a request copies its own
+  copy, so concurrent requests do not bleed ids.
+* :class:`TraceIdFilter` - a :class:`logging.Filter` that injects
+  ``record.trace_id`` from the ContextVar so format strings can use
+  ``%(trace_id)s``. It also exposes a sentinel ``"----"`` when no
+  trace is active, making formatter strings unconditional.
+* :func:`kv` / :func:`kv_log` - small helpers to emit structured
+  ``event_name key=value key=value`` log lines without standing up a
+  full structlog dependency.
+* :func:`redact_dict` - walks an arbitrary dict and short-fingerprints
+  any value whose *key* matches a sensitive pattern (token, bearer,
+  password, ...). Use it on anything that crosses a log boundary.
+
+Design notes
+------------
+* We don't replace existing ``logger.info(...)`` calls. The kv helpers
+  are additive, available at strategic observation points (hf_auth,
+  signaling relay, wifi router) without forcing a global rewrite.
+* Trace ids are deliberately short (4 chars). Cardinality across one
+  daemon session is low (typically a few hundred connection attempts);
+  4 base36 chars give us 1.6M values, more than enough to dedupe.
+* The redaction list is keyed *by name*, not *by value* - we don't
+  scan strings looking for tokens, because that's both slow and
+  unreliable. Instead, callers must pass tokens under a known key
+  (``token=``, ``hf_token=``, ``authorization=``, ...) so the filter
+  catches them.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import re
+import secrets
+from typing import Any, Mapping
+
+# 4-char base36 trace-id matches the mobile-side `newTraceId()` length.
+# Async-safe via ContextVar: spawning a task COPIES the current context,
+# so a request's trace stays scoped to that request.
+trace_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "trace_id", default=None
+)
+
+_TRACE_PLACEHOLDER = "----"
+
+
+def get_trace_id() -> str | None:
+    """Return the current trace id, or ``None`` if outside a request."""
+    return trace_id_var.get()
+
+
+def set_trace_id(trace: str | None) -> contextvars.Token[str | None]:
+    """Set the trace id for the current context.
+
+    Returns a token that callers MUST pass back to :func:`reset_trace_id`
+    once the work is done, to avoid leaking the trace across unrelated
+    coroutines (FastAPI background tasks, tests, ...). Most consumers
+    should use the :class:`TraceIdMiddleware` rather than calling this
+    directly.
+    """
+    return trace_id_var.set(trace)
+
+
+def reset_trace_id(token: contextvars.Token[str | None]) -> None:
+    """Restore the trace id that was active before :func:`set_trace_id`."""
+    trace_id_var.reset(token)
+
+
+def new_trace_id() -> str:
+    """Mint a fresh 4-char base36 trace id.
+
+    ``secrets.randbits`` over ``random.random()``: the trace id is not
+    a security boundary, but using ``secrets`` avoids depending on the
+    global PRNG state which may be seeded from sources we don't control
+    in CI / fork-after-init scenarios.
+    """
+    n = secrets.randbits(32)
+    # base36 encode, pad/truncate to 4 chars.
+    digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+    out = ""
+    while n > 0 and len(out) < 6:
+        out = digits[n % 36] + out
+        n //= 36
+    return (out or "0000")[-4:].rjust(4, "0")
+
+
+class TraceIdFilter(logging.Filter):
+    """Inject the current trace id into every :class:`LogRecord`.
+
+    Install it on each handler whose formatter uses ``%(trace_id)s``.
+    When no trace is set we emit ``"----"`` (a stable 4-char filler)
+    so the column width stays predictable in stderr logs.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D102, D401
+        record.trace_id = trace_id_var.get() or _TRACE_PLACEHOLDER
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+_SENSITIVE_KEY_RE = re.compile(
+    r"^(token|hf_token|hftoken|access_token|refresh_token|"
+    r"authorization|bearer|password|secret|api_?key)$",
+    re.IGNORECASE,
+)
+
+
+def redact_token(value: str) -> str:
+    """Short-fingerprint a sensitive string so logs stay diff-able.
+
+    Keeps 4 + 4 chars with an ellipsis in between for values long
+    enough that a fingerprint is unambiguous; emits ``"REDACTED"`` for
+    short ones.
+    """
+    if not value:
+        return value
+    if len(value) <= 12:
+        return "REDACTED"
+    return f"{value[:4]}…{value[-4:]}"
+
+
+def redact_dict(data: Any, depth: int = 0) -> Any:
+    """Recursively redact sensitive values in ``data``.
+
+    Keys are matched against :data:`_SENSITIVE_KEY_RE`. Non-string
+    values for sensitive keys are left as-is (we trust callers not to
+    stuff a token into an int). The depth limit keeps a malicious
+    self-referential dict from looping forever.
+    """
+    if data is None or depth > 6:
+        return data
+    if isinstance(data, Mapping):
+        out: dict[str, Any] = {}
+        for key, value in data.items():
+            if (
+                isinstance(key, str)
+                and _SENSITIVE_KEY_RE.match(key)
+                and isinstance(value, str)
+            ):
+                out[key] = redact_token(value)
+            else:
+                out[key] = redact_dict(value, depth + 1)
+        return out
+    if isinstance(data, (list, tuple)):
+        items = [redact_dict(v, depth + 1) for v in data]
+        return items if isinstance(data, list) else tuple(items)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Structured kv emission
+# ---------------------------------------------------------------------------
+
+
+def kv(event: str, **fields: Any) -> str:
+    """Render a structured log message as ``event key=value key=value``.
+
+    Values pass through :func:`redact_dict` first, so accidentally
+    logging ``token=hf_xyz`` will print ``token=hf_x…xyz`` instead of
+    the full bearer.
+    """
+    if not fields:
+        return event
+    safe = redact_dict(fields)
+    parts = [event]
+    for key, value in safe.items():  # type: ignore[union-attr]
+        parts.append(f"{key}={value}")
+    return " ".join(parts)
+
+
+def kv_log(
+    logger: logging.Logger,
+    level: int,
+    event: str,
+    **fields: Any,
+) -> None:
+    """Emit a structured kv log line at the given level.
+
+    Convenience wrapper around ``logger.log(level, kv(event, ...))`` that
+    keeps call sites short and greppable.
+    """
+    logger.log(level, kv(event, **fields))

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -24,6 +24,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon.app.logging_ctx import TraceIdFilter
 from reachy_mini.daemon.app.routers import (
     apps,
     camera,
@@ -38,6 +39,7 @@ from reachy_mini.daemon.app.routers import (
     state,
     volume,
 )
+from reachy_mini.daemon.app.trace_middleware import TraceIdMiddleware
 from reachy_mini.daemon.daemon import Daemon
 from reachy_mini.daemon.utils import SimulationMode
 from reachy_mini.media.audio_utils import (
@@ -253,12 +255,17 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
             health_check_event.set()
             return {"status": "ok"}
 
+    # Order matters: TraceId runs first so every downstream middleware
+    # (CORS, routing) sees the ContextVar set when they emit logs.
+    # Starlette runs middlewares in REVERSE registration order on the
+    # request side, so adding TraceId LAST puts it on top of the stack.
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],  # or restrict to your HF domain
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    app.add_middleware(TraceIdMiddleware)
 
     STATIC_DIR = Path(__file__).parent / "dashboard" / "static"
     TEMPLATES_DIR = Path(__file__).parent / "dashboard" / "templates"
@@ -296,10 +303,19 @@ def run_app(args: Args) -> None:
     root_logger = logging.getLogger()
     root_logger.setLevel(args.log_level)
 
-    # Create handler that writes to stderr with immediate flush
+    # Create handler that writes to stderr with immediate flush.
+    #
+    # The format includes %(trace_id)s so any request-scoped log line
+    # carries the same id the mobile app emits, making cross-boundary
+    # debugging a grep away. The TraceIdFilter guarantees the field is
+    # always set (sentinel "----" outside requests), so the format
+    # string is unconditional.
     handler = logging.StreamHandler(sys.stderr)
     handler.setLevel(args.log_level)
-    handler.setFormatter(logging.Formatter("%(name)s - %(levelname)s - %(message)s"))
+    handler.addFilter(TraceIdFilter())
+    handler.setFormatter(
+        logging.Formatter("[%(trace_id)s] %(name)s - %(levelname)s - %(message)s")
+    )
     root_logger.handlers.clear()
     root_logger.addHandler(handler)
 

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -167,6 +167,17 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                     hardware_config_filepath=args.hardware_config_filepath,
                 )
 
+            # Tell the backend where to forward `http_proxy` requests
+            # received over the WebRTC data channel: same FastAPI server,
+            # via the loopback interface. Done after `start()` so the
+            # backend instance is guaranteed to exist.
+            try:
+                backend = getattr(app.state.daemon, "backend", None)
+                if backend is not None and hasattr(backend, "set_loopback_http_port"):
+                    backend.set_loopback_http_port(args.fastapi_port)
+            except Exception as e:
+                logger.warning(f"Could not configure http_proxy loopback port: {e}")
+
             # Register mDNS service only after the daemon is ready
             mdns.register()
 

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -242,7 +242,12 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         app.include_router(cache.router)
         app.include_router(logs.router)
         app.include_router(update.router)
+        # Legacy mount at `/wifi/...` (used by the Bluetooth provisioning service
+        # and older first-boot tooling). Kept for backward compatibility.
         app.include_router(wifi_config.router)
+        # New mount under `/api/wifi/...` so the mobile app can reach it via
+        # the unified `RobotClient` (which prefixes everything with `/api`).
+        router.include_router(wifi_config.router)
 
     app.include_router(router)
     app.include_router(sdk_ws.router)

--- a/src/reachy_mini/daemon/app/routers/daemon.py
+++ b/src/reachy_mini/daemon/app/routers/daemon.py
@@ -85,6 +85,31 @@ async def get_daemon_status(daemon: Daemon = Depends(get_daemon)) -> DaemonStatu
     return daemon.status()
 
 
+@router.get("/version")
+async def get_daemon_version() -> dict[str, str]:
+    """Return the daemon's package version and a compatibility marker.
+
+    Mobile and remote clients call this early during the connection
+    handshake to detect a feature mismatch (e.g. an older daemon that
+    doesn't ship a new endpoint yet) and surface a soft warning rather
+    than failing later with a cryptic 404.
+
+    The endpoint is deliberately additive: it returns a dict so we can
+    grow it (build sha, kinematics engine, ...) without breaking older
+    clients that only look up ``version``.
+    """
+    from reachy_mini import __version__
+
+    return {
+        "version": __version__,
+        # Bumped whenever the HTTP surface gains/loses an endpoint or
+        # a route's response shape changes in a non-additive way.
+        # Mobile clients can rely on `api_revision >= N` to know a
+        # feature is reachable, regardless of the package version.
+        "api_revision": "1",
+    }
+
+
 @router.get("/robot-app-lock-status")
 async def get_robot_app_lock_status(
     daemon: Daemon = Depends(get_daemon),

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -18,9 +18,7 @@ router = APIRouter(prefix="/hf-auth")
 # Central signaling server that tracks which robot is currently in use by
 # which remote JS app. We proxy its /api/robot-status endpoint so the
 # desktop frontend never needs to see the raw HF token.
-CENTRAL_ROBOT_STATUS_URL = (
-    "https://cduss-reachy-mini-central.hf.space/api/robot-status"
-)
+CENTRAL_ROBOT_STATUS_URL = "https://cduss-reachy-mini-central.hf.space/api/robot-status"
 CENTRAL_ROBOT_STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 
@@ -63,6 +61,27 @@ async def save_token(request: TokenRequest) -> TokenResponse:
 async def get_auth_status() -> dict[str, Any]:
     """Check if user is authenticated with HuggingFace."""
     return hf_auth.check_token_status()
+
+
+@router.get("/token")
+async def get_token() -> dict[str, Any]:
+    """Return the stored HuggingFace token in plaintext.
+
+    This exists so remote clients (e.g. the mobile app) can bridge the
+    token into a sandboxed iframe that itself cannot go through the HF
+    OAuth flow (hit by ``X-Frame-Options: SAMEORIGIN`` on ``/login``).
+
+    Security note: the daemon's HTTP API is already unauthenticated on
+    the local network, so any client that can reach this endpoint can
+    also start/stop apps at will. Exposing the token here does not
+    meaningfully widen the attack surface, but we deliberately keep the
+    endpoint separate from ``/status`` so the desktop frontend - which
+    never needs the raw token - is not tempted to consume it.
+    """
+    token = hf_auth.get_hf_token()
+    if not token:
+        raise HTTPException(status_code=404, detail="No HF token stored")
+    return {"token": token}
 
 
 @router.get("/relay-status")
@@ -122,7 +141,9 @@ async def get_central_robot_status() -> dict[str, Any]:
         return {"available": False, "robots": [], "reason": "not_authenticated"}
 
     try:
-        async with aiohttp.ClientSession(timeout=CENTRAL_ROBOT_STATUS_TIMEOUT) as session:
+        async with aiohttp.ClientSession(
+            timeout=CENTRAL_ROBOT_STATUS_TIMEOUT
+        ) as session:
             # Token goes in the Authorization header, not the URL —
             # otherwise it leaks into central's access logs and any
             # intermediate proxy's logs. The desktop frontend already
@@ -175,9 +196,7 @@ async def is_oauth_configured() -> dict[str, Any]:
 
 
 @router.get("/oauth/start")
-async def start_oauth(
-    request: Request, use_localhost: bool = False
-) -> dict[str, Any]:
+async def start_oauth(request: Request, use_localhost: bool = False) -> dict[str, Any]:
     """Start a new OAuth authorization session.
 
     Returns the auth_url to redirect the user to HuggingFace.

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -135,9 +135,15 @@ async def refresh_relay() -> dict[str, Any]:
     token = hf_auth.get_hf_token()
 
     try:
-        from reachy_mini.media.central_signaling_relay import notify_token_change
+        from reachy_mini.media.central_signaling_relay import notify_force_reconnect
 
-        await notify_token_change(token)
+        # Unconditionally drop & reconnect. We used to call
+        # `notify_token_change(token)` here, but that path is guarded
+        # by an `old_token == new_token` early-return in the relay,
+        # which turned this endpoint into a no-op whenever the token
+        # had not changed - exactly the case we ship this endpoint
+        # for. `notify_force_reconnect` skips that guard.
+        await notify_force_reconnect()
     except ImportError:
         return {
             "status": "skipped",
@@ -145,7 +151,7 @@ async def refresh_relay() -> dict[str, Any]:
             "reason": "relay_unavailable",
         }
     except Exception as e:
-        logger.warning("[refresh-relay] notify_token_change failed: %s", e)
+        logger.warning("[refresh-relay] notify_force_reconnect failed: %s", e)
         raise HTTPException(
             status_code=500, detail=f"Failed to refresh relay: {e}"
         ) from e

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -10,6 +10,7 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
 from reachy_mini.apps.sources import hf_auth
+from reachy_mini.daemon.app.logging_ctx import kv_log
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +19,7 @@ router = APIRouter(prefix="/hf-auth")
 # Central signaling server that tracks which robot is currently in use by
 # which remote JS app. We proxy its /api/robot-status endpoint so the
 # desktop frontend never needs to see the raw HF token.
-CENTRAL_ROBOT_STATUS_URL = (
-    "https://cduss-reachy-mini-central.hf.space/api/robot-status"
-)
+CENTRAL_ROBOT_STATUS_URL = "https://cduss-reachy-mini-central.hf.space/api/robot-status"
 CENTRAL_ROBOT_STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 
@@ -49,10 +48,22 @@ async def save_token(request: TokenRequest) -> TokenResponse:
     result = hf_auth.save_hf_token(request.token)
 
     if result["status"] == "error":
+        kv_log(
+            logger,
+            logging.WARNING,
+            "auth.save_token.failure",
+            reason=result.get("message", "invalid_token"),
+        )
         raise HTTPException(
             status_code=400, detail=result.get("message", "Invalid token")
         )
 
+    kv_log(
+        logger,
+        logging.INFO,
+        "auth.save_token.success",
+        username=result.get("username"),
+    )
     return TokenResponse(
         status="success",
         username=result.get("username"),
@@ -95,8 +106,10 @@ async def delete_token() -> dict[str, str]:
     success = hf_auth.delete_hf_token()
 
     if not success:
+        kv_log(logger, logging.ERROR, "auth.delete_token.failure")
         raise HTTPException(status_code=500, detail="Failed to delete token")
 
+    kv_log(logger, logging.INFO, "auth.delete_token.success")
     return {"status": "success"}
 
 
@@ -122,7 +135,9 @@ async def get_central_robot_status() -> dict[str, Any]:
         return {"available": False, "robots": [], "reason": "not_authenticated"}
 
     try:
-        async with aiohttp.ClientSession(timeout=CENTRAL_ROBOT_STATUS_TIMEOUT) as session:
+        async with aiohttp.ClientSession(
+            timeout=CENTRAL_ROBOT_STATUS_TIMEOUT
+        ) as session:
             # Token goes in the Authorization header, not the URL —
             # otherwise it leaks into central's access logs and any
             # intermediate proxy's logs. The desktop frontend already
@@ -175,9 +190,7 @@ async def is_oauth_configured() -> dict[str, Any]:
 
 
 @router.get("/oauth/start")
-async def start_oauth(
-    request: Request, use_localhost: bool = False
-) -> dict[str, Any]:
+async def start_oauth(request: Request, use_localhost: bool = False) -> dict[str, Any]:
     """Start a new OAuth authorization session.
 
     Returns the auth_url to redirect the user to HuggingFace.

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -43,8 +43,16 @@ class TokenResponse(BaseModel):
 
 
 @router.post("/save-token")
-async def save_token(request: TokenRequest) -> TokenResponse:
-    """Save HuggingFace token after validation."""
+async def save_token(req: Request, request: TokenRequest) -> TokenResponse:
+    """Save HuggingFace token after validation.
+
+    On success this also makes sure the central signaling relay is
+    running. The relay is normally started at media-server-acquire
+    time, but the daemon may have booted without a token (so the relay
+    never came up). Without this ensure-step the robot would remain
+    invisible on central until the next daemon restart, even though
+    the token is now stored on disk.
+    """
     result = hf_auth.save_hf_token(request.token)
 
     if result["status"] == "error":
@@ -64,6 +72,20 @@ async def save_token(request: TokenRequest) -> TokenResponse:
         "auth.save_token.success",
         username=result.get("username"),
     )
+
+    daemon = getattr(req.app.state, "daemon", None)
+    if daemon is not None and getattr(daemon, "wireless_version", False):
+        try:
+            relay_result = await daemon.ensure_central_signaling_relay()
+            kv_log(
+                logger,
+                logging.INFO,
+                "auth.save_token.relay_ensured",
+                **relay_result,
+            )
+        except Exception as e:
+            logger.warning("[save-token] ensure_central_signaling_relay failed: %s", e)
+
     return TokenResponse(
         status="success",
         username=result.get("username"),
@@ -135,7 +157,7 @@ async def delete_token() -> dict[str, str]:
 
 
 @router.post("/refresh-relay")
-async def refresh_relay() -> dict[str, Any]:
+async def refresh_relay(request: Request) -> dict[str, Any]:
     """Force the central signaling relay to reconnect with the stored token.
 
     Drops the relay's current connection and re-registers with the
@@ -171,7 +193,23 @@ async def refresh_relay() -> dict[str, Any]:
     token = hf_auth.get_hf_token()
 
     try:
+        from reachy_mini.media import central_signaling_relay as _csr
         from reachy_mini.media.central_signaling_relay import notify_force_reconnect
+
+        # If the daemon booted without a token, the relay never came
+        # up. In that case `notify_force_reconnect` is a no-op. Try to
+        # bring the relay up first so this endpoint actually does
+        # something useful for the cold-boot recovery case.
+        if _csr._relay_instance is None:
+            daemon = getattr(request.app.state, "daemon", None)
+            if daemon is not None and getattr(daemon, "wireless_version", False):
+                try:
+                    await daemon.ensure_central_signaling_relay()
+                except Exception as e:
+                    logger.warning(
+                        "[refresh-relay] ensure_central_signaling_relay failed: %s",
+                        e,
+                    )
 
         # Unconditionally drop & reconnect. We used to call
         # `notify_token_change(token)` here, but that path is guarded

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -18,9 +18,7 @@ router = APIRouter(prefix="/hf-auth")
 # Central signaling server that tracks which robot is currently in use by
 # which remote JS app. We proxy its /api/robot-status endpoint so the
 # desktop frontend never needs to see the raw HF token.
-CENTRAL_ROBOT_STATUS_URL = (
-    "https://cduss-reachy-mini-central.hf.space/api/robot-status"
-)
+CENTRAL_ROBOT_STATUS_URL = "https://cduss-reachy-mini-central.hf.space/api/robot-status"
 CENTRAL_ROBOT_STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 
@@ -100,6 +98,61 @@ async def delete_token() -> dict[str, str]:
     return {"status": "success"}
 
 
+@router.post("/refresh-relay")
+async def refresh_relay() -> dict[str, Any]:
+    """Force the central signaling relay to reconnect with the stored token.
+
+    Drops the relay's current connection and re-registers with the
+    currently stored HF token.
+
+    Intended as a recovery handle for clients (e.g. the mobile app) that
+    detect a desync between ``/relay-status`` (claims ``connected``) and
+    ``/central-robot-status`` (returns ``robots: []``). That combination
+    means the relay still holds an SSE channel open with central but is
+    no longer registered as a producer for the authenticated user, most
+    commonly because the relay attached with a token that has since been
+    rotated or because a transient error during ``setPeerStatus`` went
+    unnoticed. From the outside this manifests as "the robot is online
+    but no one can call it" until someone restarts the daemon.
+
+    Rather than asking users to SSH in and run ``systemctl restart``,
+    this endpoint triggers the relay's existing ``_token_updated`` event
+    path (the same one ``save-token`` uses on login), which cleanly
+    tears down the SSE connection, refreshes the HF token from
+    ``huggingface_hub.get_token`` and reconnects. Works with any token
+    currently stored (raw user tokens or OAuth access tokens) because
+    we go through the relay's reconnect logic rather than re-validating
+    the token.
+
+    Response shape:
+        { "status": "requested", "token_available": bool, "reason"?: str }
+
+    ``token_available`` is false if the daemon has no HF token stored
+    at all (user not logged in). In that case the relay will just
+    transition to ``WAITING_FOR_TOKEN`` after the reconnect, which is
+    the correct behaviour.
+    """
+    token = hf_auth.get_hf_token()
+
+    try:
+        from reachy_mini.media.central_signaling_relay import notify_token_change
+
+        await notify_token_change(token)
+    except ImportError:
+        return {
+            "status": "skipped",
+            "token_available": bool(token),
+            "reason": "relay_unavailable",
+        }
+    except Exception as e:
+        logger.warning("[refresh-relay] notify_token_change failed: %s", e)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to refresh relay: {e}"
+        ) from e
+
+    return {"status": "requested", "token_available": bool(token)}
+
+
 @router.get("/central-robot-status")
 async def get_central_robot_status() -> dict[str, Any]:
     """Proxy to the central signaling server's /api/robot-status endpoint.
@@ -122,7 +175,9 @@ async def get_central_robot_status() -> dict[str, Any]:
         return {"available": False, "robots": [], "reason": "not_authenticated"}
 
     try:
-        async with aiohttp.ClientSession(timeout=CENTRAL_ROBOT_STATUS_TIMEOUT) as session:
+        async with aiohttp.ClientSession(
+            timeout=CENTRAL_ROBOT_STATUS_TIMEOUT
+        ) as session:
             # Token goes in the Authorization header, not the URL —
             # otherwise it leaks into central's access logs and any
             # intermediate proxy's logs. The desktop frontend already
@@ -175,9 +230,7 @@ async def is_oauth_configured() -> dict[str, Any]:
 
 
 @router.get("/oauth/start")
-async def start_oauth(
-    request: Request, use_localhost: bool = False
-) -> dict[str, Any]:
+async def start_oauth(request: Request, use_localhost: bool = False) -> dict[str, Any]:
     """Start a new OAuth authorization session.
 
     Returns the auth_url to redirect the user to HuggingFace.

--- a/src/reachy_mini/daemon/app/routers/wifi_config.py
+++ b/src/reachy_mini/daemon/app/routers/wifi_config.py
@@ -8,6 +8,8 @@ import nmcli
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from reachy_mini.daemon.app.logging_ctx import kv_log
+
 HOTSPOT_SSID = "reachy-mini-ap"
 HOTSPOT_PASSWORD = "reachy-mini"
 
@@ -112,8 +114,10 @@ def connect_to_wifi_network(
 ) -> None:
     """Connect to a WiFi network. It will create a new connection using nmcli if the specified SSID is not already configured."""
     logger.warning(f"Request to connect to WiFi network '{ssid}' received.")
+    kv_log(logger, logging.INFO, "wifi.connect.request", ssid=ssid)
 
     if busy_lock.locked():
+        kv_log(logger, logging.WARNING, "wifi.connect.busy", ssid=ssid)
         raise HTTPException(status_code=409, detail="Another operation is in progress.")
 
     def connect() -> None:
@@ -122,9 +126,17 @@ def connect_to_wifi_network(
             try:
                 error = None
                 setup_wifi_connection(name=ssid, ssid=ssid, password=password)
+                kv_log(logger, logging.INFO, "wifi.connect.success", ssid=ssid)
             except Exception as e:
                 error = e
                 logger.error(f"Failed to connect to WiFi network '{ssid}': {e}")
+                kv_log(
+                    logger,
+                    logging.WARNING,
+                    "wifi.connect.failure",
+                    ssid=ssid,
+                    error=str(e),
+                )
                 logger.info("Reverting to hotspot...")
                 remove_connection(name=ssid)
                 setup_wifi_connection(
@@ -171,6 +183,13 @@ def forget_wifi_network(ssid: str) -> None:
                 was_active = check_if_connection_active(ssid)
                 logger.info(f"Forgetting WiFi network '{ssid}'...")
                 remove_connection(ssid)
+                kv_log(
+                    logger,
+                    logging.INFO,
+                    "wifi.forget.success",
+                    ssid=ssid,
+                    was_active=was_active,
+                )
 
                 if was_active:
                     logger.info("Was connected, falling back to hotspot...")
@@ -183,6 +202,13 @@ def forget_wifi_network(ssid: str) -> None:
             except Exception as e:
                 error = e
                 logger.error(f"Failed to forget network '{ssid}': {e}")
+                kv_log(
+                    logger,
+                    logging.ERROR,
+                    "wifi.forget.failure",
+                    ssid=ssid,
+                    error=str(e),
+                )
 
     Thread(target=forget).start()
 

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -8,6 +8,7 @@ Includes a fixed NoInputNoOutput agent for automatic Just Works pairing.
 import fcntl
 import logging
 import os
+import socket
 import subprocess
 from typing import Callable
 
@@ -118,6 +119,7 @@ class Advertisement(dbus.service.Object):
         self.ad_type = advertising_type
         self.local_name = local_name
         self.service_uuids = None
+        self.manufacturer_data = None
         self.include_tx_power = False
         dbus.service.Object.__init__(self, bus, self.path)
 
@@ -128,6 +130,10 @@ class Advertisement(dbus.service.Object):
             props["LocalName"] = dbus.String(self.local_name)
         if self.service_uuids:
             props["ServiceUUIDs"] = dbus.Array(self.service_uuids, signature="s")
+        if self.manufacturer_data:
+            props["ManufacturerData"] = dbus.Dictionary(
+                self.manufacturer_data, signature="qv"
+            )
         props["Appearance"] = dbus.UInt16(0x0000)
         props["Duration"] = dbus.UInt16(0)
         props["Timeout"] = dbus.UInt16(0)
@@ -300,7 +306,7 @@ class ResponseCharacteristic(Characteristic):
         self.notifying = False
         logger.info("Response notifications disabled")
         # Stop journal streaming if running (client disconnected without JOURNAL_STOP)
-        if hasattr(self.service, '_bt_service') and self.service._bt_service:
+        if hasattr(self.service, "_bt_service") and self.service._bt_service:
             self.service._bt_service._stop_journal()
 
     def send_notification(self, text: str):
@@ -614,7 +620,17 @@ class BluetoothCommandService:
         try:
             self._journal_buffer = ""
             self._journal_proc = subprocess.Popen(
-                ["stdbuf", "-oL", "journalctl", "-f", "-n", "20", "--no-pager", "-u", "reachy-mini-daemon"],
+                [
+                    "stdbuf",
+                    "-oL",
+                    "journalctl",
+                    "-f",
+                    "-n",
+                    "20",
+                    "--no-pager",
+                    "-u",
+                    "reachy-mini-daemon",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
             )
@@ -643,7 +659,9 @@ class BluetoothCommandService:
                 if data:
                     text = data.decode("utf-8", errors="replace")
                     self._journal_buffer += text
-                    logger.info(f"Journal buffered: {len(text)} bytes, total: {len(self._journal_buffer)}")
+                    logger.info(
+                        f"Journal buffered: {len(text)} bytes, total: {len(self._journal_buffer)}"
+                    )
                     # Cap buffer to ~32KB to avoid unbounded growth
                     if len(self._journal_buffer) > 32768:
                         self._journal_buffer = self._journal_buffer[-32768:]
@@ -779,9 +797,9 @@ class BluetoothCommandService:
         # Register advertisement
         ad_manager = dbus.Interface(adapter, LE_ADVERTISING_MANAGER_IFACE)
         self.adv = Advertisement(self.bus, 0, "peripheral", self.device_name)
-        # Only advertise main service UUID to avoid advertisement size limits
-        # All services are still available when connected
         self.adv.service_uuids = [REACHY_STATUS_SERVICE_UUID]
+        self.adv.manufacturer_data = encode_network_ips()
+        self._ad_manager = ad_manager
         ad_manager.RegisterAdvertisement(
             self.adv.get_path(),
             {},
@@ -791,10 +809,34 @@ class BluetoothCommandService:
             ),
         )
 
-        # Setup periodic network status updates (every 10 seconds)
-        GLib.timeout_add_seconds(10, self.app.reachy_status.update_network_status)
+        # Refresh both GATT network characteristic and advertisement payload
+        GLib.timeout_add_seconds(10, self._refresh_network_info)
 
         logger.info(f"✓ Bluetooth service started as '{self.device_name}'")
+
+    def _refresh_network_info(self):
+        """Periodic callback: update GATT characteristic and advertisement."""
+        self.app.reachy_status.update_network_status()
+
+        new_data = encode_network_ips()
+        if new_data != self.adv.manufacturer_data:
+            self.adv.manufacturer_data = new_data
+            try:
+                self._ad_manager.UnregisterAdvertisement(self.adv.get_path())
+                self._ad_manager.RegisterAdvertisement(
+                    self.adv.get_path(),
+                    {},
+                    reply_handler=lambda: logger.info(
+                        "Advertisement re-registered with updated IPs"
+                    ),
+                    error_handler=lambda e: logger.error(
+                        f"Failed to re-register advertisement: {e}"
+                    ),
+                )
+            except dbus.exceptions.DBusException as e:
+                logger.warning(f"Could not refresh advertisement: {e}")
+
+        return True
 
     def _find_adapter(self):
         remote_om = dbus.Interface(
@@ -817,6 +859,49 @@ class BluetoothCommandService:
             logger.info("Shutting down...")
             self._stop_journal()
             self.mainloop.quit()
+
+
+POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
+
+
+def encode_network_ips() -> dict:
+    """Build ManufacturerData payload with all non-loopback IPv4 addresses.
+
+    Format per IP: 1 byte flags | 4 bytes IPv4
+      flags: 0x01 = hotspot, 0x00 = normal
+
+    Returns a dict {manufacturer_id: dbus.Array(bytes)} suitable for
+    BlueZ ManufacturerData property.  Returns empty dict when offline.
+    """
+    status = get_network_status()
+    if status == "OFFLINE" or status == "ERROR":
+        return {}
+
+    payload = bytearray()
+    is_hotspot = status.startswith("HOTSPOT")
+
+    parts = status.split("[")
+    for part in parts[1:]:
+        if "]" not in part:
+            continue
+        iface, rest = part.split("]", 1)
+        ip_str = rest.split(";")[0].strip()
+        try:
+            ip_bytes = socket.inet_aton(ip_str)
+            flag = 0x01 if (is_hotspot and iface.strip() == "wlan0") else 0x00
+            payload.append(flag)
+            payload.extend(ip_bytes)
+        except OSError:
+            continue
+
+    if not payload:
+        return {}
+
+    return {
+        dbus.UInt16(POLLEN_MANUFACTURER_ID): dbus.Array(
+            [dbus.Byte(b) for b in payload], signature="y"
+        )
+    }
 
 
 def get_pin() -> str:

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -6,9 +6,13 @@ Includes a fixed NoInputNoOutput agent for automatic Just Works pairing.
 # mypy: ignore-errors
 
 import fcntl
+import json
 import logging
 import os
 import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
 from typing import Callable
 
 import dbus
@@ -276,7 +280,7 @@ class CommandCharacteristic(Characteristic):
             dbus.Byte(b) for b in response.encode("utf-8")
         ]
         cmd_str = command_bytes.decode("utf-8", errors="replace").strip()
-        if cmd_str.upper() != "JOURNAL_READ":
+        if cmd_str.upper() not in ("JOURNAL_READ", "WIFI_STATUS"):
             logger.info(f"Command received: {response}")
 
 
@@ -300,7 +304,7 @@ class ResponseCharacteristic(Characteristic):
         self.notifying = False
         logger.info("Response notifications disabled")
         # Stop journal streaming if running (client disconnected without JOURNAL_STOP)
-        if hasattr(self.service, '_bt_service') and self.service._bt_service:
+        if hasattr(self.service, "_bt_service") and self.service._bt_service:
             self.service._bt_service._stop_journal()
 
     def send_notification(self, text: str):
@@ -614,7 +618,17 @@ class BluetoothCommandService:
         try:
             self._journal_buffer = ""
             self._journal_proc = subprocess.Popen(
-                ["stdbuf", "-oL", "journalctl", "-f", "-n", "20", "--no-pager", "-u", "reachy-mini-daemon"],
+                [
+                    "stdbuf",
+                    "-oL",
+                    "journalctl",
+                    "-f",
+                    "-n",
+                    "20",
+                    "--no-pager",
+                    "-u",
+                    "reachy-mini-daemon",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
             )
@@ -643,7 +657,9 @@ class BluetoothCommandService:
                 if data:
                     text = data.decode("utf-8", errors="replace")
                     self._journal_buffer += text
-                    logger.info(f"Journal buffered: {len(text)} bytes, total: {len(self._journal_buffer)}")
+                    logger.info(
+                        f"Journal buffered: {len(text)} bytes, total: {len(self._journal_buffer)}"
+                    )
                     # Cap buffer to ~32KB to avoid unbounded growth
                     if len(self._journal_buffer) > 32768:
                         self._journal_buffer = self._journal_buffer[-32768:]
@@ -686,12 +702,14 @@ class BluetoothCommandService:
 
     def _handle_command(self, value: bytes) -> str:
         command_str = value.decode("utf-8").strip()
-        if command_str.upper() != "JOURNAL_READ":
+        upper = command_str.upper()
+        # WIFI_STATUS and JOURNAL_READ are polled by clients; don't spam logs.
+        if upper not in ("JOURNAL_READ", "WIFI_STATUS"):
             logger.info(f"Received command: {command_str}")
         # Custom command handling
-        if command_str.upper() == "PING":
+        if upper == "PING":
             return "PONG"
-        elif command_str.upper() == "STATUS":
+        elif upper == "STATUS":
             # exec a "sudo ls" command and print the result
             try:
                 result = subprocess.run(["sudo", "ls"], capture_output=True, text=True)
@@ -699,11 +717,11 @@ class BluetoothCommandService:
             except Exception as e:
                 logger.error(f"Error executing command: {e}")
             return "OK: System running"
-        elif command_str.upper() == "JOURNAL_START":
+        elif upper == "JOURNAL_START":
             return self._start_journal()
-        elif command_str.upper() == "JOURNAL_READ":
+        elif upper == "JOURNAL_READ":
             return self._read_journal()
-        elif command_str.upper() == "JOURNAL_STOP":
+        elif upper == "JOURNAL_STOP":
             self._stop_journal()
             return "OK: Journal streaming stopped"
         elif command_str.startswith("PIN_"):
@@ -713,6 +731,27 @@ class BluetoothCommandService:
                 return "OK: Connected"
             else:
                 return "ERROR: Incorrect PIN"
+
+        # WiFi provisioning commands. WIFI_STATUS is public (read-only snapshot);
+        # mutating commands require prior PIN authentication. Unlike CMD_*, we do
+        # NOT reset `self.connected` afterwards so a client can chain
+        # scan -> connect -> poll status in a single provisioning session.
+        elif upper == "WIFI_STATUS":
+            return _wifi_status()
+        elif upper == "WIFI_SCAN":
+            if not self.connected:
+                return "ERROR: Not connected. Please authenticate first."
+            return _wifi_scan()
+        elif upper.startswith("WIFI_CONNECT "):
+            if not self.connected:
+                return "ERROR: Not connected. Please authenticate first."
+            payload = command_str[len("WIFI_CONNECT ") :]
+            return _wifi_connect(payload)
+        elif upper.startswith("WIFI_FORGET "):
+            if not self.connected:
+                return "ERROR: Not connected. Please authenticate first."
+            ssid = command_str[len("WIFI_FORGET ") :]
+            return _wifi_forget(ssid)
 
         # else if command starts with "CMD_xxxxx" check if  commands directory contains the said named script command xxxx.sh and run its, show output or/and send to read
         elif command_str.startswith("CMD_"):
@@ -817,6 +856,174 @@ class BluetoothCommandService:
             logger.info("Shutting down...")
             self._stop_journal()
             self.mainloop.quit()
+
+
+# =======================
+# WiFi provisioning over BLE
+# =======================
+# The Bluetooth service runs as its own systemd unit, separate from the FastAPI
+# daemon. For WiFi provisioning we simply proxy BLE commands over localhost HTTP
+# to the daemon's existing `/wifi/*` routes. This keeps the logic DRY (no
+# duplicated `nmcli` plumbing) and reuses the daemon's `busy_lock`, threading
+# and hotspot-fallback behavior.
+#
+# We stick to the Python stdlib (`urllib`) on purpose: the BT service uses the
+# system Python, not the daemon's venv, so we can't assume `requests` is
+# installed.
+
+DAEMON_LOCAL_URL = "http://127.0.0.1:8000"
+WIFI_HTTP_TIMEOUT_S = 4.0
+WIFI_SCAN_HTTP_TIMEOUT_S = 15.0  # nmcli rescan is slow
+WIFI_SCAN_MAX_RESULTS = 12  # keep payload inside a single BLE MTU
+
+
+def _daemon_request(
+    method: str,
+    path: str,
+    params: dict[str, str] | None = None,
+    timeout: float = WIFI_HTTP_TIMEOUT_S,
+):
+    """Perform a local HTTP request against the daemon and return parsed JSON (or None)."""
+    url = DAEMON_LOCAL_URL + path
+    if params:
+        url = url + "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read()
+        if not body:
+            return None
+        try:
+            return json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            return body.decode("utf-8", errors="replace")
+
+
+def _wifi_status() -> str:
+    """Return the current WiFi state as compact JSON suitable for a BLE read.
+
+    Shape: {"mode": str, "connected": str|null, "known": [str], "error": str|null}
+    """
+    try:
+        status = _daemon_request("GET", "/wifi/status") or {}
+        error_payload = _daemon_request("GET", "/wifi/error") or {}
+        compact = {
+            "mode": status.get("mode"),
+            "connected": status.get("connected_network"),
+            "known": status.get("known_networks", []),
+            "error": error_payload.get("error"),
+        }
+        return json.dumps(compact, separators=(",", ":"), ensure_ascii=False)
+    except urllib.error.URLError as e:
+        logger.warning(f"wifi_status: daemon unreachable: {e}")
+        return json.dumps(
+            {
+                "mode": None,
+                "connected": None,
+                "known": [],
+                "error": "daemon_unreachable",
+            },
+            separators=(",", ":"),
+        )
+    except Exception as e:
+        logger.exception("wifi_status failed")
+        return json.dumps(
+            {"mode": None, "connected": None, "known": [], "error": str(e)},
+            separators=(",", ":"),
+        )
+
+
+def _wifi_scan() -> str:
+    """Scan for nearby SSIDs. Returns a JSON array (top N) or an `ERROR:` string."""
+    try:
+        ssids = _daemon_request(
+            "POST", "/wifi/scan_and_list", timeout=WIFI_SCAN_HTTP_TIMEOUT_S
+        )
+        if not isinstance(ssids, list):
+            return json.dumps([])
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for s in ssids:
+            if isinstance(s, str) and s and s not in seen:
+                seen.add(s)
+                cleaned.append(s)
+                if len(cleaned) >= WIFI_SCAN_MAX_RESULTS:
+                    break
+        return json.dumps(cleaned, separators=(",", ":"), ensure_ascii=False)
+    except urllib.error.HTTPError as e:
+        if e.code == 409:
+            return "ERROR: Busy"
+        logger.warning(f"wifi_scan HTTP error: {e}")
+        return "ERROR: Scan failed"
+    except urllib.error.URLError as e:
+        logger.warning(f"wifi_scan: daemon unreachable: {e}")
+        return "ERROR: Daemon unreachable"
+    except Exception as e:
+        logger.exception("wifi_scan failed")
+        return f"ERROR: {e}"
+
+
+def _wifi_connect(payload: str) -> str:
+    """Kick off a connect attempt. `payload` is a JSON string: {"ssid": "...", "psk": "..."}.
+
+    Returns immediately (the daemon runs the actual `nmcli` work on a thread).
+    Clients should poll `WIFI_STATUS` to observe the outcome.
+    """
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return "ERROR: Invalid payload (expected JSON)"
+
+    ssid = data.get("ssid")
+    psk = data.get("psk") or data.get("password") or ""
+    if not isinstance(ssid, str) or not ssid:
+        return "ERROR: Missing ssid"
+    if not isinstance(psk, str):
+        return "ERROR: Invalid psk"
+
+    try:
+        # Clear any stale error so the client can observe THIS attempt via /wifi/error.
+        try:
+            _daemon_request("POST", "/wifi/reset_error")
+        except Exception:
+            pass  # non-fatal
+        _daemon_request("POST", "/wifi/connect", params={"ssid": ssid, "password": psk})
+        return f"OK: Connecting to {ssid}"
+    except urllib.error.HTTPError as e:
+        if e.code == 409:
+            return "ERROR: Busy"
+        logger.warning(f"wifi_connect HTTP error: {e}")
+        return "ERROR: Connect request failed"
+    except urllib.error.URLError as e:
+        logger.warning(f"wifi_connect: daemon unreachable: {e}")
+        return "ERROR: Daemon unreachable"
+    except Exception as e:
+        logger.exception("wifi_connect failed")
+        return f"ERROR: {e}"
+
+
+def _wifi_forget(ssid: str) -> str:
+    """Forget a saved WiFi network. Falls back to hotspot server-side if needed."""
+    ssid = ssid.strip()
+    if not ssid:
+        return "ERROR: Missing ssid"
+    try:
+        _daemon_request("POST", "/wifi/forget", params={"ssid": ssid})
+        return f"OK: Forgotten {ssid}"
+    except urllib.error.HTTPError as e:
+        if e.code == 400:
+            return "ERROR: Cannot forget hotspot"
+        if e.code == 404:
+            return "ERROR: Unknown ssid"
+        if e.code == 409:
+            return "ERROR: Busy"
+        logger.warning(f"wifi_forget HTTP error: {e}")
+        return "ERROR: Forget failed"
+    except urllib.error.URLError as e:
+        logger.warning(f"wifi_forget: daemon unreachable: {e}")
+        return "ERROR: Daemon unreachable"
+    except Exception as e:
+        logger.exception("wifi_forget failed")
+        return f"ERROR: {e}"
 
 
 def get_pin() -> str:

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -124,17 +124,25 @@ class Advertisement(dbus.service.Object):
         dbus.service.Object.__init__(self, bus, self.path)
 
     def get_properties(self):
-        """Return the properties of the advertisement."""
+        """Return the properties of the advertisement.
+
+        Note on payload size: legacy BLE advertisements are capped at
+        31 bytes total. We deliberately omit ``ServiceUUIDs`` from the
+        primary advertisement and rely on ``LocalName`` matching on
+        the client side: a 128-bit UUID alone eats 18 bytes, which
+        leaves no room for the ManufacturerData IPv4 payload (5 bytes
+        per address). The full GATT service tree is still discoverable
+        once the client connects, so this is purely an advertising-time
+        size optimisation. ``Appearance=0x0000`` ("Unknown") is also
+        skipped because it is uninformative and adds 4 bytes.
+        """
         props = {"Type": self.ad_type}
         if self.local_name:
             props["LocalName"] = dbus.String(self.local_name)
-        if self.service_uuids:
-            props["ServiceUUIDs"] = dbus.Array(self.service_uuids, signature="s")
         if self.manufacturer_data:
             props["ManufacturerData"] = dbus.Dictionary(
                 self.manufacturer_data, signature="qv"
             )
-        props["Appearance"] = dbus.UInt16(0x0000)
         props["Duration"] = dbus.UInt16(0)
         props["Timeout"] = dbus.UInt16(0)
         return {LE_ADVERTISEMENT_IFACE: props}
@@ -864,14 +872,26 @@ class BluetoothCommandService:
 POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
 
 
+# Hard cap on the number of IP addresses we cram into the BLE advert.
+# Each address eats 5 bytes (1 flag + 4 IPv4), and the legacy adv slot
+# is limited to 31 bytes total (~16 already used by flags + LocalName),
+# so 2 addresses is the safe maximum before HCI rejects the payload.
+_MAX_ADVERTISED_IPS = 2
+
+
 def encode_network_ips() -> dict:
-    """Build ManufacturerData payload with all non-loopback IPv4 addresses.
+    """Build a ManufacturerData payload with at most two IPv4 addresses.
 
     Format per IP: 1 byte flags | 4 bytes IPv4
       flags: 0x01 = hotspot, 0x00 = normal
 
     Returns a dict {manufacturer_id: dbus.Array(bytes)} suitable for
-    BlueZ ManufacturerData property.  Returns empty dict when offline.
+    BlueZ ManufacturerData property. Returns empty dict when offline.
+
+    The cap exists because the overall advert has to fit in 31 bytes
+    (see :class:`Advertisement.get_properties`). Mobile clients that
+    need more than two interfaces can still query the GATT
+    NETWORK_STATUS characteristic once connected.
     """
     status = get_network_status()
     if status == "OFFLINE" or status == "ERROR":
@@ -881,7 +901,10 @@ def encode_network_ips() -> dict:
     is_hotspot = status.startswith("HOTSPOT")
 
     parts = status.split("[")
+    encoded = 0
     for part in parts[1:]:
+        if encoded >= _MAX_ADVERTISED_IPS:
+            break
         if "]" not in part:
             continue
         iface, rest = part.split("]", 1)
@@ -891,6 +914,7 @@ def encode_network_ips() -> dict:
             flag = 0x01 if (is_hotspot and iface.strip() == "wlan0") else 0x00
             payload.append(flag)
             payload.extend(ip_bytes)
+            encoded += 1
         except OSError:
             continue
 

--- a/src/reachy_mini/daemon/app/trace_middleware.py
+++ b/src/reachy_mini/daemon/app/trace_middleware.py
@@ -1,0 +1,107 @@
+"""Starlette middleware that propagates ``X-Trace-Id`` into log context.
+
+When the mobile app issues a daemon request (over LAN HTTP or via the
+WebRTC ``http_proxy`` tunnel), it tags each request with
+``X-Trace-Id``. This middleware:
+
+1. Reads that header (or mints a new id when absent, e.g. for
+   browser-originated requests like the dashboard or for ad-hoc curl
+   testing).
+2. Sets it on the :data:`logging_ctx.trace_id_var` ContextVar.
+3. Logs a one-liner per request with the request method/path/status
+   and elapsed time, so we have a stable observation point even on
+   routers that haven't been instrumented yet.
+4. Echoes the trace back as ``X-Trace-Id`` on the response, so the
+   mobile app can confirm correlation in cases where it didn't set
+   one (e.g. dashboard Open in Browser).
+
+We deliberately filter out a small set of high-frequency polling
+paths from the per-request log (relay-status, health-check) so DEBUG
+output isn't dominated by them.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from .logging_ctx import (
+    kv,
+    new_trace_id,
+    reset_trace_id,
+    set_trace_id,
+)
+
+_logger = logging.getLogger(__name__)
+
+# Keep the per-request log free of the highest-frequency endpoints.
+# They already have their own structured events when something
+# interesting happens; otherwise they're pure noise at INFO level.
+_QUIET_PATHS = {
+    "/health-check",
+    "/api/hf-auth/relay-status",
+    "/api/hf-auth/central-robot-status",
+    "/api/daemon/status",
+    "/api/state",
+}
+
+
+class TraceIdMiddleware(BaseHTTPMiddleware):
+    """ASGI middleware: scope ``trace_id`` per request.
+
+    Subclasses :class:`BaseHTTPMiddleware` so we can ``await
+    call_next`` and observe the response. The overhead of this base
+    class (~50µs per request) is negligible against the network
+    latencies we care about, and the API is simpler than implementing
+    raw ASGI.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Bind to the wrapped ASGI app."""
+        super().__init__(app)
+
+    async def dispatch(  # type: ignore[override]
+        self, request: Request, call_next: Any
+    ) -> Response:
+        """Scope ``trace_id`` to this request and emit a one-line summary."""
+        trace = request.headers.get("X-Trace-Id") or new_trace_id()
+        token = set_trace_id(trace)
+        t0 = time.perf_counter()
+        path = request.url.path
+        try:
+            response: Response = await call_next(request)
+            elapsed_ms = int((time.perf_counter() - t0) * 1000)
+            if path not in _QUIET_PATHS:
+                level = logging.WARNING if response.status_code >= 400 else logging.INFO
+                _logger.log(
+                    level,
+                    kv(
+                        "http.request",
+                        method=request.method,
+                        path=path,
+                        status=response.status_code,
+                        latency_ms=elapsed_ms,
+                    ),
+                )
+            response.headers["X-Trace-Id"] = trace
+            return response
+        except Exception as exc:
+            elapsed_ms = int((time.perf_counter() - t0) * 1000)
+            _logger.exception(
+                kv(
+                    "http.error",
+                    method=request.method,
+                    path=path,
+                    latency_ms=elapsed_ms,
+                    exc_type=type(exc).__name__,
+                )
+            )
+            raise
+        finally:
+            reset_trace_id(token)

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -203,6 +203,24 @@ class Backend:
         self._send_message_to_webrtc: Optional[Callable[[Optional[str], str], None]] = (
             None
         )
+        # Loopback HTTP proxy support (for the mobile app's `http_proxy`
+        # WebRTC DC tunnel). The daemon's FastAPI server binds locally on
+        # this port; we issue a localhost HTTP call against ourselves to
+        # forward proxied requests to the same router stack used by LAN
+        # clients. The event loop is captured at the same time as the
+        # WebRTC handler so we can `run_coroutine_threadsafe` from the
+        # GStreamer DC callback (which runs on its own thread).
+        self._loopback_http_port: int = 8000
+        self._loopback_http_host: str = "127.0.0.1"
+        self._http_proxy_loop: Optional[asyncio.AbstractEventLoop] = None
+
+        # WebSocket proxy support (`ws_proxy` over the same WebRTC DC
+        # tunnel as `http_proxy`). Multiplex by stream_id so callers
+        # can hold several long-lived subscriptions concurrently
+        # (e.g. /api/move/ws/updates + /api/state/ws/full from the
+        # mobile app at the same time). The dict is mutated only from
+        # `_http_proxy_loop`'s thread, so no extra lock is needed.
+        self._ws_proxy_streams: Dict[str, Dict[str, Any]] = {}
 
     # Life cycle methods
     def wrapped_run(self) -> None:
@@ -723,7 +741,9 @@ class Backend:
         1.0032234352772091,
     ]
 
-    INIT_ANTENNAS_JOINT_POSITIONS = np.array((-0.1745, 0.1745))  # ~10° offset to reduce shaking at vertical
+    INIT_ANTENNAS_JOINT_POSITIONS = np.array(
+        (-0.1745, 0.1745)
+    )  # ~10° offset to reduce shaking at vertical
     SLEEP_ANTENNAS_JOINT_POSITIONS = np.array((-3.05, 3.05))
     SLEEP_HEAD_POSE = np.array(
         [
@@ -782,7 +802,9 @@ class Backend:
             if dist_to_init_pose > 30:
                 # Move to the initial position
                 await self.goto_target(
-                    self.INIT_HEAD_POSE, antennas=self.INIT_ANTENNAS_JOINT_POSITIONS, duration=1
+                    self.INIT_HEAD_POSE,
+                    antennas=self.INIT_ANTENNAS_JOINT_POSITIONS,
+                    duration=1,
                 )
                 await asyncio.sleep(0.2)
 
@@ -993,7 +1015,12 @@ class Backend:
 
         elif isinstance(
             cmd,
-            (SetVolumeCmd, GetVolumeCmd, SetMicrophoneVolumeCmd, GetMicrophoneVolumeCmd),
+            (
+                SetVolumeCmd,
+                GetVolumeCmd,
+                SetMicrophoneVolumeCmd,
+                GetMicrophoneVolumeCmd,
+            ),
         ):
             # Volume is a global robot setting, not per-session: a remote
             # change persists for the next connection. This matches the
@@ -1104,6 +1131,7 @@ class Backend:
         Stores a reference to the ``GstMediaServer`` for:
         - WebRTC data channel message handling (robot control)
         - Sound playback delegation (play_sound)
+        - HTTP proxy tunnel (`http_proxy` over DC for the mobile app)
 
         Args:
             media_server: The ``GstMediaServer`` instance.
@@ -1113,6 +1141,7 @@ class Backend:
 
         _loop = asyncio.new_event_loop()
         threading.Thread(target=_loop.run_forever, daemon=True).start()
+        self._http_proxy_loop = _loop
 
         def _threadsafe_handler(peer_id: str, message: str) -> None:
             _loop.call_soon_threadsafe(self._handle_webrtc_message, peer_id, message)
@@ -1120,9 +1149,58 @@ class Backend:
         media_server.set_message_handler(_threadsafe_handler)
         self._send_message_to_webrtc = media_server.send_data_message
 
+    def set_loopback_http_port(self, port: int, host: str = "127.0.0.1") -> None:
+        """Tell the backend where the daemon's own FastAPI server is listening.
+
+        Used by the WebRTC ``http_proxy`` handler to forward proxied
+        requests to the same router stack that LAN clients hit
+        directly. Called from the FastAPI lifespan once we know the
+        port the user passed via ``--fastapi-port``.
+        """
+        self._loopback_http_port = port
+        self._loopback_http_host = host
+
     def _handle_webrtc_message(self, peer_id: str, message: str) -> None:
         def send(resp: dict[str, Any]) -> None:
             self._send_webrtc_response(peer_id, resp)
+
+        # Peek the message type before running it through the strict
+        # `command_adapter` discriminated union: the `http_proxy`
+        # tunnel lives outside the SDK's typed command set on purpose
+        # so we don't have to widen the protocol every time a new HTTP
+        # endpoint is added on the daemon. Invalid JSON or anything
+        # that's neither `http_proxy` nor a valid SDK command falls
+        # through to the existing error path.
+        try:
+            parsed = json.loads(message)
+        except Exception as e:
+            self.logger.error(f"WebRTC invalid JSON: {e}")
+            send({"error": f"Invalid JSON: {e}"})
+            return
+
+        if isinstance(parsed, dict):
+            msg_type = parsed.get("type")
+            if msg_type == "http_proxy":
+                # Run the proxied HTTP call on this backend's event loop.
+                # `_handle_webrtc_message` itself runs on that loop already
+                # (see `setup_media_server`), so we can fire a task
+                # directly. Callers don't wait for completion; the response
+                # is sent back through the data channel when ready.
+                asyncio.create_task(self._async_http_proxy(peer_id, parsed))
+                return
+            if msg_type == "ws_open":
+                # New WebSocket subscription request from the mobile
+                # app. The pump task handles the full lifecycle and
+                # sends `ws_opened` / `ws_message` / `ws_closed` /
+                # `ws_error` frames back over the DC.
+                asyncio.create_task(self._async_ws_proxy_open(peer_id, parsed))
+                return
+            if msg_type == "ws_send":
+                self._ws_proxy_handle_send(parsed)
+                return
+            if msg_type == "ws_close":
+                self._ws_proxy_handle_close(parsed)
+                return
 
         try:
             cmd = command_adapter.validate_json(message)
@@ -1135,6 +1213,358 @@ class Backend:
         except Exception as e:
             self.logger.error(f"WebRTC command error: {e}")
             send({"error": str(e)})
+
+    async def _async_http_proxy(self, peer_id: str, req: dict[str, Any]) -> None:
+        """Tunnel an HTTP request received over the WebRTC DC.
+
+        Wire format (mirrors `reachy_mini_mobile_app/src/robot-client/
+        webrtcClient.ts`):
+
+            request:  {"type":"http_proxy", "request_id":"...",
+                       "method":"GET"|"POST"|..., "path":"/api/...",
+                       "body": <json|null>, "headers":{...}|null,
+                       "timeout_s": <float>}
+            response: {"type":"http_proxy_response", "request_id":"...",
+                       "status": <int>, "body": <json|str|null>,
+                       "headers": {<name>: <value>, ...},
+                       "error": <str|null>}
+
+        On any error (timeout, connection refused, daemon 5xx) we still
+        send back a structured response with a non-2xx status and a
+        non-null `error`, so the mobile-side `webrtcClient` always
+        resolves the pending entry instead of timing out.
+        """
+        request_id = str(req.get("request_id") or "")
+        method = str(req.get("method") or "GET").upper()
+        path = str(req.get("path") or "/")
+        body = req.get("body")
+        headers_in = req.get("headers") or {}
+        try:
+            timeout_s = float(req.get("timeout_s") or 10.0)
+        except Exception:
+            timeout_s = 10.0
+        timeout_s = max(0.5, min(300.0, timeout_s))
+
+        if not request_id:
+            self.logger.warning("http_proxy: missing request_id, dropping")
+            return
+
+        url = f"http://{self._loopback_http_host}:{self._loopback_http_port}{path}"
+
+        # Normalise headers to plain str:str. Drop hop-by-hop headers
+        # that don't survive a loopback hop; we never want a remote
+        # client to forge `Host` for example.
+        clean_headers: dict[str, str] = {}
+        if isinstance(headers_in, dict):
+            for k, v in headers_in.items():
+                if not isinstance(k, str):
+                    continue
+                if k.lower() in {"host", "content-length"}:
+                    continue
+                clean_headers[k] = str(v)
+
+        # Body encoding: dicts/lists go as JSON, str goes verbatim,
+        # None means no body. Anything else is JSON-encoded as a best
+        # effort so the daemon-side router sees a syntactically valid
+        # payload.
+        send_kwargs: dict[str, Any] = {}
+        if body is None:
+            pass
+        elif isinstance(body, (bytes, bytearray)):
+            send_kwargs["data"] = bytes(body)
+        elif isinstance(body, str):
+            send_kwargs["data"] = body
+        else:
+            send_kwargs["json"] = body
+            clean_headers.setdefault("Content-Type", "application/json")
+
+        status: int = 0
+        resp_body: Any = None
+        resp_headers: dict[str, str] = {}
+        error: Optional[str] = None
+
+        try:
+            import aiohttp
+
+            timeout = aiohttp.ClientTimeout(total=timeout_s)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.request(
+                    method, url, headers=clean_headers, **send_kwargs
+                ) as resp:
+                    status = resp.status
+                    resp_headers = {k: v for k, v in resp.headers.items()}
+                    raw = await resp.read()
+                    text = raw.decode("utf-8", errors="replace") if raw else ""
+                    ctype = resp.headers.get("Content-Type", "")
+                    if "application/json" in ctype.lower() and text:
+                        try:
+                            resp_body = json.loads(text)
+                        except Exception:
+                            resp_body = text
+                    else:
+                        resp_body = text
+        except asyncio.TimeoutError:
+            error = f"daemon loopback timeout after {timeout_s:.1f}s"
+            self.logger.warning(
+                "http_proxy timeout", extra={"path": path, "timeout_s": timeout_s}
+            )
+        except Exception as e:
+            error = f"{type(e).__name__}: {e}"
+            self.logger.warning(
+                "http_proxy error", extra={"path": path, "error": error}
+            )
+
+        response = {
+            "type": "http_proxy_response",
+            "request_id": request_id,
+            "status": status,
+            "body": resp_body,
+            "headers": resp_headers,
+            "error": error,
+        }
+        try:
+            self._send_webrtc_response(peer_id, response)
+        except Exception as e:
+            self.logger.error(f"http_proxy: failed to send response: {e}")
+
+    # ------------------------------------------------------------------
+    # WebSocket proxy (parallel to `_async_http_proxy`)
+    #
+    # Wire format (mirrors `reachy_mini_mobile_app/src/robot-client/
+    # wsProxyClient.ts`):
+    #
+    #   client → daemon
+    #   ───────────────
+    #     {"type":"ws_open",  "stream_id":"...", "path":"/api/.../ws/...",
+    #      "headers": {...}|null}
+    #     {"type":"ws_send",  "stream_id":"...", "data": "<text>"}
+    #     {"type":"ws_close", "stream_id":"...",
+    #      "code": <int>|null, "reason": <str>|null}
+    #
+    #   daemon → client
+    #   ───────────────
+    #     {"type":"ws_opened",  "stream_id":"..."}
+    #     {"type":"ws_message", "stream_id":"...", "data": "<text>"}
+    #     {"type":"ws_closed",  "stream_id":"...",
+    #      "code": <int>, "reason": <str>}
+    #     {"type":"ws_error",   "stream_id":"...", "error": "..."}
+    #
+    # Only TEXT frames are tunnelled today: every Reachy daemon WS
+    # endpoint sends JSON-as-text and a base64-encoded BINARY carve-out
+    # would just bloat the wire format with no caller. The daemon-side
+    # handshake is best-effort: any failure (handshake refused, server
+    # disconnects mid-stream, JSON-encoding error) is reported with a
+    # single `ws_error` frame and the stream entry is dropped, so the
+    # mobile-side dispatcher always sees a terminal event per stream.
+    # ------------------------------------------------------------------
+
+    async def _async_ws_proxy_open(self, peer_id: str, req: dict[str, Any]) -> None:
+        """Tunnel a WebSocket connection received over the WebRTC DC."""
+        stream_id = str(req.get("stream_id") or "")
+        path = str(req.get("path") or "/")
+        headers_in = req.get("headers") or {}
+
+        if not stream_id:
+            self.logger.warning("ws_proxy: missing stream_id, dropping")
+            return
+        if stream_id in self._ws_proxy_streams:
+            # Re-using an in-flight stream_id is a client-side bug. We
+            # answer with a single error frame instead of silently
+            # dropping so the mobile side surfaces it in logs.
+            self._send_webrtc_response(
+                peer_id,
+                {
+                    "type": "ws_error",
+                    "stream_id": stream_id,
+                    "error": "stream_id already in use",
+                },
+            )
+            return
+
+        # Drop hop-by-hop and handshake-owned headers; aiohttp picks
+        # the right `Sec-WebSocket-*` values itself and a remote client
+        # forging `Host` would let a malicious peer impersonate the
+        # loopback origin.
+        clean_headers: dict[str, str] = {}
+        if isinstance(headers_in, dict):
+            for k, v in headers_in.items():
+                if not isinstance(k, str):
+                    continue
+                lk = k.lower()
+                if lk in {
+                    "host",
+                    "content-length",
+                    "upgrade",
+                    "connection",
+                    "sec-websocket-key",
+                    "sec-websocket-version",
+                    "sec-websocket-extensions",
+                    "sec-websocket-protocol",
+                }:
+                    continue
+                clean_headers[k] = str(v)
+
+        url = f"ws://{self._loopback_http_host}:{self._loopback_http_port}{path}"
+
+        # Allocate the stream record up-front so a fast `ws_close`
+        # arriving while the handshake is in flight has somewhere to
+        # land. The pump task wires `task` and we own the queue here.
+        incoming: "asyncio.Queue[Optional[str]]" = asyncio.Queue()
+        self._ws_proxy_streams[stream_id] = {
+            "incoming": incoming,
+            "task": None,
+            "peer_id": peer_id,
+            "closing": False,
+        }
+
+        async def pump() -> None:
+            import aiohttp
+
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.ws_connect(
+                        url,
+                        headers=clean_headers or None,
+                        heartbeat=30.0,
+                    ) as ws:
+                        self._send_webrtc_response(
+                            peer_id,
+                            {"type": "ws_opened", "stream_id": stream_id},
+                        )
+                        self.logger.info(
+                            "ws_proxy opened",
+                            extra={"stream_id": stream_id, "path": path},
+                        )
+
+                        async def writer() -> None:
+                            while True:
+                                data = await incoming.get()
+                                if data is None:
+                                    if not ws.closed:
+                                        try:
+                                            await ws.close()
+                                        except Exception:
+                                            pass
+                                    return
+                                try:
+                                    await ws.send_str(data)
+                                except Exception as e:
+                                    self.logger.warning(
+                                        "ws_proxy writer error",
+                                        extra={
+                                            "stream_id": stream_id,
+                                            "error": str(e),
+                                        },
+                                    )
+                                    return
+
+                        writer_task = asyncio.create_task(writer())
+                        try:
+                            async for msg in ws:
+                                if msg.type == aiohttp.WSMsgType.TEXT:
+                                    self._send_webrtc_response(
+                                        peer_id,
+                                        {
+                                            "type": "ws_message",
+                                            "stream_id": stream_id,
+                                            "data": msg.data,
+                                        },
+                                    )
+                                elif msg.type == aiohttp.WSMsgType.ERROR:
+                                    err_obj = ws.exception()
+                                    self._send_webrtc_response(
+                                        peer_id,
+                                        {
+                                            "type": "ws_error",
+                                            "stream_id": stream_id,
+                                            "error": str(err_obj or "ws error"),
+                                        },
+                                    )
+                                    break
+                                elif msg.type in (
+                                    aiohttp.WSMsgType.CLOSE,
+                                    aiohttp.WSMsgType.CLOSED,
+                                    aiohttp.WSMsgType.CLOSING,
+                                ):
+                                    break
+                                # Binary frames are dropped on purpose.
+                        finally:
+                            writer_task.cancel()
+                            try:
+                                await writer_task
+                            except (asyncio.CancelledError, Exception):
+                                pass
+
+                        code = ws.close_code if ws.close_code is not None else 1000
+                        self._send_webrtc_response(
+                            peer_id,
+                            {
+                                "type": "ws_closed",
+                                "stream_id": stream_id,
+                                "code": code,
+                                "reason": "",
+                            },
+                        )
+                        self.logger.info(
+                            "ws_proxy closed",
+                            extra={
+                                "stream_id": stream_id,
+                                "code": code,
+                                "path": path,
+                            },
+                        )
+            except asyncio.CancelledError:
+                # Backend shutting down: don't try to send anything.
+                raise
+            except Exception as e:
+                self.logger.warning(
+                    "ws_proxy connect error",
+                    extra={
+                        "stream_id": stream_id,
+                        "path": path,
+                        "error": f"{type(e).__name__}: {e}",
+                    },
+                )
+                self._send_webrtc_response(
+                    peer_id,
+                    {
+                        "type": "ws_error",
+                        "stream_id": stream_id,
+                        "error": f"{type(e).__name__}: {e}",
+                    },
+                )
+            finally:
+                self._ws_proxy_streams.pop(stream_id, None)
+
+        task = asyncio.create_task(pump())
+        # Re-fetch the slot in case `ws_close` already removed it
+        # before we got here (extremely tight race, but free to guard).
+        slot = self._ws_proxy_streams.get(stream_id)
+        if slot is not None:
+            slot["task"] = task
+
+    def _ws_proxy_handle_send(self, req: dict[str, Any]) -> None:
+        """Forward a `ws_send` payload to the matching pump's writer queue."""
+        stream_id = str(req.get("stream_id") or "")
+        if not stream_id:
+            return
+        stream = self._ws_proxy_streams.get(stream_id)
+        if not stream or stream.get("closing"):
+            return
+        data = req.get("data")
+        if isinstance(data, str):
+            stream["incoming"].put_nowait(data)
+
+    def _ws_proxy_handle_close(self, req: dict[str, Any]) -> None:
+        """Mark a stream as closing and signal the writer to drain."""
+        stream_id = str(req.get("stream_id") or "")
+        if not stream_id:
+            return
+        stream = self._ws_proxy_streams.get(stream_id)
+        if not stream or stream.get("closing"):
+            return
+        stream["closing"] = True
+        stream["incoming"].put_nowait(None)
 
     def _send_webrtc_response(self, peer_id: str, response: dict[str, Any]) -> None:
         if self._send_message_to_webrtc:

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -153,6 +153,36 @@ class Daemon:
         self._status.media_released = False
         self.logger.info("Media hardware re-acquired.")
 
+    async def ensure_central_signaling_relay(self) -> dict[str, Any]:
+        """Ensure the central signaling relay is running.
+
+        Idempotent helper used by HTTP routes (e.g. ``save-token``,
+        ``refresh-relay``) to recover from the cold-boot case where the
+        daemon started without an HF token. In that case
+        ``_start_central_signaling_relay`` ran once at media-acquire
+        time, found no token, and returned without setting
+        ``_relay_instance``. After the user pushes a token via
+        ``save-token``, ``notify_token_change`` is a no-op (because
+        ``_relay_instance is None``), so the robot stays invisible on
+        central until the next daemon restart. This method closes that
+        gap by re-running the start path.
+
+        Returns a small dict describing what happened, suitable for
+        bubbling up to API responses.
+        """
+        from reachy_mini.media import central_signaling_relay as _csr
+
+        if _csr._relay_instance is not None:
+            return {"started": False, "reason": "already_running"}
+        if not self._media_server or self._media_released:
+            return {"started": False, "reason": "media_unavailable"}
+
+        await self._start_central_signaling_relay()
+
+        if _csr._relay_instance is None:
+            return {"started": False, "reason": "no_token_or_failed"}
+        return {"started": True}
+
     async def _start_central_signaling_relay(self) -> None:
         """Start the central signaling relay for remote WebRTC access."""
         global _central_relay_task

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -772,7 +772,14 @@ class CentralSignalingRelay:
 
     async def _send_to_central(self, msg: dict[str, Any]) -> None:
         """Send a message to the central server via HTTP POST."""
+        msg_type = msg.get("type", "?")
         if not self._http_session or not self.hf_token:
+            logger.warning(
+                "[Central Relay] _send_to_central skipped (type=%s, http_session=%s, hf_token=%s)",
+                msg_type,
+                bool(self._http_session),
+                bool(self.hf_token),
+            )
             return
 
         # Token goes in the Authorization header only, not the URL.
@@ -783,12 +790,24 @@ class CentralSignalingRelay:
                 send_url, json=msg, headers=headers
             ) as response:
                 if response.status != 200:
+                    body = ""
+                    try:
+                        body = (await response.text())[:300]
+                    except Exception:
+                        pass
                     logger.warning(
-                        f"[Central Relay] Failed to send message to central server: HTTP {response.status}"
+                        "[Central Relay] _send_to_central FAILED type=%s HTTP %s body=%r",
+                        msg_type,
+                        response.status,
+                        body,
                     )
+                else:
+                    logger.info("[Central Relay] _send_to_central OK type=%s", msg_type)
         except Exception as e:
             logger.error(
-                f"[Central Relay] Error sending message to central server: {e}"
+                "[Central Relay] _send_to_central exception type=%s err=%s",
+                msg_type,
+                e,
             )
 
     async def _send_to_local(self, msg: dict[str, Any]) -> None:
@@ -809,17 +828,28 @@ class CentralSignalingRelay:
         if msg_type == "welcome":
             # Received our peer ID from central server
             self._central_peer_id = msg.get("peerId")
-            self._set_state(
-                RelayState.CONNECTED, f"Remote access enabled as '{self.robot_name}'"
+            logger.info(
+                "[Central Relay] central welcome received peer_id=%s; registering as producer name=%r",
+                self._central_peer_id,
+                self.robot_name,
             )
 
-            # Register as producer
+            # Register as producer FIRST, then flip to CONNECTED. If we
+            # set CONNECTED before producer registration, observers (UI,
+            # mobile app, /relay-status pollers) can see "connected" while
+            # central does not yet know we are a producer for this user,
+            # which produces the desync described in /refresh-relay's
+            # docstring.
             await self._send_to_central(
                 {
                     "type": "setPeerStatus",
                     "roles": ["producer"],
                     "meta": {"name": self.robot_name},
                 }
+            )
+
+            self._set_state(
+                RelayState.CONNECTED, f"Remote access enabled as '{self.robot_name}'"
             )
 
         elif msg_type == "list":

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -170,6 +170,20 @@ class CentralSignalingRelay:
         else:
             logger.debug(log_msg)
 
+        # Structured kv form: easy to grep, easy to dashboard. The
+        # human-readable line above stays for compatibility with anyone
+        # reading the systemd journal directly.
+        from reachy_mini.daemon.app.logging_ctx import kv_log
+
+        kv_log(
+            logger,
+            logging.INFO if state != RelayState.ERROR else logging.WARNING,
+            "central.relay.state",
+            from_=old_state.value,
+            to=state.value,
+            message=message,
+        )
+
         # Notify callback if set
         if self._on_state_change:
             try:
@@ -194,7 +208,9 @@ class CentralSignalingRelay:
         # coroutine is invoked on the main asyncio loop and schedules the
         # actual tear-down on the relay's own thread loop.
         if self._robot_app_lock is not None:
-            self._robot_app_lock.set_remote_eviction_handler(self._handle_remote_eviction)
+            self._robot_app_lock.set_remote_eviction_handler(
+                self._handle_remote_eviction
+            )
 
         # Run the relay in its own thread with a dedicated event loop.
         # This is necessary because the caller (daemon.start) may run in a temporary

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -194,7 +194,9 @@ class CentralSignalingRelay:
         # coroutine is invoked on the main asyncio loop and schedules the
         # actual tear-down on the relay's own thread loop.
         if self._robot_app_lock is not None:
-            self._robot_app_lock.set_remote_eviction_handler(self._handle_remote_eviction)
+            self._robot_app_lock.set_remote_eviction_handler(
+                self._handle_remote_eviction
+            )
 
         # Run the relay in its own thread with a dedicated event loop.
         # This is necessary because the caller (daemon.start) may run in a temporary
@@ -331,17 +333,38 @@ class CentralSignalingRelay:
             logger.debug("[Central Relay] Token unchanged, no action needed")
             return
 
-        if new_token:
-            self._set_state(
-                RelayState.RECONNECTING, "HF token updated, reconnecting..."
-            )
-            self._connection_attempts = 0  # Reset retry counter on new token
+        await self._reconnect_now(new_token, reason="HF token updated, reconnecting...")
+
+    async def force_reconnect(self) -> None:
+        """Drop the current connection and reconnect with the stored token.
+
+        Unlike ``update_token``, this path is NOT guarded by a token
+        equality check - it always tears down the SSE and reconnects.
+
+        Intended as a recovery handle for split-brain states where the
+        relay thinks it is connected but central no longer lists this
+        robot as a producer (see ``POST /api/hf-auth/refresh-relay``).
+        """
+        await self._reconnect_now(self.hf_token, reason="Forced relay reconnect")
+
+    async def _reconnect_now(self, token: Optional[str], reason: str) -> None:
+        """Shared core of token-change and force-reconnect paths.
+
+        Transitions the relay into the right state and signals the run
+        loop to tear down the current connection and try connecting
+        again. Safe to call from any thread - if we have a running
+        thread loop we schedule the close/set there, otherwise we set
+        the event directly (covers the case where the relay has not
+        started its background thread yet).
+        """
+        if token:
+            self._set_state(RelayState.RECONNECTING, reason)
+            self._connection_attempts = 0
         else:
             self._set_state(RelayState.WAITING_FOR_TOKEN, "Logged out from HuggingFace")
 
-        # Signal the run loop to wake up and try connecting (thread-safe)
         if self._thread_loop and self._thread_loop.is_running():
-            # Schedule _close_connections and token_updated.set in the thread's event loop
+
             async def _reconnect() -> None:
                 await self._close_connections()
                 self._token_updated.set()
@@ -1146,3 +1169,19 @@ async def notify_token_change(new_token: Optional[str] = None) -> None:
             pass
 
     await _relay_instance.update_token(new_token)
+
+
+async def notify_force_reconnect() -> None:
+    """Ask the relay to drop its SSE channel and reconnect right now.
+
+    Unlike ``notify_token_change``, this always triggers a reconnect
+    even when the stored token is unchanged. Used by the
+    ``POST /api/hf-auth/refresh-relay`` endpoint to recover from
+    zombie-relay states where central no longer lists the robot as a
+    producer but the relay still thinks it is connected.
+    """
+    if _relay_instance is None:
+        logger.debug("[Central Relay] No relay instance, ignoring force reconnect")
+        return
+
+    await _relay_instance.force_reconnect()

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -438,8 +438,39 @@ class CentralSignalingRelay:
                 try:
                     await self._connect_and_relay()
                 except asyncio.CancelledError:
-                    logger.info("[Central Relay] _run_loop cancelled during connect")
-                    raise  # Re-raise to exit the outer try
+                    # CancelledError at this layer has two possible sources:
+                    #
+                    # 1. `stop()` flipped `self._running` to False. This is the
+                    #    shutdown path and we must re-raise so the thread exits.
+                    # 2. An in-flight `_close_connections()` (triggered by
+                    #    `force_reconnect` / `update_token`) cancelled a task
+                    #    that aiohttp was holding the cancellation for - e.g.
+                    #    a `session.get(...)` wedged inside `_resolve_host` on
+                    #    a flaky network. aiohttp propagates that cancellation
+                    #    up through `_handle_central_sse`, which lands here.
+                    #    In that case we very much want to stay in the loop and
+                    #    reconnect - killing the thread here means every
+                    #    subsequent `/refresh-relay` POST is a no-op because
+                    #    there's no loop left to service the token_updated
+                    #    event.
+                    #
+                    # `self._running` is our authoritative signal for (1). If
+                    # it's still True, treat the cancellation as a reconnect
+                    # request and loop around.
+                    if not self._running:
+                        logger.info(
+                            "[Central Relay] _run_loop cancelled (stop requested)"
+                        )
+                        raise
+                    logger.info(
+                        "[Central Relay] Connect attempt cancelled mid-flight "
+                        "(likely from force_reconnect / token update); restarting loop"
+                    )
+                    had_exception = True
+                    self._set_state(
+                        RelayState.RECONNECTING,
+                        "Restarting after cancelled connect",
+                    )
                 except Exception as e:
                     logger.warning(
                         f"[Central Relay] Connection attempt failed with exception: {type(e).__name__}: {e}"

--- a/src/reachy_mini/media/device_detection.py
+++ b/src/reachy_mini/media/device_detection.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import platform
 import re
+import sys
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, Sequence, Tuple
 
@@ -272,7 +273,23 @@ def gst_monitor_devices(filter_class: str) -> list[DeviceInfo]:
     try:
         return gst_devices_to_device_infos(monitor.get_devices())
     finally:
-        monitor.stop()
+        # Workaround: on macOS (observed on macOS 26 "Tahoe") calling
+        # Gst.DeviceMonitor.stop() can segfault inside
+        # gst_device_provider_stop -> avfdeviceprovider, killing the whole
+        # Python daemon with SIGSEGV before any traceback can be emitted.
+        # The monitor is short-lived (one enumeration at boot) so skipping
+        # the explicit stop is acceptable: the underlying providers are
+        # reclaimed when the Python object is garbage collected and when
+        # the process exits.
+        if sys.platform == "darwin":
+            _logger.debug(
+                "Skipping Gst.DeviceMonitor.stop() on macOS (known crash)",
+            )
+        else:
+            try:
+                monitor.stop()
+            except Exception:  # pragma: no cover - defensive
+                _logger.exception("Gst.DeviceMonitor.stop() failed")
 
 
 def find_audio_device(


### PR DESCRIPTION
## What this PR is

Tracking / umbrella PR for the daemon-side work backing the new **Reachy Mini mobile app**. It bundles all the small feature PRs into one branch (`integration/mobile-app-daemon`) so reviewers can:

- See the full picture of the mobile-app daemon contract in one diff.
- Smoke-test the whole stack at once on a real robot before each child PR is merged separately.
- Track aggregate CI / merge readiness in one place.

This PR is **not meant to be merged directly**: it is closed once all the children below have been merged into `main`, at which point its diff goes empty.

## Child PRs (foundation)

Each one is independently reviewable and targets `main` directly:

- [ ] #1029 `feat(bluetooth): broadcast network IPs in BLE advertisement` (`feat/ble-advertise-network-ip`)
- [ ] #1045 `feat(bluetooth): add BLE commands for WiFi provisioning` (`feat/ble-wifi-provisioning`)
- [ ] #1046 `feat(hf-auth): expose /token endpoint for mobile token bridging` (`feat/hf-token-endpoint`)
- [ ] #1047 `feat(hf-auth): POST /refresh-relay to recover zombie relay` (`feat/hf-auth-refresh-relay`)
- [ ] #1048 `feat(webrtc): generic HTTP-proxy command for unified transport` (`feat/webrtc-http-proxy`)

## Roadmap follow-up (drafts)

Daemon-side complements to the mobile-app roadmap (see [`pollen-robotics/reachy_mini_mobile_app/docs/ROADMAP.md`](https://github.com/pollen-robotics/reachy_mini_mobile_app/blob/main/docs/ROADMAP.md)):

- [ ] #1050 `feat: structured logging (PR-B)` -- permanent observability points + trace-id middleware
- [ ] #1051 `feat: Wi-Fi forget HTTP endpoint` -- enables the mobile "Forget Wi-Fi" feature over the unified `RobotClient` (consumed by the mobile PR-F)

## Why those four foundation PRs

The new mobile app needs to:

1. **Provision Wi-Fi** on a brand-new robot over BLE without any pre-existing network: #1045.
2. **Bridge the daemon's HF OAuth state to the app** so the app can reuse the daemon-acquired token without doing a second round trip: #1046.
3. **Recover from a zombie relay state** where the daemon thinks it's connected to HF central but central has not registered it as a producer (raced welcome handler): #1047.
4. **Reach the full daemon HTTP API from a remote phone** (off-LAN, mixed-content, NAT) by tunnelling REST calls over the existing WebRTC DataChannel: #1048.

Together these turn the daemon into a transport-agnostic peer: LAN apps see a normal HTTP server, remote apps see a tunnelled superset of it through WebRTC, and the BLE channel can bootstrap Wi-Fi on a robot that has never been online.

#1029 is a passive-discovery improvement that complements the BLE flow: it broadcasts the robot's IPs in `ManufacturerData`, so the mobile app can short-circuit GATT for IP lookup.

## Test plan

Each child PR has its own scoped test plan. End-to-end validation on this umbrella branch:

- [x] BLE Wi-Fi provisioning verified on iOS / Android with the mobile app.
- [x] OAuth via the daemon's /token endpoint verified end-to-end on the mobile app.
- [x] /refresh-relay recovers a stuck "connected but unknown to central" relay (verified on robot, daemon logs show `setPeerStatus producer` registered before the state flips).
- [x] `POST /api/hf-auth/refresh-relay` proxied over the WebRTC DataChannel returns 200 with the expected body in <1 s round-trip.
- [ ] End-to-end test of the four PRs once `feat/webrtc-http-proxy` is wired into the mobile app's `RobotClient` abstraction.

## How to merge

Merge each child PR into `main` independently. Once all foundation PRs are in, this umbrella PR becomes empty and can be closed. The roadmap follow-up PRs continue independently as part of the mobile-app integration roadmap.