### PR TITLE
feat(daemon): expose GET /api/daemon/version

### DIFF
--- a/src/reachy_mini/daemon/app/routers/daemon.py
+++ b/src/reachy_mini/daemon/app/routers/daemon.py
@@ -85,6 +85,31 @@ async def get_daemon_status(daemon: Daemon = Depends(get_daemon)) -> DaemonStatu
     return daemon.status()
 
 
+@router.get("/version")
+async def get_daemon_version() -> dict[str, str]:
+    """Return the daemon's package version and a compatibility marker.
+
+    Mobile and remote clients call this early during the connection
+    handshake to detect a feature mismatch (e.g. an older daemon that
+    doesn't ship a new endpoint yet) and surface a soft warning rather
+    than failing later with a cryptic 404.
+
+    The endpoint is deliberately additive: it returns a dict so we can
+    grow it (build sha, kinematics engine, ...) without breaking older
+    clients that only look up ``version``.
+    """
+    from reachy_mini import __version__
+
+    return {
+        "version": __version__,
+        # Bumped whenever the HTTP surface gains/loses an endpoint or
+        # a route's response shape changes in a non-additive way.
+        # Mobile clients can rely on `api_revision >= N` to know a
+        # feature is reachable, regardless of the package version.
+        "api_revision": "1",
+    }
+
+
 @router.get("/robot-app-lock-status")
 async def get_robot_app_lock_status(
     daemon: Daemon = Depends(get_daemon),


### PR DESCRIPTION
## Summary

Adds a tiny additive endpoint that mobile and remote clients call
during connection handshake to detect daemon feature mismatches.

```http
GET /api/daemon/version
→ {"version": "X.Y.Z", "api_revision": "1"}
```

`api_revision` is a daemon-controlled monotonic marker bumped whenever
the HTTP surface changes. Clients can rely on it for `>= N` feature
gating without tying logic to the pip package version.

No auth, no robot needed. Safe to call as the first probe.

## Why

Older daemons silently 404 on newer endpoints (e.g. `/api/wifi/forget`
on the integration branch), leading to UI features that "do nothing"
without diagnostic signal. With a version probe we can show a soft
warning banner: "some features may not work, please update your robot".

## Test plan

- [ ] `curl http://reachy.local:8080/api/daemon/version` returns the
      JSON shape above.
- [ ] Smoke test: integrated with the mobile app's PR-D handshake.


Made with [Cursor](https://cursor.com)