### PR TITLE
Warn on SDK daemon version mismatch

### DIFF
--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -9,6 +9,8 @@ It also includes methods for multimedia interactions like playing sounds and loo
 import asyncio
 import logging
 import time
+import warnings
+from importlib.metadata import PackageNotFoundError, version
 from typing import Dict, List, Literal, Optional, Union, cast
 
 import numpy as np
@@ -19,6 +21,7 @@ from scipy.spatial.transform import Rotation as R
 from reachy_mini.daemon.utils import daemon_check, is_local_camera_available
 from reachy_mini.io.protocol import (
     AppendRecordCmd,
+    DaemonStatus,
     GotoTaskRequest,
     SetAntennasCmd,
     SetAutomaticBodyYawCmd,
@@ -275,6 +278,7 @@ class ReachyMini:
         names handled by ``_resolve_backend``).
         """
         daemon_status = self.client.get_status()
+        self._warn_if_daemon_version_mismatch(daemon_status)
 
         # Resolve camera specs from the daemon-detected camera name
         specs_name = getattr(daemon_status, "camera_specs_name", "")
@@ -332,6 +336,36 @@ class ReachyMini:
             signalling_host=daemon_status.wlan_ip or "localhost",
             camera_specs=camera_specs,
             daemon_url=self._daemon_http_url,
+        )
+
+    @staticmethod
+    def _get_sdk_version() -> str | None:
+        try:
+            return version("reachy_mini")
+        except PackageNotFoundError:
+            return None
+
+    def _warn_if_daemon_version_mismatch(self, daemon_status: DaemonStatus) -> None:
+        """Warn users when the SDK and daemon package versions differ."""
+        sdk_version = self._get_sdk_version()
+        daemon_version = daemon_status.version
+
+        if sdk_version is None or daemon_version is None:
+            return
+
+        sdk_version = sdk_version.strip()
+        daemon_version = daemon_version.strip()
+
+        if sdk_version == daemon_version:
+            return
+
+        warnings.warn(
+            "Reachy Mini SDK and daemon versions do not match: "
+            f"SDK={sdk_version}, daemon={daemon_version}. "
+            "Running different versions can create issues. "
+            "Install matching reachy_mini versions for the SDK and daemon.",
+            RuntimeWarning,
+            stacklevel=3,
         )
 
     def _normalize_connection_mode(

--- a/tests/unit_tests/test_daemon.py
+++ b/tests/unit_tests/test_daemon.py
@@ -95,6 +95,23 @@ async def test_daemon_client_disconnection() -> None:
 
 
 @pytest.mark.asyncio
+async def test_sdk_warns_on_daemon_version_mismatch() -> None:
+    daemon, server, thread, port = await _start_app_server()
+    daemon._status.version = "0.0.0"
+
+    try:
+        with pytest.warns(
+            RuntimeWarning,
+            match="Reachy Mini SDK and daemon versions do not match",
+        ):
+            with ReachyMini(host="localhost", port=port, media_backend="no_media"):
+                pass
+    finally:
+        await daemon.stop(goto_sleep_on_stop=False)
+        await _stop_app_server(server, thread)
+
+
+@pytest.mark.asyncio
 async def test_daemon_early_stop() -> None:
     daemon, server, thread, port = await _start_app_server()
 


### PR DESCRIPTION
## Summary

Adds an SDK-side version check using the daemon status already fetched during media manager setup. If the installed SDK package version differs from the daemon-reported package version, the SDK emits a visible `RuntimeWarning` explaining that mismatched versions can create issues.

## Validation

- `uv run pytest tests/unit_tests/test_daemon.py::test_sdk_warns_on_daemon_version_mismatch -q`
- `uv run pytest tests/unit_tests/test_daemon.py -q`
- `uv run ruff check src/reachy_mini/reachy_mini.py`
- `uv run mypy src/reachy_mini/reachy_mini.py`