### PR TITLE
Add audio board startup config helpers

### DIFF
--- a/docs/source/API/media.mdx
+++ b/docs/source/API/media.mdx
@@ -7,6 +7,8 @@
 
 ## Audio
 
+[[autodoc]] reachy_mini.media.audio_base.AudioBase
+
 [[autodoc]] reachy_mini.media.audio_gstreamer.GStreamerAudio
 
 ### Audio Utils Functions
@@ -26,31 +28,6 @@
 [[autodoc]] reachy_mini.media.audio_control_utils.find
 
 [[autodoc]] reachy_mini.media.audio_control_utils.init_respeaker_usb
-
-### Audio Board Configuration
-
-Advanced apps can tune XVF3800 audio parameters by passing caller-defined
-parameter values to the media audio backend:
-
-```python
-from reachy_mini import ReachyMini
-
-# Replace the parameter names and values with the config for your app.
-custom_audio_config = (
-    ("PARAMETER_NAME", (value_1, value_2)),
-)
-
-with ReachyMini(media_backend="local") as mini:
-    applied = mini.media.audio.apply_audio_config(custom_audio_config)
-```
-
-`apply_audio_config()` returns `True` when all parameters were written and
-verified successfully. It returns `False` if the ReSpeaker audio board cannot
-be found or if verification fails.
-
-The SDK does not provide default values for these parameters. Use values tuned
-for your app and refer to the advanced media controls documentation for the
-available XVF3800 parameter names.
 
 ## Camera
 

--- a/docs/source/API/media.mdx
+++ b/docs/source/API/media.mdx
@@ -27,6 +27,31 @@
 
 [[autodoc]] reachy_mini.media.audio_control_utils.init_respeaker_usb
 
+### Audio Board Configuration
+
+Advanced apps can tune XVF3800 audio parameters by passing caller-defined
+parameter values to the media audio backend:
+
+```python
+from reachy_mini import ReachyMini
+
+# Replace the parameter names and values with the config for your app.
+custom_audio_config = (
+    ("PARAMETER_NAME", (value_1, value_2)),
+)
+
+with ReachyMini(media_backend="local") as mini:
+    applied = mini.media.audio.apply_audio_config(custom_audio_config)
+```
+
+`apply_audio_config()` returns `True` when all parameters were written and
+verified successfully. It returns `False` if the ReSpeaker audio board cannot
+be found or if verification fails.
+
+The SDK does not provide default values for these parameters. Use values tuned
+for your app and refer to the advanced media controls documentation for the
+available XVF3800 parameter names.
+
 ## Camera
 
 [[autodoc]] reachy_mini.media.camera_gstreamer.GStreamerCamera

--- a/docs/source/platforms/reachy_mini/media_advanced_controls.md
+++ b/docs/source/platforms/reachy_mini/media_advanced_controls.md
@@ -74,6 +74,25 @@ python src/reachy_mini/media/audio_control_utils.py PP_MIN_NS --values 0
 # Write operation completed successfully
 ```
 
+Apps can also apply a group of custom audio parameters through the SDK when
+they run on the same machine as the audio board:
+
+```python
+from reachy_mini import ReachyMini
+
+# Replace the parameter names and values with the config for your app.
+custom_audio_config = (
+    ("PARAMETER_NAME", (value_1, value_2)),
+)
+
+with ReachyMini(media_backend="local") as mini:
+    applied = mini.media.audio.apply_audio_config(custom_audio_config)
+```
+
+For Reachy Mini Wireless, run this from the robot itself so the process can
+access the USB audio board. Remote REST/WebRTC audio-board configuration is
+not exposed yet.
+
 The microphone array outputs a stereo channel, so it is not possible to get the raw output of all 4 mics at once. However, you can output two raw microphones at a time:
 
 ```bash

--- a/docs/source/platforms/reachy_mini_lite/media_advanced_controls.md
+++ b/docs/source/platforms/reachy_mini_lite/media_advanced_controls.md
@@ -92,3 +92,8 @@ camsrc.set_property("device", cam_path)
 ## Microphones and Speakers
 
 Refer to the [Reachy Mini documentation](../reachy_mini/media_advanced_controls.md#microphones-and-speakers). The hardware is exactly the same for the Lite version.
+
+On Reachy Mini Lite, the ReSpeaker audio board is connected to your computer
+over USB. SDK audio-board configuration helpers such as
+`mini.media.audio.apply_audio_config(...)` are available when using the local
+media backend from that computer.

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -809,6 +809,9 @@ You can play back a sound while recording simultaneously to test the echo cancel
 - Ensure the `.asoundrc` file exists in the home directory
 - Check that the microphone is detected: `arecord -l`
 - Check that the speaker is detected: `aplay -l`
+- If audio-board configuration fails with `No Reachy Mini Audio USB device found!`,
+  run the SDK code on the machine that has the ReSpeaker audio board connected.
+  For Lite this is your computer; for Wireless this is the robot itself.
 
 </details>
 

--- a/src/reachy_mini/media/audio_base.py
+++ b/src/reachy_mini/media/audio_base.py
@@ -114,7 +114,24 @@ class AudioBase(ABC):
         verify: bool = True,
         write_settle_seconds: float = WRITE_SETTLE_SECONDS,
     ) -> bool:
-        """Apply audio control parameters to the ReSpeaker."""
+        """Apply caller-provided audio control parameters to the ReSpeaker.
+
+        This opens a short-lived ReSpeaker USB handle, writes each parameter in
+        ``config``, and optionally verifies the written values. The SDK does
+        not provide default values for these parameters; callers should pass the
+        values tuned for their own app.
+
+        Args:
+            config: Sequence of ``(parameter_name, values)`` pairs to write.
+            verify: When true, read each parameter back after writing it.
+            write_settle_seconds: Delay after each write before readback.
+
+        Returns:
+            True when all parameters were written and verified successfully.
+            False when the ReSpeaker audio board is unavailable or a parameter
+            write/readback fails.
+
+        """
         respeaker = init_respeaker_usb()
         if respeaker is None:
             self.logger.warning("ReSpeaker device not found.")

--- a/src/reachy_mini/media/audio_base.py
+++ b/src/reachy_mini/media/audio_base.py
@@ -22,6 +22,11 @@ from typing import Optional
 import numpy as np
 import numpy.typing as npt
 
+from reachy_mini.media.audio_control_utils import (
+    WRITE_SETTLE_SECONDS,
+    AudioConfig,
+    init_respeaker_usb,
+)
 from reachy_mini.media.audio_doa import AudioDoA
 from reachy_mini.media.gstreamer_utils import get_sample
 
@@ -101,6 +106,27 @@ class AudioBase(ABC):
 
         """
         return self._doa.get_DoA()
+
+    def apply_audio_config(
+        self,
+        config: AudioConfig,
+        *,
+        verify: bool = True,
+        write_settle_seconds: float = WRITE_SETTLE_SECONDS,
+    ) -> bool:
+        """Apply audio control parameters to the ReSpeaker."""
+        respeaker = init_respeaker_usb()
+        if respeaker is None:
+            self.logger.warning("ReSpeaker device not found.")
+            return False
+        try:
+            return respeaker.apply_audio_config(
+                config,
+                verify=verify,
+                write_settle_seconds=write_settle_seconds,
+            )
+        finally:
+            respeaker.close()
 
     def cleanup(self) -> None:
         """Release shared resources (DoA USB device)."""

--- a/src/reachy_mini/media/audio_control_utils.py
+++ b/src/reachy_mini/media/audio_control_utils.py
@@ -24,6 +24,7 @@ import logging
 import struct
 import sys
 import time
+from collections.abc import Sequence
 from typing import Any, Optional
 
 import usb.core
@@ -34,6 +35,12 @@ logger = logging.getLogger(__name__)
 
 CONTROL_SUCCESS = 0
 SERVICER_COMMAND_RETRY = 64
+WRITE_SETTLE_SECONDS = 0.1
+VERIFY_TOLERANCE = 1e-3
+
+AudioControlValue = float | int
+AudioParameterValues = tuple[AudioControlValue, ...]
+AudioConfig = Sequence[tuple[str, Sequence[AudioControlValue]]]
 
 # name, resid, cmdid, length, type
 PARAMETERS = {
@@ -315,6 +322,139 @@ class ReSpeaker:
             result = response.tolist()
 
         return result
+
+    def read_values(self, name: str) -> AudioParameterValues | None:
+        """Read a parameter and decode it into numeric values."""
+        raw_values = self.read(name)
+        return self._decode_parameter_values(name, raw_values)
+
+    def apply_audio_config(
+        self,
+        config: AudioConfig,
+        *,
+        verify: bool = True,
+        write_settle_seconds: float = WRITE_SETTLE_SECONDS,
+    ) -> bool:
+        """Apply a set of audio control parameters to the ReSpeaker.
+
+        Args:
+            config: Parameter names and values to write.
+            verify: When true, read each parameter back after writing it.
+            write_settle_seconds: Delay after each write before readback.
+
+        Returns:
+            True when all parameters were written and verified successfully.
+
+        """
+        failures = 0
+
+        for name, values in config:
+            expected_values = tuple(values)
+            try:
+                self.write(name, expected_values)
+                if write_settle_seconds > 0:
+                    time.sleep(write_settle_seconds)
+
+                if verify:
+                    actual_values = self.read_values(name)
+                    if not self._values_match(actual_values, expected_values):
+                        failures += 1
+                        logger.warning(
+                            "Audio parameter verification failed for %s: expected %s, got %s",
+                            name,
+                            self._format_values(expected_values),
+                            self._format_values(actual_values),
+                        )
+            except Exception as exc:
+                failures += 1
+                logger.warning(
+                    "Failed to apply audio parameter %s=%s: %s",
+                    name,
+                    self._format_values(expected_values),
+                    exc,
+                )
+
+        if failures:
+            logger.warning(
+                "Reachy Mini audio config completed with %d failed parameter(s).",
+                failures,
+            )
+            return False
+
+        logger.info("Applied Reachy Mini audio config: %s", self._format_config(config))
+        return True
+
+    def _decode_parameter_values(
+        self, name: str, raw_values: object
+    ) -> AudioParameterValues | None:
+        parameter = PARAMETERS.get(name)
+        if raw_values is None or parameter is None:
+            return None
+
+        value_count = int(parameter[2])
+        value_type = str(parameter[4])
+
+        if value_type in {"float", "radians"}:
+            if not isinstance(raw_values, Sequence):
+                return None
+            return tuple(float(value) for value in raw_values[:value_count])
+
+        if value_type in {"int32", "uint32"}:
+            return self._decode_int32_values(
+                raw_values, value_count, signed=value_type == "int32"
+            )
+
+        if value_type == "uint8":
+            if not isinstance(raw_values, Sequence):
+                return None
+            offset = 1 if len(raw_values) == value_count + 1 else 0
+            return tuple(
+                int(value) for value in raw_values[offset : offset + value_count]
+            )
+
+        return None
+
+    def _decode_int32_values(
+        self, raw_values: object, value_count: int, *, signed: bool
+    ) -> tuple[int, ...] | None:
+        if not isinstance(raw_values, Sequence):
+            return None
+
+        if len(raw_values) == value_count * 4 + 1:
+            payload = bytes(int(value) & 0xFF for value in raw_values[1:])
+            format_char = "i" if signed else "I"
+            return tuple(
+                int(value)
+                for value in struct.unpack("<" + format_char * value_count, payload)
+            )
+
+        if len(raw_values) >= value_count:
+            return tuple(int(value) for value in raw_values[:value_count])
+
+        return None
+
+    def _values_match(
+        self,
+        actual_values: Sequence[AudioControlValue] | None,
+        expected_values: Sequence[AudioControlValue],
+    ) -> bool:
+        if actual_values is None or len(actual_values) != len(expected_values):
+            return False
+
+        return all(
+            abs(float(actual) - float(expected)) <= VERIFY_TOLERANCE
+            for actual, expected in zip(actual_values, expected_values)
+        )
+
+    def _format_config(self, config: AudioConfig) -> str:
+        return ", ".join(
+            f"{name}={self._format_values(values)}" for name, values in config
+        )
+
+    def _format_values(self, values: Sequence[AudioControlValue] | None) -> str:
+        if values is None:
+            return "unreadable"
+        return " ".join(str(value) for value in values)
 
     def close(self) -> None:
         """Close the interface."""

--- a/tests/unit_tests/test_audio_control_utils.py
+++ b/tests/unit_tests/test_audio_control_utils.py
@@ -1,0 +1,139 @@
+"""Tests for Reachy Mini audio control helpers."""
+
+import struct
+from array import array
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini.media.audio_base import AudioBase
+from reachy_mini.media.audio_control_utils import PARAMETERS, ReSpeaker
+
+pytestmark = pytest.mark.audio
+
+CUSTOM_AUDIO_CONFIG = (
+    ("PP_MIN_NS", (0.8,)),
+    ("PP_NLATTENONOFF", (0,)),
+    ("PP_MGSCALE", (4.0, 1.0, 1.0)),
+)
+
+
+class FakeUSBDevice:
+    """Minimal USB control-transfer surface used by ReSpeaker tests."""
+
+    def __init__(self) -> None:
+        """Initialize the fake parameter storage."""
+        self.payloads: dict[tuple[int, int], bytes] = {}
+        self.read_overrides: dict[tuple[int, int], bytes] = {}
+        self.writes: list[tuple[int, int, bytes]] = []
+
+    def ctrl_transfer(
+        self,
+        request_type: int,
+        request: int,
+        wvalue: int,
+        windex: int,
+        data_or_w_length: object,
+        timeout: int,
+    ) -> int | array:
+        """Record writes and return status-prefixed readback payloads."""
+        if isinstance(data_or_w_length, int):
+            cmdid = wvalue & 0x7F
+            length = data_or_w_length
+            payload = self.read_overrides.get(
+                (windex, cmdid), self.payloads.get((windex, cmdid), b"")
+            )
+            payload = payload[: length - 1].ljust(length - 1, b"\x00")
+            return array("B", [0, *payload])
+
+        payload = bytes(int(value) & 0xFF for value in data_or_w_length)  # type: ignore[union-attr]
+        self.payloads[(windex, wvalue)] = payload
+        self.writes.append((windex, wvalue, payload))
+        return len(payload)
+
+
+def _parameter_key(name: str) -> tuple[int, int]:
+    parameter = PARAMETERS[name]
+    return int(parameter[0]), int(parameter[1])
+
+
+def test_respeaker_read_values_decodes_numeric_parameters() -> None:
+    """Numeric readback should be normalized to tuples without status bytes."""
+    respeaker = ReSpeaker(FakeUSBDevice())  # type: ignore[arg-type]
+
+    respeaker.write("PP_MGSCALE", (4.0, 1.0, 1.0))
+    assert respeaker.read_values("PP_MGSCALE") == pytest.approx((4.0, 1.0, 1.0))
+
+    respeaker.write("PP_NLATTENONOFF", (0,))
+    assert respeaker.read_values("PP_NLATTENONOFF") == (0,)
+
+
+def test_respeaker_apply_audio_config_writes_and_verifies_custom_config() -> None:
+    """Custom config writes should be verified against device readback."""
+    device = FakeUSBDevice()
+    respeaker = ReSpeaker(device)  # type: ignore[arg-type]
+
+    applied = respeaker.apply_audio_config(CUSTOM_AUDIO_CONFIG, write_settle_seconds=0)
+
+    assert applied is True
+    assert [(windex, wvalue) for windex, wvalue, _ in device.writes] == [
+        _parameter_key(name) for name, _ in CUSTOM_AUDIO_CONFIG
+    ]
+
+
+def test_respeaker_apply_audio_config_returns_false_when_readback_differs() -> None:
+    """Apply should report failure when a write does not stick."""
+    device = FakeUSBDevice()
+    device.read_overrides[_parameter_key("PP_MGSCALE")] = struct.pack(
+        "<fff", 1000.0, 1.0, 1.0
+    )
+    respeaker = ReSpeaker(device)  # type: ignore[arg-type]
+
+    applied = respeaker.apply_audio_config(
+        (("PP_MGSCALE", (4.0, 1.0, 1.0)),),
+        write_settle_seconds=0,
+    )
+
+    assert applied is False
+
+
+def test_audio_base_apply_audio_config_uses_respeaker() -> None:
+    """Audio backends should use a short-lived ReSpeaker for config writes."""
+    config = (("PP_MIN_NS", (0.8,)),)
+    respeaker = MagicMock()
+    respeaker.apply_audio_config.return_value = True
+    audio = MagicMock()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "reachy_mini.media.audio_base.init_respeaker_usb",
+            lambda: respeaker,
+        )
+        applied = AudioBase.apply_audio_config(
+            audio, config, verify=False, write_settle_seconds=0
+        )
+
+    assert applied is True
+    respeaker.apply_audio_config.assert_called_once_with(
+        config,
+        verify=False,
+        write_settle_seconds=0,
+    )
+    respeaker.close.assert_called_once_with()
+
+
+def test_audio_base_apply_audio_config_returns_false_without_respeaker() -> None:
+    """Audio config application should fail gracefully when no device is found."""
+    audio = MagicMock()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "reachy_mini.media.audio_base.init_respeaker_usb",
+            lambda: None,
+        )
+        applied = AudioBase.apply_audio_config(
+            audio, (("PP_MIN_NS", (0.8,)),), write_settle_seconds=0
+        )
+
+    assert applied is False
+    audio.logger.warning.assert_called_once_with("ReSpeaker device not found.")

--- a/tests/unit_tests/test_audio_control_utils.py
+++ b/tests/unit_tests/test_audio_control_utils.py
@@ -1,139 +1,60 @@
 """Tests for Reachy Mini audio control helpers."""
 
-import struct
-from array import array
-from unittest.mock import MagicMock
-
 import pytest
 
-from reachy_mini.media.audio_base import AudioBase
-from reachy_mini.media.audio_control_utils import PARAMETERS, ReSpeaker
+from reachy_mini.media.audio_control_utils import PARAMETERS, init_respeaker_usb
+from reachy_mini.media.media_manager import MediaBackend, MediaManager
 
-pytestmark = pytest.mark.audio
-
-CUSTOM_AUDIO_CONFIG = (
-    ("PP_MIN_NS", (0.8,)),
-    ("PP_NLATTENONOFF", (0,)),
-    ("PP_MGSCALE", (4.0, 1.0, 1.0)),
-)
+AUDIO_CONFIG_PARAMETER_NAMES = ("PP_MIN_NS", "PP_NLATTENONOFF", "PP_MGSCALE")
 
 
-class FakeUSBDevice:
-    """Minimal USB control-transfer surface used by ReSpeaker tests."""
-
-    def __init__(self) -> None:
-        """Initialize the fake parameter storage."""
-        self.payloads: dict[tuple[int, int], bytes] = {}
-        self.read_overrides: dict[tuple[int, int], bytes] = {}
-        self.writes: list[tuple[int, int, bytes]] = []
-
-    def ctrl_transfer(
-        self,
-        request_type: int,
-        request: int,
-        wvalue: int,
-        windex: int,
-        data_or_w_length: object,
-        timeout: int,
-    ) -> int | array:
-        """Record writes and return status-prefixed readback payloads."""
-        if isinstance(data_or_w_length, int):
-            cmdid = wvalue & 0x7F
-            length = data_or_w_length
-            payload = self.read_overrides.get(
-                (windex, cmdid), self.payloads.get((windex, cmdid), b"")
-            )
-            payload = payload[: length - 1].ljust(length - 1, b"\x00")
-            return array("B", [0, *payload])
-
-        payload = bytes(int(value) & 0xFF for value in data_or_w_length)  # type: ignore[union-attr]
-        self.payloads[(windex, wvalue)] = payload
-        self.writes.append((windex, wvalue, payload))
-        return len(payload)
+@pytest.mark.audio
+def test_respeaker_read_values_reads_board_parameters() -> None:
+    """Numeric readback should be normalized from the real audio board."""
+    respeaker = init_respeaker_usb()
+    assert respeaker is not None, "Reachy Mini Audio board is required."
+    try:
+        for name in AUDIO_CONFIG_PARAMETER_NAMES:
+            values = respeaker.read_values(name)
+            assert values is not None
+            assert len(values) == PARAMETERS[name][2]
+            assert all(isinstance(value, (float, int)) for value in values)
+    finally:
+        respeaker.close()
 
 
-def _parameter_key(name: str) -> tuple[int, int]:
-    parameter = PARAMETERS[name]
-    return int(parameter[0]), int(parameter[1])
+@pytest.mark.audio
+def test_respeaker_apply_audio_config_writes_current_board_values() -> None:
+    """Custom config writes should be verified against real board readback."""
+    respeaker = init_respeaker_usb()
+    assert respeaker is not None, "Reachy Mini Audio board is required."
+    try:
+        config = []
+        for name in AUDIO_CONFIG_PARAMETER_NAMES:
+            values = respeaker.read_values(name)
+            assert values is not None
+            config.append((name, values))
+
+        assert respeaker.apply_audio_config(tuple(config))
+        for name, expected_values in config:
+            assert respeaker.read_values(name) == pytest.approx(expected_values)
+    finally:
+        respeaker.close()
 
 
-def test_respeaker_read_values_decodes_numeric_parameters() -> None:
-    """Numeric readback should be normalized to tuples without status bytes."""
-    respeaker = ReSpeaker(FakeUSBDevice())  # type: ignore[arg-type]
+@pytest.mark.audio
+def test_media_audio_apply_audio_config_uses_real_board() -> None:
+    """Media audio should apply caller-provided config through the real board."""
+    respeaker = init_respeaker_usb()
+    assert respeaker is not None, "Reachy Mini Audio board is required."
+    try:
+        values = respeaker.read_values("PP_MIN_NS")
+        assert values is not None
+    finally:
+        respeaker.close()
 
-    respeaker.write("PP_MGSCALE", (4.0, 1.0, 1.0))
-    assert respeaker.read_values("PP_MGSCALE") == pytest.approx((4.0, 1.0, 1.0))
-
-    respeaker.write("PP_NLATTENONOFF", (0,))
-    assert respeaker.read_values("PP_NLATTENONOFF") == (0,)
-
-
-def test_respeaker_apply_audio_config_writes_and_verifies_custom_config() -> None:
-    """Custom config writes should be verified against device readback."""
-    device = FakeUSBDevice()
-    respeaker = ReSpeaker(device)  # type: ignore[arg-type]
-
-    applied = respeaker.apply_audio_config(CUSTOM_AUDIO_CONFIG, write_settle_seconds=0)
-
-    assert applied is True
-    assert [(windex, wvalue) for windex, wvalue, _ in device.writes] == [
-        _parameter_key(name) for name, _ in CUSTOM_AUDIO_CONFIG
-    ]
-
-
-def test_respeaker_apply_audio_config_returns_false_when_readback_differs() -> None:
-    """Apply should report failure when a write does not stick."""
-    device = FakeUSBDevice()
-    device.read_overrides[_parameter_key("PP_MGSCALE")] = struct.pack(
-        "<fff", 1000.0, 1.0, 1.0
-    )
-    respeaker = ReSpeaker(device)  # type: ignore[arg-type]
-
-    applied = respeaker.apply_audio_config(
-        (("PP_MGSCALE", (4.0, 1.0, 1.0)),),
-        write_settle_seconds=0,
-    )
-
-    assert applied is False
-
-
-def test_audio_base_apply_audio_config_uses_respeaker() -> None:
-    """Audio backends should use a short-lived ReSpeaker for config writes."""
-    config = (("PP_MIN_NS", (0.8,)),)
-    respeaker = MagicMock()
-    respeaker.apply_audio_config.return_value = True
-    audio = MagicMock()
-
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setattr(
-            "reachy_mini.media.audio_base.init_respeaker_usb",
-            lambda: respeaker,
-        )
-        applied = AudioBase.apply_audio_config(
-            audio, config, verify=False, write_settle_seconds=0
-        )
-
-    assert applied is True
-    respeaker.apply_audio_config.assert_called_once_with(
-        config,
-        verify=False,
-        write_settle_seconds=0,
-    )
-    respeaker.close.assert_called_once_with()
-
-
-def test_audio_base_apply_audio_config_returns_false_without_respeaker() -> None:
-    """Audio config application should fail gracefully when no device is found."""
-    audio = MagicMock()
-
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setattr(
-            "reachy_mini.media.audio_base.init_respeaker_usb",
-            lambda: None,
-        )
-        applied = AudioBase.apply_audio_config(
-            audio, (("PP_MIN_NS", (0.8,)),), write_settle_seconds=0
-        )
-
-    assert applied is False
-    audio.logger.warning.assert_called_once_with("ReSpeaker device not found.")
+    media = MediaManager(backend=MediaBackend.LOCAL)
+    try:
+        assert media.audio.apply_audio_config((("PP_MIN_NS", values),))
+    finally:
+        media.close()

--- a/tests/unit_tests/test_audio_control_utils.py
+++ b/tests/unit_tests/test_audio_control_utils.py
@@ -43,6 +43,28 @@ def test_respeaker_apply_audio_config_writes_current_board_values() -> None:
 
 
 @pytest.mark.audio
+def test_respeaker_apply_audio_config_changes_value_and_restores_it() -> None:
+    """Custom config writes should change a real value and restore it."""
+    parameter_name = "PP_NLATTENONOFF"
+    respeaker = init_respeaker_usb()
+    assert respeaker is not None, "Reachy Mini Audio board is required."
+    original_values = None
+    try:
+        original_values = respeaker.read_values(parameter_name)
+        assert original_values is not None
+        original_value = int(original_values[0])
+        changed_value = 0 if original_value else 1
+
+        assert respeaker.apply_audio_config(((parameter_name, (changed_value,)),))
+        assert respeaker.read_values(parameter_name) == (changed_value,)
+    finally:
+        if original_values is not None:
+            assert respeaker.apply_audio_config(((parameter_name, original_values),))
+            assert respeaker.read_values(parameter_name) == original_values
+        respeaker.close()
+
+
+@pytest.mark.audio
 def test_media_audio_apply_audio_config_uses_real_board() -> None:
     """Media audio should apply caller-provided config through the real board."""
     respeaker = init_respeaker_usb()


### PR DESCRIPTION
## Summary

Moves the reusable audio-board configuration helper from `pollen-robotics/reachy_mini_conversation_app#331` into the Reachy Mini SDK without shipping conversation-app-specific values.

This adds:

- `ReSpeaker.read_values(...)` for normalized numeric readback from the XVF3800 control API
- `ReSpeaker.apply_audio_config(config, ...)` to write and optionally verify caller-provided parameter sets
- `AudioBase.apply_audio_config(config, ...)`, so apps can call `robot.media.audio.apply_audio_config(config)` with their own values
- a short-lived ReSpeaker handle in the `AudioBase` wrapper, avoiding access to private `_respeaker` on `AudioDoA`
- real audio-board tests, each marked with `@pytest.mark.audio` like the existing local-only audio tests
- documentation in the media API, Wireless and Lite advanced media controls, and troubleshooting

## Context

The conversation app needs its own tuned startup values, but the reusable SDK piece is the generic ability for any app to apply and verify custom XVF3800 audio parameters. This PR does not add default audio config values to the SDK.

The tests now use the real audio board instead of a fake USB device. They read board values directly, write current values back, and include one reversible test that changes `PP_NLATTENONOFF` before restoring its original value in a `finally` block.

The docs note that SDK audio-board configuration requires running on the machine that can see the USB audio board: the robot itself for Wireless, or the connected computer for Lite.

## Validation

- `uv run pytest tests/unit_tests/test_audio_control_utils.py -m 'not audio' --collect-only -q` deselects all 4 tests as expected
- `uv run ruff check tests/unit_tests/test_audio_control_utils.py src/reachy_mini/media/audio_control_utils.py src/reachy_mini/media/audio_base.py`
- `uv run mypy src/reachy_mini/media/audio_control_utils.py src/reachy_mini/media/audio_base.py`
- `git diff --check`

Hardware validation to run on a machine with the Reachy Mini Audio USB board attached:

- `uv run pytest tests/unit_tests/test_audio_control_utils.py -m audio -q`

I tried the hardware command locally, but this machine does not have a Reachy Mini Audio USB board attached, so discovery fails with `No Reachy Mini Audio USB device found!`.