### PR TITLE
draft: mobile app daemon integration (dev/mobile-app-integration)

### DIFF
--- a/docs/SIGNALING.md
+++ b/docs/SIGNALING.md
@@ -122,7 +122,7 @@ yield, the sweeper would never evict the zombie.
 ### Heartbeat protocol
 
 - The daemon re-emits `setPeerStatus(roles=["producer"], meta=…)` every
-  `HEARTBEAT_INTERVAL_SECONDS` (default 20 s) **even if the meta payload is
+  `self._heartbeat_interval_seconds` **even if the meta payload is
   identical**. This arrives at central as a real `POST /send`, which is the
   only authoritative liveness signal we accept.
 - Meta deltas (health flips from `ok` to `degraded`, name change, …) are
@@ -135,17 +135,56 @@ yield, the sweeper would never evict the zombie.
   heartbeat to keep the HTTP/2 connection from being culled by the
   reverse proxy. It does **not** touch `last_seen`.
 
+### Heartbeat negotiation (server-driven)
+
+The heartbeat interval is **negotiated at handshake** so server operators
+can tune the liveness contract from one place (`LEASE_SECONDS` env var on
+the central Space) and every connected daemon auto-aligns on its next
+reconnect, with **zero coordinated daemon redeploy**.
+
+- Central's `welcome` SSE frame carries:
+  ```json
+  {
+    "type": "welcome",
+    "peerId": "...",
+    "username": "...",
+    "lease_seconds": 15,
+    "recommended_heartbeat_interval_seconds": 5
+  }
+  ```
+- The daemon stores the recommended value into
+  `self._heartbeat_interval_seconds`, clamped to
+  `[MIN_HEARTBEAT_INTERVAL_SECONDS, MAX_HEARTBEAT_INTERVAL_SECONDS]`
+  (`[1.0, 60.0]`) as a defence against a malformed welcome.
+- If the field is missing (older central, partial deploy), the daemon
+  keeps the module-level default
+  (`HEARTBEAT_INTERVAL_SECONDS`, currently `5.0`). Full backwards
+  compatibility.
+- `recommended_heartbeat_interval_seconds = LEASE_SECONDS / 3` by
+  convention so a daemon tolerates two consecutive missed POSTs before
+  hitting the lease.
+
 ### Eviction guarantees
 
-- Background sweeper scans every 10 s. Any peer with
-  `now - last_seen > LEASE_SECONDS` (default 45 s) is `disconnect_peer()`'d
-  (= removed from `peers`, `producers`, `token_to_peer`, sessions ended).
+- Background sweeper scans every `SWEEPER_INTERVAL_SECONDS` (default
+  3 s). Any peer with `now - last_seen > LEASE_SECONDS` (default 15 s)
+  is `disconnect_peer()`'d (= removed from `peers`, `producers`,
+  `token_to_peer`, sessions ended).
 - `request.is_disconnected()` inside the SSE generator stays as a
   fast-path: if the OS already noticed the dead socket (FIN/RST), we evict
   in <30 s without waiting for the lease.
 - Worst case for an uncooperative death: `LEASE_SECONDS + sweeper_interval`
-  ≈ 55 s. With heartbeat=20 s and lease=45 s we tolerate two consecutive
+  ≈ 18 s. With heartbeat=5 s and lease=15 s we tolerate two consecutive
   missed heartbeats before eviction kicks in.
+
+### Tuning the contract
+
+To shrink the staleness window further (or open it to absorb more
+network instability), change **only** `LEASE_SECONDS` on the central
+Space, then redeploy the central. Daemons re-derive their heartbeat
+interval on the next reconnect; nothing else needs to change. Keep the
+ratio `lease : heartbeat ≥ 3 : 1` so a single missed POST never causes
+eviction.
 
 ### Cooperative withdraw on graceful network loss
 
@@ -195,6 +234,33 @@ session of the old producer is ended with `reason="install_id_takeover"`.
 
 When in doubt, ask: "if a different team owned this layer, would they
 expect to see this code?" If no, it's in the wrong layer.
+
+## Observability (debugging the staleness window)
+
+Operators can introspect the running contract without redeploying:
+
+| Endpoint | Auth | What it tells you |
+|----------|------|-------------------|
+| `GET /health` | none | Active `lease_seconds`, `sweeper_interval_seconds`, `recommended_heartbeat_interval_seconds`, raw counts. Cheap, public. |
+| `GET /api/robot-status` | HF Bearer | Per producer: `last_seen_age_seconds` (seconds since the last inbound POST). Plus `lease_seconds` mirrored at the top level. Caller-filtered. |
+| `GET /api/debug/peers` | HF Bearer | Owner-filtered dump of *every* peer (producers AND consumers): role, connected, session, full meta, `last_seen`, `last_seen_age_seconds`. Use this when a robot does not show up where expected. |
+
+On the daemon side:
+
+| Surface | What it tells you |
+|---------|-------------------|
+| `get_relay_status()` (Python) / `/api/daemon/status` | `state`, `is_connected`, plus the negotiated `heartbeat_interval_seconds` and `central_lease_seconds` so you can confirm the contract the daemon is currently honouring. |
+| Central relay startup log | `[Central Relay] central welcome received peer_id=… heartbeat=5.0s lease=15.0s; …` — pin the active interval to a wall-clock at handshake time. |
+
+Recommended client guard for "is this row really fresh?":
+
+```ts
+const STALE_GRACE = 0.6; // tighter than the server-side sweeper
+const isFresh = robot.last_seen_age_seconds < lease_seconds * STALE_GRACE;
+```
+
+This lets the mobile/desktop UI hide a row 40% earlier than the
+server-side eviction would, without depending on the sweeper interval.
 
 ## Versioning & migration
 

--- a/docs/SIGNALING.md
+++ b/docs/SIGNALING.md
@@ -1,0 +1,184 @@
+# Reachy Mini Signaling Lifecycle
+
+> Single source of truth for **how a Reachy Mini instance announces itself**,
+> stays announced, and disappears across the central server, BLE, mDNS and
+> loopback HTTP discovery channels.
+>
+> If you change anything in `central_signaling_relay.py`, the central server
+> (`reachy_mini_central/app.py`) or the mobile/desktop client's discovery
+> aggregator, **read this first** and update it after.
+
+## Three layers, three jobs
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Layer       Owner of                                Lives in        │
+├──────────────────────────────────────────────────────────────────────┤
+│  Daemon      "Am I a healthy robot, what can I do?"  reachy_mini     │
+│  Central     "Who is online RIGHT NOW for user X?"   reachy_mini_central │
+│  Client      "Show one row per physical robot"       mobile / tray / web │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The daemon never decides what a client should display. The central never
+decides whether a robot is healthy. The client never invents fields.
+Each layer is allowed to add new fields - never to override another layer's.
+
+## The `meta` payload (stable contract, additive only)
+
+The daemon sends this with every `setPeerStatus(roles=["producer"])`. Central
+forwards it verbatim to listeners. Client reads it without re-interpreting.
+
+```jsonc
+{
+  "schema_version": 1,        // bump only on breaking field semantics
+
+  // Identity (set once per install, survives reboots)
+  "name": "reachy_mini",      // user-facing label, mutable via UI rename
+  "install_id": "639d5558364f41d6b39ffe5be1466793",
+  "kind": "robot",            // "robot" | "tray"  - what runs the daemon
+
+  // Health (refreshed every status tick, debounced 1 s)
+  "health": "ok",             // "ok" | "degraded" | "error"
+  "error_code": null,         // short stable taxonomy when health != "ok",
+                              //   e.g. "motor_comm" | "no_backend" | "media"
+
+  // Optional capabilities the client can light up against
+  "capabilities": ["motion", "audio", "camera"],
+  "wireless_version": true,
+  "version": "1.7.0"
+}
+```
+
+Rules:
+
+- **Add fields freely** - older clients ignore unknown keys.
+- **Never repurpose a field**. If semantics change, bump `schema_version` and
+  add a new field; clients then branch on the version.
+- **Never leak transient data** (current motor angles, RTT, etc.). Heartbeat
+  density belongs to ping/pong, not `meta`.
+
+### `health` semantics
+
+| Value | When | Client policy |
+|-------|------|---------------|
+| `ok` | Backend ready, motors enabled, no error in `_status`. | Listed normally. Auto-connect allowed. |
+| `degraded` | Daemon up, backend up, but a non-critical subsystem is down (camera failed, audio failed). | Listed with a yellow badge. Auto-connect allowed; client surfaces a warning if the missing capability matters to its current screen. |
+| `error` | `state == ERROR` or `backend_status is None` or `backend.ready` not set after grace period. | Listed with a red badge. **Never auto-connect.** Tap shows the error code so the user can act (replug USB, check power, retry). |
+
+## Lifecycle - cooperative path (the daemon is alive)
+
+Daemon transitions emit explicit central messages.
+
+```
+boot                                  shutdown
+ │                                     ▲
+ ├─ start_central_relay()              │
+ ├─ welcome from central               │
+ ├─ setPeerStatus(roles=["producer"],  │
+ │     meta={..., health: H1})         │
+ │                                     │
+ ├─ on health change (debounced 1s):   │
+ │     setPeerStatus(roles=["producer"], meta={..., health: H2})
+ │                                     │
+ ├─ on tray + no_backend > 30s:        │
+ │     setPeerStatus(roles=[])  ─→ central drops from producers list
+ │     (peer object kept on central, can re-register)
+ │                                     │
+ ├─ on backend recovery (tray):        │
+ │     setPeerStatus(roles=["producer"], meta={..., health: "ok"})
+ │                                     │
+ └─────────────── SIGTERM / SIGINT / lifespan finally ───┘
+                  │
+                  ├─ withdraw():       setPeerStatus(roles=[])  // best-effort, 500ms timeout
+                  ├─ stop():           close central WebSocket
+                  └─ central observes WS close → disconnect_peer()
+```
+
+Two distinct primitives:
+
+- `relay.withdraw()` - send `setPeerStatus(roles=[])`, wait for ack with
+  short timeout, **leave the WebSocket open**. Used for "I'm here but no
+  longer want to be listed" (backend lost, hardware unplugged, transient
+  condition that may resolve).
+- `relay.stop()` - send `roles=[]` THEN close the WebSocket. Used for
+  shutdown.
+
+## Lifecycle - uncooperative path (daemon dies without warning)
+
+`SIGKILL`, panic, kernel oops, WiFi cable yanked, Pi power loss. The daemon
+gets no chance to send `roles=[]`. Coverage falls to **central-side TTL**:
+
+- Central tracks `last_seen: float` per peer, refreshed by:
+  - any incoming `POST /send` from that peer, or
+  - SSE heartbeat round-trip (server `ping` -> client TCP ack reaches OS).
+- A background sweeper task scans every 10 s. Any peer with
+  `now - last_seen > LEASE_SECONDS` (default 45 s) is `disconnect_peer()`'d
+  (= removed from `peers`, `producers`, `token_to_peer`, sessions ended).
+- `request.is_disconnected()` inside the SSE generator stays as a
+  fast-path: if the OS already noticed the dead socket, we evict in <30 s
+  without waiting for the lease.
+
+Result: under any failure mode, a peer disappears from `/api/robot-status`
+within `LEASE_SECONDS`.
+
+## install_id - the anchor across channels
+
+Every channel publishes `install_id`:
+
+| Channel | Field | Example |
+|---------|-------|---------|
+| Central | `meta.install_id` | full UUID4 hex |
+| BLE GATT | TLV in advertisement payload | first 8 bytes (16 hex) |
+| mDNS TXT | `install_id=` | full UUID4 hex |
+| Loopback HTTP | `/api/daemon/identity` JSON | full UUID4 hex |
+
+Client merges by **prefix match on the truncated form** when comparing a BLE
+sighting with a central row, by **full match** otherwise.
+
+### Collision policy
+
+A daemon flashed onto a different robot keeps its `install_id`. A daemon
+re-installed on the same robot generates a new `install_id`. So **two
+producers with the same `install_id` and the same HF user can only mean
+one of them is stale**.
+
+Central applies **last-writer-wins**: when a new producer registers with an
+`install_id` already held by another producer of the same user, central
+evicts the older one (`disconnect_peer`) before accepting the new one. Any
+session of the old producer is ended with `reason="install_id_takeover"`.
+
+## What lives where (responsibility cheat-sheet)
+
+| Question | Answer |
+|----------|--------|
+| Is this robot reachable on the LAN right now? | Client (probes BLE / mDNS / loopback). |
+| Is this robot's hardware healthy? | Daemon (`peer_health.compute()`) → `meta.health`. |
+| Should we hide a robot row from the user? | Client (gates on `meta.health` + presence on at least one channel). |
+| Is the central listing stale? | Central (TTL sweeper). |
+| Two listings for the same physical robot? | Client (dedup by `install_id`). |
+| Two daemons fighting over one `install_id`? | Central (last-writer-wins eviction). |
+
+When in doubt, ask: "if a different team owned this layer, would they
+expect to see this code?" If no, it's in the wrong layer.
+
+## Versioning & migration
+
+- `schema_version` is incremented when **field semantics** break. Adding a
+  field never bumps it.
+- Central never inspects `schema_version`; it forwards verbatim. Only the
+  client branches on it.
+- When bumping, support `version - 1` in clients for at least one release
+  cycle so out-of-date daemons remain usable.
+
+## Tests we keep green
+
+- `peer_health.compute(...)` truth table (24 cases).
+- Central: `setPeerStatus(roles=[])` removes from `producers`, broadcasts
+  `peerStatusChanged` to other listeners of the same user.
+- Central: install_id collision evicts older, ends its session.
+- Central: TTL sweeper purges a peer that stops sending after
+  `LEASE_SECONDS`.
+- Mobile: hides any row whose only present channel is central + `health=error`.
+- Mobile: keeps a row visible if BLE or mDNS sees it locally even when
+  central marks it `error`.

--- a/docs/SIGNALING.md
+++ b/docs/SIGNALING.md
@@ -106,21 +106,55 @@ Two distinct primitives:
 
 ## Lifecycle - uncooperative path (daemon dies without warning)
 
-`SIGKILL`, panic, kernel oops, WiFi cable yanked, Pi power loss. The daemon
-gets no chance to send `roles=[]`. Coverage falls to **central-side TTL**:
+`SIGKILL`, panic, kernel oops, WiFi yanked, Pi power loss. The daemon gets
+no chance to send `roles=[]`. Coverage falls to **central-side TTL**, driven
+by an explicit application-level heartbeat.
 
-- Central tracks `last_seen: float` per peer, refreshed by:
-  - any incoming `POST /send` from that peer, or
-  - SSE heartbeat round-trip (server `ping` -> client TCP ack reaches OS).
-- A background sweeper task scans every 10 s. Any peer with
+### Why server-pushed keepalives are NOT a liveness signal
+
+A naive design refreshes `last_seen` whenever the central yields a keepalive
+ping on the SSE channel. **That doesn't work** behind HTTP/2 reverse proxies
+(HF Spaces, Cloudflare, etc.): the local TCP send buffer absorbs writes
+silently on a half-open socket, so `yield` returns without raising for
+several minutes after the peer's network has died. With a touch on every
+yield, the sweeper would never evict the zombie.
+
+### Heartbeat protocol
+
+- The daemon re-emits `setPeerStatus(roles=["producer"], meta=…)` every
+  `HEARTBEAT_INTERVAL_SECONDS` (default 20 s) **even if the meta payload is
+  identical**. This arrives at central as a real `POST /send`, which is the
+  only authoritative liveness signal we accept.
+- Meta deltas (health flips from `ok` to `degraded`, name change, …) are
+  emitted immediately on the daemon's 1 Hz status tick, not gated on the
+  heartbeat. So health transitions still propagate within 1 s.
+- Central's `signaling.touch(peer_id)` is called **only** on:
+  - `POST /send` arriving from the peer (covers heartbeat + applicative),
+  - a session message successfully delivered through its message queue.
+- The SSE keepalive yield (`{"event": "ping"}`) is purely a proxy
+  heartbeat to keep the HTTP/2 connection from being culled by the
+  reverse proxy. It does **not** touch `last_seen`.
+
+### Eviction guarantees
+
+- Background sweeper scans every 10 s. Any peer with
   `now - last_seen > LEASE_SECONDS` (default 45 s) is `disconnect_peer()`'d
   (= removed from `peers`, `producers`, `token_to_peer`, sessions ended).
 - `request.is_disconnected()` inside the SSE generator stays as a
-  fast-path: if the OS already noticed the dead socket, we evict in <30 s
-  without waiting for the lease.
+  fast-path: if the OS already noticed the dead socket (FIN/RST), we evict
+  in <30 s without waiting for the lease.
+- Worst case for an uncooperative death: `LEASE_SECONDS + sweeper_interval`
+  ≈ 55 s. With heartbeat=20 s and lease=45 s we tolerate two consecutive
+  missed heartbeats before eviction kicks in.
 
-Result: under any failure mode, a peer disappears from `/api/robot-status`
-within `LEASE_SECONDS`.
+### Cooperative withdraw on graceful network loss
+
+Some user-initiated actions (`POST /wifi/forget`, `POST /wifi/forget_all`)
+are about to take the daemon offline by wiping its only network. The daemon
+calls `notify_withdraw(timeout=1s)` **while still on WiFi** so central
+removes the producer instantly, instead of leaving the user staring at a
+ghost row for ~55 s. Best-effort: if the withdraw POST fails for any
+reason we still proceed with the WiFi reset and rely on TTL eviction.
 
 ## install_id - the anchor across channels
 
@@ -179,6 +213,12 @@ expect to see this code?" If no, it's in the wrong layer.
 - Central: install_id collision evicts older, ends its session.
 - Central: TTL sweeper purges a peer that stops sending after
   `LEASE_SECONDS`.
+- Central: SSE keepalive ping does NOT refresh `last_seen` (regression
+  guard for the half-open zombie bug).
+- Central: `POST /send` (carrying e.g. a heartbeat-shaped
+  `setPeerStatus`) DOES refresh `last_seen`.
+- Daemon relay: `update_producer_meta()` re-emits with identical meta
+  once the heartbeat interval elapses.
 - Mobile: hides any row whose only present channel is central + `health=error`.
 - Mobile: keeps a row visible if BLE or mDNS sees it locally even when
   central marks it `error`.

--- a/docs/known-issues/libnice-session-reuse-crash.md
+++ b/docs/known-issues/libnice-session-reuse-crash.md
@@ -1,0 +1,107 @@
+# libnice abort on session reuse (consumer peer ID stickiness)
+
+- **Status**: open, no fix shipped
+- **Severity**: high (kills the daemon process every few sessions on Wi-Fi/central path)
+- **Affects**: every WebRTC client going through HF central (mobile app, web SDK, conversation app on Spaces, any future client). USB/loopback path is immune.
+- **First observed**: 2026-04-30, on `reachy-mini.local` (192.168.1.19), `libnice10 0.1.22-1`, `gstreamer1.0-nice 0.1.22-1` (Debian 12 arm64).
+- **Triage author**: investigation captured during a chat session, see `agent-transcripts` for the live trace.
+
+## Symptom
+
+From the user's point of view: the iPhone app connects to a Wi-Fi robot the first 1-3 times, then a connection attempt to **the same robot, shortly after disconnecting**, fails with the conversation engine reporting `Session stopped` and a flood of `webrtc.proxy fetch.no_dc` warnings. The robot disappears from the central list for ~5-10 seconds, then comes back and the next attempt may succeed.
+
+USB connections to the same robot (or to the Mac tray daemon) are never affected.
+
+## Diagnostic
+
+The daemon process aborts in the middle of ICE negotiation:
+
+```
+libnice:ERROR:../agent/conncheck.c:987:priv_conn_check_tick_stream_nominate:
+  assertion failed: (p->state == NICE_CHECK_SUCCEEDED)
+Bail out!
+reachy-mini-daemon.service: Main process exited, code=exited, status=134/n/a
+```
+
+`SIGABRT` from a `g_assert_cmpint` inside libnice's connectivity check nomination loop. systemd restarts the daemon, which forces a brand new central-relay peer ID. The next session works again, until the next accumulation cycle.
+
+### Reproducer (on `reachy-mini.local`, 2026-04-30)
+
+```
+10:12:58 -> 10:13:13   session 1   consumer afe0fd7c   OK
+10:14:16 -> 10:14:29   session 2   consumer afe0fd7c   OK
+10:16:44 -> 10:16:59   session 3   consumer afe0fd7c   OK
+10:17:19 -> 10:17:20   session 4   consumer afe0fd7c   abort  <-- libnice crash
+10:18:04 -> 10:18:32   session 5   consumer 3988be23   OK     (post-restart, fresh consumer)
+```
+
+The pattern is consistent: every session enqueued under the **same GStreamer signaling consumer peer ID** eventually trips the libnice assertion. After systemd restarts the daemon, the central relay reconnects and gets a new consumer ID, resetting the counter.
+
+The exact ICE candidate that triggered the crash on session 4:
+
+```
+candidate:1592251543 1 udp 1677732095
+  2a01:cb11:482:9d00:9dc7:c52e:301:d90e 56290 typ srflx
+  raddr 2a01:cb11:482:9d00:9dc7:c52e:301:d90e rport 56290
+```
+
+That is a self-mapped IPv6 srflx (`raddr == candidate addr`), valid by spec but rare; libnice's nomination logic walks a check pair that is in `NICE_CHECK_FROZEN`/`NICE_CHECK_IN_PROGRESS` instead of the expected `NICE_CHECK_SUCCEEDED`. The bug is **state pollution carried across sessions** under the same consumer, not the candidate per se.
+
+## Root cause (hypothesis)
+
+`gst-plugin-webrtc-rs` keeps the GST signaling consumer registration alive across sessions for the same `central_signaling_relay` connection, and the `webrtcbin`/`niceagent` lifecycle in `reachy_mini.media.media_server` does not fully tear down libnice's per-stream state between consumer-added/consumer-removed cycles. Some `NiceComponent`/`NiceStream` handles or check-pair entries leak forward into the next session, and the nomination tick eventually walks a stale entry.
+
+This is consistent with:
+
+- Only the central path is affected (loopback path uses `aiortc`, no libnice).
+- A fresh consumer (after systemd restart) always works on session 1.
+- Failures cluster after multiple back-to-back sessions, not from cold start.
+
+## Mitigations, ranked by where the fix lives
+
+| # | Where | Effort | Pérennité | Notes |
+|---|---|---|---|---|
+| 1 | mobile app SDK shim | XS | weak | rotate the signaling websocket and force a new central peer ID before every `startSession()`. Hides the bug for the mobile app only; every other client (Python SDK, web SDK, HF Space conv app) stays vulnerable. Useful as a stop-gap. |
+| 2 | daemon `media_server.py` | M | strong | strict per-session lifecycle: explicit `set_state(NULL)` + `unref` of `webrtcbin` + drop the `niceagent` on `consumer removed`, and instantiate brand new objects on `consumer added`. This is the *real* fix. |
+| 3 | daemon process supervision | M | strong (defense-in-depth) | run the GStreamer pipeline in a dedicated subprocess supervised by the daemon. A libnice abort kills only that subprocess, not the API/BLE/relay/lock. Recovery is ~200 ms. Doesn't fix the root cause but bounds the blast radius for the entire class of C-side bugs. |
+| 4 | OS package | L | external | upgrade `libnice10` past 0.1.22 (the upstream `priv_conn_check_tick_stream_nominate` codepath has churned in master). Heavy: needs a custom Debian build for arm64 and a daemon-image update flow. |
+
+The **honest** robust answer is **2 + 3 together**, in the daemon repo, `reachy_mini/src/reachy_mini/media/`. 2 fixes the cause; 3 prevents the next equivalent native-side bug from taking down the daemon.
+
+The mobile-app workaround (option 1) is acceptable as an interim mitigation, but should be tagged with a `TODO` referencing this document so it gets removed once 2 lands.
+
+## Suggested implementation outline (option 2)
+
+In `reachy_mini/src/reachy_mini/media/media_server.py`, audit the consumer-added / consumer-removed handlers:
+
+1. Confirm a new `webrtcbin` is created per session (currently appears to be the case per the GStreamer logs).
+2. Verify the `webrtcbin` is set to `Gst.State.NULL` and **removed from the pipeline** on `consumer removed`, before any new consumer is accepted on the same registration.
+3. Drop any cached `Gst.WebRTCBin`, `Gst.WebRTCRTPTransceiver`, audio/video pads, and queue elements created for the session. Run with `GST_DEBUG=GST_REFCOUNTING:5` once to make sure refcount drops to 0 (no leaked pad / probe / pipeline-level reference holding `niceagent` alive).
+4. If refcounts can't be brought to zero cleanly (custom probes, pad handlers), tear down and recreate the parent `pipeline` element on every consumer-removed. Slower (~50-100 ms cold start for GStreamer elements), but bullet-proof.
+
+Reproduction harness: on a Wi-Fi-connected robot, use a Python script that opens a `ReachyMini` session via central, sleeps 200 ms, closes, and loops. The current build aborts within 4-10 iterations.
+
+## Suggested implementation outline (option 3)
+
+Move the GStreamer media path into a dedicated `media-pipeline` subprocess (multiprocessing or `asyncio.subprocess`). The main daemon (FastAPI + BLE + central relay + robot lock) speaks to it over a Unix socket / pipe. Crashes in the subprocess are caught by the supervisor, which restarts it, re-attaches to the local GST signaling server, and emits a `central.relay.state` transition through `connecting` so the app shows a brief "reconnecting" toast instead of "robot offline".
+
+This also gives us a clean isolation boundary for any future native dependency we pull in (rust audio plugins, custom encoders, etc.).
+
+## Stop-gap (option 1) for the mobile app
+
+Until the daemon-side fix is shipped, in `reachy_mini_mobile_app/src/conversation/useReachySdk.ts` (or in the vendored `reachy-mini.js`):
+
+- Before each `startSession()`, force the SDK to reconnect its central WebSocket so the central server assigns a new consumer peer ID.
+- Mark the patch `// TODO(known-issue: libnice-session-reuse-crash) remove once daemon fix lands`.
+
+This does not change behavior on USB/loopback (no central peer ID involved) and only adds ~200 ms to the second-and-onward connection.
+
+## References
+
+- libnice tracker: https://gitlab.freedesktop.org/libnice/libnice/-/issues (search for `priv_conn_check_tick_stream_nominate`).
+- GStreamer plugin: `gst-plugins-rs/net/webrtc` (the producer/consumer signaling we use).
+- Daemon entry points relevant to this bug:
+  - `reachy_mini/src/reachy_mini/media/media_server.py` (`consumer added` / `consumer removed` handlers)
+  - `reachy_mini/src/reachy_mini/media/central_signaling_relay.py` (central session mapping)
+- App-side observability: `[ReachyMini trace] dc.open` / `webrtc.proxy fetch.no_dc` in `useReachySdk.ts` and `webrtcClient.ts`.
+- Live evidence captured 2026-04-30: see chat transcript [libnice abort on Wi-Fi reuse](fb11cb70-58e2-4ce2-bba1-b6d7fd7944c9).

--- a/docs/source/SDK/javascript-sdk.md
+++ b/docs/source/SDK/javascript-sdk.md
@@ -164,7 +164,7 @@ robot.logout();              // clear HF credentials
 
 ```js
 new ReachyMini({
-    signalingUrl: "https://cduss-reachy-mini-central.hf.space",  // default
+    signalingUrl: "https://tfrere-reachy-mini-central.hf.space",  // default
     enableMicrophone: true,  // default — request mic on startSession()
 })
 ```

--- a/js/reachy-mini.js
+++ b/js/reachy-mini.js
@@ -56,7 +56,7 @@
  * CONSTRUCTOR OPTIONS
  * ───────────────────
  *   new ReachyMini({
- *     signalingUrl:     string,   // default: "https://cduss-reachy-mini-central.hf.space"
+ *     signalingUrl:     string,   // default: "https://tfrere-reachy-mini-central.hf.space"
  *     enableMicrophone: boolean,  // default: true — acquire mic for bidirectional audio
  *   })
  *
@@ -164,7 +164,7 @@ export class ReachyMini extends EventTarget {
     /** @param {{ signalingUrl?: string, enableMicrophone?: boolean, clientId?: string, appName?: string }} [options] */
     constructor(options = {}) {
         super();
-        this._signalingUrl = options.signalingUrl || 'https://cduss-reachy-mini-central.hf.space';
+        this._signalingUrl = options.signalingUrl || 'https://tfrere-reachy-mini-central.hf.space';
         this._enableMicrophone = options.enableMicrophone !== false;
         this._clientId = options.clientId || null;
         this._appName = options.appName || 'unknown';

--- a/src/reachy_mini/daemon/app/config.py
+++ b/src/reachy_mini/daemon/app/config.py
@@ -4,11 +4,21 @@ Holds a tiny JSON document under ``$XDG_CONFIG_HOME/reachy_mini/daemon.json``
 (default ``~/.config/reachy_mini/daemon.json``) for daemon-level state that
 must survive restarts and re-installs of the upstream tray app.
 
-Currently the only persisted field is ``robot_name`` - the human-readable
-label the user picked for this Reachy. We deliberately keep this file
-separate from any tray ``data_dir`` so that:
+Two fields live here today:
 
-- the same physical Reachy keeps its name across a tray ``reset_bootstrap``,
+- ``robot_name`` - the human-readable label the user picked for this
+  Reachy.
+- ``install_id`` - a stable opaque identifier (UUID4 hex) generated on
+  first boot and never rotated. Acts as the canonical reconciliation
+  key across discovery transports (BLE / mDNS / HF central): the same
+  physical robot reports the same ``install_id`` on every channel, so
+  the mobile app can merge "this is the robot I see on BLE *and* on
+  central" into a single row even before the user picks a name.
+
+We deliberately keep this file separate from any tray ``data_dir`` so that:
+
+- the same physical Reachy keeps its name + install_id across a tray
+  ``reset_bootstrap``,
 - the same daemon code path applies on the Wireless robot (where there is
   no tray at all) and on the Lite/desktop tray on macOS or Linux,
 - destroying the HF token cache does not nuke the user's robot label.
@@ -16,6 +26,9 @@ separate from any tray ``data_dir`` so that:
 Reads and writes are tolerant: a missing or corrupt file is treated as
 "no persisted config", and a write failure is logged but never raises.
 The naming flow always has a mandatory in-memory fallback (``reachy_mini``).
+The install_id has a per-process in-memory fallback too so two daemons
+that fail to write disk still report stable values within their own
+lifetime.
 
 Concurrency: writes are ``fsync`` + atomic rename, so a crash mid-write
 cannot leave the config in a half-written state. There is no in-process
@@ -30,6 +43,7 @@ import json
 import logging
 import os
 import tempfile
+import uuid
 from pathlib import Path
 from typing import Any, Optional
 
@@ -149,3 +163,68 @@ def set_persisted_robot_name(name: str) -> bool:
     config = load_config()
     config["robot_name"] = name
     return save_config(config)
+
+
+# Process-local fallback for ``install_id`` when disk persistence
+# fails. Keeps the value stable across a single daemon process even on
+# read-only filesystems; it does NOT survive restarts in that case.
+_install_id_memo: Optional[str] = None
+
+
+def get_or_create_install_id() -> str:
+    """Return this install's stable opaque identifier, creating it on first call.
+
+    The id is a 32-char lowercase hex (UUID4 without dashes). It is
+    generated exactly once per install, persisted to ``daemon.json``,
+    and then read back on every subsequent boot. Never rotates: a
+    rename of the robot, a new HF token, or a tray ``reset_bootstrap``
+    all leave it untouched.
+
+    Why not a hardware serial: we don't have a stable hardware-anchored
+    id we can read from every supported platform (Wireless Pi, macOS
+    tray, Linux tray). A persisted UUID gives us "stable across all
+    channels for one user's lifetime of this robot install" which is
+    exactly what fleet reconciliation needs.
+
+    Failure mode: if disk writes fail (permissions, full disk, ...),
+    we fall back to a process-local memo so reads from this daemon
+    are at least internally consistent. The next daemon restart will
+    generate a fresh id and try to persist again.
+    """
+    global _install_id_memo
+
+    config = load_config()
+    raw = config.get("install_id")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+
+    if _install_id_memo is not None:
+        return _install_id_memo
+
+    new_id = uuid.uuid4().hex
+    config["install_id"] = new_id
+    if save_config(config):
+        logger.info("[config] generated new install_id=%s", new_id)
+    else:
+        logger.warning(
+            "[config] generated install_id=%s but persistence failed; "
+            "value will not survive a restart",
+            new_id,
+        )
+
+    _install_id_memo = new_id
+    return new_id
+
+
+def get_install_id() -> Optional[str]:
+    """Return the persisted install_id without creating one.
+
+    Used by callers that want to read but not initialise (e.g. the BLE
+    service when probing). Daemon startup always goes through
+    ``get_or_create_install_id`` so a missing file there is fixed
+    immediately.
+    """
+    raw = load_config().get("install_id")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return _install_id_memo

--- a/src/reachy_mini/daemon/app/config.py
+++ b/src/reachy_mini/daemon/app/config.py
@@ -1,0 +1,151 @@
+"""Persistent daemon configuration.
+
+Holds a tiny JSON document under ``$XDG_CONFIG_HOME/reachy_mini/daemon.json``
+(default ``~/.config/reachy_mini/daemon.json``) for daemon-level state that
+must survive restarts and re-installs of the upstream tray app.
+
+Currently the only persisted field is ``robot_name`` - the human-readable
+label the user picked for this Reachy. We deliberately keep this file
+separate from any tray ``data_dir`` so that:
+
+- the same physical Reachy keeps its name across a tray ``reset_bootstrap``,
+- the same daemon code path applies on the Wireless robot (where there is
+  no tray at all) and on the Lite/desktop tray on macOS or Linux,
+- destroying the HF token cache does not nuke the user's robot label.
+
+Reads and writes are tolerant: a missing or corrupt file is treated as
+"no persisted config", and a write failure is logged but never raises.
+The naming flow always has a mandatory in-memory fallback (``reachy_mini``).
+
+Concurrency: writes are ``fsync`` + atomic rename, so a crash mid-write
+cannot leave the config in a half-written state. There is no in-process
+locking here; the caller (single FastAPI worker) is responsible for not
+issuing parallel ``save_config`` calls. The HTTP route that mutates the
+name guards itself with an ``asyncio.Lock``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_FILENAME = "daemon.json"
+
+# Hard-coded fallback used when the user has not yet customised their
+# robot's name. Kept here so every layer of the daemon (config loader,
+# resolver in main.py, central-relay gate in daemon.py, rename HTTP route)
+# agrees on the same string and a single rename touches one place.
+DEFAULT_ROBOT_NAME = "reachy_mini"
+
+
+def _config_dir() -> Path:
+    """Resolve the directory that holds ``daemon.json``.
+
+    Honours ``$XDG_CONFIG_HOME`` when set (used by both Linux conventions
+    and the macOS tray when it wants a custom location), otherwise falls
+    back to ``~/.config`` per the XDG Base Directory spec. The ``reachy_mini``
+    subfolder keeps daemon config separate from any other Reachy tooling.
+    """
+    base = os.environ.get("XDG_CONFIG_HOME")
+    if base:
+        return Path(base) / "reachy_mini"
+    return Path.home() / ".config" / "reachy_mini"
+
+
+def get_config_path() -> Path:
+    """Return the absolute path to ``daemon.json`` (file may not exist)."""
+    return _config_dir() / _CONFIG_FILENAME
+
+
+def load_config() -> dict[str, Any]:
+    """Load the persisted daemon config.
+
+    Returns an empty dict when the file is missing or unreadable. Never
+    raises: corrupted config must not prevent the daemon from booting.
+    """
+    path = get_config_path()
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+            if isinstance(data, dict):
+                return data
+            logger.warning("[config] %s does not contain a JSON object, ignoring", path)
+            return {}
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("[config] failed to read %s: %s", path, exc)
+        return {}
+
+
+def save_config(config: dict[str, Any]) -> bool:
+    """Persist ``config`` atomically.
+
+    Writes to a temp file in the same directory, fsyncs it, then renames
+    over the target. Returns ``True`` on success, ``False`` on failure.
+    Never raises.
+    """
+    path = get_config_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("[config] failed to mkdir %s: %s", path.parent, exc)
+        return False
+
+    try:
+        # ``delete=False`` so we keep control of the rename ourselves.
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=".daemon.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            json.dump(config, tmp, indent=2, sort_keys=True)
+            tmp.write("\n")
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp_path = Path(tmp.name)
+    except OSError as exc:
+        logger.warning("[config] failed to write tmp file in %s: %s", path.parent, exc)
+        return False
+
+    try:
+        os.replace(tmp_path, path)
+    except OSError as exc:
+        logger.warning(
+            "[config] failed to atomically rename %s -> %s: %s", tmp_path, path, exc
+        )
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        return False
+
+    return True
+
+
+def get_persisted_robot_name() -> Optional[str]:
+    """Return the previously saved robot name, or ``None`` if unset."""
+    name = load_config().get("robot_name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return None
+
+
+def set_persisted_robot_name(name: str) -> bool:
+    """Persist ``name`` as the robot name. Returns whether the write succeeded.
+
+    Reads-modifies-writes the config so we don't clobber sibling fields
+    that future versions may add.
+    """
+    config = load_config()
+    config["robot_name"] = name
+    return save_config(config)

--- a/src/reachy_mini/daemon/app/logging_ctx.py
+++ b/src/reachy_mini/daemon/app/logging_ctx.py
@@ -1,0 +1,197 @@
+"""Structured logging context for the Reachy Mini daemon.
+
+Mirrors the mobile app's `src/logger/` layer (PR-A) so that a single
+``X-Trace-Id`` header travels from the phone, through the optional
+WebRTC ``http_proxy`` tunnel, into the daemon's HTTP handlers, and ends
+up tagged on every Python log line emitted while servicing that
+request.
+
+What it provides
+----------------
+* :data:`trace_id_var` - a :class:`contextvars.ContextVar` holding the
+  current trace id (4-char base36 to match the mobile side). Async-safe
+  by design: every coroutine spawned inside a request copies its own
+  copy, so concurrent requests do not bleed ids.
+* :class:`TraceIdFilter` - a :class:`logging.Filter` that injects
+  ``record.trace_id`` from the ContextVar so format strings can use
+  ``%(trace_id)s``. It also exposes a sentinel ``"----"`` when no
+  trace is active, making formatter strings unconditional.
+* :func:`kv` / :func:`kv_log` - small helpers to emit structured
+  ``event_name key=value key=value`` log lines without standing up a
+  full structlog dependency.
+* :func:`redact_dict` - walks an arbitrary dict and short-fingerprints
+  any value whose *key* matches a sensitive pattern (token, bearer,
+  password, ...). Use it on anything that crosses a log boundary.
+
+Design notes
+------------
+* We don't replace existing ``logger.info(...)`` calls. The kv helpers
+  are additive, available at strategic observation points (hf_auth,
+  signaling relay, wifi router) without forcing a global rewrite.
+* Trace ids are deliberately short (4 chars). Cardinality across one
+  daemon session is low (typically a few hundred connection attempts);
+  4 base36 chars give us 1.6M values, more than enough to dedupe.
+* The redaction list is keyed *by name*, not *by value* - we don't
+  scan strings looking for tokens, because that's both slow and
+  unreliable. Instead, callers must pass tokens under a known key
+  (``token=``, ``hf_token=``, ``authorization=``, ...) so the filter
+  catches them.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import re
+import secrets
+from typing import Any, Mapping
+
+# 4-char base36 trace-id matches the mobile-side `newTraceId()` length.
+# Async-safe via ContextVar: spawning a task COPIES the current context,
+# so a request's trace stays scoped to that request.
+trace_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "trace_id", default=None
+)
+
+_TRACE_PLACEHOLDER = "----"
+
+
+def get_trace_id() -> str | None:
+    """Return the current trace id, or ``None`` if outside a request."""
+    return trace_id_var.get()
+
+
+def set_trace_id(trace: str | None) -> contextvars.Token[str | None]:
+    """Set the trace id for the current context.
+
+    Returns a token that callers MUST pass back to :func:`reset_trace_id`
+    once the work is done, to avoid leaking the trace across unrelated
+    coroutines (FastAPI background tasks, tests, ...). Most consumers
+    should use the :class:`TraceIdMiddleware` rather than calling this
+    directly.
+    """
+    return trace_id_var.set(trace)
+
+
+def reset_trace_id(token: contextvars.Token[str | None]) -> None:
+    """Restore the trace id that was active before :func:`set_trace_id`."""
+    trace_id_var.reset(token)
+
+
+def new_trace_id() -> str:
+    """Mint a fresh 4-char base36 trace id.
+
+    ``secrets.randbits`` over ``random.random()``: the trace id is not
+    a security boundary, but using ``secrets`` avoids depending on the
+    global PRNG state which may be seeded from sources we don't control
+    in CI / fork-after-init scenarios.
+    """
+    n = secrets.randbits(32)
+    # base36 encode, pad/truncate to 4 chars.
+    digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+    out = ""
+    while n > 0 and len(out) < 6:
+        out = digits[n % 36] + out
+        n //= 36
+    return (out or "0000")[-4:].rjust(4, "0")
+
+
+class TraceIdFilter(logging.Filter):
+    """Inject the current trace id into every :class:`LogRecord`.
+
+    Install it on each handler whose formatter uses ``%(trace_id)s``.
+    When no trace is set we emit ``"----"`` (a stable 4-char filler)
+    so the column width stays predictable in stderr logs.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D102, D401
+        record.trace_id = trace_id_var.get() or _TRACE_PLACEHOLDER
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+_SENSITIVE_KEY_RE = re.compile(
+    r"^(token|hf_token|hftoken|access_token|refresh_token|"
+    r"authorization|bearer|password|secret|api_?key)$",
+    re.IGNORECASE,
+)
+
+
+def redact_token(value: str) -> str:
+    """Short-fingerprint a sensitive string so logs stay diff-able.
+
+    Keeps 4 + 4 chars with an ellipsis in between for values long
+    enough that a fingerprint is unambiguous; emits ``"REDACTED"`` for
+    short ones.
+    """
+    if not value:
+        return value
+    if len(value) <= 12:
+        return "REDACTED"
+    return f"{value[:4]}…{value[-4:]}"
+
+
+def redact_dict(data: Any, depth: int = 0) -> Any:
+    """Recursively redact sensitive values in ``data``.
+
+    Keys are matched against :data:`_SENSITIVE_KEY_RE`. Non-string
+    values for sensitive keys are left as-is (we trust callers not to
+    stuff a token into an int). The depth limit keeps a malicious
+    self-referential dict from looping forever.
+    """
+    if data is None or depth > 6:
+        return data
+    if isinstance(data, Mapping):
+        out: dict[str, Any] = {}
+        for key, value in data.items():
+            if (
+                isinstance(key, str)
+                and _SENSITIVE_KEY_RE.match(key)
+                and isinstance(value, str)
+            ):
+                out[key] = redact_token(value)
+            else:
+                out[key] = redact_dict(value, depth + 1)
+        return out
+    if isinstance(data, (list, tuple)):
+        items = [redact_dict(v, depth + 1) for v in data]
+        return items if isinstance(data, list) else tuple(items)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Structured kv emission
+# ---------------------------------------------------------------------------
+
+
+def kv(event: str, **fields: Any) -> str:
+    """Render a structured log message as ``event key=value key=value``.
+
+    Values pass through :func:`redact_dict` first, so accidentally
+    logging ``token=hf_xyz`` will print ``token=hf_x…xyz`` instead of
+    the full bearer.
+    """
+    if not fields:
+        return event
+    safe = redact_dict(fields)
+    parts = [event]
+    for key, value in safe.items():  # type: ignore[union-attr]
+        parts.append(f"{key}={value}")
+    return " ".join(parts)
+
+
+def kv_log(
+    logger: logging.Logger,
+    level: int,
+    event: str,
+    **fields: Any,
+) -> None:
+    """Emit a structured kv log line at the given level.
+
+    Convenience wrapper around ``logger.log(level, kv(event, ...))`` that
+    keeps call sites short and greppable.
+    """
+    logger.log(level, kv(event, **fields))

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -148,7 +148,11 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         args = app.state.args  # type: Args
         dataset_updater_task: asyncio.Task[None] | None = None
 
-        mdns = MdnsServiceRegistration(args.robot_name, args.fastapi_port)
+        mdns = MdnsServiceRegistration(
+            args.robot_name,
+            args.fastapi_port,
+            install_id=app.state.daemon.install_id,
+        )
         # Expose the registration so the rename route can rebroadcast the
         # mDNS record under the new name without restarting the daemon.
         app.state.mdns = mdns

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -24,6 +24,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon.app.logging_ctx import TraceIdFilter
 from reachy_mini.daemon.app.routers import (
     apps,
     camera,
@@ -38,6 +39,7 @@ from reachy_mini.daemon.app.routers import (
     state,
     volume,
 )
+from reachy_mini.daemon.app.trace_middleware import TraceIdMiddleware
 from reachy_mini.daemon.daemon import Daemon
 from reachy_mini.daemon.utils import SimulationMode
 from reachy_mini.media.audio_utils import (
@@ -253,12 +255,17 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
             health_check_event.set()
             return {"status": "ok"}
 
+    # Order matters: TraceId runs first so every downstream middleware
+    # (CORS, routing) sees the ContextVar set when they emit logs.
+    # Starlette runs middlewares in REVERSE registration order on the
+    # request side, so adding TraceId LAST puts it on top of the stack.
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],  # or restrict to your HF domain
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    app.add_middleware(TraceIdMiddleware)
 
     STATIC_DIR = Path(__file__).parent / "dashboard" / "static"
     TEMPLATES_DIR = Path(__file__).parent / "dashboard" / "templates"
@@ -296,10 +303,19 @@ def run_app(args: Args) -> None:
     root_logger = logging.getLogger()
     root_logger.setLevel(args.log_level)
 
-    # Create handler that writes to stderr with immediate flush
+    # Create handler that writes to stderr with immediate flush.
+    #
+    # The format includes %(trace_id)s so any request-scoped log line
+    # carries the same id the mobile app emits, making cross-boundary
+    # debugging a grep away. The TraceIdFilter guarantees the field is
+    # always set (sentinel "----" outside requests), so the format
+    # string is unconditional.
     handler = logging.StreamHandler(sys.stderr)
     handler.setLevel(args.log_level)
-    handler.setFormatter(logging.Formatter("%(name)s - %(levelname)s - %(message)s"))
+    handler.addFilter(TraceIdFilter())
+    handler.setFormatter(
+        logging.Formatter("[%(trace_id)s] %(name)s - %(levelname)s - %(message)s")
+    )
     root_logger.handlers.clear()
     root_logger.addHandler(handler)
 

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -167,6 +167,17 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                     hardware_config_filepath=args.hardware_config_filepath,
                 )
 
+            # Tell the backend where to forward `http_proxy` requests
+            # received over the WebRTC data channel: same FastAPI server,
+            # via the loopback interface. Done after `start()` so the
+            # backend instance is guaranteed to exist.
+            try:
+                backend = getattr(app.state.daemon, "backend", None)
+                if backend is not None and hasattr(backend, "set_loopback_http_port"):
+                    backend.set_loopback_http_port(args.fastapi_port)
+            except Exception as e:
+                logger.warning(f"Could not configure http_proxy loopback port: {e}")
+
             # Register mDNS service only after the daemon is ready
             mdns.register()
 

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -14,7 +14,7 @@ import types
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Optional
 
 import uvicorn
 from fastapi import APIRouter, FastAPI, Request
@@ -24,6 +24,12 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon.app.config import (
+    DEFAULT_ROBOT_NAME as _DEFAULT_ROBOT_NAME,
+)
+from reachy_mini.daemon.app.config import (
+    get_persisted_robot_name,
+)
 from reachy_mini.daemon.app.logging_ctx import TraceIdFilter
 from reachy_mini.daemon.app.routers import (
     apps,
@@ -89,7 +95,12 @@ class Args:
     preload_datasets: bool = False
     dataset_update_interval_hours: float = 24.0  # 0 to disable periodic updates
 
-    robot_name: str = "reachy_mini"
+    # ``None`` means "no explicit value passed on the CLI": resolution
+    # falls back first to the persisted ``daemon.json`` (set by the
+    # mobile app's rename flow), then to the default ``"reachy_mini"``.
+    # An explicit CLI flag always wins so factory provisioning and
+    # tests stay deterministic.
+    robot_name: Optional[str] = None
 
     fastapi_host: str = "0.0.0.0"
     fastapi_port: int = 8000
@@ -97,8 +108,34 @@ class Args:
     localhost_only: bool | None = None
 
 
+def _resolve_robot_name(args_value: Optional[str]) -> str:
+    """Pick the runtime robot name from CLI / persisted config / default.
+
+    Order of precedence:
+        1. explicit ``--robot-name`` CLI flag (``args_value`` is not None);
+        2. previously persisted name from ``daemon.json``;
+        3. hard-coded fallback ``reachy_mini``.
+    """
+    if args_value is not None:
+        return args_value
+    persisted = get_persisted_robot_name()
+    if persisted:
+        return persisted
+    return _DEFAULT_ROBOT_NAME
+
+
 def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
+    # Resolve the canonical robot name once for the lifetime of the app.
+    # Subsequent live renames go through ``Daemon.set_robot_name`` and
+    # update both ``args.robot_name`` and the daemon attribute, so the
+    # rest of the create_app body keeps reading from ``args.robot_name``.
+    # Capture whether the CLI passed an explicit value before we mutate
+    # ``args``; the rename route uses this to label the source as ``"cli"``
+    # so the mobile app knows the persisted name is being overridden.
+    args._robot_name_cli_explicit = args.robot_name is not None  # type: ignore[attr-defined]
+    args.robot_name = _resolve_robot_name(args.robot_name)
+
     localhost_only = (
         args.localhost_only
         if args.localhost_only is not None
@@ -112,6 +149,9 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         dataset_updater_task: asyncio.Task[None] | None = None
 
         mdns = MdnsServiceRegistration(args.robot_name, args.fastapi_port)
+        # Expose the registration so the rename route can rebroadcast the
+        # mDNS record under the new name without restarting the daemon.
+        app.state.mdns = mdns
 
         def preload_with_logging() -> None:
             """Download datasets with logging."""
@@ -473,7 +513,11 @@ def main() -> None:
         "--robot-name",
         type=str,
         default=default_args.robot_name,
-        help="Name of the robot (default: reachy_mini).",
+        help=(
+            "Override the robot name. When omitted, the daemon reads the "
+            "persisted name from ``~/.config/reachy_mini/daemon.json`` (set "
+            "by the mobile app) and falls back to ``reachy_mini``."
+        ),
     )
 
     # Real robot mode

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -242,7 +242,12 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         app.include_router(cache.router)
         app.include_router(logs.router)
         app.include_router(update.router)
+        # Legacy mount at `/wifi/...` (used by the Bluetooth provisioning service
+        # and older first-boot tooling). Kept for backward compatibility.
         app.include_router(wifi_config.router)
+        # New mount under `/api/wifi/...` so the mobile app can reach it via
+        # the unified `RobotClient` (which prefixes everything with `/api`).
+        router.include_router(wifi_config.router)
 
     app.include_router(router)
     app.include_router(sdk_ws.router)

--- a/src/reachy_mini/daemon/app/routers/daemon.py
+++ b/src/reachy_mini/daemon/app/routers/daemon.py
@@ -185,8 +185,42 @@ async def get_daemon_version() -> dict[str, str]:
         # Revision history:
         #   "1" - initial mobile-app-facing surface (http_proxy, ws_proxy)
         #   "2" - GET / POST /api/daemon/robot-name + persisted daemon.json
-        "api_revision": "2",
+        #   "3" - GET /api/daemon/identity (install_id) + central
+        #         relay always-on (no robot-name gate)
+        "api_revision": "3",
     }
+
+
+class DaemonIdentityResponse(BaseModel):
+    """Stable identifying information for this daemon install.
+
+    Used by the mobile app's robot registry to merge sightings of the
+    same physical robot across BLE / mDNS / loopback HTTP / HF central
+    into a single entry. ``install_id`` is the canonical key; the
+    other fields are convenience metadata so a single round-trip is
+    enough to render a row.
+    """
+
+    install_id: str
+    robot_name: str
+
+
+@router.get("/identity", response_model=DaemonIdentityResponse)
+async def get_daemon_identity(
+    daemon: Daemon = Depends(get_daemon),
+) -> DaemonIdentityResponse:
+    """Return the stable per-install identifier and current robot name.
+
+    ``install_id`` is generated on first daemon boot and persisted to
+    ``~/.config/reachy_mini/daemon.json``. It does NOT change when the
+    user renames the robot, swaps HF tokens, or reinstalls the tray:
+    it is the only field of this daemon that the mobile app can rely
+    on as a long-lived reconciliation key.
+    """
+    return DaemonIdentityResponse(
+        install_id=daemon.install_id,
+        robot_name=daemon.robot_name,
+    )
 
 
 @router.get("/robot-name", response_model=RobotNameResponse)

--- a/src/reachy_mini/daemon/app/routers/daemon.py
+++ b/src/reachy_mini/daemon/app/routers/daemon.py
@@ -85,6 +85,31 @@ async def get_daemon_status(daemon: Daemon = Depends(get_daemon)) -> DaemonStatu
     return daemon.status()
 
 
+@router.get("/version")
+async def get_daemon_version() -> dict[str, str]:
+    """Return the daemon's package version and a compatibility marker.
+
+    Mobile and remote clients call this early during the connection
+    handshake to detect a feature mismatch (e.g. an older daemon that
+    doesn't ship a new endpoint yet) and surface a soft warning rather
+    than failing later with a cryptic 404.
+
+    The endpoint is deliberately additive: it returns a dict so we can
+    grow it (build sha, kinematics engine, ...) without breaking older
+    clients that only look up ``version``.
+    """
+    from reachy_mini import __version__
+
+    return {
+        "version": __version__,
+        # Bumped whenever the HTTP surface gains/loses an endpoint or
+        # a route's response shape changes in a non-additive way.
+        # Mobile clients can rely on `api_revision >= N` to know a
+        # feature is reachable, regardless of the package version.
+        "api_revision": "1",
+    }
+
+
 @router.get("/robot-app-lock-status")
 async def get_robot_app_lock_status(
     daemon: Daemon = Depends(get_daemon),

--- a/src/reachy_mini/daemon/app/routers/daemon.py
+++ b/src/reachy_mini/daemon/app/routers/daemon.py
@@ -203,6 +203,13 @@ class DaemonIdentityResponse(BaseModel):
 
     install_id: str
     robot_name: str
+    # Producer peer id assigned by HF central on the latest ``welcome``
+    # frame. Optional because the relay may not be running (no token,
+    # offline, ...) and because it rotates on every reconnect. Mobile
+    # clients use this as a fallback dedup key against the central
+    # listing while the central server does not yet propagate
+    # ``meta.install_id``.
+    central_peer_id: str | None = None
 
 
 @router.get("/identity", response_model=DaemonIdentityResponse)
@@ -216,10 +223,20 @@ async def get_daemon_identity(
     user renames the robot, swaps HF tokens, or reinstalls the tray:
     it is the only field of this daemon that the mobile app can rely
     on as a long-lived reconciliation key.
+
+    ``central_peer_id`` is volatile: it is the id central just handed
+    us back on the WebSocket ``welcome`` frame and rotates on every
+    reconnect. Returned as a best-effort dedup key for mobile clients
+    that want to merge a "this Mac" loopback row against the same
+    physical robot's central listing without waiting for central to
+    propagate ``meta.install_id``.
     """
+    from reachy_mini.media.central_signaling_relay import get_central_peer_id
+
     return DaemonIdentityResponse(
         install_id=daemon.install_id,
         robot_name=daemon.robot_name,
+        central_peer_id=get_central_peer_id(),
     )
 
 

--- a/src/reachy_mini/daemon/app/routers/daemon.py
+++ b/src/reachy_mini/daemon/app/routers/daemon.py
@@ -1,21 +1,97 @@
 """Daemon-related API routes."""
 
+import asyncio
 import logging
+import re
 import threading
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
 
 from reachy_mini.daemon.app import bg_job_register
+from reachy_mini.daemon.app.config import (
+    DEFAULT_ROBOT_NAME as _DEFAULT_ROBOT_NAME,
+)
+from reachy_mini.daemon.app.config import (
+    get_persisted_robot_name,
+)
 from reachy_mini.daemon.robot_app_lock import RobotAppLockStatus
 from reachy_mini.io.protocol import DaemonStatus
 
 from ...daemon import Daemon
 from ..dependencies import get_daemon
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(
     prefix="/daemon",
 )
 busy_lock = threading.Lock()
+
+# Single-writer guard for the rename flow: two parallel POSTs would race
+# on persistence + ``setPeerStatus`` re-emit. Acquired only inside the
+# rename route, never held across awaits longer than necessary.
+_robot_name_lock = asyncio.Lock()
+
+# Hard cap chosen so the result fits in mDNS TXT records, the WebSocket
+# producer ``meta.name`` field central displays in its dashboard, and
+# realistic UI labels. Lower bound rejects ``""`` and pure whitespace.
+_ROBOT_NAME_MIN_LEN = 1
+_ROBOT_NAME_MAX_LEN = 32
+
+# ASCII printable + space, no control characters. We deliberately keep
+# Unicode out for now because a) the BLE LocalName layer can't fit
+# arbitrary UTF-8 in a 31-byte advertisement, b) mDNS service names need
+# to round-trip through DNS-safe encoding, and c) the daemon HTTP layer
+# itself is fine with anything but downstream consumers (logs, dashboards)
+# get noisier with non-ASCII. Easy to relax later if real users ask.
+_ROBOT_NAME_PATTERN = re.compile(r"^[\x20-\x7E]+$")
+
+
+class RobotNameResponse(BaseModel):
+    """Current robot name and where it was sourced from."""
+
+    name: str
+    # ``"persisted"`` -> read from ``daemon.json`` on disk;
+    # ``"cli"`` -> ``--robot-name`` flag at daemon launch overrides config;
+    # ``"default"`` -> nobody set anything yet, mobile app should prompt.
+    source: str
+
+
+class SetRobotNameRequest(BaseModel):
+    """Body for ``POST /api/daemon/robot-name``."""
+
+    name: str = Field(
+        min_length=_ROBOT_NAME_MIN_LEN,
+        max_length=_ROBOT_NAME_MAX_LEN,
+        description="Human-readable label for the robot.",
+    )
+
+
+def _validate_robot_name(raw: str) -> str:
+    """Trim, validate, and return a name ready for persistence.
+
+    Raises ``HTTPException(422)`` with a precise reason on failure so
+    the mobile app can render a useful inline error.
+    """
+    name = raw.strip()
+    if len(name) < _ROBOT_NAME_MIN_LEN or len(name) > _ROBOT_NAME_MAX_LEN:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Robot name must be {_ROBOT_NAME_MIN_LEN}-{_ROBOT_NAME_MAX_LEN} "
+                f"characters after trimming whitespace."
+            ),
+        )
+    if not _ROBOT_NAME_PATTERN.match(name):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Robot name must only contain printable ASCII characters "
+                "(letters, digits, spaces, common punctuation)."
+            ),
+        )
+    return name
 
 
 @router.post("/start")
@@ -106,8 +182,91 @@ async def get_daemon_version() -> dict[str, str]:
         # a route's response shape changes in a non-additive way.
         # Mobile clients can rely on `api_revision >= N` to know a
         # feature is reachable, regardless of the package version.
-        "api_revision": "1",
+        # Revision history:
+        #   "1" - initial mobile-app-facing surface (http_proxy, ws_proxy)
+        #   "2" - GET / POST /api/daemon/robot-name + persisted daemon.json
+        "api_revision": "2",
     }
+
+
+@router.get("/robot-name", response_model=RobotNameResponse)
+async def get_robot_name(
+    request: Request, daemon: Daemon = Depends(get_daemon)
+) -> RobotNameResponse:
+    """Return the current robot name and tell the client where it came from.
+
+    The ``source`` field lets the mobile app decide whether to prompt
+    the user for a name on first connection: when the value is
+    ``"default"`` the user has never customised it, so we surface the
+    naming screen; when it is ``"persisted"`` or ``"cli"`` we trust the
+    existing label and skip the prompt.
+    """
+    args = getattr(request.app.state, "args", None)
+    cli_override = args is not None and getattr(args, "_robot_name_cli_explicit", False)
+
+    persisted = get_persisted_robot_name()
+
+    if cli_override:
+        source = "cli"
+    elif persisted and persisted == daemon.robot_name:
+        source = "persisted"
+    elif daemon.robot_name == _DEFAULT_ROBOT_NAME and not persisted:
+        source = "default"
+    else:
+        # Live rename in flight, or persisted vs in-memory disagree.
+        # ``persisted`` wins as the source label since we just wrote it
+        # there before mutating ``daemon.robot_name``.
+        source = "persisted" if persisted else "default"
+
+    return RobotNameResponse(name=daemon.robot_name, source=source)
+
+
+@router.post("/robot-name", response_model=DaemonStatus)
+async def set_robot_name(
+    body: SetRobotNameRequest,
+    daemon: Daemon = Depends(get_daemon),
+    request: Request = None,  # type: ignore[assignment]
+) -> DaemonStatus:
+    """Rename the robot live and persist the new label across restarts.
+
+    The new name is propagated to:
+
+    - in-memory ``Daemon.robot_name`` and ``DaemonStatus.robot_name``;
+    - ``~/.config/reachy_mini/daemon.json`` (atomic write);
+    - the central signaling relay (live ``setPeerStatus`` re-emit, no
+      reconnect required), so the HF fleet listing reflects the change
+      within a few seconds without dropping any in-flight WebRTC session;
+    - the mDNS service registration, when one is active (LAN listeners
+      see the goodbye + new advertisement).
+
+    Idempotent: a no-op when ``name`` already matches the current value
+    (after trimming). Concurrency-safe via an ``asyncio.Lock``: parallel
+    requests are serialised and the second one observes the new state
+    as a no-op.
+
+    Returns the full ``DaemonStatus`` snapshot so the mobile app can
+    refresh its connection summary in a single round-trip.
+    """
+    new_name = _validate_robot_name(body.name)
+
+    async with _robot_name_lock:
+        if new_name == daemon.robot_name:
+            # Idempotent fast-path: don't touch disk, don't churn central.
+            return daemon.status()
+
+        await daemon.set_robot_name(new_name)
+
+        # Forward to the mDNS handle owned by the FastAPI lifespan, when
+        # one exists (it doesn't on test harnesses that build the app
+        # without going through ``create_app``'s lifespan).
+        mdns = getattr(request.app.state, "mdns", None) if request else None
+        if mdns is not None:
+            try:
+                mdns.update_robot_name(new_name)
+            except Exception as exc:
+                logger.warning("[daemon.rename] mDNS update failed: %s", exc)
+
+    return daemon.status()
 
 
 @router.get("/robot-app-lock-status")

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -18,9 +18,7 @@ router = APIRouter(prefix="/hf-auth")
 # Central signaling server that tracks which robot is currently in use by
 # which remote JS app. We proxy its /api/robot-status endpoint so the
 # desktop frontend never needs to see the raw HF token.
-CENTRAL_ROBOT_STATUS_URL = (
-    "https://cduss-reachy-mini-central.hf.space/api/robot-status"
-)
+CENTRAL_ROBOT_STATUS_URL = "https://cduss-reachy-mini-central.hf.space/api/robot-status"
 CENTRAL_ROBOT_STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 
@@ -63,6 +61,27 @@ async def save_token(request: TokenRequest) -> TokenResponse:
 async def get_auth_status() -> dict[str, Any]:
     """Check if user is authenticated with HuggingFace."""
     return hf_auth.check_token_status()
+
+
+@router.get("/token")
+async def get_token() -> dict[str, Any]:
+    """Return the stored HuggingFace token in plaintext.
+
+    This exists so remote clients (e.g. the mobile app) can bridge the
+    token into a sandboxed iframe that itself cannot go through the HF
+    OAuth flow (hit by ``X-Frame-Options: SAMEORIGIN`` on ``/login``).
+
+    Security note: the daemon's HTTP API is already unauthenticated on
+    the local network, so any client that can reach this endpoint can
+    also start/stop apps at will. Exposing the token here does not
+    meaningfully widen the attack surface, but we deliberately keep the
+    endpoint separate from ``/status`` so the desktop frontend - which
+    never needs the raw token - is not tempted to consume it.
+    """
+    token = hf_auth.get_hf_token()
+    if not token:
+        raise HTTPException(status_code=404, detail="No HF token stored")
+    return {"token": token}
 
 
 @router.get("/relay-status")
@@ -122,7 +141,9 @@ async def get_central_robot_status() -> dict[str, Any]:
         return {"available": False, "robots": [], "reason": "not_authenticated"}
 
     try:
-        async with aiohttp.ClientSession(timeout=CENTRAL_ROBOT_STATUS_TIMEOUT) as session:
+        async with aiohttp.ClientSession(
+            timeout=CENTRAL_ROBOT_STATUS_TIMEOUT
+        ) as session:
             # Token goes in the Authorization header, not the URL —
             # otherwise it leaks into central's access logs and any
             # intermediate proxy's logs. The desktop frontend already
@@ -175,9 +196,7 @@ async def is_oauth_configured() -> dict[str, Any]:
 
 
 @router.get("/oauth/start")
-async def start_oauth(
-    request: Request, use_localhost: bool = False
-) -> dict[str, Any]:
+async def start_oauth(request: Request, use_localhost: bool = False) -> dict[str, Any]:
     """Start a new OAuth authorization session.
 
     Returns the auth_url to redirect the user to HuggingFace.

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -135,9 +135,15 @@ async def refresh_relay() -> dict[str, Any]:
     token = hf_auth.get_hf_token()
 
     try:
-        from reachy_mini.media.central_signaling_relay import notify_token_change
+        from reachy_mini.media.central_signaling_relay import notify_force_reconnect
 
-        await notify_token_change(token)
+        # Unconditionally drop & reconnect. We used to call
+        # `notify_token_change(token)` here, but that path is guarded
+        # by an `old_token == new_token` early-return in the relay,
+        # which turned this endpoint into a no-op whenever the token
+        # had not changed - exactly the case we ship this endpoint
+        # for. `notify_force_reconnect` skips that guard.
+        await notify_force_reconnect()
     except ImportError:
         return {
             "status": "skipped",
@@ -145,7 +151,7 @@ async def refresh_relay() -> dict[str, Any]:
             "reason": "relay_unavailable",
         }
     except Exception as e:
-        logger.warning("[refresh-relay] notify_token_change failed: %s", e)
+        logger.warning("[refresh-relay] notify_force_reconnect failed: %s", e)
         raise HTTPException(
             status_code=500, detail=f"Failed to refresh relay: {e}"
         ) from e

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -10,6 +10,7 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
 from reachy_mini.apps.sources import hf_auth
+from reachy_mini.daemon.app.logging_ctx import kv_log
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +19,7 @@ router = APIRouter(prefix="/hf-auth")
 # Central signaling server that tracks which robot is currently in use by
 # which remote JS app. We proxy its /api/robot-status endpoint so the
 # desktop frontend never needs to see the raw HF token.
-CENTRAL_ROBOT_STATUS_URL = (
-    "https://cduss-reachy-mini-central.hf.space/api/robot-status"
-)
+CENTRAL_ROBOT_STATUS_URL = "https://cduss-reachy-mini-central.hf.space/api/robot-status"
 CENTRAL_ROBOT_STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 
@@ -49,10 +48,22 @@ async def save_token(request: TokenRequest) -> TokenResponse:
     result = hf_auth.save_hf_token(request.token)
 
     if result["status"] == "error":
+        kv_log(
+            logger,
+            logging.WARNING,
+            "auth.save_token.failure",
+            reason=result.get("message", "invalid_token"),
+        )
         raise HTTPException(
             status_code=400, detail=result.get("message", "Invalid token")
         )
 
+    kv_log(
+        logger,
+        logging.INFO,
+        "auth.save_token.success",
+        username=result.get("username"),
+    )
     return TokenResponse(
         status="success",
         username=result.get("username"),
@@ -95,8 +106,10 @@ async def delete_token() -> dict[str, str]:
     success = hf_auth.delete_hf_token()
 
     if not success:
+        kv_log(logger, logging.ERROR, "auth.delete_token.failure")
         raise HTTPException(status_code=500, detail="Failed to delete token")
 
+    kv_log(logger, logging.INFO, "auth.delete_token.success")
     return {"status": "success"}
 
 
@@ -122,7 +135,9 @@ async def get_central_robot_status() -> dict[str, Any]:
         return {"available": False, "robots": [], "reason": "not_authenticated"}
 
     try:
-        async with aiohttp.ClientSession(timeout=CENTRAL_ROBOT_STATUS_TIMEOUT) as session:
+        async with aiohttp.ClientSession(
+            timeout=CENTRAL_ROBOT_STATUS_TIMEOUT
+        ) as session:
             # Token goes in the Authorization header, not the URL —
             # otherwise it leaks into central's access logs and any
             # intermediate proxy's logs. The desktop frontend already
@@ -175,9 +190,7 @@ async def is_oauth_configured() -> dict[str, Any]:
 
 
 @router.get("/oauth/start")
-async def start_oauth(
-    request: Request, use_localhost: bool = False
-) -> dict[str, Any]:
+async def start_oauth(request: Request, use_localhost: bool = False) -> dict[str, Any]:
     """Start a new OAuth authorization session.
 
     Returns the auth_url to redirect the user to HuggingFace.

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -43,8 +43,16 @@ class TokenResponse(BaseModel):
 
 
 @router.post("/save-token")
-async def save_token(request: TokenRequest) -> TokenResponse:
-    """Save HuggingFace token after validation."""
+async def save_token(req: Request, request: TokenRequest) -> TokenResponse:
+    """Save HuggingFace token after validation.
+
+    On success this also makes sure the central signaling relay is
+    running. The relay is normally started at media-server-acquire
+    time, but the daemon may have booted without a token (so the relay
+    never came up). Without this ensure-step the robot would remain
+    invisible on central until the next daemon restart, even though
+    the token is now stored on disk.
+    """
     result = hf_auth.save_hf_token(request.token)
 
     if result["status"] == "error":
@@ -64,6 +72,20 @@ async def save_token(request: TokenRequest) -> TokenResponse:
         "auth.save_token.success",
         username=result.get("username"),
     )
+
+    daemon = getattr(req.app.state, "daemon", None)
+    if daemon is not None and getattr(daemon, "wireless_version", False):
+        try:
+            relay_result = await daemon.ensure_central_signaling_relay()
+            kv_log(
+                logger,
+                logging.INFO,
+                "auth.save_token.relay_ensured",
+                **relay_result,
+            )
+        except Exception as e:
+            logger.warning("[save-token] ensure_central_signaling_relay failed: %s", e)
+
     return TokenResponse(
         status="success",
         username=result.get("username"),
@@ -135,7 +157,7 @@ async def delete_token() -> dict[str, str]:
 
 
 @router.post("/refresh-relay")
-async def refresh_relay() -> dict[str, Any]:
+async def refresh_relay(request: Request) -> dict[str, Any]:
     """Force the central signaling relay to reconnect with the stored token.
 
     Drops the relay's current connection and re-registers with the
@@ -171,7 +193,23 @@ async def refresh_relay() -> dict[str, Any]:
     token = hf_auth.get_hf_token()
 
     try:
+        from reachy_mini.media import central_signaling_relay as _csr
         from reachy_mini.media.central_signaling_relay import notify_force_reconnect
+
+        # If the daemon booted without a token, the relay never came
+        # up. In that case `notify_force_reconnect` is a no-op. Try to
+        # bring the relay up first so this endpoint actually does
+        # something useful for the cold-boot recovery case.
+        if _csr._relay_instance is None:
+            daemon = getattr(request.app.state, "daemon", None)
+            if daemon is not None and getattr(daemon, "wireless_version", False):
+                try:
+                    await daemon.ensure_central_signaling_relay()
+                except Exception as e:
+                    logger.warning(
+                        "[refresh-relay] ensure_central_signaling_relay failed: %s",
+                        e,
+                    )
 
         # Unconditionally drop & reconnect. We used to call
         # `notify_token_change(token)` here, but that path is guarded

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -18,9 +18,7 @@ router = APIRouter(prefix="/hf-auth")
 # Central signaling server that tracks which robot is currently in use by
 # which remote JS app. We proxy its /api/robot-status endpoint so the
 # desktop frontend never needs to see the raw HF token.
-CENTRAL_ROBOT_STATUS_URL = (
-    "https://cduss-reachy-mini-central.hf.space/api/robot-status"
-)
+CENTRAL_ROBOT_STATUS_URL = "https://cduss-reachy-mini-central.hf.space/api/robot-status"
 CENTRAL_ROBOT_STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 
@@ -100,6 +98,61 @@ async def delete_token() -> dict[str, str]:
     return {"status": "success"}
 
 
+@router.post("/refresh-relay")
+async def refresh_relay() -> dict[str, Any]:
+    """Force the central signaling relay to reconnect with the stored token.
+
+    Drops the relay's current connection and re-registers with the
+    currently stored HF token.
+
+    Intended as a recovery handle for clients (e.g. the mobile app) that
+    detect a desync between ``/relay-status`` (claims ``connected``) and
+    ``/central-robot-status`` (returns ``robots: []``). That combination
+    means the relay still holds an SSE channel open with central but is
+    no longer registered as a producer for the authenticated user, most
+    commonly because the relay attached with a token that has since been
+    rotated or because a transient error during ``setPeerStatus`` went
+    unnoticed. From the outside this manifests as "the robot is online
+    but no one can call it" until someone restarts the daemon.
+
+    Rather than asking users to SSH in and run ``systemctl restart``,
+    this endpoint triggers the relay's existing ``_token_updated`` event
+    path (the same one ``save-token`` uses on login), which cleanly
+    tears down the SSE connection, refreshes the HF token from
+    ``huggingface_hub.get_token`` and reconnects. Works with any token
+    currently stored (raw user tokens or OAuth access tokens) because
+    we go through the relay's reconnect logic rather than re-validating
+    the token.
+
+    Response shape:
+        { "status": "requested", "token_available": bool, "reason"?: str }
+
+    ``token_available`` is false if the daemon has no HF token stored
+    at all (user not logged in). In that case the relay will just
+    transition to ``WAITING_FOR_TOKEN`` after the reconnect, which is
+    the correct behaviour.
+    """
+    token = hf_auth.get_hf_token()
+
+    try:
+        from reachy_mini.media.central_signaling_relay import notify_token_change
+
+        await notify_token_change(token)
+    except ImportError:
+        return {
+            "status": "skipped",
+            "token_available": bool(token),
+            "reason": "relay_unavailable",
+        }
+    except Exception as e:
+        logger.warning("[refresh-relay] notify_token_change failed: %s", e)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to refresh relay: {e}"
+        ) from e
+
+    return {"status": "requested", "token_available": bool(token)}
+
+
 @router.get("/central-robot-status")
 async def get_central_robot_status() -> dict[str, Any]:
     """Proxy to the central signaling server's /api/robot-status endpoint.
@@ -122,7 +175,9 @@ async def get_central_robot_status() -> dict[str, Any]:
         return {"available": False, "robots": [], "reason": "not_authenticated"}
 
     try:
-        async with aiohttp.ClientSession(timeout=CENTRAL_ROBOT_STATUS_TIMEOUT) as session:
+        async with aiohttp.ClientSession(
+            timeout=CENTRAL_ROBOT_STATUS_TIMEOUT
+        ) as session:
             # Token goes in the Authorization header, not the URL —
             # otherwise it leaks into central's access logs and any
             # intermediate proxy's logs. The desktop frontend already
@@ -175,9 +230,7 @@ async def is_oauth_configured() -> dict[str, Any]:
 
 
 @router.get("/oauth/start")
-async def start_oauth(
-    request: Request, use_localhost: bool = False
-) -> dict[str, Any]:
+async def start_oauth(request: Request, use_localhost: bool = False) -> dict[str, Any]:
     """Start a new OAuth authorization session.
 
     Returns the auth_url to redirect the user to HuggingFace.

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -75,8 +75,16 @@ async def save_token(req: Request, request: TokenRequest) -> TokenResponse:
         username=result.get("username"),
     )
 
+    # Bring the central signaling relay up after a successful token push,
+    # regardless of wireless / lite. The relay itself gates on
+    # `_media_server` and HF token presence (see
+    # `_start_central_signaling_relay`); a tray daemon piloting a Reachy
+    # over USB has both, so it should be reachable from anywhere via
+    # central WebRTC just like the wireless image. The producer meta
+    # carries `kind="tray"` (vs `"robot"`) so the mobile listing knows
+    # how to render it.
     daemon = getattr(req.app.state, "daemon", None)
-    if daemon is not None and getattr(daemon, "wireless_version", False):
+    if daemon is not None:
         try:
             relay_result = await daemon.ensure_central_signaling_relay()
             kv_log(
@@ -123,16 +131,15 @@ async def get_token() -> dict[str, Any]:
 
 @router.get("/relay-status")
 async def get_relay_status(request: Request) -> dict[str, Any]:
-    """Get the central signaling relay connection status."""
-    # Check if this is a Lite version (no WebRTC support)
-    daemon = getattr(request.app.state, "daemon", None)
-    if daemon and not daemon.wireless_version:
-        return {
-            "state": "unavailable",
-            "message": "Coming soon to Lite version",
-            "is_connected": False,
-        }
+    """Get the central signaling relay connection status.
 
+    The relay runs on both wireless and lite (tray) daemons - the
+    wireless gate that used to live here predated the central WebRTC
+    consolidation and is no longer accurate. The relay's own state
+    machine is the source of truth (``WAITING_FOR_TOKEN`` if no
+    HF token is stored, ``CONNECTED`` once registered, etc.), so we
+    just delegate.
+    """
     try:
         from reachy_mini.media.central_signaling_relay import get_relay_status
 
@@ -204,7 +211,7 @@ async def refresh_relay(request: Request) -> dict[str, Any]:
         # something useful for the cold-boot recovery case.
         if _csr._relay_instance is None:
             daemon = getattr(request.app.state, "daemon", None)
-            if daemon is not None and getattr(daemon, "wireless_version", False):
+            if daemon is not None:
                 try:
                     await daemon.ensure_central_signaling_relay()
                 except Exception as e:

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -11,15 +11,17 @@ from pydantic import BaseModel
 
 from reachy_mini.apps.sources import hf_auth
 from reachy_mini.daemon.app.logging_ctx import kv_log
+from reachy_mini.media.central_signaling_relay import CENTRAL_SIGNALING_SERVER
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/hf-auth")
 
-# Central signaling server that tracks which robot is currently in use by
-# which remote JS app. We proxy its /api/robot-status endpoint so the
-# desktop frontend never needs to see the raw HF token.
-CENTRAL_ROBOT_STATUS_URL = "https://cduss-reachy-mini-central.hf.space/api/robot-status"
+# We proxy the central /api/robot-status endpoint so the desktop frontend
+# never needs to see the raw HF token. Single source of truth for the
+# central base URL (and its REACHY_CENTRAL_URL override) is the relay
+# module — importing it here keeps the default in lock-step.
+CENTRAL_ROBOT_STATUS_URL = f"{CENTRAL_SIGNALING_SERVER}/api/robot-status"
 CENTRAL_ROBOT_STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 

--- a/src/reachy_mini/daemon/app/routers/wifi_config.py
+++ b/src/reachy_mini/daemon/app/routers/wifi_config.py
@@ -8,6 +8,8 @@ import nmcli
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from reachy_mini.daemon.app.logging_ctx import kv_log
+
 HOTSPOT_SSID = "reachy-mini-ap"
 HOTSPOT_PASSWORD = "reachy-mini"
 
@@ -112,8 +114,10 @@ def connect_to_wifi_network(
 ) -> None:
     """Connect to a WiFi network. It will create a new connection using nmcli if the specified SSID is not already configured."""
     logger.warning(f"Request to connect to WiFi network '{ssid}' received.")
+    kv_log(logger, logging.INFO, "wifi.connect.request", ssid=ssid)
 
     if busy_lock.locked():
+        kv_log(logger, logging.WARNING, "wifi.connect.busy", ssid=ssid)
         raise HTTPException(status_code=409, detail="Another operation is in progress.")
 
     def connect() -> None:
@@ -122,9 +126,17 @@ def connect_to_wifi_network(
             try:
                 error = None
                 setup_wifi_connection(name=ssid, ssid=ssid, password=password)
+                kv_log(logger, logging.INFO, "wifi.connect.success", ssid=ssid)
             except Exception as e:
                 error = e
                 logger.error(f"Failed to connect to WiFi network '{ssid}': {e}")
+                kv_log(
+                    logger,
+                    logging.WARNING,
+                    "wifi.connect.failure",
+                    ssid=ssid,
+                    error=str(e),
+                )
                 logger.info("Reverting to hotspot...")
                 remove_connection(name=ssid)
                 setup_wifi_connection(
@@ -171,6 +183,13 @@ def forget_wifi_network(ssid: str) -> None:
                 was_active = check_if_connection_active(ssid)
                 logger.info(f"Forgetting WiFi network '{ssid}'...")
                 remove_connection(ssid)
+                kv_log(
+                    logger,
+                    logging.INFO,
+                    "wifi.forget.success",
+                    ssid=ssid,
+                    was_active=was_active,
+                )
 
                 if was_active:
                     logger.info("Was connected, falling back to hotspot...")
@@ -183,6 +202,13 @@ def forget_wifi_network(ssid: str) -> None:
             except Exception as e:
                 error = e
                 logger.error(f"Failed to forget network '{ssid}': {e}")
+                kv_log(
+                    logger,
+                    logging.ERROR,
+                    "wifi.forget.failure",
+                    ssid=ssid,
+                    error=str(e),
+                )
 
     Thread(target=forget).start()
 

--- a/src/reachy_mini/daemon/app/routers/wifi_config.py
+++ b/src/reachy_mini/daemon/app/routers/wifi_config.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from reachy_mini.daemon.app.logging_ctx import kv_log
+from reachy_mini.media.central_signaling_relay import notify_withdraw
 
 HOTSPOT_SSID = "reachy-mini-ap"
 HOTSPOT_PASSWORD = "reachy-mini"
@@ -181,6 +182,37 @@ def forget_wifi_network(ssid: str) -> None:
             try:
                 error = None
                 was_active = check_if_connection_active(ssid)
+
+                # Cooperative central withdraw BEFORE wiping the active
+                # connection. While we're still on the WiFi we have
+                # internet and can tell central "drop me from the
+                # producers list" instantly. Without this, central
+                # would hold the now-unreachable producer for up to
+                # ``LEASE_SECONDS + sweeper_interval`` (~55 s) before
+                # the TTL sweeper evicts the zombie. Bounded best-
+                # effort: short timeout so a slow central never
+                # blocks the forget operation.
+                if was_active:
+                    try:
+                        notify_withdraw(timeout=1.0)
+                        kv_log(
+                            logger,
+                            logging.INFO,
+                            "wifi.forget.central_withdraw.ok",
+                            ssid=ssid,
+                        )
+                    except Exception as e:
+                        # Withdraw is opportunistic: if it fails
+                        # (network already wonky, central down) we
+                        # still proceed and rely on TTL eviction.
+                        kv_log(
+                            logger,
+                            logging.WARNING,
+                            "wifi.forget.central_withdraw.failed",
+                            ssid=ssid,
+                            error=str(e),
+                        )
+
                 logger.info(f"Forgetting WiFi network '{ssid}'...")
                 remove_connection(ssid)
                 kv_log(
@@ -226,6 +258,29 @@ def forget_all_wifi_networks() -> None:
                 error = None
                 connections = get_wifi_connections()
                 forgotten = []
+
+                # If any active non-Hotspot connection is about to be
+                # wiped we'll lose internet, so cooperatively withdraw
+                # from central while we still have it. Same rationale
+                # as the single-network ``forget`` path.
+                will_lose_internet = any(
+                    c.name != "Hotspot" and c.device != "--" for c in connections
+                )
+                if will_lose_internet:
+                    try:
+                        notify_withdraw(timeout=1.0)
+                        kv_log(
+                            logger,
+                            logging.INFO,
+                            "wifi.forget_all.central_withdraw.ok",
+                        )
+                    except Exception as e:
+                        kv_log(
+                            logger,
+                            logging.WARNING,
+                            "wifi.forget_all.central_withdraw.failed",
+                            error=str(e),
+                        )
 
                 for conn in connections:
                     if conn.name != "Hotspot":

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -8,6 +8,7 @@ Includes a fixed NoInputNoOutput agent for automatic Just Works pairing.
 import fcntl
 import logging
 import os
+import socket
 import subprocess
 from typing import Callable
 
@@ -118,6 +119,7 @@ class Advertisement(dbus.service.Object):
         self.ad_type = advertising_type
         self.local_name = local_name
         self.service_uuids = None
+        self.manufacturer_data = None
         self.include_tx_power = False
         dbus.service.Object.__init__(self, bus, self.path)
 
@@ -128,6 +130,10 @@ class Advertisement(dbus.service.Object):
             props["LocalName"] = dbus.String(self.local_name)
         if self.service_uuids:
             props["ServiceUUIDs"] = dbus.Array(self.service_uuids, signature="s")
+        if self.manufacturer_data:
+            props["ManufacturerData"] = dbus.Dictionary(
+                self.manufacturer_data, signature="qv"
+            )
         props["Appearance"] = dbus.UInt16(0x0000)
         props["Duration"] = dbus.UInt16(0)
         props["Timeout"] = dbus.UInt16(0)
@@ -300,7 +306,7 @@ class ResponseCharacteristic(Characteristic):
         self.notifying = False
         logger.info("Response notifications disabled")
         # Stop journal streaming if running (client disconnected without JOURNAL_STOP)
-        if hasattr(self.service, '_bt_service') and self.service._bt_service:
+        if hasattr(self.service, "_bt_service") and self.service._bt_service:
             self.service._bt_service._stop_journal()
 
     def send_notification(self, text: str):
@@ -614,7 +620,17 @@ class BluetoothCommandService:
         try:
             self._journal_buffer = ""
             self._journal_proc = subprocess.Popen(
-                ["stdbuf", "-oL", "journalctl", "-f", "-n", "20", "--no-pager", "-u", "reachy-mini-daemon"],
+                [
+                    "stdbuf",
+                    "-oL",
+                    "journalctl",
+                    "-f",
+                    "-n",
+                    "20",
+                    "--no-pager",
+                    "-u",
+                    "reachy-mini-daemon",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
             )
@@ -643,7 +659,9 @@ class BluetoothCommandService:
                 if data:
                     text = data.decode("utf-8", errors="replace")
                     self._journal_buffer += text
-                    logger.info(f"Journal buffered: {len(text)} bytes, total: {len(self._journal_buffer)}")
+                    logger.info(
+                        f"Journal buffered: {len(text)} bytes, total: {len(self._journal_buffer)}"
+                    )
                     # Cap buffer to ~32KB to avoid unbounded growth
                     if len(self._journal_buffer) > 32768:
                         self._journal_buffer = self._journal_buffer[-32768:]
@@ -779,9 +797,9 @@ class BluetoothCommandService:
         # Register advertisement
         ad_manager = dbus.Interface(adapter, LE_ADVERTISING_MANAGER_IFACE)
         self.adv = Advertisement(self.bus, 0, "peripheral", self.device_name)
-        # Only advertise main service UUID to avoid advertisement size limits
-        # All services are still available when connected
         self.adv.service_uuids = [REACHY_STATUS_SERVICE_UUID]
+        self.adv.manufacturer_data = encode_network_ips()
+        self._ad_manager = ad_manager
         ad_manager.RegisterAdvertisement(
             self.adv.get_path(),
             {},
@@ -791,10 +809,34 @@ class BluetoothCommandService:
             ),
         )
 
-        # Setup periodic network status updates (every 10 seconds)
-        GLib.timeout_add_seconds(10, self.app.reachy_status.update_network_status)
+        # Refresh both GATT network characteristic and advertisement payload
+        GLib.timeout_add_seconds(10, self._refresh_network_info)
 
         logger.info(f"✓ Bluetooth service started as '{self.device_name}'")
+
+    def _refresh_network_info(self):
+        """Periodic callback: update GATT characteristic and advertisement."""
+        self.app.reachy_status.update_network_status()
+
+        new_data = encode_network_ips()
+        if new_data != self.adv.manufacturer_data:
+            self.adv.manufacturer_data = new_data
+            try:
+                self._ad_manager.UnregisterAdvertisement(self.adv.get_path())
+                self._ad_manager.RegisterAdvertisement(
+                    self.adv.get_path(),
+                    {},
+                    reply_handler=lambda: logger.info(
+                        "Advertisement re-registered with updated IPs"
+                    ),
+                    error_handler=lambda e: logger.error(
+                        f"Failed to re-register advertisement: {e}"
+                    ),
+                )
+            except dbus.exceptions.DBusException as e:
+                logger.warning(f"Could not refresh advertisement: {e}")
+
+        return True
 
     def _find_adapter(self):
         remote_om = dbus.Interface(
@@ -817,6 +859,49 @@ class BluetoothCommandService:
             logger.info("Shutting down...")
             self._stop_journal()
             self.mainloop.quit()
+
+
+POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
+
+
+def encode_network_ips() -> dict:
+    """Build ManufacturerData payload with all non-loopback IPv4 addresses.
+
+    Format per IP: 1 byte flags | 4 bytes IPv4
+      flags: 0x01 = hotspot, 0x00 = normal
+
+    Returns a dict {manufacturer_id: dbus.Array(bytes)} suitable for
+    BlueZ ManufacturerData property.  Returns empty dict when offline.
+    """
+    status = get_network_status()
+    if status == "OFFLINE" or status == "ERROR":
+        return {}
+
+    payload = bytearray()
+    is_hotspot = status.startswith("HOTSPOT")
+
+    parts = status.split("[")
+    for part in parts[1:]:
+        if "]" not in part:
+            continue
+        iface, rest = part.split("]", 1)
+        ip_str = rest.split(";")[0].strip()
+        try:
+            ip_bytes = socket.inet_aton(ip_str)
+            flag = 0x01 if (is_hotspot and iface.strip() == "wlan0") else 0x00
+            payload.append(flag)
+            payload.extend(ip_bytes)
+        except OSError:
+            continue
+
+    if not payload:
+        return {}
+
+    return {
+        dbus.UInt16(POLLEN_MANUFACTURER_ID): dbus.Array(
+            [dbus.Byte(b) for b in payload], signature="y"
+        )
+    }
 
 
 def get_pin() -> str:

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -40,6 +40,12 @@ REACHY_STATUS_SERVICE_UUID = "12345678-1234-5678-1234-56789abcdef3"
 NETWORK_STATUS_UUID = "12345678-1234-5678-1234-56789abcdef4"
 SYSTEM_STATUS_UUID = "12345678-1234-5678-1234-56789abcdef5"
 AVAILABLE_COMMANDS_UUID = "12345678-1234-5678-1234-56789abcdef6"
+# install_id (UUID4 hex, generated once on first daemon boot). Same value
+# also surfaces via mDNS TXT, the central listing's ``meta``, and
+# ``GET /api/daemon/identity`` - so the mobile robot registry can merge
+# this BLE row with the same robot's other sightings on this stable key.
+INSTALL_ID_UUID = "12345678-1234-5678-1234-56789abcdef7"
+ROBOT_NAME_UUID = "12345678-1234-5678-1234-56789abcdef8"
 
 BLUEZ_SERVICE_NAME = "org.bluez"
 GATT_MANAGER_IFACE = "org.bluez.GattManager1"
@@ -538,6 +544,23 @@ class ReachyStatusService(dbus.service.Object):
             )
         )
 
+        # Identity characteristics (install_id + current robot name).
+        # Resolved lazily through the daemon's local HTTP endpoint so
+        # they keep up with rename + first-boot persistence without us
+        # having to wire a second IPC channel into this DBus-only
+        # service. ``Dynamic`` is fine here: the read frequency is
+        # tiny (once at scan time on the mobile side).
+        self.add_characteristic(
+            DynamicCharacteristic(
+                bus, 3, INSTALL_ID_UUID, self, _get_install_id, "Install ID"
+            )
+        )
+        self.add_characteristic(
+            DynamicCharacteristic(
+                bus, 4, ROBOT_NAME_UUID, self, _get_robot_name, "Robot Name"
+            )
+        )
+
     def update_network_status(self):
         """Update the network status characteristic value."""
         if hasattr(self, "network_char"):
@@ -923,6 +946,62 @@ DAEMON_LOCAL_URL = "http://127.0.0.1:8000"
 WIFI_HTTP_TIMEOUT_S = 4.0
 WIFI_SCAN_HTTP_TIMEOUT_S = 15.0  # nmcli rescan is slow
 WIFI_SCAN_MAX_RESULTS = 12  # keep payload inside a single BLE MTU
+IDENTITY_HTTP_TIMEOUT_S = 1.5  # called from a GATT read; must not block
+
+# Cache so a burst of GATT reads (mobile clients tend to pre-warm
+# every characteristic on connect) doesn't hammer the local daemon.
+# Values are immutable across the daemon's lifetime (install_id
+# definitionally so; robot_name is mutable but a 5s lag during a
+# rename is harmless because the mobile re-fetches via HTTP anyway).
+_identity_cache: dict[str, str | float] = {
+    "install_id": "",
+    "robot_name": "",
+    "ts": 0.0,
+}
+_IDENTITY_CACHE_TTL_S = 5.0
+
+
+def _fetch_identity() -> dict[str, str]:
+    """Return a fresh ``{install_id, robot_name}`` dict from the daemon.
+
+    Falls back to empty strings on any error (daemon down, route 404
+    on a pre-revision-3 daemon, ...). GATT reads must never raise.
+    """
+    import time
+
+    now = time.monotonic()
+    if now - float(_identity_cache.get("ts", 0.0)) < _IDENTITY_CACHE_TTL_S:
+        return {
+            "install_id": str(_identity_cache.get("install_id", "")),
+            "robot_name": str(_identity_cache.get("robot_name", "")),
+        }
+
+    install_id = ""
+    robot_name = ""
+    try:
+        payload = _daemon_request(
+            "GET", "/api/daemon/identity", timeout=IDENTITY_HTTP_TIMEOUT_S
+        )
+        if isinstance(payload, dict):
+            install_id = str(payload.get("install_id") or "")
+            robot_name = str(payload.get("robot_name") or "")
+    except Exception as e:
+        logger.debug(f"identity fetch failed (returning blanks): {e}")
+
+    _identity_cache["install_id"] = install_id
+    _identity_cache["robot_name"] = robot_name
+    _identity_cache["ts"] = now
+    return {"install_id": install_id, "robot_name": robot_name}
+
+
+def _get_install_id() -> str:
+    """GATT getter: return the install_id as a UTF-8 string (or "")."""
+    return _fetch_identity()["install_id"]
+
+
+def _get_robot_name() -> str:
+    """GATT getter: return the human-readable robot_name as UTF-8 (or "")."""
+    return _fetch_identity()["robot_name"]
 
 
 def _daemon_request(

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -6,9 +6,13 @@ Includes a fixed NoInputNoOutput agent for automatic Just Works pairing.
 # mypy: ignore-errors
 
 import fcntl
+import json
 import logging
 import os
 import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
 from typing import Callable
 
 import dbus
@@ -276,7 +280,7 @@ class CommandCharacteristic(Characteristic):
             dbus.Byte(b) for b in response.encode("utf-8")
         ]
         cmd_str = command_bytes.decode("utf-8", errors="replace").strip()
-        if cmd_str.upper() != "JOURNAL_READ":
+        if cmd_str.upper() not in ("JOURNAL_READ", "WIFI_STATUS"):
             logger.info(f"Command received: {response}")
 
 
@@ -300,7 +304,7 @@ class ResponseCharacteristic(Characteristic):
         self.notifying = False
         logger.info("Response notifications disabled")
         # Stop journal streaming if running (client disconnected without JOURNAL_STOP)
-        if hasattr(self.service, '_bt_service') and self.service._bt_service:
+        if hasattr(self.service, "_bt_service") and self.service._bt_service:
             self.service._bt_service._stop_journal()
 
     def send_notification(self, text: str):
@@ -614,7 +618,17 @@ class BluetoothCommandService:
         try:
             self._journal_buffer = ""
             self._journal_proc = subprocess.Popen(
-                ["stdbuf", "-oL", "journalctl", "-f", "-n", "20", "--no-pager", "-u", "reachy-mini-daemon"],
+                [
+                    "stdbuf",
+                    "-oL",
+                    "journalctl",
+                    "-f",
+                    "-n",
+                    "20",
+                    "--no-pager",
+                    "-u",
+                    "reachy-mini-daemon",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
             )
@@ -643,7 +657,9 @@ class BluetoothCommandService:
                 if data:
                     text = data.decode("utf-8", errors="replace")
                     self._journal_buffer += text
-                    logger.info(f"Journal buffered: {len(text)} bytes, total: {len(self._journal_buffer)}")
+                    logger.info(
+                        f"Journal buffered: {len(text)} bytes, total: {len(self._journal_buffer)}"
+                    )
                     # Cap buffer to ~32KB to avoid unbounded growth
                     if len(self._journal_buffer) > 32768:
                         self._journal_buffer = self._journal_buffer[-32768:]
@@ -686,12 +702,14 @@ class BluetoothCommandService:
 
     def _handle_command(self, value: bytes) -> str:
         command_str = value.decode("utf-8").strip()
-        if command_str.upper() != "JOURNAL_READ":
+        upper = command_str.upper()
+        # WIFI_STATUS and JOURNAL_READ are polled by clients; don't spam logs.
+        if upper not in ("JOURNAL_READ", "WIFI_STATUS"):
             logger.info(f"Received command: {command_str}")
         # Custom command handling
-        if command_str.upper() == "PING":
+        if upper == "PING":
             return "PONG"
-        elif command_str.upper() == "STATUS":
+        elif upper == "STATUS":
             # exec a "sudo ls" command and print the result
             try:
                 result = subprocess.run(["sudo", "ls"], capture_output=True, text=True)
@@ -699,11 +717,11 @@ class BluetoothCommandService:
             except Exception as e:
                 logger.error(f"Error executing command: {e}")
             return "OK: System running"
-        elif command_str.upper() == "JOURNAL_START":
+        elif upper == "JOURNAL_START":
             return self._start_journal()
-        elif command_str.upper() == "JOURNAL_READ":
+        elif upper == "JOURNAL_READ":
             return self._read_journal()
-        elif command_str.upper() == "JOURNAL_STOP":
+        elif upper == "JOURNAL_STOP":
             self._stop_journal()
             return "OK: Journal streaming stopped"
         elif command_str.startswith("PIN_"):
@@ -713,6 +731,27 @@ class BluetoothCommandService:
                 return "OK: Connected"
             else:
                 return "ERROR: Incorrect PIN"
+
+        # WiFi provisioning commands. WIFI_STATUS is public (read-only snapshot);
+        # mutating commands require prior PIN authentication. Unlike CMD_*, we do
+        # NOT reset `self.connected` afterwards so a client can chain
+        # scan -> connect -> poll status in a single provisioning session.
+        elif upper == "WIFI_STATUS":
+            return _wifi_status()
+        elif upper == "WIFI_SCAN":
+            if not self.connected:
+                return "ERROR: Not connected. Please authenticate first."
+            return _wifi_scan()
+        elif upper.startswith("WIFI_CONNECT "):
+            if not self.connected:
+                return "ERROR: Not connected. Please authenticate first."
+            payload = command_str[len("WIFI_CONNECT ") :]
+            return _wifi_connect(payload)
+        elif upper.startswith("WIFI_FORGET "):
+            if not self.connected:
+                return "ERROR: Not connected. Please authenticate first."
+            ssid = command_str[len("WIFI_FORGET ") :]
+            return _wifi_forget(ssid)
 
         # else if command starts with "CMD_xxxxx" check if  commands directory contains the said named script command xxxx.sh and run its, show output or/and send to read
         elif command_str.startswith("CMD_"):
@@ -817,6 +856,174 @@ class BluetoothCommandService:
             logger.info("Shutting down...")
             self._stop_journal()
             self.mainloop.quit()
+
+
+# =======================
+# WiFi provisioning over BLE
+# =======================
+# The Bluetooth service runs as its own systemd unit, separate from the FastAPI
+# daemon. For WiFi provisioning we simply proxy BLE commands over localhost HTTP
+# to the daemon's existing `/wifi/*` routes. This keeps the logic DRY (no
+# duplicated `nmcli` plumbing) and reuses the daemon's `busy_lock`, threading
+# and hotspot-fallback behavior.
+#
+# We stick to the Python stdlib (`urllib`) on purpose: the BT service uses the
+# system Python, not the daemon's venv, so we can't assume `requests` is
+# installed.
+
+DAEMON_LOCAL_URL = "http://127.0.0.1:8000"
+WIFI_HTTP_TIMEOUT_S = 4.0
+WIFI_SCAN_HTTP_TIMEOUT_S = 15.0  # nmcli rescan is slow
+WIFI_SCAN_MAX_RESULTS = 12  # keep payload inside a single BLE MTU
+
+
+def _daemon_request(
+    method: str,
+    path: str,
+    params: dict[str, str] | None = None,
+    timeout: float = WIFI_HTTP_TIMEOUT_S,
+):
+    """Perform a local HTTP request against the daemon and return parsed JSON (or None)."""
+    url = DAEMON_LOCAL_URL + path
+    if params:
+        url = url + "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read()
+        if not body:
+            return None
+        try:
+            return json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            return body.decode("utf-8", errors="replace")
+
+
+def _wifi_status() -> str:
+    """Return the current WiFi state as compact JSON suitable for a BLE read.
+
+    Shape: {"mode": str, "connected": str|null, "known": [str], "error": str|null}
+    """
+    try:
+        status = _daemon_request("GET", "/wifi/status") or {}
+        error_payload = _daemon_request("GET", "/wifi/error") or {}
+        compact = {
+            "mode": status.get("mode"),
+            "connected": status.get("connected_network"),
+            "known": status.get("known_networks", []),
+            "error": error_payload.get("error"),
+        }
+        return json.dumps(compact, separators=(",", ":"), ensure_ascii=False)
+    except urllib.error.URLError as e:
+        logger.warning(f"wifi_status: daemon unreachable: {e}")
+        return json.dumps(
+            {
+                "mode": None,
+                "connected": None,
+                "known": [],
+                "error": "daemon_unreachable",
+            },
+            separators=(",", ":"),
+        )
+    except Exception as e:
+        logger.exception("wifi_status failed")
+        return json.dumps(
+            {"mode": None, "connected": None, "known": [], "error": str(e)},
+            separators=(",", ":"),
+        )
+
+
+def _wifi_scan() -> str:
+    """Scan for nearby SSIDs. Returns a JSON array (top N) or an `ERROR:` string."""
+    try:
+        ssids = _daemon_request(
+            "POST", "/wifi/scan_and_list", timeout=WIFI_SCAN_HTTP_TIMEOUT_S
+        )
+        if not isinstance(ssids, list):
+            return json.dumps([])
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for s in ssids:
+            if isinstance(s, str) and s and s not in seen:
+                seen.add(s)
+                cleaned.append(s)
+                if len(cleaned) >= WIFI_SCAN_MAX_RESULTS:
+                    break
+        return json.dumps(cleaned, separators=(",", ":"), ensure_ascii=False)
+    except urllib.error.HTTPError as e:
+        if e.code == 409:
+            return "ERROR: Busy"
+        logger.warning(f"wifi_scan HTTP error: {e}")
+        return "ERROR: Scan failed"
+    except urllib.error.URLError as e:
+        logger.warning(f"wifi_scan: daemon unreachable: {e}")
+        return "ERROR: Daemon unreachable"
+    except Exception as e:
+        logger.exception("wifi_scan failed")
+        return f"ERROR: {e}"
+
+
+def _wifi_connect(payload: str) -> str:
+    """Kick off a connect attempt. `payload` is a JSON string: {"ssid": "...", "psk": "..."}.
+
+    Returns immediately (the daemon runs the actual `nmcli` work on a thread).
+    Clients should poll `WIFI_STATUS` to observe the outcome.
+    """
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return "ERROR: Invalid payload (expected JSON)"
+
+    ssid = data.get("ssid")
+    psk = data.get("psk") or data.get("password") or ""
+    if not isinstance(ssid, str) or not ssid:
+        return "ERROR: Missing ssid"
+    if not isinstance(psk, str):
+        return "ERROR: Invalid psk"
+
+    try:
+        # Clear any stale error so the client can observe THIS attempt via /wifi/error.
+        try:
+            _daemon_request("POST", "/wifi/reset_error")
+        except Exception:
+            pass  # non-fatal
+        _daemon_request("POST", "/wifi/connect", params={"ssid": ssid, "password": psk})
+        return f"OK: Connecting to {ssid}"
+    except urllib.error.HTTPError as e:
+        if e.code == 409:
+            return "ERROR: Busy"
+        logger.warning(f"wifi_connect HTTP error: {e}")
+        return "ERROR: Connect request failed"
+    except urllib.error.URLError as e:
+        logger.warning(f"wifi_connect: daemon unreachable: {e}")
+        return "ERROR: Daemon unreachable"
+    except Exception as e:
+        logger.exception("wifi_connect failed")
+        return f"ERROR: {e}"
+
+
+def _wifi_forget(ssid: str) -> str:
+    """Forget a saved WiFi network. Falls back to hotspot server-side if needed."""
+    ssid = ssid.strip()
+    if not ssid:
+        return "ERROR: Missing ssid"
+    try:
+        _daemon_request("POST", "/wifi/forget", params={"ssid": ssid})
+        return f"OK: Forgotten {ssid}"
+    except urllib.error.HTTPError as e:
+        if e.code == 400:
+            return "ERROR: Cannot forget hotspot"
+        if e.code == 404:
+            return "ERROR: Unknown ssid"
+        if e.code == 409:
+            return "ERROR: Busy"
+        logger.warning(f"wifi_forget HTTP error: {e}")
+        return "ERROR: Forget failed"
+    except urllib.error.URLError as e:
+        logger.warning(f"wifi_forget: daemon unreachable: {e}")
+        return "ERROR: Daemon unreachable"
+    except Exception as e:
+        logger.exception("wifi_forget failed")
+        return f"ERROR: {e}"
 
 
 def get_pin() -> str:

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -124,17 +124,25 @@ class Advertisement(dbus.service.Object):
         dbus.service.Object.__init__(self, bus, self.path)
 
     def get_properties(self):
-        """Return the properties of the advertisement."""
+        """Return the properties of the advertisement.
+
+        Note on payload size: legacy BLE advertisements are capped at
+        31 bytes total. We deliberately omit ``ServiceUUIDs`` from the
+        primary advertisement and rely on ``LocalName`` matching on
+        the client side: a 128-bit UUID alone eats 18 bytes, which
+        leaves no room for the ManufacturerData IPv4 payload (5 bytes
+        per address). The full GATT service tree is still discoverable
+        once the client connects, so this is purely an advertising-time
+        size optimisation. ``Appearance=0x0000`` ("Unknown") is also
+        skipped because it is uninformative and adds 4 bytes.
+        """
         props = {"Type": self.ad_type}
         if self.local_name:
             props["LocalName"] = dbus.String(self.local_name)
-        if self.service_uuids:
-            props["ServiceUUIDs"] = dbus.Array(self.service_uuids, signature="s")
         if self.manufacturer_data:
             props["ManufacturerData"] = dbus.Dictionary(
                 self.manufacturer_data, signature="qv"
             )
-        props["Appearance"] = dbus.UInt16(0x0000)
         props["Duration"] = dbus.UInt16(0)
         props["Timeout"] = dbus.UInt16(0)
         return {LE_ADVERTISEMENT_IFACE: props}
@@ -864,14 +872,26 @@ class BluetoothCommandService:
 POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
 
 
+# Hard cap on the number of IP addresses we cram into the BLE advert.
+# Each address eats 5 bytes (1 flag + 4 IPv4), and the legacy adv slot
+# is limited to 31 bytes total (~16 already used by flags + LocalName),
+# so 2 addresses is the safe maximum before HCI rejects the payload.
+_MAX_ADVERTISED_IPS = 2
+
+
 def encode_network_ips() -> dict:
-    """Build ManufacturerData payload with all non-loopback IPv4 addresses.
+    """Build a ManufacturerData payload with at most two IPv4 addresses.
 
     Format per IP: 1 byte flags | 4 bytes IPv4
       flags: 0x01 = hotspot, 0x00 = normal
 
     Returns a dict {manufacturer_id: dbus.Array(bytes)} suitable for
-    BlueZ ManufacturerData property.  Returns empty dict when offline.
+    BlueZ ManufacturerData property. Returns empty dict when offline.
+
+    The cap exists because the overall advert has to fit in 31 bytes
+    (see :class:`Advertisement.get_properties`). Mobile clients that
+    need more than two interfaces can still query the GATT
+    NETWORK_STATUS characteristic once connected.
     """
     status = get_network_status()
     if status == "OFFLINE" or status == "ERROR":
@@ -881,7 +901,10 @@ def encode_network_ips() -> dict:
     is_hotspot = status.startswith("HOTSPOT")
 
     parts = status.split("[")
+    encoded = 0
     for part in parts[1:]:
+        if encoded >= _MAX_ADVERTISED_IPS:
+            break
         if "]" not in part:
             continue
         iface, rest = part.split("]", 1)
@@ -891,6 +914,7 @@ def encode_network_ips() -> dict:
             flag = 0x01 if (is_hotspot and iface.strip() == "wlan0") else 0x00
             payload.append(flag)
             payload.extend(ip_bytes)
+            encoded += 1
         except OSError:
             continue
 

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -5,10 +5,12 @@ Includes a fixed NoInputNoOutput agent for automatic Just Works pairing.
 """
 # mypy: ignore-errors
 
+import concurrent.futures
 import fcntl
 import json
 import logging
 import os
+import socket
 import subprocess
 import urllib.error
 import urllib.parse
@@ -768,12 +770,15 @@ class BluetoothCommandService:
             else:
                 return "ERROR: Incorrect PIN"
 
-        # WiFi provisioning commands. WIFI_STATUS is public (read-only snapshot);
-        # mutating commands require prior PIN authentication. Unlike CMD_*, we do
-        # NOT reset `self.connected` afterwards so a client can chain
-        # scan -> connect -> poll status in a single provisioning session.
+        # WiFi provisioning commands. WIFI_STATUS and WIFI_PROBE are public
+        # (read-only snapshots); mutating commands require prior PIN
+        # authentication. Unlike CMD_*, we do NOT reset `self.connected`
+        # afterwards so a client can chain scan -> connect -> poll status in a
+        # single provisioning session.
         elif upper == "WIFI_STATUS":
             return _wifi_status()
+        elif upper == "WIFI_PROBE":
+            return _wifi_probe()
         elif upper == "WIFI_SCAN":
             if not self.connected:
                 return "ERROR: Not connected. Please authenticate first."
@@ -865,6 +870,7 @@ class BluetoothCommandService:
         self.adv.manufacturer_data = encode_advert_manufacturer_data(
             identity.get("install_id", ""),
             identity.get("central_peer_id", ""),
+            _current_network_mode_byte(),
         )
         self._ad_manager = ad_manager
         ad_manager.RegisterAdvertisement(
@@ -884,13 +890,19 @@ class BluetoothCommandService:
     def _refresh_network_info(self):
         """Periodic callback: update GATT characteristic and advertisement.
 
-        Re-publishes the BLE advert when either of the install_id /
-        central_peer_id TLV payloads changes. install_id is stable
-        for the daemon's lifetime (the very first ticks may run before
-        ``/api/daemon/identity`` is reachable, hence the upgrade),
-        whereas central_peer_id is volatile - it rotates on every
-        relay reconnect, so this tick is also the cadence at which
-        mobile scanners will see the new peerId.
+        Re-publishes the BLE advert when any of the three TLV
+        payloads changes:
+
+          - install_id (stable; the very first ticks may run before
+            ``/api/daemon/identity`` is reachable, hence the upgrade)
+          - central_peer_id (volatile; rotates on every relay
+            reconnect - this tick is the cadence at which mobile
+            scanners see the new peerId)
+          - network_mode (dynamic; flips between OFFLINE / HOTSPOT /
+            CONNECTED as the user joins a Wi-Fi or the daemon falls
+            back to its own AP). The 10s tick is fast enough that a
+            mobile scanner sees the transition before the user gives
+            up retrying.
         """
         self.app.reachy_status.update_network_status()
 
@@ -898,6 +910,7 @@ class BluetoothCommandService:
         new_data = encode_advert_manufacturer_data(
             identity.get("install_id", ""),
             identity.get("central_peer_id", ""),
+            _current_network_mode_byte(),
         )
         if new_data != self.adv.manufacturer_data:
             self.adv.manufacturer_data = new_data
@@ -962,6 +975,21 @@ POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
 #         BLE row vs the central listing while the central server
 #         does not yet propagate ``meta.install_id``. Absent when the
 #         relay is offline / the daemon has no token.
+#   0x03  network_mode : len=1 byte enum.
+#           0x00 = OFFLINE   - no usable IP on any interface.
+#           0x01 = HOTSPOT   - daemon is broadcasting its own AP
+#                              (wlan0 == 10.42.0.1).
+#           0x02 = CONNECTED - daemon has a real LAN/WAN IP (Wi-Fi
+#                              joined OR USB-tether interface up).
+#         Reads off ``ip -4 addr`` directly, so it reflects the
+#         daemon's *local* network state - independent of whether
+#         HF central / Internet are reachable. Mobile clients use
+#         this to render an authoritative "Setup pending" badge
+#         without false positives caused by transient relay flaps
+#         (cf. tag 0x02 which depends on 6+ conditions and flickers
+#         when central is unstable). Always emitted - we send 0x00
+#         OFFLINE on subprocess failure rather than dropping the
+#         TLV, so absence = "old daemon, no support".
 #
 # We deliberately drop the legacy IPv4 list from the advert: the
 # 31-byte legacy advertising payload is essentially full once
@@ -971,8 +999,14 @@ POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
 ADVERT_FORMAT_VERSION = 0x02
 ADVERT_TLV_INSTALL_ID = 0x01
 ADVERT_TLV_CENTRAL_PEER_ID = 0x02
+ADVERT_TLV_NETWORK_MODE = 0x03
 ADVERT_INSTALL_ID_PREFIX_BYTES = 8
 ADVERT_CENTRAL_PEER_ID_PREFIX_BYTES = 8
+
+# 1-byte enum values for ADVERT_TLV_NETWORK_MODE.
+ADVERT_NETWORK_MODE_OFFLINE = 0x00
+ADVERT_NETWORK_MODE_HOTSPOT = 0x01
+ADVERT_NETWORK_MODE_CONNECTED = 0x02
 
 
 # =======================
@@ -1210,6 +1244,198 @@ def _wifi_forget(ssid: str) -> str:
         return f"ERROR: {e}"
 
 
+# =======================
+# WiFi reachability probe
+# =======================
+#
+# Runs entirely from the robot's point of view. The mobile app calls
+# this once after ``WIFI_STATUS`` reports ``mode=wlan`` so it can tell
+# the user *why* the robot is or is not actually online (vs. just
+# blindly polling /api/daemon/status from the phone, which only works
+# if the phone happens to share the WiFi).
+#
+# Hard rule: NO TLS in any of these probes. The Pi has no RTC; on a
+# fresh boot it can sit at 1970-01-01 until ``systemd-timesyncd``
+# catches up via the freshly-joined network. An HTTPS check would
+# spuriously fail certificate validation in that window and lie to the
+# user about being offline. Plain TCP / plain DNS sidesteps that
+# entirely - we only care that packets reach the right places, not
+# that the cert chain is healthy.
+#
+# Each individual probe is bounded by a short timeout, all four run in
+# parallel, and the whole call returns within
+# ``_PROBE_TOTAL_TIMEOUT_S`` so the BT command loop never stalls.
+
+# 1.1.1.1 (Cloudflare) and one.one.one.one are deliberately chosen:
+#  - hostnames are short, ASCII, and resolve fast
+#  - both AS13335 endpoints have global anycast PoPs (low jitter)
+#  - 443/tcp is the most common port that's *not* MITM'd by guest WiFi
+_PROBE_DNS_HOST = "one.one.one.one"
+_PROBE_INTERNET_HOST = "1.1.1.1"
+_PROBE_INTERNET_PORT = 443
+_PROBE_DNS_TIMEOUT_S = 1.5
+_PROBE_TCP_TIMEOUT_S = 1.5
+_PROBE_DAEMON_TIMEOUT_S = 1.0
+# Total budget for the whole WIFI_PROBE call. With 4 parallel checks
+# capped at 1.5s each, 2.5s is plenty of slack.
+_PROBE_TOTAL_TIMEOUT_S = 2.5
+
+
+def _probe_default_gateway_ip() -> str | None:
+    """Return the IPv4 default gateway from ``/proc/net/route``, if any.
+
+    Pure /proc parsing - no external command, no DNS, no network call.
+    Returns ``None`` when there's no default route (= robot has no LAN
+    yet, even if it has a link-local IP).
+    """
+    try:
+        with open("/proc/net/route", "r", encoding="ascii") as f:
+            next(f, None)  # skip header
+            for line in f:
+                fields = line.split()
+                if len(fields) < 11:
+                    continue
+                # /proc/net/route uses little-endian hex for IPs
+                # Default route has Destination=00000000 and a Gateway field
+                if fields[1] != "00000000":
+                    continue
+                gw_hex = fields[2]
+                if gw_hex == "00000000":
+                    continue
+                octets = [int(gw_hex[i : i + 2], 16) for i in (6, 4, 2, 0)]
+                return ".".join(str(o) for o in octets)
+    except Exception as e:
+        logger.debug(f"_probe_default_gateway_ip failed: {e}")
+    return None
+
+
+def _probe_check_gateway() -> str:
+    """Return ``"ok"`` if a TCP SYN reaches the default gateway.
+
+    Uses port 53 (DNS) by convention - most home routers run a DNS
+    resolver, and if they don't, the TCP RST itself counts as
+    reachability proof (we'd see ConnectionRefusedError, not timeout).
+    """
+    gw = _probe_default_gateway_ip()
+    if not gw:
+        return "fail"
+    try:
+        with socket.create_connection((gw, 53), timeout=_PROBE_TCP_TIMEOUT_S):
+            return "ok"
+    except ConnectionRefusedError:
+        # The router answered with TCP RST - it's reachable, just not
+        # listening on :53. Counts as a healthy LAN gateway for our
+        # purposes.
+        return "ok"
+    except (TimeoutError, socket.timeout, OSError):
+        return "fail"
+
+
+def _probe_check_dns() -> str:
+    """Return ``"ok"`` if a public hostname resolves via the system resolver."""
+    socket.setdefaulttimeout(_PROBE_DNS_TIMEOUT_S)
+    try:
+        socket.gethostbyname(_PROBE_DNS_HOST)
+        return "ok"
+    except (socket.gaierror, socket.timeout, OSError):
+        return "fail"
+    finally:
+        socket.setdefaulttimeout(None)
+
+
+def _probe_check_internet() -> str:
+    """Return ``"ok"`` if a TCP SYN reaches a public anycast endpoint.
+
+    Plain TCP, no TLS - tolerant to a missing system clock.
+    """
+    try:
+        with socket.create_connection(
+            (_PROBE_INTERNET_HOST, _PROBE_INTERNET_PORT),
+            timeout=_PROBE_TCP_TIMEOUT_S,
+        ):
+            return "ok"
+    except (TimeoutError, socket.timeout, OSError):
+        return "fail"
+
+
+def _probe_check_daemon() -> str:
+    """Return ``"ok"``, ``"loading"`` or ``"fail"`` based on the daemon's status.
+
+    The mobile app uses this to wait gracefully when a fresh-booted
+    robot has joined WiFi *before* the daemon's backend has finished
+    loading - so we don't sling the user into a conversation that
+    immediately 503s.
+    """
+    try:
+        payload = _daemon_request(
+            "GET", "/api/daemon/status", timeout=_PROBE_DAEMON_TIMEOUT_S
+        )
+    except urllib.error.HTTPError as e:
+        if e.code in (502, 503):
+            return "loading"
+        return "fail"
+    except (urllib.error.URLError, TimeoutError, socket.timeout, OSError):
+        return "fail"
+    except Exception:
+        return "fail"
+
+    if not isinstance(payload, dict):
+        return "fail"
+
+    # The daemon exposes a `state` field that flips through
+    # ``starting`` -> ``loading`` -> ``running``. Anything other than
+    # ``running`` is "loading" from the client's POV.
+    state = str(payload.get("state", "")).lower()
+    if state in ("running", "ready", "ok"):
+        return "ok"
+    if state in ("starting", "loading", "booting", "initializing"):
+        return "loading"
+    # Unknown state shape (older daemons): if we got a 200 with a JSON
+    # body, treat the daemon as up.
+    return "ok"
+
+
+def _wifi_probe() -> str:
+    """Diagnose end-to-end reachability from the robot's POV.
+
+    Returns a JSON string (single BLE write fits in default MTU):
+
+        {"wlan":"ok","gateway":"ok","dns":"ok","internet":"ok","daemon":"ok"}
+
+    All four network checks run in parallel and are bounded by
+    ``_PROBE_TOTAL_TIMEOUT_S`` so the BT command loop never stalls.
+    """
+    # WLAN status comes from the same helper used for the BLE TLV 0x03
+    # network_mode byte - keep them aligned.
+    mode_byte = _current_network_mode_byte()
+    if mode_byte == ADVERT_NETWORK_MODE_CONNECTED:
+        wlan = "ok"
+    elif mode_byte == ADVERT_NETWORK_MODE_HOTSPOT:
+        wlan = "hotspot"
+    else:
+        wlan = "fail"
+
+    result: dict[str, str] = {"wlan": wlan}
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
+        futures = {
+            "gateway": ex.submit(_probe_check_gateway),
+            "dns": ex.submit(_probe_check_dns),
+            "internet": ex.submit(_probe_check_internet),
+            "daemon": ex.submit(_probe_check_daemon),
+        }
+        for name, fut in futures.items():
+            try:
+                result[name] = fut.result(timeout=_PROBE_TOTAL_TIMEOUT_S)
+            except concurrent.futures.TimeoutError:
+                result[name] = "fail"
+            except Exception as e:
+                logger.debug(f"_wifi_probe[{name}] failed: {e}")
+                result[name] = "fail"
+
+    return json.dumps(result, separators=(",", ":"))
+
+
 def _hex_id_prefix_bytes(value: str, prefix_bytes: int) -> bytes:
     """Decode the first ``prefix_bytes`` of a hex string ``value``.
 
@@ -1251,22 +1477,92 @@ def _central_peer_id_prefix_bytes(central_peer_id: str) -> bytes:
     return _hex_id_prefix_bytes(central_peer_id, ADVERT_CENTRAL_PEER_ID_PREFIX_BYTES)
 
 
-def encode_advert_manufacturer_data(install_id: str, central_peer_id: str = "") -> dict:
+def _current_network_mode_byte() -> int | None:
+    """Derive the BLE TLV 0x03 byte from the local network state.
+
+    Reads ``ip -4 addr show`` once, classifies the wlan0 IP literal
+    against the well-known hotspot range (``10.42.0.1``) and returns:
+
+        - ``0x02 CONNECTED`` if any real interface has an IP that
+          isn't the hotspot literal,
+        - ``0x01 HOTSPOT``   if wlan0 holds the hotspot fallback
+          address (and no other real interface is up),
+        - ``0x00 OFFLINE``   if no IPv4 is configured anywhere.
+
+    Returns ``None`` only if the subprocess itself fails (rare); the
+    caller then drops the TLV rather than emitting a misleading
+    OFFLINE byte that could confuse mobile clients during boot.
+    """
+    try:
+        result = subprocess.run(
+            ["ip", "-4", "addr", "show"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+    except Exception as e:
+        logger.debug(f"_current_network_mode_byte: subprocess failed: {e}")
+        return None
+
+    interfaces: dict[str, str] = {}
+    current_iface = None
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line and not line.startswith("inet"):
+            parts = line.split(":")
+            if len(parts) >= 2 and parts[1].strip():
+                iface = parts[1].strip()
+                if iface != "lo":
+                    current_iface = iface
+        elif line.startswith("inet ") and current_iface:
+            inet_parts = line.split()
+            if len(inet_parts) >= 2:
+                ip_with_mask = inet_parts[1]
+                ip_addr = ip_with_mask.split("/")[0]
+                interfaces[current_iface] = ip_addr
+
+    if not interfaces:
+        return ADVERT_NETWORK_MODE_OFFLINE
+
+    # Connected if ANY interface holds a non-hotspot IP. Wired
+    # tether (usb0, eth0, ...) counts as connected even when wlan0
+    # is in hotspot fallback - the robot can still talk to central
+    # via the tether, and the user has nothing to set up Wi-Fi-wise.
+    has_connected_iface = any(
+        not ip.startswith("10.42.0.1") for ip in interfaces.values()
+    )
+    if has_connected_iface:
+        return ADVERT_NETWORK_MODE_CONNECTED
+
+    # All interfaces are on the hotspot literal ⇒ daemon is in setup
+    # mode (broadcasting its own AP).
+    return ADVERT_NETWORK_MODE_HOTSPOT
+
+
+def encode_advert_manufacturer_data(
+    install_id: str,
+    central_peer_id: str = "",
+    network_mode: int | None = None,
+) -> dict:
     """Build the BLE advertisement ``ManufacturerData`` payload.
 
     Returns a ``{manufacturer_id: dbus.Array[byte]}`` dict suitable
     for the BlueZ ``ManufacturerData`` advertisement property, with a
-    versioned TLV stream carrying the daemon's install_id prefix and
-    (when available) its central peerId prefix. See the ``ADVERT_*``
-    constants at the top of this module for the on-wire layout.
+    versioned TLV stream carrying the daemon's install_id prefix,
+    (when available) its central peerId prefix, and (when known) a
+    1-byte network_mode descriptor. See the ``ADVERT_*`` constants
+    at the top of this module for the on-wire layout.
 
-    Returns an empty dict when neither id is available yet so the
-    advert just goes out without a ManufacturerData section (rather
-    than a malformed one).
+    ``network_mode`` should be one of ``ADVERT_NETWORK_MODE_*`` or
+    ``None`` (TLV omitted - signals "old daemon" to mobile clients).
+
+    Returns an empty dict when no payload at all is available yet so
+    the advert just goes out without a ManufacturerData section
+    (rather than a malformed one).
     """
     install_prefix = _install_id_prefix_bytes(install_id)
     cp_prefix = _central_peer_id_prefix_bytes(central_peer_id)
-    if not install_prefix and not cp_prefix:
+    if not install_prefix and not cp_prefix and network_mode is None:
         return {}
 
     payload = bytearray()
@@ -1279,6 +1575,10 @@ def encode_advert_manufacturer_data(install_id: str, central_peer_id: str = "") 
         payload.append(ADVERT_TLV_CENTRAL_PEER_ID)
         payload.append(len(cp_prefix))
         payload.extend(cp_prefix)
+    if network_mode is not None:
+        payload.append(ADVERT_TLV_NETWORK_MODE)
+        payload.append(1)
+        payload.append(network_mode & 0xFF)
 
     return {
         dbus.UInt16(POLLEN_MANUFACTURER_ID): dbus.Array(

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 """Bluetooth service for Reachy Mini using direct DBus API.
 
-Includes a fixed NoInputNoOutput agent for automatic Just Works pairing.
+Pairing/bonding is intentionally DISABLED at the adapter level: every
+GATT characteristic exposed by this service is unencrypted on purpose
+(commands, responses, install_id, network status are all public-by-
+design). Without pairing the iOS / Android stacks no longer prompt
+the user with a "Pair this accessory?" dialog when the mobile app
+opens a BLE connection. A NoInputNoOutput Just Works agent class is
+kept in this file for reference but is not registered with BlueZ.
 """
 # mypy: ignore-errors
 
@@ -824,14 +830,17 @@ class BluetoothCommandService:
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
         self.bus = dbus.SystemBus()
 
-        # BLE Agent registration
-        agent_manager = dbus.Interface(
-            self.bus.get_object("org.bluez", "/org/bluez"), "org.bluez.AgentManager1"
-        )
-        self.agent = NoInputAgent(self.bus, AGENT_PATH)
-        agent_manager.RegisterAgent(AGENT_PATH, "NoInputNoOutput")
-        agent_manager.RequestDefaultAgent(AGENT_PATH)
-        logger.info("BLE Agent registered for Just Works pairing")
+        # No BLE Agent / no pairing. All GATT characteristics are
+        # unencrypted (see the SERVICE_UUID definitions above and the
+        # ["read"|"write"|"notify"] flags on each Characteristic), so
+        # there is no security benefit in bonding. Skipping the agent
+        # registration prevents BlueZ from advertising itself as
+        # pairable, which in turn stops iOS / Android from prompting
+        # the user with a "Pair this accessory?" dialog the first time
+        # the mobile app connects. The NoInputAgent class above is
+        # kept for reference in case we ever want to re-enable Just
+        # Works bonding (e.g. for a future encrypted-write characteristic).
+        self.agent = None
 
         # Find adapter
         adapter = self._find_adapter()
@@ -842,7 +851,10 @@ class BluetoothCommandService:
         adapter_props.Set("org.bluez.Adapter1", "Powered", dbus.Boolean(True))
         adapter_props.Set("org.bluez.Adapter1", "Discoverable", dbus.Boolean(True))
         adapter_props.Set("org.bluez.Adapter1", "DiscoverableTimeout", dbus.UInt32(0))
-        adapter_props.Set("org.bluez.Adapter1", "Pairable", dbus.Boolean(True))
+        # Pairable=False so any incoming SMP pairing request is
+        # rejected by BlueZ before it ever reaches the mobile OS UI.
+        # See the module docstring for the rationale.
+        adapter_props.Set("org.bluez.Adapter1", "Pairable", dbus.Boolean(False))
 
         # Register GATT application
         service_manager = dbus.Interface(adapter, GATT_MANAGER_IFACE)

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -9,7 +9,6 @@ import fcntl
 import json
 import logging
 import os
-import socket
 import subprocess
 import urllib.error
 import urllib.parse
@@ -856,7 +855,17 @@ class BluetoothCommandService:
         ad_manager = dbus.Interface(adapter, LE_ADVERTISING_MANAGER_IFACE)
         self.adv = Advertisement(self.bus, 0, "peripheral", self.device_name)
         self.adv.service_uuids = [REACHY_STATUS_SERVICE_UUID]
-        self.adv.manufacturer_data = encode_network_ips()
+        # Pull install_id + central_peer_id once at boot through the
+        # identity endpoint that the GATT install_id characteristic
+        # also reads. The advertis re-published on every refresh tick (see
+        # :meth:`_refresh_network_info`) so a daemon that boots before
+        # ``/api/daemon/identity`` is reachable still ends up with the
+        # correct payload.
+        identity = _fetch_identity()
+        self.adv.manufacturer_data = encode_advert_manufacturer_data(
+            identity.get("install_id", ""),
+            identity.get("central_peer_id", ""),
+        )
         self._ad_manager = ad_manager
         ad_manager.RegisterAdvertisement(
             self.adv.get_path(),
@@ -873,10 +882,23 @@ class BluetoothCommandService:
         logger.info(f"✓ Bluetooth service started as '{self.device_name}'")
 
     def _refresh_network_info(self):
-        """Periodic callback: update GATT characteristic and advertisement."""
+        """Periodic callback: update GATT characteristic and advertisement.
+
+        Re-publishes the BLE advert when either of the install_id /
+        central_peer_id TLV payloads changes. install_id is stable
+        for the daemon's lifetime (the very first ticks may run before
+        ``/api/daemon/identity`` is reachable, hence the upgrade),
+        whereas central_peer_id is volatile - it rotates on every
+        relay reconnect, so this tick is also the cadence at which
+        mobile scanners will see the new peerId.
+        """
         self.app.reachy_status.update_network_status()
 
-        new_data = encode_network_ips()
+        identity = _fetch_identity()
+        new_data = encode_advert_manufacturer_data(
+            identity.get("install_id", ""),
+            identity.get("central_peer_id", ""),
+        )
         if new_data != self.adv.manufacturer_data:
             self.adv.manufacturer_data = new_data
             try:
@@ -885,7 +907,7 @@ class BluetoothCommandService:
                     self.adv.get_path(),
                     {},
                     reply_handler=lambda: logger.info(
-                        "Advertisement re-registered with updated IPs"
+                        "Advertisement re-registered with updated install_id payload"
                     ),
                     error_handler=lambda e: logger.error(
                         f"Failed to re-register advertisement: {e}"
@@ -921,12 +943,36 @@ class BluetoothCommandService:
 
 POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
 
-
-# Hard cap on the number of IP addresses we cram into the BLE advert.
-# Each address eats 5 bytes (1 flag + 4 IPv4), and the legacy adv slot
-# is limited to 31 bytes total (~16 already used by flags + LocalName),
-# so 2 addresses is the safe maximum before HCI rejects the payload.
-_MAX_ADVERTISED_IPS = 2
+# Versioned ManufacturerData layout we publish in the advertisement:
+#
+#   byte 0      : format version (currently 0x02)
+#   bytes 1..N  : TLV blocks  -  [tag][len][value]
+#
+# Tag values:
+#   0x01  install_id_prefix : len=8 bytes, the first 8 bytes of the
+#         daemon's install_id (UUID4 hex). Used by mobile clients to
+#         dedupe a BLE row against the same physical robot's localhost
+#         loopback row + (eventually) its central listing without
+#         having to GATT connect first (a connect breaks the scan +
+#         needs pairing).
+#   0x02  central_peer_id_prefix : len=8 bytes, the first 8 bytes of
+#         the relay-assigned central peerId we got back on the
+#         welcome frame. Volatile (rotates on every relay reconnect)
+#         but used by mobile clients as a fallback dedup key for the
+#         BLE row vs the central listing while the central server
+#         does not yet propagate ``meta.install_id``. Absent when the
+#         relay is offline / the daemon has no token.
+#
+# We deliberately drop the legacy IPv4 list from the advert: the
+# 31-byte legacy advertising payload is essentially full once
+# Flags + LocalName ("reachy-mini" = 13B) are accounted for, and
+# every existing client reads IPs via the GATT NETWORK_STATUS
+# characteristic anyway.
+ADVERT_FORMAT_VERSION = 0x02
+ADVERT_TLV_INSTALL_ID = 0x01
+ADVERT_TLV_CENTRAL_PEER_ID = 0x02
+ADVERT_INSTALL_ID_PREFIX_BYTES = 8
+ADVERT_CENTRAL_PEER_ID_PREFIX_BYTES = 8
 
 
 # =======================
@@ -956,13 +1002,16 @@ IDENTITY_HTTP_TIMEOUT_S = 1.5  # called from a GATT read; must not block
 _identity_cache: dict[str, str | float] = {
     "install_id": "",
     "robot_name": "",
+    "central_peer_id": "",
     "ts": 0.0,
 }
+# central_peer_id rotates on every relay reconnect, so don't cache it
+# longer than the BLE refresh tick can react to it.
 _IDENTITY_CACHE_TTL_S = 5.0
 
 
 def _fetch_identity() -> dict[str, str]:
-    """Return a fresh ``{install_id, robot_name}`` dict from the daemon.
+    """Return a fresh ``{install_id, robot_name, central_peer_id}`` dict.
 
     Falls back to empty strings on any error (daemon down, route 404
     on a pre-revision-3 daemon, ...). GATT reads must never raise.
@@ -974,10 +1023,12 @@ def _fetch_identity() -> dict[str, str]:
         return {
             "install_id": str(_identity_cache.get("install_id", "")),
             "robot_name": str(_identity_cache.get("robot_name", "")),
+            "central_peer_id": str(_identity_cache.get("central_peer_id", "")),
         }
 
     install_id = ""
     robot_name = ""
+    central_peer_id = ""
     try:
         payload = _daemon_request(
             "GET", "/api/daemon/identity", timeout=IDENTITY_HTTP_TIMEOUT_S
@@ -985,13 +1036,19 @@ def _fetch_identity() -> dict[str, str]:
         if isinstance(payload, dict):
             install_id = str(payload.get("install_id") or "")
             robot_name = str(payload.get("robot_name") or "")
+            central_peer_id = str(payload.get("central_peer_id") or "")
     except Exception as e:
         logger.debug(f"identity fetch failed (returning blanks): {e}")
 
     _identity_cache["install_id"] = install_id
     _identity_cache["robot_name"] = robot_name
+    _identity_cache["central_peer_id"] = central_peer_id
     _identity_cache["ts"] = now
-    return {"install_id": install_id, "robot_name": robot_name}
+    return {
+        "install_id": install_id,
+        "robot_name": robot_name,
+        "central_peer_id": central_peer_id,
+    }
 
 
 def _get_install_id() -> str:
@@ -1153,47 +1210,75 @@ def _wifi_forget(ssid: str) -> str:
         return f"ERROR: {e}"
 
 
-def encode_network_ips() -> dict:
-    """Build a ManufacturerData payload with at most two IPv4 addresses.
+def _hex_id_prefix_bytes(value: str, prefix_bytes: int) -> bytes:
+    """Decode the first ``prefix_bytes`` of a hex string ``value``.
 
-    Format per IP: 1 byte flags | 4 bytes IPv4
-      flags: 0x01 = hotspot, 0x00 = normal
-
-    Returns a dict {manufacturer_id: dbus.Array(bytes)} suitable for
-    BlueZ ManufacturerData property. Returns empty dict when offline.
-
-    The cap exists because the overall advert has to fit in 31 bytes
-    (see :class:`Advertisement.get_properties`). Mobile clients that
-    need more than two interfaces can still query the GATT
-    NETWORK_STATUS characteristic once connected.
+    Tolerant by design: dashes (eg from a UUID like
+    ``204c2579-28c9-4d22-...``) are stripped, the input is lowercased,
+    and any decoding failure yields ``b""`` so callers can simply skip
+    the corresponding TLV instead of crashing the daemon.
     """
-    status = get_network_status()
-    if status == "OFFLINE" or status == "ERROR":
+    if not value:
+        return b""
+    candidate = value.strip().lower().replace("-", "")
+    needed_hex_chars = prefix_bytes * 2
+    if len(candidate) < needed_hex_chars:
+        return b""
+    try:
+        return bytes.fromhex(candidate[:needed_hex_chars])
+    except ValueError:
+        return b""
+
+
+def _install_id_prefix_bytes(install_id: str) -> bytes:
+    """Return the first ``ADVERT_INSTALL_ID_PREFIX_BYTES`` bytes of ``install_id``.
+
+    ``install_id`` is the daemon's UUID4 hex (32 chars). We take its
+    first 16 hex chars and decode them to 8 raw bytes (= 64 bits of
+    uniqueness, collision-safe for any realistic fleet size).
+    """
+    return _hex_id_prefix_bytes(install_id, ADVERT_INSTALL_ID_PREFIX_BYTES)
+
+
+def _central_peer_id_prefix_bytes(central_peer_id: str) -> bytes:
+    """Return the first ``ADVERT_CENTRAL_PEER_ID_PREFIX_BYTES`` of the central peerId.
+
+    Central hands us back a UUID-shaped peerId (with dashes) on the
+    welcome frame. We compress it the same way as install_id so the
+    mobile parser can match it against the central listing's peerId
+    truncated to its first 16 hex chars.
+    """
+    return _hex_id_prefix_bytes(central_peer_id, ADVERT_CENTRAL_PEER_ID_PREFIX_BYTES)
+
+
+def encode_advert_manufacturer_data(install_id: str, central_peer_id: str = "") -> dict:
+    """Build the BLE advertisement ``ManufacturerData`` payload.
+
+    Returns a ``{manufacturer_id: dbus.Array[byte]}`` dict suitable
+    for the BlueZ ``ManufacturerData`` advertisement property, with a
+    versioned TLV stream carrying the daemon's install_id prefix and
+    (when available) its central peerId prefix. See the ``ADVERT_*``
+    constants at the top of this module for the on-wire layout.
+
+    Returns an empty dict when neither id is available yet so the
+    advert just goes out without a ManufacturerData section (rather
+    than a malformed one).
+    """
+    install_prefix = _install_id_prefix_bytes(install_id)
+    cp_prefix = _central_peer_id_prefix_bytes(central_peer_id)
+    if not install_prefix and not cp_prefix:
         return {}
 
     payload = bytearray()
-    is_hotspot = status.startswith("HOTSPOT")
-
-    parts = status.split("[")
-    encoded = 0
-    for part in parts[1:]:
-        if encoded >= _MAX_ADVERTISED_IPS:
-            break
-        if "]" not in part:
-            continue
-        iface, rest = part.split("]", 1)
-        ip_str = rest.split(";")[0].strip()
-        try:
-            ip_bytes = socket.inet_aton(ip_str)
-            flag = 0x01 if (is_hotspot and iface.strip() == "wlan0") else 0x00
-            payload.append(flag)
-            payload.extend(ip_bytes)
-            encoded += 1
-        except OSError:
-            continue
-
-    if not payload:
-        return {}
+    payload.append(ADVERT_FORMAT_VERSION)
+    if install_prefix:
+        payload.append(ADVERT_TLV_INSTALL_ID)
+        payload.append(len(install_prefix))
+        payload.extend(install_prefix)
+    if cp_prefix:
+        payload.append(ADVERT_TLV_CENTRAL_PEER_ID)
+        payload.append(len(cp_prefix))
+        payload.extend(cp_prefix)
 
     return {
         dbus.UInt16(POLLEN_MANUFACTURER_ID): dbus.Array(

--- a/src/reachy_mini/daemon/app/trace_middleware.py
+++ b/src/reachy_mini/daemon/app/trace_middleware.py
@@ -1,0 +1,107 @@
+"""Starlette middleware that propagates ``X-Trace-Id`` into log context.
+
+When the mobile app issues a daemon request (over LAN HTTP or via the
+WebRTC ``http_proxy`` tunnel), it tags each request with
+``X-Trace-Id``. This middleware:
+
+1. Reads that header (or mints a new id when absent, e.g. for
+   browser-originated requests like the dashboard or for ad-hoc curl
+   testing).
+2. Sets it on the :data:`logging_ctx.trace_id_var` ContextVar.
+3. Logs a one-liner per request with the request method/path/status
+   and elapsed time, so we have a stable observation point even on
+   routers that haven't been instrumented yet.
+4. Echoes the trace back as ``X-Trace-Id`` on the response, so the
+   mobile app can confirm correlation in cases where it didn't set
+   one (e.g. dashboard Open in Browser).
+
+We deliberately filter out a small set of high-frequency polling
+paths from the per-request log (relay-status, health-check) so DEBUG
+output isn't dominated by them.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from .logging_ctx import (
+    kv,
+    new_trace_id,
+    reset_trace_id,
+    set_trace_id,
+)
+
+_logger = logging.getLogger(__name__)
+
+# Keep the per-request log free of the highest-frequency endpoints.
+# They already have their own structured events when something
+# interesting happens; otherwise they're pure noise at INFO level.
+_QUIET_PATHS = {
+    "/health-check",
+    "/api/hf-auth/relay-status",
+    "/api/hf-auth/central-robot-status",
+    "/api/daemon/status",
+    "/api/state",
+}
+
+
+class TraceIdMiddleware(BaseHTTPMiddleware):
+    """ASGI middleware: scope ``trace_id`` per request.
+
+    Subclasses :class:`BaseHTTPMiddleware` so we can ``await
+    call_next`` and observe the response. The overhead of this base
+    class (~50µs per request) is negligible against the network
+    latencies we care about, and the API is simpler than implementing
+    raw ASGI.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Bind to the wrapped ASGI app."""
+        super().__init__(app)
+
+    async def dispatch(  # type: ignore[override]
+        self, request: Request, call_next: Any
+    ) -> Response:
+        """Scope ``trace_id`` to this request and emit a one-line summary."""
+        trace = request.headers.get("X-Trace-Id") or new_trace_id()
+        token = set_trace_id(trace)
+        t0 = time.perf_counter()
+        path = request.url.path
+        try:
+            response: Response = await call_next(request)
+            elapsed_ms = int((time.perf_counter() - t0) * 1000)
+            if path not in _QUIET_PATHS:
+                level = logging.WARNING if response.status_code >= 400 else logging.INFO
+                _logger.log(
+                    level,
+                    kv(
+                        "http.request",
+                        method=request.method,
+                        path=path,
+                        status=response.status_code,
+                        latency_ms=elapsed_ms,
+                    ),
+                )
+            response.headers["X-Trace-Id"] = trace
+            return response
+        except Exception as exc:
+            elapsed_ms = int((time.perf_counter() - t0) * 1000)
+            _logger.exception(
+                kv(
+                    "http.error",
+                    method=request.method,
+                    path=path,
+                    latency_ms=elapsed_ms,
+                    exc_type=type(exc).__name__,
+                )
+            )
+            raise
+        finally:
+            reset_trace_id(token)

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -203,6 +203,24 @@ class Backend:
         self._send_message_to_webrtc: Optional[Callable[[Optional[str], str], None]] = (
             None
         )
+        # Loopback HTTP proxy support (for the mobile app's `http_proxy`
+        # WebRTC DC tunnel). The daemon's FastAPI server binds locally on
+        # this port; we issue a localhost HTTP call against ourselves to
+        # forward proxied requests to the same router stack used by LAN
+        # clients. The event loop is captured at the same time as the
+        # WebRTC handler so we can `run_coroutine_threadsafe` from the
+        # GStreamer DC callback (which runs on its own thread).
+        self._loopback_http_port: int = 8000
+        self._loopback_http_host: str = "127.0.0.1"
+        self._http_proxy_loop: Optional[asyncio.AbstractEventLoop] = None
+
+        # WebSocket proxy support (`ws_proxy` over the same WebRTC DC
+        # tunnel as `http_proxy`). Multiplex by stream_id so callers
+        # can hold several long-lived subscriptions concurrently
+        # (e.g. /api/move/ws/updates + /api/state/ws/full from the
+        # mobile app at the same time). The dict is mutated only from
+        # `_http_proxy_loop`'s thread, so no extra lock is needed.
+        self._ws_proxy_streams: Dict[str, Dict[str, Any]] = {}
 
     # Life cycle methods
     def wrapped_run(self) -> None:
@@ -723,7 +741,9 @@ class Backend:
         1.0032234352772091,
     ]
 
-    INIT_ANTENNAS_JOINT_POSITIONS = np.array((-0.1745, 0.1745))  # ~10° offset to reduce shaking at vertical
+    INIT_ANTENNAS_JOINT_POSITIONS = np.array(
+        (-0.1745, 0.1745)
+    )  # ~10° offset to reduce shaking at vertical
     SLEEP_ANTENNAS_JOINT_POSITIONS = np.array((-3.05, 3.05))
     SLEEP_HEAD_POSE = np.array(
         [
@@ -782,7 +802,9 @@ class Backend:
             if dist_to_init_pose > 30:
                 # Move to the initial position
                 await self.goto_target(
-                    self.INIT_HEAD_POSE, antennas=self.INIT_ANTENNAS_JOINT_POSITIONS, duration=1
+                    self.INIT_HEAD_POSE,
+                    antennas=self.INIT_ANTENNAS_JOINT_POSITIONS,
+                    duration=1,
                 )
                 await asyncio.sleep(0.2)
 
@@ -993,7 +1015,12 @@ class Backend:
 
         elif isinstance(
             cmd,
-            (SetVolumeCmd, GetVolumeCmd, SetMicrophoneVolumeCmd, GetMicrophoneVolumeCmd),
+            (
+                SetVolumeCmd,
+                GetVolumeCmd,
+                SetMicrophoneVolumeCmd,
+                GetMicrophoneVolumeCmd,
+            ),
         ):
             # Volume is a global robot setting, not per-session: a remote
             # change persists for the next connection. This matches the
@@ -1104,6 +1131,7 @@ class Backend:
         Stores a reference to the ``GstMediaServer`` for:
         - WebRTC data channel message handling (robot control)
         - Sound playback delegation (play_sound)
+        - HTTP proxy tunnel (`http_proxy` over DC for the mobile app)
 
         Args:
             media_server: The ``GstMediaServer`` instance.
@@ -1113,6 +1141,7 @@ class Backend:
 
         _loop = asyncio.new_event_loop()
         threading.Thread(target=_loop.run_forever, daemon=True).start()
+        self._http_proxy_loop = _loop
 
         def _threadsafe_handler(peer_id: str, message: str) -> None:
             _loop.call_soon_threadsafe(self._handle_webrtc_message, peer_id, message)
@@ -1120,9 +1149,58 @@ class Backend:
         media_server.set_message_handler(_threadsafe_handler)
         self._send_message_to_webrtc = media_server.send_data_message
 
+    def set_loopback_http_port(self, port: int, host: str = "127.0.0.1") -> None:
+        """Tell the backend where the daemon's own FastAPI server is listening.
+
+        Used by the WebRTC ``http_proxy`` handler to forward proxied
+        requests to the same router stack that LAN clients hit
+        directly. Called from the FastAPI lifespan once we know the
+        port the user passed via ``--fastapi-port``.
+        """
+        self._loopback_http_port = port
+        self._loopback_http_host = host
+
     def _handle_webrtc_message(self, peer_id: str, message: str) -> None:
         def send(resp: dict[str, Any]) -> None:
             self._send_webrtc_response(peer_id, resp)
+
+        # Peek the message type before running it through the strict
+        # `command_adapter` discriminated union: the `http_proxy`
+        # tunnel lives outside the SDK's typed command set on purpose
+        # so we don't have to widen the protocol every time a new HTTP
+        # endpoint is added on the daemon. Invalid JSON or anything
+        # that's neither `http_proxy` nor a valid SDK command falls
+        # through to the existing error path.
+        try:
+            parsed = json.loads(message)
+        except Exception as e:
+            self.logger.error(f"WebRTC invalid JSON: {e}")
+            send({"error": f"Invalid JSON: {e}"})
+            return
+
+        if isinstance(parsed, dict):
+            msg_type = parsed.get("type")
+            if msg_type == "http_proxy":
+                # Run the proxied HTTP call on this backend's event loop.
+                # `_handle_webrtc_message` itself runs on that loop already
+                # (see `setup_media_server`), so we can fire a task
+                # directly. Callers don't wait for completion; the response
+                # is sent back through the data channel when ready.
+                asyncio.create_task(self._async_http_proxy(peer_id, parsed))
+                return
+            if msg_type == "ws_open":
+                # New WebSocket subscription request from the mobile
+                # app. The pump task handles the full lifecycle and
+                # sends `ws_opened` / `ws_message` / `ws_closed` /
+                # `ws_error` frames back over the DC.
+                asyncio.create_task(self._async_ws_proxy_open(peer_id, parsed))
+                return
+            if msg_type == "ws_send":
+                self._ws_proxy_handle_send(parsed)
+                return
+            if msg_type == "ws_close":
+                self._ws_proxy_handle_close(parsed)
+                return
 
         try:
             cmd = command_adapter.validate_json(message)
@@ -1135,6 +1213,358 @@ class Backend:
         except Exception as e:
             self.logger.error(f"WebRTC command error: {e}")
             send({"error": str(e)})
+
+    async def _async_http_proxy(self, peer_id: str, req: dict[str, Any]) -> None:
+        """Tunnel an HTTP request received over the WebRTC DC.
+
+        Wire format (mirrors `reachy_mini_mobile_app/src/robot-client/
+        webrtcClient.ts`):
+
+            request:  {"type":"http_proxy", "request_id":"...",
+                       "method":"GET"|"POST"|..., "path":"/api/...",
+                       "body": <json|null>, "headers":{...}|null,
+                       "timeout_s": <float>}
+            response: {"type":"http_proxy_response", "request_id":"...",
+                       "status": <int>, "body": <json|str|null>,
+                       "headers": {<name>: <value>, ...},
+                       "error": <str|null>}
+
+        On any error (timeout, connection refused, daemon 5xx) we still
+        send back a structured response with a non-2xx status and a
+        non-null `error`, so the mobile-side `webrtcClient` always
+        resolves the pending entry instead of timing out.
+        """
+        request_id = str(req.get("request_id") or "")
+        method = str(req.get("method") or "GET").upper()
+        path = str(req.get("path") or "/")
+        body = req.get("body")
+        headers_in = req.get("headers") or {}
+        try:
+            timeout_s = float(req.get("timeout_s") or 10.0)
+        except Exception:
+            timeout_s = 10.0
+        timeout_s = max(0.5, min(300.0, timeout_s))
+
+        if not request_id:
+            self.logger.warning("http_proxy: missing request_id, dropping")
+            return
+
+        url = f"http://{self._loopback_http_host}:{self._loopback_http_port}{path}"
+
+        # Normalise headers to plain str:str. Drop hop-by-hop headers
+        # that don't survive a loopback hop; we never want a remote
+        # client to forge `Host` for example.
+        clean_headers: dict[str, str] = {}
+        if isinstance(headers_in, dict):
+            for k, v in headers_in.items():
+                if not isinstance(k, str):
+                    continue
+                if k.lower() in {"host", "content-length"}:
+                    continue
+                clean_headers[k] = str(v)
+
+        # Body encoding: dicts/lists go as JSON, str goes verbatim,
+        # None means no body. Anything else is JSON-encoded as a best
+        # effort so the daemon-side router sees a syntactically valid
+        # payload.
+        send_kwargs: dict[str, Any] = {}
+        if body is None:
+            pass
+        elif isinstance(body, (bytes, bytearray)):
+            send_kwargs["data"] = bytes(body)
+        elif isinstance(body, str):
+            send_kwargs["data"] = body
+        else:
+            send_kwargs["json"] = body
+            clean_headers.setdefault("Content-Type", "application/json")
+
+        status: int = 0
+        resp_body: Any = None
+        resp_headers: dict[str, str] = {}
+        error: Optional[str] = None
+
+        try:
+            import aiohttp
+
+            timeout = aiohttp.ClientTimeout(total=timeout_s)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.request(
+                    method, url, headers=clean_headers, **send_kwargs
+                ) as resp:
+                    status = resp.status
+                    resp_headers = {k: v for k, v in resp.headers.items()}
+                    raw = await resp.read()
+                    text = raw.decode("utf-8", errors="replace") if raw else ""
+                    ctype = resp.headers.get("Content-Type", "")
+                    if "application/json" in ctype.lower() and text:
+                        try:
+                            resp_body = json.loads(text)
+                        except Exception:
+                            resp_body = text
+                    else:
+                        resp_body = text
+        except asyncio.TimeoutError:
+            error = f"daemon loopback timeout after {timeout_s:.1f}s"
+            self.logger.warning(
+                "http_proxy timeout", extra={"path": path, "timeout_s": timeout_s}
+            )
+        except Exception as e:
+            error = f"{type(e).__name__}: {e}"
+            self.logger.warning(
+                "http_proxy error", extra={"path": path, "error": error}
+            )
+
+        response = {
+            "type": "http_proxy_response",
+            "request_id": request_id,
+            "status": status,
+            "body": resp_body,
+            "headers": resp_headers,
+            "error": error,
+        }
+        try:
+            self._send_webrtc_response(peer_id, response)
+        except Exception as e:
+            self.logger.error(f"http_proxy: failed to send response: {e}")
+
+    # ------------------------------------------------------------------
+    # WebSocket proxy (parallel to `_async_http_proxy`)
+    #
+    # Wire format (mirrors `reachy_mini_mobile_app/src/robot-client/
+    # wsProxyClient.ts`):
+    #
+    #   client → daemon
+    #   ───────────────
+    #     {"type":"ws_open",  "stream_id":"...", "path":"/api/.../ws/...",
+    #      "headers": {...}|null}
+    #     {"type":"ws_send",  "stream_id":"...", "data": "<text>"}
+    #     {"type":"ws_close", "stream_id":"...",
+    #      "code": <int>|null, "reason": <str>|null}
+    #
+    #   daemon → client
+    #   ───────────────
+    #     {"type":"ws_opened",  "stream_id":"..."}
+    #     {"type":"ws_message", "stream_id":"...", "data": "<text>"}
+    #     {"type":"ws_closed",  "stream_id":"...",
+    #      "code": <int>, "reason": <str>}
+    #     {"type":"ws_error",   "stream_id":"...", "error": "..."}
+    #
+    # Only TEXT frames are tunnelled today: every Reachy daemon WS
+    # endpoint sends JSON-as-text and a base64-encoded BINARY carve-out
+    # would just bloat the wire format with no caller. The daemon-side
+    # handshake is best-effort: any failure (handshake refused, server
+    # disconnects mid-stream, JSON-encoding error) is reported with a
+    # single `ws_error` frame and the stream entry is dropped, so the
+    # mobile-side dispatcher always sees a terminal event per stream.
+    # ------------------------------------------------------------------
+
+    async def _async_ws_proxy_open(self, peer_id: str, req: dict[str, Any]) -> None:
+        """Tunnel a WebSocket connection received over the WebRTC DC."""
+        stream_id = str(req.get("stream_id") or "")
+        path = str(req.get("path") or "/")
+        headers_in = req.get("headers") or {}
+
+        if not stream_id:
+            self.logger.warning("ws_proxy: missing stream_id, dropping")
+            return
+        if stream_id in self._ws_proxy_streams:
+            # Re-using an in-flight stream_id is a client-side bug. We
+            # answer with a single error frame instead of silently
+            # dropping so the mobile side surfaces it in logs.
+            self._send_webrtc_response(
+                peer_id,
+                {
+                    "type": "ws_error",
+                    "stream_id": stream_id,
+                    "error": "stream_id already in use",
+                },
+            )
+            return
+
+        # Drop hop-by-hop and handshake-owned headers; aiohttp picks
+        # the right `Sec-WebSocket-*` values itself and a remote client
+        # forging `Host` would let a malicious peer impersonate the
+        # loopback origin.
+        clean_headers: dict[str, str] = {}
+        if isinstance(headers_in, dict):
+            for k, v in headers_in.items():
+                if not isinstance(k, str):
+                    continue
+                lk = k.lower()
+                if lk in {
+                    "host",
+                    "content-length",
+                    "upgrade",
+                    "connection",
+                    "sec-websocket-key",
+                    "sec-websocket-version",
+                    "sec-websocket-extensions",
+                    "sec-websocket-protocol",
+                }:
+                    continue
+                clean_headers[k] = str(v)
+
+        url = f"ws://{self._loopback_http_host}:{self._loopback_http_port}{path}"
+
+        # Allocate the stream record up-front so a fast `ws_close`
+        # arriving while the handshake is in flight has somewhere to
+        # land. The pump task wires `task` and we own the queue here.
+        incoming: "asyncio.Queue[Optional[str]]" = asyncio.Queue()
+        self._ws_proxy_streams[stream_id] = {
+            "incoming": incoming,
+            "task": None,
+            "peer_id": peer_id,
+            "closing": False,
+        }
+
+        async def pump() -> None:
+            import aiohttp
+
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.ws_connect(
+                        url,
+                        headers=clean_headers or None,
+                        heartbeat=30.0,
+                    ) as ws:
+                        self._send_webrtc_response(
+                            peer_id,
+                            {"type": "ws_opened", "stream_id": stream_id},
+                        )
+                        self.logger.info(
+                            "ws_proxy opened",
+                            extra={"stream_id": stream_id, "path": path},
+                        )
+
+                        async def writer() -> None:
+                            while True:
+                                data = await incoming.get()
+                                if data is None:
+                                    if not ws.closed:
+                                        try:
+                                            await ws.close()
+                                        except Exception:
+                                            pass
+                                    return
+                                try:
+                                    await ws.send_str(data)
+                                except Exception as e:
+                                    self.logger.warning(
+                                        "ws_proxy writer error",
+                                        extra={
+                                            "stream_id": stream_id,
+                                            "error": str(e),
+                                        },
+                                    )
+                                    return
+
+                        writer_task = asyncio.create_task(writer())
+                        try:
+                            async for msg in ws:
+                                if msg.type == aiohttp.WSMsgType.TEXT:
+                                    self._send_webrtc_response(
+                                        peer_id,
+                                        {
+                                            "type": "ws_message",
+                                            "stream_id": stream_id,
+                                            "data": msg.data,
+                                        },
+                                    )
+                                elif msg.type == aiohttp.WSMsgType.ERROR:
+                                    err_obj = ws.exception()
+                                    self._send_webrtc_response(
+                                        peer_id,
+                                        {
+                                            "type": "ws_error",
+                                            "stream_id": stream_id,
+                                            "error": str(err_obj or "ws error"),
+                                        },
+                                    )
+                                    break
+                                elif msg.type in (
+                                    aiohttp.WSMsgType.CLOSE,
+                                    aiohttp.WSMsgType.CLOSED,
+                                    aiohttp.WSMsgType.CLOSING,
+                                ):
+                                    break
+                                # Binary frames are dropped on purpose.
+                        finally:
+                            writer_task.cancel()
+                            try:
+                                await writer_task
+                            except (asyncio.CancelledError, Exception):
+                                pass
+
+                        code = ws.close_code if ws.close_code is not None else 1000
+                        self._send_webrtc_response(
+                            peer_id,
+                            {
+                                "type": "ws_closed",
+                                "stream_id": stream_id,
+                                "code": code,
+                                "reason": "",
+                            },
+                        )
+                        self.logger.info(
+                            "ws_proxy closed",
+                            extra={
+                                "stream_id": stream_id,
+                                "code": code,
+                                "path": path,
+                            },
+                        )
+            except asyncio.CancelledError:
+                # Backend shutting down: don't try to send anything.
+                raise
+            except Exception as e:
+                self.logger.warning(
+                    "ws_proxy connect error",
+                    extra={
+                        "stream_id": stream_id,
+                        "path": path,
+                        "error": f"{type(e).__name__}: {e}",
+                    },
+                )
+                self._send_webrtc_response(
+                    peer_id,
+                    {
+                        "type": "ws_error",
+                        "stream_id": stream_id,
+                        "error": f"{type(e).__name__}: {e}",
+                    },
+                )
+            finally:
+                self._ws_proxy_streams.pop(stream_id, None)
+
+        task = asyncio.create_task(pump())
+        # Re-fetch the slot in case `ws_close` already removed it
+        # before we got here (extremely tight race, but free to guard).
+        slot = self._ws_proxy_streams.get(stream_id)
+        if slot is not None:
+            slot["task"] = task
+
+    def _ws_proxy_handle_send(self, req: dict[str, Any]) -> None:
+        """Forward a `ws_send` payload to the matching pump's writer queue."""
+        stream_id = str(req.get("stream_id") or "")
+        if not stream_id:
+            return
+        stream = self._ws_proxy_streams.get(stream_id)
+        if not stream or stream.get("closing"):
+            return
+        data = req.get("data")
+        if isinstance(data, str):
+            stream["incoming"].put_nowait(data)
+
+    def _ws_proxy_handle_close(self, req: dict[str, Any]) -> None:
+        """Mark a stream as closing and signal the writer to drain."""
+        stream_id = str(req.get("stream_id") or "")
+        if not stream_id:
+            return
+        stream = self._ws_proxy_streams.get(stream_id)
+        if not stream or stream.get("closing"):
+            return
+        stream["closing"] = True
+        stream["incoming"].put_nowait(None)
 
     def _send_webrtc_response(self, peer_id: str, response: dict[str, Any]) -> None:
         if self._send_message_to_webrtc:

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -22,6 +22,7 @@ from reachy_mini.io.protocol import DaemonState, DaemonStatus, MotorControlMode
 from reachy_mini.io.ws_server import WSServer
 from reachy_mini.tools.reflash_motors import reflash_motors_if_needed
 
+from .app.config import DEFAULT_ROBOT_NAME as _DEFAULT_ROBOT_NAME
 from .backend.mockup_sim import MockupSimBackend
 from .backend.mujoco import MujocoBackend
 from .backend.robot import RobotBackend
@@ -153,6 +154,68 @@ class Daemon:
         self._status.media_released = False
         self.logger.info("Media hardware re-acquired.")
 
+    async def set_robot_name(self, robot_name: str) -> "DaemonStatus":
+        """Rename the robot live, without restarting the daemon.
+
+        Updates the in-memory canonical ``robot_name`` (mirrored on
+        ``self._status.robot_name``), persists the new value to
+        ``daemon.json`` so it survives a restart, and pushes the change
+        downstream to the components that advertise the name:
+
+        - the central signaling relay (``setPeerStatus`` re-emit, no
+          reconnect required);
+        - the mDNS service registration, when one exists. The mDNS
+          handle is held by the FastAPI lifespan so the route layer is
+          responsible for forwarding it (kept out of ``Daemon`` to avoid
+          a circular import with the FastAPI app).
+
+        Idempotent: a no-op when ``robot_name`` already matches.
+        Persistence failure is logged but does not raise: the in-memory
+        rename has already taken effect and central has already been
+        notified, so the user-visible behaviour is correct - it just
+        won't survive a daemon restart.
+        """
+        from reachy_mini.daemon.app.config import set_persisted_robot_name
+        from reachy_mini.media.central_signaling_relay import notify_robot_name_change
+
+        if robot_name == self.robot_name:
+            return self._status
+
+        was_default = self.robot_name == _DEFAULT_ROBOT_NAME
+        self.logger.info("Renaming robot: %r -> %r", self.robot_name, robot_name)
+        self.robot_name = robot_name
+        self._status.robot_name = robot_name
+
+        if not set_persisted_robot_name(robot_name):
+            self.logger.warning(
+                "Persisted config write failed; rename will not survive restart"
+            )
+
+        if was_default and robot_name != _DEFAULT_ROBOT_NAME:
+            # Crossing the "default -> custom" boundary: the relay was
+            # gated off at boot in ``_start_central_signaling_relay`` to
+            # keep the HF fleet free of anonymous duplicates. Now that
+            # the user picked a real name, kick off the relay so this
+            # robot becomes visible on central within seconds.
+            try:
+                relay_result = await self.ensure_central_signaling_relay()
+                self.logger.info("Post-rename central relay state: %s", relay_result)
+            except Exception as exc:
+                self.logger.warning(
+                    "Failed to ensure central relay after rename: %s", exc
+                )
+        else:
+            try:
+                await notify_robot_name_change(robot_name)
+            except Exception as exc:
+                # ``notify_robot_name_change`` already logs at warning level;
+                # downgrade further failures to debug so we don't double-log.
+                self.logger.debug(
+                    "notify_robot_name_change raised after handling: %s", exc
+                )
+
+        return self._status
+
     async def ensure_central_signaling_relay(self) -> dict[str, Any]:
         """Ensure the central signaling relay is running.
 
@@ -184,10 +247,35 @@ class Daemon:
         return {"started": True}
 
     async def _start_central_signaling_relay(self) -> None:
-        """Start the central signaling relay for remote WebRTC access."""
+        """Start the central signaling relay for remote WebRTC access.
+
+        Three preconditions must hold for the relay to actually start:
+
+        - the media server is up (no point relaying audio/video that
+          doesn't exist);
+        - an HF token is available (central rejects anonymous producers);
+        - the robot has a user-chosen name (we refuse to register on the
+          fleet under the default ``reachy_mini`` label, otherwise every
+          new robot would clutter the user's HF dashboard with anonymous
+          duplicates that are impossible to tell apart). The relay starts
+          automatically the moment the user picks a name through
+          ``POST /api/daemon/robot-name``, so this is a soft gate.
+
+        Each gate logs at INFO level so a Wireless robot stuck without a
+        name surfaces clearly in the journal.
+        """
         global _central_relay_task
 
         if not self._media_server:
+            return
+
+        if self.robot_name == _DEFAULT_ROBOT_NAME:
+            self.logger.info(
+                "Central signaling relay deferred: robot still has the default "
+                "name %r. Set a custom name via POST /api/daemon/robot-name "
+                "(or the mobile app onboarding) to register on the HF fleet.",
+                self.robot_name,
+            )
             return
 
         try:

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -153,6 +153,36 @@ class Daemon:
         self._status.media_released = False
         self.logger.info("Media hardware re-acquired.")
 
+    async def ensure_central_signaling_relay(self) -> dict[str, Any]:
+        """Ensure the central signaling relay is running.
+
+        Idempotent helper used by HTTP routes (e.g. ``save-token``,
+        ``refresh-relay``) to recover from the cold-boot case where the
+        daemon started without an HF token. In that case
+        ``_start_central_signaling_relay`` ran once at media-acquire
+        time, found no token, and returned without setting
+        ``_relay_instance``. After the user pushes a token via
+        ``save-token``, ``notify_token_change`` is a no-op (because
+        ``_relay_instance is None``), so the robot stays invisible on
+        central until the next daemon restart. This method closes that
+        gap by re-running the start path.
+
+        Returns a small dict describing what happened, suitable for
+        bubbling up to API responses.
+        """
+        from reachy_mini.media import central_signaling_relay as _csr
+
+        if _csr._relay_instance is not None:
+            return {"started": False, "reason": "already_running"}
+        if not self._media_server or self._media_released:
+            return {"started": False, "reason": "media_unavailable"}
+
+        await self._start_central_signaling_relay()
+
+        if _csr._relay_instance is None:
+            return {"started": False, "reason": "no_token_or_failed"}
+        return {"started": True}
+
     async def _start_central_signaling_relay(self) -> None:
         """Start the central signaling relay for remote WebRTC access."""
         global _central_relay_task

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -22,7 +22,7 @@ from reachy_mini.io.protocol import DaemonState, DaemonStatus, MotorControlMode
 from reachy_mini.io.ws_server import WSServer
 from reachy_mini.tools.reflash_motors import reflash_motors_if_needed
 
-from .app.config import DEFAULT_ROBOT_NAME as _DEFAULT_ROBOT_NAME
+from .app.config import get_or_create_install_id
 from .backend.mockup_sim import MockupSimBackend
 from .backend.mujoco import MujocoBackend
 from .backend.robot import RobotBackend
@@ -53,6 +53,14 @@ class Daemon:
 
         self.robot_name = robot_name
 
+        # Stable per-install id, created on first boot and persisted
+        # alongside ``robot_name`` in ``daemon.json``. Read once at init
+        # and held as ``self.install_id`` so it can be passed verbatim
+        # to every layer that needs to advertise the robot (central
+        # relay meta, mDNS TXT, BLE GATT char, HTTP /identity).
+        self.install_id: str = get_or_create_install_id()
+        self.logger.info("Daemon install_id: %s", self.install_id)
+
         self.wireless_version = wireless_version
         self.desktop_app_daemon = desktop_app_daemon
         self.no_media = no_media
@@ -68,6 +76,7 @@ class Daemon:
 
         self._status = DaemonStatus(
             robot_name=robot_name,
+            install_id=self.install_id,
             state=DaemonState.NOT_INITIALIZED,
             wireless_version=wireless_version,
             desktop_app_daemon=desktop_app_daemon,
@@ -174,6 +183,12 @@ class Daemon:
         rename has already taken effect and central has already been
         notified, so the user-visible behaviour is correct - it just
         won't survive a daemon restart.
+
+        Note: as of the install_id rollout there is no longer a "first
+        rename triggers central registration" path - the relay always
+        runs as soon as a token is available and reconciliation is
+        done by ``install_id``. So this method is purely an advertise
+        update on a relay that's already (or will soon be) up.
         """
         from reachy_mini.daemon.app.config import set_persisted_robot_name
         from reachy_mini.media.central_signaling_relay import notify_robot_name_change
@@ -181,7 +196,6 @@ class Daemon:
         if robot_name == self.robot_name:
             return self._status
 
-        was_default = self.robot_name == _DEFAULT_ROBOT_NAME
         self.logger.info("Renaming robot: %r -> %r", self.robot_name, robot_name)
         self.robot_name = robot_name
         self._status.robot_name = robot_name
@@ -191,28 +205,12 @@ class Daemon:
                 "Persisted config write failed; rename will not survive restart"
             )
 
-        if was_default and robot_name != _DEFAULT_ROBOT_NAME:
-            # Crossing the "default -> custom" boundary: the relay was
-            # gated off at boot in ``_start_central_signaling_relay`` to
-            # keep the HF fleet free of anonymous duplicates. Now that
-            # the user picked a real name, kick off the relay so this
-            # robot becomes visible on central within seconds.
-            try:
-                relay_result = await self.ensure_central_signaling_relay()
-                self.logger.info("Post-rename central relay state: %s", relay_result)
-            except Exception as exc:
-                self.logger.warning(
-                    "Failed to ensure central relay after rename: %s", exc
-                )
-        else:
-            try:
-                await notify_robot_name_change(robot_name)
-            except Exception as exc:
-                # ``notify_robot_name_change`` already logs at warning level;
-                # downgrade further failures to debug so we don't double-log.
-                self.logger.debug(
-                    "notify_robot_name_change raised after handling: %s", exc
-                )
+        try:
+            await notify_robot_name_change(robot_name)
+        except Exception as exc:
+            # ``notify_robot_name_change`` already logs at warning level;
+            # downgrade further failures to debug so we don't double-log.
+            self.logger.debug("notify_robot_name_change raised after handling: %s", exc)
 
         return self._status
 
@@ -249,33 +247,24 @@ class Daemon:
     async def _start_central_signaling_relay(self) -> None:
         """Start the central signaling relay for remote WebRTC access.
 
-        Three preconditions must hold for the relay to actually start:
+        Two preconditions must hold for the relay to actually start:
 
         - the media server is up (no point relaying audio/video that
           doesn't exist);
-        - an HF token is available (central rejects anonymous producers);
-        - the robot has a user-chosen name (we refuse to register on the
-          fleet under the default ``reachy_mini`` label, otherwise every
-          new robot would clutter the user's HF dashboard with anonymous
-          duplicates that are impossible to tell apart). The relay starts
-          automatically the moment the user picks a name through
-          ``POST /api/daemon/robot-name``, so this is a soft gate.
+        - an HF token is available (central rejects anonymous producers).
 
-        Each gate logs at INFO level so a Wireless robot stuck without a
-        name surfaces clearly in the journal.
+        We deliberately do NOT gate on the robot name. Every robot with
+        a token registers on central, and the mobile app reconciles
+        sightings across BLE, mDNS, loopback HTTP, and central by
+        ``install_id`` - so two unnamed ``reachy_mini`` instances end
+        up as two distinguishable rows in the listing rather than two
+        indistinguishable duplicates. The user-facing label is still
+        the human-readable ``robot_name``; ``install_id`` is the
+        technical key.
         """
         global _central_relay_task
 
         if not self._media_server:
-            return
-
-        if self.robot_name == _DEFAULT_ROBOT_NAME:
-            self.logger.info(
-                "Central signaling relay deferred: robot still has the default "
-                "name %r. Set a custom name via POST /api/daemon/robot-name "
-                "(or the mobile app onboarding) to register on the HF fleet.",
-                self.robot_name,
-            )
             return
 
         try:
@@ -293,10 +282,15 @@ class Daemon:
         try:
             from reachy_mini.media.central_signaling_relay import start_central_relay
 
-            self.logger.info("Starting central signaling relay...")
+            self.logger.info(
+                "Starting central signaling relay (name=%r, install_id=%s)...",
+                self.robot_name,
+                self.install_id,
+            )
             await start_central_relay(
                 hf_token=hf_token,
                 robot_name=self.robot_name,
+                install_id=self.install_id,
                 robot_app_lock=self.robot_app_lock,
             )
             self.logger.info("Central signaling relay started")

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -634,6 +634,20 @@ class Daemon:
         else:
             self._status.backend_status = None
 
+        # Refresh the volatile relay-assigned peer id on every call: the
+        # relay rotates this on each reconnect and we don't have a hook
+        # that wakes ``Daemon`` up on welcome frames. Cheap (single
+        # attribute load) so doing it on every status read is fine.
+        try:
+            from reachy_mini.media.central_signaling_relay import (
+                get_central_peer_id,
+            )
+
+            self._status.central_peer_id = get_central_peer_id()
+        except Exception:
+            # The relay module is optional in some test harnesses.
+            self._status.central_peer_id = None
+
         return self._status
 
     def _publish_status(self) -> None:

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -10,7 +10,10 @@ import logging
 import time
 from importlib.metadata import PackageNotFoundError, version
 from threading import Event, Thread
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from reachy_mini.daemon.peer_health import PeerHealth
 
 from reachy_mini.daemon.robot_app_lock import RobotAppLock
 from reachy_mini.daemon.utils import (
@@ -292,15 +295,86 @@ class Daemon:
                 robot_name=self.robot_name,
                 install_id=self.install_id,
                 robot_app_lock=self.robot_app_lock,
+                # Layer A of docs/SIGNALING.md - the relay forwards
+                # the daemon-derived health verdict to central without
+                # reinterpreting it. Capabilities are static here
+                # because the only way to lose them today is a daemon
+                # restart; if that ever changes (hot-plug audio, etc.)
+                # we should swap this for a callable provider too.
+                kind=("tray" if self.desktop_app_daemon else "robot"),
+                wireless_version=self.wireless_version,
+                version=self._status.version,
+                capabilities=self._compute_capabilities(),
+                health_provider=self._compute_peer_health,
             )
             self.logger.info("Central signaling relay started")
         except Exception as e:
             self.logger.warning(f"Failed to start central signaling relay: {e}")
 
+    def _compute_capabilities(self) -> list[str]:
+        """Build the static list of capability tokens advertised on the relay.
+
+        Listed in ``meta.capabilities`` so clients can light up / grey
+        out features per row without probing the robot. Recomputed only
+        at relay-start time: capabilities are decided by daemon flags
+        (``no_media``, ``simulation_enabled``, …) that don't move at
+        runtime today.
+
+        See ``docs/SIGNALING.md`` for the canonical token list.
+        """
+        caps: list[str] = ["motion"]  # always available
+        if not self.no_media and self._media_server is not None:
+            caps.append("audio")
+            caps.append("camera")
+        return caps
+
+    def _compute_peer_health(self) -> "PeerHealth":
+        """Compute the health snapshot the relay forwards as ``meta.health``.
+
+        Indirection through this method (vs. exposing ``peer_health.compute``
+        directly) lets the relay stay decoupled from the daemon's
+        internals: it only knows it has a zero-arg callable returning a
+        ``PeerHealth``. We rebuild a fresh ``DaemonStatus`` snapshot on
+        every call so transient transitions show up promptly; ``status()``
+        is cheap (single attribute read + backend.get_status() if any).
+        """
+        from reachy_mini.daemon.peer_health import compute
+
+        return compute(self.status())
+
     async def _stop_central_signaling_relay(self) -> None:
-        """Stop the central signaling relay."""
+        """Tear down the relay, with an explicit withdraw beforehand.
+
+        Order matters:
+
+        1. ``withdraw()``: tells central "stop listing me" via
+           ``setPeerStatus(roles=[])`` while the WebSocket is still
+           open. Central removes the peer from ``producers`` and
+           broadcasts ``peerStatusChanged(roles=[])`` to listeners,
+           so any mobile/desktop client looking at the listing gets
+           an immediate "this robot just left" event.
+        2. ``stop_central_relay()``: closes the SSE/WebSocket
+           channel. Central's SSE loop sees ``is_disconnected()``
+           and runs ``disconnect_peer`` for any residual cleanup.
+
+        Without step 1 the user sees the robot "linger" in the
+        listing for the time it takes the SSE close to propagate +
+        any TTL in the central. With step 1 the disappearance is
+        instant. The withdraw is best-effort with a tight timeout
+        so a stuck central never blocks daemon shutdown.
+        """
         try:
-            from reachy_mini.media.central_signaling_relay import stop_central_relay
+            from reachy_mini.media.central_signaling_relay import (
+                get_relay,
+                stop_central_relay,
+            )
+
+            relay = get_relay()
+            if relay is not None:
+                try:
+                    await relay.withdraw(timeout=0.5)
+                except Exception as e:
+                    self.logger.debug(f"Error withdrawing from central: {e}")
 
             await stop_central_relay()
             self.logger.info("Central signaling relay stopped")
@@ -650,16 +724,89 @@ class Daemon:
 
         return self._status
 
+    # Grace period before a desktop-tray daemon with no backend
+    # voluntarily withdraws from the central listing (cf. layer B of
+    # docs/SIGNALING.md). 30s is long enough to ride out a USB
+    # re-enumeration after a sleep/wake without flapping, short enough
+    # that an unplugged tray disappears from the mobile picker before
+    # the user has time to scroll.
+    _NO_HARDWARE_GRACE_SECONDS = 30.0
+
     def _publish_status(self) -> None:
+        """Publish status over WS at 1 Hz and keep central in sync.
+
+        This loop is the daemon's single broadcast tick: every iteration
+        we (1) push the current snapshot to the local WebSocket clients,
+        (2) call ``notify_meta_change`` so the central relay re-emits a
+        ``setPeerStatus`` IFF the producer ``meta`` actually moved
+        (debounce lives inside the relay), and (3) for desktop-tray
+        daemons, run the "no backend for too long → withdraw"
+        watchdog. All three are cheap and self-contained, so doing
+        them on the same 1 s tick keeps the threading story simple.
+        """
+        from reachy_mini.media.central_signaling_relay import (
+            notify_meta_change,
+            notify_withdraw,
+        )
+
         self._thread_event_publish_status.clear()
+        no_backend_since: Optional[float] = None
+        withdrawn_for_no_hardware = False
+
         while self._thread_event_publish_status.is_set() is False:
-            json_str = self.status().model_dump_json()
+            current = self.status()
+            json_str = current.model_dump_json()
             if self.ws_server is None:
                 self.logger.warning(
                     f"WS server not initialized, cannot publish status: {json_str}"
                 )
             else:
                 self.ws_server.publish_status(json_str)
+
+            # Forward any meta change to central (no-op when nothing
+            # moved). Wrapped in try/except so a transient relay error
+            # never breaks the local-WS publishing path.
+            try:
+                notify_meta_change()
+            except Exception as exc:
+                self.logger.debug("notify_meta_change failed: %s", exc)
+
+            # Layer-B watchdog: tray daemon with no hardware. Plain
+            # robots (Pi) never trigger this branch because
+            # ``desktop_app_daemon`` is False, so the watchdog stays
+            # off. We re-publish (`update_producer_meta` is cheap)
+            # rather than withdraw on the first tick to absorb USB
+            # re-enumerations that take a few hundred ms.
+            if self.desktop_app_daemon:
+                if current.backend_status is None:
+                    if no_backend_since is None:
+                        no_backend_since = time.monotonic()
+                    elif (
+                        not withdrawn_for_no_hardware
+                        and time.monotonic() - no_backend_since
+                        >= self._NO_HARDWARE_GRACE_SECONDS
+                    ):
+                        self.logger.info(
+                            "Tray daemon has no hardware after %.0fs; withdrawing from central",
+                            self._NO_HARDWARE_GRACE_SECONDS,
+                        )
+                        try:
+                            notify_withdraw()
+                        except Exception as exc:
+                            self.logger.debug("notify_withdraw failed: %s", exc)
+                        withdrawn_for_no_hardware = True
+                else:
+                    if withdrawn_for_no_hardware:
+                        # Hardware came back: ``notify_meta_change``
+                        # above will already have re-registered us as
+                        # producer because the cached meta was cleared
+                        # on withdraw(). Just clear the local flag.
+                        self.logger.info(
+                            "Tray daemon recovered hardware; re-registering on central"
+                        )
+                        withdrawn_for_no_hardware = False
+                    no_backend_since = None
+
             time.sleep(1)
 
     def _setup_backend(

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -337,10 +337,20 @@ class Daemon:
         ``PeerHealth``. We rebuild a fresh ``DaemonStatus`` snapshot on
         every call so transient transitions show up promptly; ``status()``
         is cheap (single attribute read + backend.get_status() if any).
+
+        We pass the live ``backend.ready`` Event value as
+        ``backend_ready_override`` because ``RobotBackendStatus.ready``
+        (the static pydantic field) is never refreshed after backend
+        init - the runtime authority is the Event. Without the override
+        ``compute()`` would always see ``ready=False`` and report
+        ``error/backend_not_ready`` even on a perfectly healthy robot.
         """
         from reachy_mini.daemon.peer_health import compute
 
-        return compute(self.status())
+        backend_ready = (
+            self.backend.ready.is_set() if self.backend is not None else None
+        )
+        return compute(self.status(), backend_ready_override=backend_ready)
 
     async def _stop_central_signaling_relay(self) -> None:
         """Tear down the relay, with an explicit withdraw beforehand.

--- a/src/reachy_mini/daemon/peer_health.py
+++ b/src/reachy_mini/daemon/peer_health.py
@@ -1,0 +1,123 @@
+"""Health derivation for the central signaling ``meta`` payload.
+
+This module owns *one* question: given a snapshot of the daemon's state,
+what value of ``meta.health`` should the central listing publish?
+
+It deliberately knows nothing about:
+
+- the central signaling relay (we are called *by* it, never the other way),
+- WebRTC, HTTP, BLE, or any transport,
+- the difference between a desktop tray and a robot Pi (the caller has
+  that knowledge and passes it explicitly).
+
+The result is a small dataclass the caller copies into the ``meta`` dict.
+Keeping the logic in a pure function makes the truth table easy to test
+and lets the central relay treat health as opaque data.
+
+See ``docs/SIGNALING.md`` for the published contract values and the
+client-side policy attached to each.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from reachy_mini.io.protocol import DaemonState, DaemonStatus
+
+HealthValue = Literal["ok", "degraded", "error"]
+"""Tri-state matching the values mobile/desktop clients understand.
+
+- ``ok``       fully operational, auto-connect allowed
+- ``degraded`` daemon up, optional subsystem missing (camera, audio, …)
+- ``error``    do not auto-connect, surface to user
+"""
+
+
+@dataclass(frozen=True)
+class PeerHealth:
+    """The health verdict for a single status snapshot.
+
+    ``health`` is the user-facing tri-state. ``error_code`` is a short
+    stable taxonomy attached when ``health != "ok"`` so clients can
+    branch (e.g. show a "no hardware" prompt vs. a "media subsystem
+    failed" warning) without parsing free-text messages. It is
+    intentionally a small set; do not invent codes per call site.
+    """
+
+    health: HealthValue
+    error_code: Optional[str]
+
+
+# Stable error code taxonomy. Add values here and update SIGNALING.md
+# (the "stable taxonomy" sentence) whenever a new code ships.
+ERR_NO_BACKEND = "no_backend"  # tray/robot with no backend instance attached
+ERR_BACKEND_NOT_READY = (
+    "backend_not_ready"  # backend object exists but ready Event never set
+)
+ERR_MOTOR_COMM = "motor_comm"  # serial/USB error reported by the backend
+ERR_DAEMON_FATAL = "daemon_fatal"  # daemon state == ERROR with no more specific cause
+ERR_MEDIA = "media"  # camera/audio missing - degraded only, not error
+
+
+def compute(status: DaemonStatus) -> PeerHealth:
+    """Derive the published ``health`` from a daemon status snapshot.
+
+    The caller is expected to pass the ``DaemonStatus`` it just produced
+    via ``daemon.status()``. Everything we need lives there:
+
+    - ``state`` for fatal transitions (ERROR, STOPPING, …)
+    - ``backend_status.ready`` for hardware readiness
+    - ``backend_status.error`` for explicit motor / serial errors
+    - ``no_media`` to avoid flagging "media missing" when it was disabled
+      on purpose (``--no-media``)
+
+    No I/O, no mutation, no logging. This function must remain a pure
+    transformation of its argument so the truth-table tests in
+    ``tests/test_peer_health.py`` stay reliable.
+    """
+    # Hard fatal states first - they short-circuit every other check.
+    if status.state in (DaemonState.STOPPING, DaemonState.STOPPED):
+        # We're tearing down on purpose. Don't tell listeners we're "ok"
+        # for the few seconds it takes to actually close the relay; the
+        # client should immediately stop showing us as auto-connectable.
+        return PeerHealth(health="error", error_code=ERR_DAEMON_FATAL)
+
+    if status.state == DaemonState.ERROR:
+        # Surface the most informative code we can find.
+        backend = status.backend_status
+        if backend is not None and getattr(backend, "error", None):
+            return PeerHealth(health="error", error_code=ERR_MOTOR_COMM)
+        if backend is None:
+            return PeerHealth(health="error", error_code=ERR_NO_BACKEND)
+        return PeerHealth(health="error", error_code=ERR_DAEMON_FATAL)
+
+    # Daemon is in a non-fatal state. Now look at the backend.
+    backend = status.backend_status
+    if backend is None:
+        # Most common reason: a desktop tray daemon was started but no
+        # USB hardware was detected, so we never instantiated a
+        # RobotBackend. From a remote-listing point of view this is an
+        # error: nothing on this peer can serve a session.
+        return PeerHealth(health="error", error_code=ERR_NO_BACKEND)
+
+    if not getattr(backend, "ready", False):
+        # Backend object exists but its readiness Event is not set.
+        # During NOT_INITIALIZED / STARTING this can happen briefly;
+        # we still report ``error`` so the client doesn't auto-connect
+        # mid-bootstrap. The next status tick will correct it once the
+        # Event flips.
+        return PeerHealth(health="error", error_code=ERR_BACKEND_NOT_READY)
+
+    if getattr(backend, "error", None):
+        # Backend is "ready" but has logged a recoverable error
+        # (transient motor read failure, etc.). Treat as degraded for
+        # now - the user can still control the robot, we just want a
+        # warning surface.
+        return PeerHealth(health="degraded", error_code=ERR_MOTOR_COMM)
+
+    # Media subsystem was requested but failed to come up.
+    if not status.no_media and not status.camera_specs_name:
+        return PeerHealth(health="degraded", error_code=ERR_MEDIA)
+
+    return PeerHealth(health="ok", error_code=None)

--- a/src/reachy_mini/daemon/peer_health.py
+++ b/src/reachy_mini/daemon/peer_health.py
@@ -60,7 +60,11 @@ ERR_DAEMON_FATAL = "daemon_fatal"  # daemon state == ERROR with no more specific
 ERR_MEDIA = "media"  # camera/audio missing - degraded only, not error
 
 
-def compute(status: DaemonStatus) -> PeerHealth:
+def compute(
+    status: DaemonStatus,
+    *,
+    backend_ready_override: Optional[bool] = None,
+) -> PeerHealth:
     """Derive the published ``health`` from a daemon status snapshot.
 
     The caller is expected to pass the ``DaemonStatus`` it just produced
@@ -72,8 +76,16 @@ def compute(status: DaemonStatus) -> PeerHealth:
     - ``no_media`` to avoid flagging "media missing" when it was disabled
       on purpose (``--no-media``)
 
+    ``backend_ready_override`` is provided because the canonical
+    "backend is up" signal lives on the runtime ``backend.ready``
+    Event, and ``RobotBackendStatus.ready`` (the static field on the
+    pydantic model) is never refreshed after init. The Daemon hands us
+    the live Event value here so we don't trip on that asymmetry. When
+    ``None`` we fall back to the model field, which keeps tests and
+    third-party callers without a live Event still functional.
+
     No I/O, no mutation, no logging. This function must remain a pure
-    transformation of its argument so the truth-table tests in
+    transformation of its arguments so the truth-table tests in
     ``tests/test_peer_health.py`` stay reliable.
     """
     # Hard fatal states first - they short-circuit every other check.
@@ -101,7 +113,12 @@ def compute(status: DaemonStatus) -> PeerHealth:
         # error: nothing on this peer can serve a session.
         return PeerHealth(health="error", error_code=ERR_NO_BACKEND)
 
-    if not getattr(backend, "ready", False):
+    backend_ready = (
+        backend_ready_override
+        if backend_ready_override is not None
+        else bool(getattr(backend, "ready", False))
+    )
+    if not backend_ready:
         # Backend object exists but its readiness Event is not set.
         # During NOT_INITIALIZED / STARTING this can happen briefly;
         # we still report ``error`` so the client doesn't auto-connect

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -89,6 +89,13 @@ class DaemonStatus(BaseModel):
     # human-readable name. Optional only for backward compatibility
     # with older daemons / tests that build a status by hand.
     install_id: Optional[str] = None
+    # Producer peer id assigned by the HF central signaling server on the
+    # ``welcome`` frame. Volatile (rotates on every relay reconnect),
+    # forwarded to mobile clients so they can dedupe a "this Mac" loopback
+    # row against the same physical robot's central listing while the HF
+    # central server does not yet propagate ``meta.install_id``. Always
+    # ``None`` when the relay is offline (no token, no network, etc.).
+    central_peer_id: Optional[str] = None
     state: DaemonState
     wireless_version: bool
     desktop_app_daemon: bool

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -81,6 +81,14 @@ class DaemonStatus(BaseModel):
 
     type: Literal["daemon_status"] = "daemon_status"
     robot_name: str
+    # Stable, opaque per-install identifier (UUID4 hex). Generated on
+    # first boot and persisted alongside ``robot_name`` in
+    # ``daemon.json``. Used by the mobile app to merge sightings of the
+    # same physical robot across BLE, mDNS, loopback HTTP, and the HF
+    # central listing into a single row even before the user picks a
+    # human-readable name. Optional only for backward compatibility
+    # with older daemons / tests that build a status by hand.
+    install_id: Optional[str] = None
     state: DaemonState
     wireless_version: bool
     desktop_app_daemon: bool

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -772,7 +772,14 @@ class CentralSignalingRelay:
 
     async def _send_to_central(self, msg: dict[str, Any]) -> None:
         """Send a message to the central server via HTTP POST."""
+        msg_type = msg.get("type", "?")
         if not self._http_session or not self.hf_token:
+            logger.warning(
+                "[Central Relay] _send_to_central skipped (type=%s, http_session=%s, hf_token=%s)",
+                msg_type,
+                bool(self._http_session),
+                bool(self.hf_token),
+            )
             return
 
         # Token goes in the Authorization header only, not the URL.
@@ -783,12 +790,24 @@ class CentralSignalingRelay:
                 send_url, json=msg, headers=headers
             ) as response:
                 if response.status != 200:
+                    body = ""
+                    try:
+                        body = (await response.text())[:300]
+                    except Exception:
+                        pass
                     logger.warning(
-                        f"[Central Relay] Failed to send message to central server: HTTP {response.status}"
+                        "[Central Relay] _send_to_central FAILED type=%s HTTP %s body=%r",
+                        msg_type,
+                        response.status,
+                        body,
                     )
+                else:
+                    logger.info("[Central Relay] _send_to_central OK type=%s", msg_type)
         except Exception as e:
             logger.error(
-                f"[Central Relay] Error sending message to central server: {e}"
+                "[Central Relay] _send_to_central exception type=%s err=%s",
+                msg_type,
+                e,
             )
 
     async def _send_to_local(self, msg: dict[str, Any]) -> None:
@@ -809,17 +828,28 @@ class CentralSignalingRelay:
         if msg_type == "welcome":
             # Received our peer ID from central server
             self._central_peer_id = msg.get("peerId")
-            self._set_state(
-                RelayState.CONNECTED, f"Remote access enabled as '{self.robot_name}'"
+            logger.info(
+                "[Central Relay] central welcome received peer_id=%s; registering as producer name=%r",
+                self._central_peer_id,
+                self.robot_name,
             )
 
-            # Register as producer
+            # Register as producer FIRST, then flip to CONNECTED. If we
+            # set CONNECTED before producer registration, observers (UI,
+            # mobile app, /relay-status pollers) can see "connected" while
+            # central does not yet know we are a producer for this user,
+            # which produces the desync described in /refresh-relay's
+            # docstring.
             await self._send_to_central(
                 {
                     "type": "setPeerStatus",
                     "roles": ["producer"],
                     "meta": {"name": self.robot_name},
                 }
+            )
+
+            self._set_state(
+                RelayState.CONNECTED, f"Remote access enabled as '{self.robot_name}'"
             )
 
         elif msg_type == "list":

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -1130,6 +1130,45 @@ class CentralSignalingRelay:
                 ):
                     self._robot_app_lock.release_remote()
 
+    async def update_producer_name(self, robot_name: str) -> None:
+        """Update the producer name advertised to central, live.
+
+        Used by the daemon when the user renames the robot from the mobile
+        app: we need central's view of the fleet to reflect the new label
+        immediately, without forcing a full relay reconnect (which would
+        churn the WebSocket and momentarily evict any active remote
+        session).
+
+        Idempotent: a no-op when the name has not changed. Safe to call
+        before the relay is connected; the new value will be picked up by
+        the next ``setPeerStatus`` emitted on ``welcome``.
+
+        Must be invoked from the relay's own thread loop (or via
+        ``asyncio.run_coroutine_threadsafe`` for cross-thread callers) so
+        that the ``_send_to_central`` HTTP call uses the right session.
+        """
+        if robot_name == self.robot_name:
+            return
+
+        self.robot_name = robot_name
+        logger.info(
+            "[Central Relay] producer name updated to %r (state=%s)",
+            robot_name,
+            self._state.value,
+        )
+
+        # Only emit setPeerStatus when we're actually registered with
+        # central. In any other state the next ``welcome`` will use the
+        # already-updated ``self.robot_name``.
+        if self._state == RelayState.CONNECTED and self._central_peer_id is not None:
+            await self._send_to_central(
+                {
+                    "type": "setPeerStatus",
+                    "roles": ["producer"],
+                    "meta": {"name": self.robot_name},
+                }
+            )
+
 
 # Singleton instance for integration
 _relay_instance: Optional[CentralSignalingRelay] = None
@@ -1260,3 +1299,44 @@ async def notify_force_reconnect() -> None:
         return
 
     await _relay_instance.force_reconnect()
+
+
+async def notify_robot_name_change(new_name: str) -> None:
+    """Push a renamed robot to central without reconnecting.
+
+    Called by ``Daemon.set_robot_name`` after the in-memory and on-disk
+    state has been updated. No-op when there is no relay (Lite, no token,
+    relay not started yet); the relay will pick up the new name on its
+    next ``start()`` because the daemon also passes the fresh name to
+    ``start_central_relay``.
+
+    The actual ``setPeerStatus`` send happens on the relay's own thread
+    loop via ``run_coroutine_threadsafe``: ``_send_to_central`` uses the
+    relay-local ``aiohttp.ClientSession``, which is bound to that loop.
+    """
+    if _relay_instance is None:
+        logger.debug(
+            "[Central Relay] No relay instance, robot name change is in-memory only"
+        )
+        return
+
+    loop = _relay_instance._thread_loop
+    if loop is None or not loop.is_running():
+        # Relay thread not up yet; just update the attribute so the next
+        # ``welcome`` advertises the right name.
+        _relay_instance.robot_name = new_name
+        return
+
+    fut = asyncio.run_coroutine_threadsafe(
+        _relay_instance.update_producer_name(new_name), loop
+    )
+    try:
+        # Bound the wait so a stuck relay thread cannot freeze the HTTP
+        # request that triggered the rename. Failure here is non-fatal:
+        # the on-disk + in-memory state is already updated, central will
+        # catch up on its next reconnect / welcome.
+        await asyncio.get_event_loop().run_in_executor(None, fut.result, 5.0)
+    except Exception as exc:
+        logger.warning(
+            "[Central Relay] update_producer_name(%r) failed: %s", new_name, exc
+        )

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -170,6 +170,20 @@ class CentralSignalingRelay:
         else:
             logger.debug(log_msg)
 
+        # Structured kv form: easy to grep, easy to dashboard. The
+        # human-readable line above stays for compatibility with anyone
+        # reading the systemd journal directly.
+        from reachy_mini.daemon.app.logging_ctx import kv_log
+
+        kv_log(
+            logger,
+            logging.INFO if state != RelayState.ERROR else logging.WARNING,
+            "central.relay.state",
+            from_=old_state.value,
+            to=state.value,
+            message=message,
+        )
+
         # Notify callback if set
         if self._on_state_change:
             try:
@@ -194,7 +208,9 @@ class CentralSignalingRelay:
         # coroutine is invoked on the main asyncio loop and schedules the
         # actual tear-down on the relay's own thread loop.
         if self._robot_app_lock is not None:
-            self._robot_app_lock.set_remote_eviction_handler(self._handle_remote_eviction)
+            self._robot_app_lock.set_remote_eviction_handler(
+                self._handle_remote_eviction
+            )
 
         # Run the relay in its own thread with a dedicated event loop.
         # This is necessary because the caller (daemon.start) may run in a temporary

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -194,7 +194,9 @@ class CentralSignalingRelay:
         # coroutine is invoked on the main asyncio loop and schedules the
         # actual tear-down on the relay's own thread loop.
         if self._robot_app_lock is not None:
-            self._robot_app_lock.set_remote_eviction_handler(self._handle_remote_eviction)
+            self._robot_app_lock.set_remote_eviction_handler(
+                self._handle_remote_eviction
+            )
 
         # Run the relay in its own thread with a dedicated event loop.
         # This is necessary because the caller (daemon.start) may run in a temporary
@@ -331,17 +333,38 @@ class CentralSignalingRelay:
             logger.debug("[Central Relay] Token unchanged, no action needed")
             return
 
-        if new_token:
-            self._set_state(
-                RelayState.RECONNECTING, "HF token updated, reconnecting..."
-            )
-            self._connection_attempts = 0  # Reset retry counter on new token
+        await self._reconnect_now(new_token, reason="HF token updated, reconnecting...")
+
+    async def force_reconnect(self) -> None:
+        """Drop the current connection and reconnect with the stored token.
+
+        Unlike ``update_token``, this path is NOT guarded by a token
+        equality check - it always tears down the SSE and reconnects.
+
+        Intended as a recovery handle for split-brain states where the
+        relay thinks it is connected but central no longer lists this
+        robot as a producer (see ``POST /api/hf-auth/refresh-relay``).
+        """
+        await self._reconnect_now(self.hf_token, reason="Forced relay reconnect")
+
+    async def _reconnect_now(self, token: Optional[str], reason: str) -> None:
+        """Shared core of token-change and force-reconnect paths.
+
+        Transitions the relay into the right state and signals the run
+        loop to tear down the current connection and try connecting
+        again. Safe to call from any thread - if we have a running
+        thread loop we schedule the close/set there, otherwise we set
+        the event directly (covers the case where the relay has not
+        started its background thread yet).
+        """
+        if token:
+            self._set_state(RelayState.RECONNECTING, reason)
+            self._connection_attempts = 0
         else:
             self._set_state(RelayState.WAITING_FOR_TOKEN, "Logged out from HuggingFace")
 
-        # Signal the run loop to wake up and try connecting (thread-safe)
         if self._thread_loop and self._thread_loop.is_running():
-            # Schedule _close_connections and token_updated.set in the thread's event loop
+
             async def _reconnect() -> None:
                 await self._close_connections()
                 self._token_updated.set()
@@ -1146,3 +1169,19 @@ async def notify_token_change(new_token: Optional[str] = None) -> None:
             pass
 
     await _relay_instance.update_token(new_token)
+
+
+async def notify_force_reconnect() -> None:
+    """Ask the relay to drop its SSE channel and reconnect right now.
+
+    Unlike ``notify_token_change``, this always triggers a reconnect
+    even when the stored token is unchanged. Used by the
+    ``POST /api/hf-auth/refresh-relay`` endpoint to recover from
+    zombie-relay states where central no longer lists the robot as a
+    producer but the relay still thinks it is connected.
+    """
+    if _relay_instance is None:
+        logger.debug("[Central Relay] No relay instance, ignoring force reconnect")
+        return
+
+    await _relay_instance.force_reconnect()

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -147,6 +147,20 @@ class CentralSignalingRelay:
         """Get additional info about the current state."""
         return self._state_message
 
+    @property
+    def central_peer_id(self) -> Optional[str]:
+        """The producer peer id central assigned to this relay.
+
+        Set on the ``welcome`` frame the first time we connect, cleared
+        on disconnect/teardown. Read by callers outside the relay thread
+        (HTTP handlers, daemon status snapshots): a single attribute load
+        on a `str | None` is atomic in CPython, so we do not need a lock
+        here. Callers MUST treat this as advisory - a freshly reconnected
+        relay can return a new id, and consumers (mobile dedupe, status
+        endpoints) should re-read on every refresh.
+        """
+        return self._central_peer_id
+
     def _set_state(self, state: RelayState, message: Optional[str] = None) -> None:
         """Update the connection state with logging."""
         old_state = self._state
@@ -1227,6 +1241,19 @@ def get_relay_status() -> dict[str, Any]:
         "message": _relay_instance.state_message,
         "is_connected": _relay_instance.state == RelayState.CONNECTED,
     }
+
+
+def get_central_peer_id() -> Optional[str]:
+    """Best-effort lookup of the producer peer id central assigned us.
+
+    Returns ``None`` when the relay is not running or has not yet
+    received the ``welcome`` frame. Used by callers (HTTP handlers,
+    daemon identity endpoint) that want to expose this value to clients
+    without taking a hard dependency on the relay singleton.
+    """
+    if _relay_instance is None:
+        return None
+    return _relay_instance.central_peer_id
 
 
 async def start_central_relay(

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -438,8 +438,39 @@ class CentralSignalingRelay:
                 try:
                     await self._connect_and_relay()
                 except asyncio.CancelledError:
-                    logger.info("[Central Relay] _run_loop cancelled during connect")
-                    raise  # Re-raise to exit the outer try
+                    # CancelledError at this layer has two possible sources:
+                    #
+                    # 1. `stop()` flipped `self._running` to False. This is the
+                    #    shutdown path and we must re-raise so the thread exits.
+                    # 2. An in-flight `_close_connections()` (triggered by
+                    #    `force_reconnect` / `update_token`) cancelled a task
+                    #    that aiohttp was holding the cancellation for - e.g.
+                    #    a `session.get(...)` wedged inside `_resolve_host` on
+                    #    a flaky network. aiohttp propagates that cancellation
+                    #    up through `_handle_central_sse`, which lands here.
+                    #    In that case we very much want to stay in the loop and
+                    #    reconnect - killing the thread here means every
+                    #    subsequent `/refresh-relay` POST is a no-op because
+                    #    there's no loop left to service the token_updated
+                    #    event.
+                    #
+                    # `self._running` is our authoritative signal for (1). If
+                    # it's still True, treat the cancellation as a reconnect
+                    # request and loop around.
+                    if not self._running:
+                        logger.info(
+                            "[Central Relay] _run_loop cancelled (stop requested)"
+                        )
+                        raise
+                    logger.info(
+                        "[Central Relay] Connect attempt cancelled mid-flight "
+                        "(likely from force_reconnect / token update); restarting loop"
+                    )
+                    had_exception = True
+                    self._set_state(
+                        RelayState.RECONNECTING,
+                        "Restarting after cancelled connect",
+                    )
                 except Exception as e:
                     logger.warning(
                         f"[Central Relay] Connection attempt failed with exception: {type(e).__name__}: {e}"

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -73,6 +73,7 @@ class CentralSignalingRelay:
         local_uri: str = LOCAL_GSTREAMER_SIGNALING,
         hf_token: Optional[str] = None,
         robot_name: str = "reachymini",
+        install_id: Optional[str] = None,
         on_state_change: Optional[Callable[["RelayState", Optional[str]], None]] = None,
         robot_app_lock: Optional[RobotAppLock] = None,
     ):
@@ -83,6 +84,12 @@ class CentralSignalingRelay:
             local_uri: WebSocket URI of local GStreamer signaling server
             hf_token: HuggingFace token for authentication (will be refreshed)
             robot_name: Name to register as producer
+            install_id: Stable per-install opaque identifier (UUID4
+                hex). Forwarded as ``meta.install_id`` on every
+                ``setPeerStatus`` so the central listing carries the
+                same reconciliation key the BLE / mDNS / loopback
+                surfaces report. Omitted when no install id is known
+                yet (very early boot, tests).
             on_state_change: Callback when state changes (state, message)
             robot_app_lock: Shared lock coordinating local vs remote access to
                 the robot. When provided, incoming remote sessions are
@@ -94,6 +101,7 @@ class CentralSignalingRelay:
         self.local_uri = local_uri
         self.hf_token = hf_token
         self.robot_name = robot_name
+        self.install_id = install_id
         self._on_state_change = on_state_change
         self._robot_app_lock = robot_app_lock
 
@@ -858,7 +866,7 @@ class CentralSignalingRelay:
                 {
                     "type": "setPeerStatus",
                     "roles": ["producer"],
-                    "meta": {"name": self.robot_name},
+                    "meta": self._build_producer_meta(),
                 }
             )
 
@@ -1165,9 +1173,25 @@ class CentralSignalingRelay:
                 {
                     "type": "setPeerStatus",
                     "roles": ["producer"],
-                    "meta": {"name": self.robot_name},
+                    "meta": self._build_producer_meta(),
                 }
             )
+
+    def _build_producer_meta(self) -> dict[str, Any]:
+        """Assemble the ``meta`` payload sent on every ``setPeerStatus``.
+
+        Always includes ``name`` (human-readable robot label). Adds
+        ``install_id`` when one is known: this is the stable
+        reconciliation key that lets the mobile app's robot registry
+        merge a central row with the same robot's BLE / mDNS / loopback
+        sightings. We deliberately keep the payload additive so older
+        central versions that don't know about ``install_id`` ignore
+        it without complaining.
+        """
+        meta: dict[str, Any] = {"name": self.robot_name}
+        if self.install_id:
+            meta["install_id"] = self.install_id
+        return meta
 
 
 # Singleton instance for integration
@@ -1208,6 +1232,7 @@ def get_relay_status() -> dict[str, Any]:
 async def start_central_relay(
     hf_token: Optional[str] = None,
     robot_name: str = "reachymini",
+    install_id: Optional[str] = None,
     central_uri: str = CENTRAL_SIGNALING_SERVER,
     on_state_change: Optional[Callable[[RelayState, Optional[str]], None]] = None,
     robot_app_lock: Optional[RobotAppLock] = None,
@@ -1217,6 +1242,8 @@ async def start_central_relay(
     Args:
         hf_token: HuggingFace token for authentication (will auto-refresh)
         robot_name: Name to register as producer
+        install_id: Stable per-install reconciliation key (forwarded to
+            the producer ``meta``). See ``CentralSignalingRelay``.
         central_uri: Central server URI
         on_state_change: Callback when connection state changes
         robot_app_lock: Shared lock coordinating local vs remote robot access.
@@ -1243,6 +1270,7 @@ async def start_central_relay(
         central_uri=central_uri,
         hf_token=hf_token,
         robot_name=robot_name,
+        install_id=install_id,
         on_state_change=on_state_change,
         robot_app_lock=robot_app_lock,
     )

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -66,12 +66,32 @@ CONNECTION_STALE_THRESHOLD = 90.0  # seconds - consider connection stale if no a
 # otherwise post nothing for minutes and get falsely evicted by the
 # TTL sweeper.
 #
-# 20 s pairs with the central's 45 s lease: tolerates two consecutive
-# missed heartbeats (network blip, transient relay restart) before
-# eviction kicks in. Tunable via env for failure-mode testing.
+# This module-level constant is the *fallback* default. The relay also
+# negotiates the actual heartbeat interval from the ``welcome`` SSE
+# frame (``recommended_heartbeat_interval_seconds`` field), so the
+# central server is the single source of truth: bumping ``LEASE_SECONDS``
+# on the server propagates to all daemons on their next reconnect with
+# zero daemon redeploy. The default below is used only:
+#   1. before the first welcome arrives (initial connect window),
+#   2. when talking to an older central that does not advertise the
+#      recommended interval (full backwards-compatibility),
+#   3. for unit tests that exercise the heartbeat loop without a real
+#      central.
+#
+# 5 s pairs with the central's default 15 s lease (tolerates two
+# consecutive missed heartbeats: 5+5+5=15 → just at the edge, sweeper
+# gives ~3 s of margin). Tunable via env for failure-mode testing.
 HEARTBEAT_INTERVAL_SECONDS = float(
-    os.getenv("REACHY_CENTRAL_HEARTBEAT_INTERVAL", "20.0")
+    os.getenv("REACHY_CENTRAL_HEARTBEAT_INTERVAL", "5.0")
 )
+
+# Bounds applied to a server-recommended heartbeat to defend against a
+# malformed welcome (typo, type confusion, partial deploy). 1 s lower
+# bound avoids spamming central with sub-second posts; 60 s upper bound
+# is roughly 3x the largest reasonable lease (180 s) so we never under-
+# heartbeat a legitimately-conservative server config.
+MIN_HEARTBEAT_INTERVAL_SECONDS = 1.0
+MAX_HEARTBEAT_INTERVAL_SECONDS = 60.0
 
 
 class CentralSignalingRelay:
@@ -167,10 +187,22 @@ class CentralSignalingRelay:
         # Monotonic timestamp of the last ``setPeerStatus`` actually
         # sent (initial registration counts). Drives the heartbeat:
         # ``update_producer_meta`` re-emits an identical meta when the
-        # gap exceeds ``HEARTBEAT_INTERVAL_SECONDS`` so central can
-        # refresh ``last_seen`` without our own SSE keepalive (which is
-        # not a valid liveness proof - see ``docs/SIGNALING.md``).
+        # gap exceeds ``self._heartbeat_interval_seconds`` so central
+        # can refresh ``last_seen`` without our own SSE keepalive
+        # (which is not a valid liveness proof - see
+        # ``docs/SIGNALING.md``).
         self._last_published_at: Optional[float] = None
+        # Active heartbeat interval. Initialised from the module-level
+        # default and overridden when the central server advertises
+        # ``recommended_heartbeat_interval_seconds`` in its ``welcome``
+        # frame. This makes ``LEASE_SECONDS`` (server-side) the single
+        # source of truth for the liveness contract, with daemons
+        # auto-aligning on every reconnect. See ``docs/SIGNALING.md``.
+        self._heartbeat_interval_seconds: float = HEARTBEAT_INTERVAL_SECONDS
+        # Last lease advertised by central (informational only, used in
+        # logs and in ``DaemonStatus`` snapshots so operators can see
+        # the contract the daemon is currently honouring).
+        self._central_lease_seconds: Optional[float] = None
 
         self._running = False
         self._state = RelayState.STOPPED
@@ -923,6 +955,50 @@ class CentralSignalingRelay:
                     f"[Central Relay] Failed to send message to local GStreamer: {e}"
                 )
 
+    def _apply_welcome_negotiation(self, msg: dict[str, Any]) -> None:
+        """Honour the heartbeat / lease parameters sent by central.
+
+        Best-effort: malformed or absent fields fall back to the
+        module-level default so a partial-deploy or older central
+        keeps working. The result is clamped to
+        ``[MIN_HEARTBEAT_INTERVAL_SECONDS, MAX_HEARTBEAT_INTERVAL_SECONDS]``
+        as a defence against typos / type confusion (a welcome saying
+        ``"recommended_heartbeat_interval_seconds": "5"`` is legal JSON
+        but must not coerce us into busy-looping).
+        """
+        recommended = msg.get("recommended_heartbeat_interval_seconds")
+        try:
+            recommended_f = float(recommended) if recommended is not None else None
+        except (TypeError, ValueError):
+            logger.warning(
+                "[Central Relay] welcome had non-numeric heartbeat hint %r; ignoring",
+                recommended,
+            )
+            recommended_f = None
+
+        if recommended_f is not None:
+            clamped = max(
+                MIN_HEARTBEAT_INTERVAL_SECONDS,
+                min(MAX_HEARTBEAT_INTERVAL_SECONDS, recommended_f),
+            )
+            if clamped != recommended_f:
+                logger.warning(
+                    "[Central Relay] welcome heartbeat hint %.2fs out of bounds, clamped to %.2fs",
+                    recommended_f,
+                    clamped,
+                )
+            self._heartbeat_interval_seconds = clamped
+        else:
+            # No hint: keep the module-level default so a daemon talking
+            # to a pre-negotiation central still heartbeats.
+            self._heartbeat_interval_seconds = HEARTBEAT_INTERVAL_SECONDS
+
+        lease = msg.get("lease_seconds")
+        try:
+            self._central_lease_seconds = float(lease) if lease is not None else None
+        except (TypeError, ValueError):
+            self._central_lease_seconds = None
+
     async def _process_central_message(self, msg: dict[str, Any]) -> None:
         """Process a message from the central server."""
         msg_type = msg.get("type", "")
@@ -931,9 +1007,25 @@ class CentralSignalingRelay:
         if msg_type == "welcome":
             # Received our peer ID from central server
             self._central_peer_id = msg.get("peerId")
+
+            # Negotiate the heartbeat interval from central's welcome.
+            # The server picks the value (LEASE / 3 by convention) so
+            # operators only ever tune ``LEASE_SECONDS`` server-side
+            # and every daemon auto-aligns on the next reconnect with
+            # zero coordinated redeploy. Older central versions omit
+            # these fields; we keep the module-level fallback intact so
+            # the daemon still works against pre-negotiation servers.
+            self._apply_welcome_negotiation(msg)
+
             logger.info(
-                "[Central Relay] central welcome received peer_id=%s; registering as producer name=%r",
+                "[Central Relay] central welcome received peer_id=%s heartbeat=%.1fs lease=%s; registering as producer name=%r",
                 self._central_peer_id,
+                self._heartbeat_interval_seconds,
+                (
+                    f"{self._central_lease_seconds:.1f}s"
+                    if self._central_lease_seconds is not None
+                    else "n/a"
+                ),
                 self.robot_name,
             )
 
@@ -1343,12 +1435,14 @@ class CentralSignalingRelay:
            tick, no waiting for a heartbeat.
 
         2. **Heartbeat**: even when the meta is identical, force a
-           re-emit if more than ``HEARTBEAT_INTERVAL_SECONDS`` have
-           elapsed since the last send. This is the ONLY way central
-           can refresh ``last_seen`` for an idle-but-online producer:
-           server-pushed SSE keepalives don't prove the peer is alive
-           (a half-open TCP socket happily absorbs writes), so central
-           ignores them and relies on inbound application traffic.
+           re-emit if more than ``self._heartbeat_interval_seconds``
+           have elapsed since the last send. This is the ONLY way
+           central can refresh ``last_seen`` for an idle-but-online
+           producer: server-pushed SSE keepalives don't prove the peer
+           is alive (a half-open TCP socket happily absorbs writes),
+           so central ignores them and relies on inbound application
+           traffic. The interval itself is negotiated from the
+           ``welcome`` SSE frame (see ``_apply_welcome_negotiation``).
 
         Same threading rules as ``update_producer_name``: must run on
         the relay's own loop. Cross-thread callers go through
@@ -1369,7 +1463,7 @@ class CentralSignalingRelay:
         now = time.monotonic()
         heartbeat_due = (
             self._last_published_at is None
-            or (now - self._last_published_at) >= HEARTBEAT_INTERVAL_SECONDS
+            or (now - self._last_published_at) >= self._heartbeat_interval_seconds
         )
         if not meta_changed and not heartbeat_due:
             return False
@@ -1458,7 +1552,12 @@ def get_relay_status() -> dict[str, Any]:
     """Get the current status of the central relay.
 
     Returns:
-        A dict with state, message, and is_connected fields
+        A dict with state, message, is_connected fields, plus the
+        liveness contract negotiated with central
+        (``heartbeat_interval_seconds``, ``central_lease_seconds``).
+        The liveness fields are present even when the relay is
+        connecting/error so operators can correlate the active config
+        with eviction logs without restarting the daemon.
 
     """
     if _relay_instance is None:
@@ -1466,12 +1565,16 @@ def get_relay_status() -> dict[str, Any]:
             "state": RelayState.STOPPED.value,
             "message": "Relay not initialized",
             "is_connected": False,
+            "heartbeat_interval_seconds": HEARTBEAT_INTERVAL_SECONDS,
+            "central_lease_seconds": None,
         }
 
     return {
         "state": _relay_instance.state.value,
         "message": _relay_instance.state_message,
         "is_connected": _relay_instance.state == RelayState.CONNECTED,
+        "heartbeat_interval_seconds": _relay_instance._heartbeat_interval_seconds,
+        "central_lease_seconds": _relay_instance._central_lease_seconds,
     }
 
 

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -12,6 +12,7 @@ The relay automatically:
 import asyncio
 import json
 import logging
+import os
 import threading
 import time
 from enum import Enum
@@ -37,8 +38,11 @@ class RelayState(Enum):
     ERROR = "error"
 
 
-# Central signaling server URL
-CENTRAL_SIGNALING_SERVER = "https://cduss-reachy-mini-central.hf.space"
+# Central signaling server URL. Override via the REACHY_CENTRAL_URL env
+# var at startup to point at a fork (test Space, staging, etc.).
+CENTRAL_SIGNALING_SERVER = os.getenv(
+    "REACHY_CENTRAL_URL", "https://cduss-reachy-mini-central.hf.space"
+)
 LOCAL_GSTREAMER_SIGNALING = "ws://127.0.0.1:8443"
 
 # Reconnection settings

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -42,7 +42,7 @@ class RelayState(Enum):
 # Central signaling server URL. Override via the REACHY_CENTRAL_URL env
 # var at startup to point at a fork (test Space, staging, etc.).
 CENTRAL_SIGNALING_SERVER = os.getenv(
-    "REACHY_CENTRAL_URL", "https://cduss-reachy-mini-central.hf.space"
+    "REACHY_CENTRAL_URL", "https://tfrere-reachy-mini-central.hf.space"
 )
 LOCAL_GSTREAMER_SIGNALING = "ws://127.0.0.1:8443"
 

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -59,6 +59,20 @@ SSE_READ_TIMEOUT = (
 CONNECTION_WATCHDOG_INTERVAL = 30.0  # seconds - how often to check connection health
 CONNECTION_STALE_THRESHOLD = 90.0  # seconds - consider connection stale if no activity
 
+# How often the daemon re-emits its ``setPeerStatus`` payload even when
+# nothing actually changed. The central server uses ``last_seen`` (only
+# refreshed on inbound application traffic, NOT on its own SSE
+# keepalive) to evict zombie producers. A daemon at steady state would
+# otherwise post nothing for minutes and get falsely evicted by the
+# TTL sweeper.
+#
+# 20 s pairs with the central's 45 s lease: tolerates two consecutive
+# missed heartbeats (network blip, transient relay restart) before
+# eviction kicks in. Tunable via env for failure-mode testing.
+HEARTBEAT_INTERVAL_SECONDS = float(
+    os.getenv("REACHY_CENTRAL_HEARTBEAT_INTERVAL", "20.0")
+)
+
 
 class CentralSignalingRelay:
     """Relay signaling messages between central server (HTTP/SSE) and local GStreamer (WebSocket).
@@ -150,6 +164,13 @@ class CentralSignalingRelay:
         # circuit identical re-emissions and avoid flooding central
         # with non-events when the daemon's status loop ticks at 1 Hz.
         self._last_published_meta: Optional[dict[str, Any]] = None
+        # Monotonic timestamp of the last ``setPeerStatus`` actually
+        # sent (initial registration counts). Drives the heartbeat:
+        # ``update_producer_meta`` re-emits an identical meta when the
+        # gap exceeds ``HEARTBEAT_INTERVAL_SECONDS`` so central can
+        # refresh ``last_seen`` without our own SSE keepalive (which is
+        # not a valid liveness proof - see ``docs/SIGNALING.md``).
+        self._last_published_at: Optional[float] = None
 
         self._running = False
         self._state = RelayState.STOPPED
@@ -931,8 +952,11 @@ class CentralSignalingRelay:
                 }
             )
             # Cache so ``update_producer_meta`` can short-circuit
-            # identical re-emissions on subsequent status ticks.
+            # identical re-emissions on subsequent status ticks. The
+            # ``_last_published_at`` stamp seeds the heartbeat timer
+            # so we don't immediately re-emit on the very next tick.
             self._last_published_meta = initial_meta
+            self._last_published_at = time.monotonic()
 
             self._set_state(
                 RelayState.CONNECTED, f"Remote access enabled as '{self.robot_name}'"
@@ -1242,6 +1266,7 @@ class CentralSignalingRelay:
                 }
             )
             self._last_published_meta = new_meta
+            self._last_published_at = time.monotonic()
 
     # Bumped only when field semantics break - additive changes (new
     # keys) keep schema_version=1. See ``docs/SIGNALING.md``.
@@ -1306,14 +1331,24 @@ class CentralSignalingRelay:
         return meta
 
     async def update_producer_meta(self) -> bool:
-        """Re-emit ``setPeerStatus`` if the meta payload has changed.
+        """Re-emit ``setPeerStatus`` if the meta changed or heartbeat is due.
 
         The daemon's status loop calls this on every tick (typically
-        1 Hz). We rebuild the meta from the current
-        ``health_provider``, compare to ``_last_published_meta``, and
-        send only if something actually changed - so a robot sitting at
-        ``health=ok`` with stable name and version produces zero
-        central traffic between explicit transitions.
+        1 Hz). Two trigger paths:
+
+        1. **Meta delta**: rebuild the meta from the current
+           ``health_provider``, compare to ``_last_published_meta``,
+           send if anything changed. So a robot transitioning to
+           ``health=degraded`` propagates to listeners on the next
+           tick, no waiting for a heartbeat.
+
+        2. **Heartbeat**: even when the meta is identical, force a
+           re-emit if more than ``HEARTBEAT_INTERVAL_SECONDS`` have
+           elapsed since the last send. This is the ONLY way central
+           can refresh ``last_seen`` for an idle-but-online producer:
+           server-pushed SSE keepalives don't prove the peer is alive
+           (a half-open TCP socket happily absorbs writes), so central
+           ignores them and relies on inbound application traffic.
 
         Same threading rules as ``update_producer_name``: must run on
         the relay's own loop. Cross-thread callers go through
@@ -1330,7 +1365,13 @@ class CentralSignalingRelay:
             return False
 
         new_meta = self._build_producer_meta()
-        if new_meta == self._last_published_meta:
+        meta_changed = new_meta != self._last_published_meta
+        now = time.monotonic()
+        heartbeat_due = (
+            self._last_published_at is None
+            or (now - self._last_published_at) >= HEARTBEAT_INTERVAL_SECONDS
+        )
+        if not meta_changed and not heartbeat_due:
             return False
 
         await self._send_to_central(
@@ -1341,6 +1382,12 @@ class CentralSignalingRelay:
             }
         )
         self._last_published_meta = new_meta
+        self._last_published_at = now
+        if not meta_changed:
+            logger.debug(
+                "[Central Relay] heartbeat re-emit (gap=%.1fs)",
+                now - (self._last_published_at or now),
+            )
         return True
 
     async def withdraw(self, *, timeout: float = 0.5) -> None:
@@ -1386,8 +1433,11 @@ class CentralSignalingRelay:
             # We are no longer claiming the producer slot, regardless
             # of whether central acked. Clear the cached meta so a
             # subsequent ``update_producer_meta`` re-sends the full
-            # payload when we reannounce.
+            # payload when we reannounce, and clear the heartbeat
+            # timestamp so the first re-announce isn't gated on the
+            # heartbeat interval.
             self._last_published_meta = None
+            self._last_published_at = None
 
 
 # Singleton instance for integration

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -22,6 +22,7 @@ import aiohttp
 import websockets
 from websockets.asyncio.client import ClientConnection
 
+from reachy_mini.daemon.peer_health import PeerHealth
 from reachy_mini.daemon.robot_app_lock import RobotAppLock
 
 logger = logging.getLogger(__name__)
@@ -80,6 +81,11 @@ class CentralSignalingRelay:
         install_id: Optional[str] = None,
         on_state_change: Optional[Callable[["RelayState", Optional[str]], None]] = None,
         robot_app_lock: Optional[RobotAppLock] = None,
+        kind: str = "robot",
+        wireless_version: Optional[bool] = None,
+        version: Optional[str] = None,
+        capabilities: Optional[list[str]] = None,
+        health_provider: Optional[Callable[[], "PeerHealth"]] = None,
     ):
         """Initialize the relay.
 
@@ -99,6 +105,32 @@ class CentralSignalingRelay:
                 the robot. When provided, incoming remote sessions are
                 gated on this lock and a local-app acquire evicts any
                 active remote session.
+            kind: ``"robot"`` for a Pi-side daemon backing real hardware,
+                ``"tray"`` for the desktop-app daemon spawned by the Mac
+                tray. Forwarded verbatim in ``meta.kind`` so the mobile
+                app can hide tray rows that lost their hardware
+                without the user having to figure out which row is the
+                "real" robot. See ``docs/SIGNALING.md``.
+            wireless_version: True for the Pi wireless image, False for
+                the wired image, None when unknown. Surfaced in
+                ``meta.wireless_version`` for the listing UI.
+            version: Daemon package version string ("1.7.0" etc.) for
+                the listing UI / debug overlays. ``None`` when the
+                package metadata cannot be read.
+            capabilities: Optional list of capability tokens advertised
+                in ``meta.capabilities`` (``"motion"``, ``"audio"``,
+                ``"camera"``). The mobile app uses this to disable the
+                conversation button when no audio backend is available,
+                etc. Ordering is informational, do not depend on it.
+            health_provider: Zero-arg callable returning a
+                ``PeerHealth`` snapshot. Called on every ``setPeerStatus``
+                emission and on every ``update_producer_meta`` tick to
+                decide what ``meta.health`` and ``meta.error_code`` are
+                advertised. Wired to ``Daemon._publish_status`` so the
+                relay reflects backend transitions without owning any
+                of the daemon's state. ``None`` keeps the legacy
+                "always look healthy" behaviour for tests / harnesses
+                that don't have a daemon.
 
         """
         self.central_uri = central_uri
@@ -108,6 +140,16 @@ class CentralSignalingRelay:
         self.install_id = install_id
         self._on_state_change = on_state_change
         self._robot_app_lock = robot_app_lock
+        self.kind = kind
+        self.wireless_version = wireless_version
+        self.version = version
+        self.capabilities = list(capabilities) if capabilities else None
+        self._health_provider = health_provider
+        # Last meta dict emitted via ``setPeerStatus`` (initialised after
+        # the first send). Used by ``update_producer_meta`` to short-
+        # circuit identical re-emissions and avoid flooding central
+        # with non-events when the daemon's status loop ticks at 1 Hz.
+        self._last_published_meta: Optional[dict[str, Any]] = None
 
         self._running = False
         self._state = RelayState.STOPPED
@@ -880,13 +922,17 @@ class CentralSignalingRelay:
             # central does not yet know we are a producer for this user,
             # which produces the desync described in /refresh-relay's
             # docstring.
+            initial_meta = self._build_producer_meta()
             await self._send_to_central(
                 {
                     "type": "setPeerStatus",
                     "roles": ["producer"],
-                    "meta": self._build_producer_meta(),
+                    "meta": initial_meta,
                 }
             )
+            # Cache so ``update_producer_meta`` can short-circuit
+            # identical re-emissions on subsequent status ticks.
+            self._last_published_meta = initial_meta
 
             self._set_state(
                 RelayState.CONNECTED, f"Remote access enabled as '{self.robot_name}'"
@@ -1187,29 +1233,161 @@ class CentralSignalingRelay:
         # central. In any other state the next ``welcome`` will use the
         # already-updated ``self.robot_name``.
         if self._state == RelayState.CONNECTED and self._central_peer_id is not None:
+            new_meta = self._build_producer_meta()
             await self._send_to_central(
                 {
                     "type": "setPeerStatus",
                     "roles": ["producer"],
-                    "meta": self._build_producer_meta(),
+                    "meta": new_meta,
                 }
             )
+            self._last_published_meta = new_meta
+
+    # Bumped only when field semantics break - additive changes (new
+    # keys) keep schema_version=1. See ``docs/SIGNALING.md``.
+    META_SCHEMA_VERSION = 1
 
     def _build_producer_meta(self) -> dict[str, Any]:
         """Assemble the ``meta`` payload sent on every ``setPeerStatus``.
 
-        Always includes ``name`` (human-readable robot label). Adds
-        ``install_id`` when one is known: this is the stable
-        reconciliation key that lets the mobile app's robot registry
-        merge a central row with the same robot's BLE / mDNS / loopback
-        sightings. We deliberately keep the payload additive so older
-        central versions that don't know about ``install_id`` ignore
-        it without complaining.
+        Strict contract (see ``docs/SIGNALING.md``): keys are additive,
+        values come from explicit constructor arguments and the
+        ``health_provider`` callback. The relay never invents fields
+        and never re-derives values it was already given.
+
+        Always includes:
+            - ``schema_version`` so future clients can branch safely;
+            - ``name`` (human-readable robot label, mutable via rename);
+            - ``kind`` so the client distinguishes a desktop tray
+              daemon from a robot Pi daemon without parsing other
+              fields.
+
+        Conditionally includes:
+            - ``install_id`` when one is known (stable per-install
+              dedup key across BLE / mDNS / loopback / central);
+            - ``health`` + ``error_code`` from ``health_provider``;
+            - ``capabilities``, ``wireless_version``, ``version`` when
+              the daemon passed them at construction time.
         """
-        meta: dict[str, Any] = {"name": self.robot_name}
+        meta: dict[str, Any] = {
+            "schema_version": self.META_SCHEMA_VERSION,
+            "name": self.robot_name,
+            "kind": self.kind,
+        }
         if self.install_id:
             meta["install_id"] = self.install_id
+
+        # Health snapshot. We catch broadly here because anything thrown
+        # by the provider (a malformed status, a torn-down daemon)
+        # should not stop us from registering as a producer at all.
+        # In that case we publish "error/unknown" rather than nothing,
+        # which keeps the meta shape stable for the mobile app.
+        if self._health_provider is not None:
+            try:
+                health: PeerHealth = self._health_provider()
+                meta["health"] = health.health
+                if health.error_code is not None:
+                    meta["error_code"] = health.error_code
+            except Exception as e:
+                logger.debug(
+                    "[Central Relay] health_provider raised %r, falling back to error",
+                    e,
+                )
+                meta["health"] = "error"
+                meta["error_code"] = "health_provider_error"
+
+        if self.capabilities is not None:
+            meta["capabilities"] = self.capabilities
+        if self.wireless_version is not None:
+            meta["wireless_version"] = self.wireless_version
+        if self.version is not None:
+            meta["version"] = self.version
+
         return meta
+
+    async def update_producer_meta(self) -> bool:
+        """Re-emit ``setPeerStatus`` if the meta payload has changed.
+
+        The daemon's status loop calls this on every tick (typically
+        1 Hz). We rebuild the meta from the current
+        ``health_provider``, compare to ``_last_published_meta``, and
+        send only if something actually changed - so a robot sitting at
+        ``health=ok`` with stable name and version produces zero
+        central traffic between explicit transitions.
+
+        Same threading rules as ``update_producer_name``: must run on
+        the relay's own loop. Cross-thread callers go through
+        ``notify_meta_change`` (below) which schedules the coroutine
+        with ``run_coroutine_threadsafe``.
+
+        Returns:
+            True iff a ``setPeerStatus`` frame was sent.
+
+        """
+        if self._state != RelayState.CONNECTED or self._central_peer_id is None:
+            # Not registered yet. The next ``welcome`` will pick the
+            # latest values up via ``_build_producer_meta``.
+            return False
+
+        new_meta = self._build_producer_meta()
+        if new_meta == self._last_published_meta:
+            return False
+
+        await self._send_to_central(
+            {
+                "type": "setPeerStatus",
+                "roles": ["producer"],
+                "meta": new_meta,
+            }
+        )
+        self._last_published_meta = new_meta
+        return True
+
+    async def withdraw(self, *, timeout: float = 0.5) -> None:
+        """Send ``setPeerStatus(roles=[])`` and keep the WebSocket open.
+
+        Distinct from ``stop()``: we want central to remove us from
+        the public producers listing (so the mobile app stops showing a
+        broken robot) but keep our SSE channel alive so the daemon can
+        re-register when the underlying problem clears (USB replugged,
+        backend recovered, network blip resolved).
+
+        Best-effort with a short timeout because this is typically
+        called from a tight transition window (e.g. shutdown lifespan
+        finally) where blocking forever on a stuck central would hang
+        the rest of the teardown.
+        """
+        if self._state != RelayState.CONNECTED or self._central_peer_id is None:
+            logger.debug(
+                "[Central Relay] withdraw() no-op (state=%s)", self._state.value
+            )
+            return
+
+        try:
+            await asyncio.wait_for(
+                self._send_to_central(
+                    {
+                        "type": "setPeerStatus",
+                        "roles": [],
+                        "meta": self._build_producer_meta(),
+                    }
+                ),
+                timeout=timeout,
+            )
+            logger.info("[Central Relay] withdrew producer registration")
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[Central Relay] withdraw() timed out after %.1fs - central will fall back on TTL",
+                timeout,
+            )
+        except Exception as e:
+            logger.warning("[Central Relay] withdraw() failed: %r", e)
+        finally:
+            # We are no longer claiming the producer slot, regardless
+            # of whether central acked. Clear the cached meta so a
+            # subsequent ``update_producer_meta`` re-sends the full
+            # payload when we reannounce.
+            self._last_published_meta = None
 
 
 # Singleton instance for integration
@@ -1267,6 +1445,11 @@ async def start_central_relay(
     central_uri: str = CENTRAL_SIGNALING_SERVER,
     on_state_change: Optional[Callable[[RelayState, Optional[str]], None]] = None,
     robot_app_lock: Optional[RobotAppLock] = None,
+    kind: str = "robot",
+    wireless_version: Optional[bool] = None,
+    version: Optional[str] = None,
+    capabilities: Optional[list[str]] = None,
+    health_provider: Optional[Callable[[], PeerHealth]] = None,
 ) -> CentralSignalingRelay:
     """Start the central signaling relay.
 
@@ -1278,6 +1461,14 @@ async def start_central_relay(
         central_uri: Central server URI
         on_state_change: Callback when connection state changes
         robot_app_lock: Shared lock coordinating local vs remote robot access.
+        kind: Producer ``meta.kind`` (``"robot"`` | ``"tray"``).
+        wireless_version: Surfaced in ``meta.wireless_version``.
+        version: Daemon package version surfaced in ``meta.version``.
+        capabilities: List of capability tokens (``"motion"``, ``"audio"``,
+            ``"camera"``) surfaced in ``meta.capabilities``.
+        health_provider: Zero-arg callable returning a ``PeerHealth``
+            snapshot, used to populate ``meta.health`` and
+            ``meta.error_code``. See ``CentralSignalingRelay``.
 
     Returns:
         The relay instance
@@ -1304,6 +1495,11 @@ async def start_central_relay(
         install_id=install_id,
         on_state_change=on_state_change,
         robot_app_lock=robot_app_lock,
+        kind=kind,
+        wireless_version=wireless_version,
+        version=version,
+        capabilities=capabilities,
+        health_provider=health_provider,
     )
     await _relay_instance.start()
     return _relay_instance
@@ -1399,3 +1595,50 @@ async def notify_robot_name_change(new_name: str) -> None:
         logger.warning(
             "[Central Relay] update_producer_name(%r) failed: %s", new_name, exc
         )
+
+
+def notify_meta_change() -> bool:
+    """Re-emit producer ``setPeerStatus`` if the meta payload changed.
+
+    Synchronous wrapper around ``CentralSignalingRelay.update_producer_meta``
+    designed to be called from the daemon's status thread. Returns
+    ``True`` when an update was actually scheduled (the meta differed
+    from the cached one), ``False`` for any "nothing to do" case
+    (no relay instance, relay loop not running, meta unchanged).
+
+    Fire-and-forget: we schedule the coroutine on the relay's loop and
+    return immediately. The relay does the diff itself and short-circuits
+    when nothing changed, so calling this on every status tick is cheap.
+    """
+    if _relay_instance is None:
+        return False
+
+    loop = _relay_instance._thread_loop
+    if loop is None or not loop.is_running():
+        return False
+
+    asyncio.run_coroutine_threadsafe(_relay_instance.update_producer_meta(), loop)
+    return True
+
+
+def notify_withdraw(*, timeout: float = 0.5) -> None:
+    """Schedule a ``CentralSignalingRelay.withdraw()`` from any thread.
+
+    Used by the daemon's "tray with no hardware after grace period"
+    watchdog and by any non-async cleanup hook (atexit, signal handler)
+    that needs to tell central "stop listing me" without going through
+    the full ``stop()`` path. Best-effort: silent no-op when the relay
+    is not running, bounded wait so we never block teardown.
+    """
+    if _relay_instance is None:
+        return
+    loop = _relay_instance._thread_loop
+    if loop is None or not loop.is_running():
+        return
+    fut = asyncio.run_coroutine_threadsafe(
+        _relay_instance.withdraw(timeout=timeout), loop
+    )
+    try:
+        fut.result(timeout=timeout + 0.5)
+    except Exception as exc:
+        logger.debug("[Central Relay] notify_withdraw() failed: %s", exc)

--- a/src/reachy_mini/media/device_detection.py
+++ b/src/reachy_mini/media/device_detection.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import platform
 import re
+import sys
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, Sequence, Tuple
 
@@ -272,7 +273,23 @@ def gst_monitor_devices(filter_class: str) -> list[DeviceInfo]:
     try:
         return gst_devices_to_device_infos(monitor.get_devices())
     finally:
-        monitor.stop()
+        # Workaround: on macOS (observed on macOS 26 "Tahoe") calling
+        # Gst.DeviceMonitor.stop() can segfault inside
+        # gst_device_provider_stop -> avfdeviceprovider, killing the whole
+        # Python daemon with SIGSEGV before any traceback can be emitted.
+        # The monitor is short-lived (one enumeration at boot) so skipping
+        # the explicit stop is acceptable: the underlying providers are
+        # reclaimed when the Python object is garbage collected and when
+        # the process exits.
+        if sys.platform == "darwin":
+            _logger.debug(
+                "Skipping Gst.DeviceMonitor.stop() on macOS (known crash)",
+            )
+        else:
+            try:
+                monitor.stop()
+            except Exception:  # pragma: no cover - defensive
+                _logger.exception("Gst.DeviceMonitor.stop() failed")
 
 
 def find_audio_device(

--- a/src/reachy_mini/utils/discovery.py
+++ b/src/reachy_mini/utils/discovery.py
@@ -56,10 +56,22 @@ def _get_local_ip() -> str:
 class MdnsServiceRegistration:
     """Register a Reachy Mini daemon as an mDNS service."""
 
-    def __init__(self, robot_name: str, port: int) -> None:
-        """Initialize with robot name and port to advertise."""
+    def __init__(
+        self,
+        robot_name: str,
+        port: int,
+        install_id: str | None = None,
+    ) -> None:
+        """Initialize with robot name, port and (optional) install_id to advertise.
+
+        ``install_id`` is published as a TXT property so LAN clients can
+        reconcile this advertisement with the same robot's central
+        listing entry. Always emitted when known; absent on legacy
+        callers / tests.
+        """
         self._robot_name = robot_name
         self._port = port
+        self._install_id = install_id
         self._zeroconf: Zeroconf | None = None
         self._info: ServiceInfo | None = None
         self._register_thread: threading.Thread | None = None
@@ -150,6 +162,12 @@ class MdnsServiceRegistration:
             "ws_path": "/ws/sdk",
             "address": _get_local_ip(),
         }
+        if self._install_id:
+            # Stable per-install reconciliation key; same value also
+            # appears in the central listing's ``meta`` and at
+            # ``GET /api/daemon/identity``. Mobile clients merge mDNS
+            # rows with central rows on this key.
+            properties["install_id"] = self._install_id
 
         try:
             self._zeroconf = Zeroconf()

--- a/src/reachy_mini/utils/discovery.py
+++ b/src/reachy_mini/utils/discovery.py
@@ -32,7 +32,9 @@ class DiscoveredRobot:
 
     def __repr__(self) -> str:
         """Return a human-readable representation."""
-        return f"DiscoveredRobot(name={self.name!r}, host={self.host!r}, port={self.port})"
+        return (
+            f"DiscoveredRobot(name={self.name!r}, host={self.host!r}, port={self.port})"
+        )
 
 
 def _get_local_ip() -> str:
@@ -61,6 +63,9 @@ class MdnsServiceRegistration:
         self._zeroconf: Zeroconf | None = None
         self._info: ServiceInfo | None = None
         self._register_thread: threading.Thread | None = None
+        # Serialise register/update/unregister: zeroconf is thread-safe at the
+        # protocol level but we mutate ``_info`` and ``_zeroconf`` ourselves.
+        self._lock = threading.Lock()
 
     def register(self) -> None:
         """Register the mDNS service in a background thread.
@@ -88,6 +93,50 @@ class MdnsServiceRegistration:
         thread = threading.Thread(target=self._do_unregister, daemon=True)
         thread.start()
         thread.join(timeout=5.0)
+
+    def update_robot_name(self, robot_name: str) -> None:
+        """Re-publish the mDNS service under a new robot name.
+
+        Idempotent: a no-op when the new name matches the current one.
+        Safe to call before the initial ``register()`` (the new name will
+        simply be picked up at register time).
+
+        We unregister and re-register because zeroconf does not let us
+        mutate ``ServiceInfo.name`` in place: the service name encodes the
+        identity advertised on the network and clients caching the old
+        name need to see the goodbye to drop it.
+        """
+        with self._lock:
+            if robot_name == self._robot_name:
+                return
+            self._robot_name = robot_name
+
+            # If we never registered yet (or a previous attempt failed),
+            # there is nothing to tear down. The next ``register()`` call
+            # will use the updated name.
+            if self._register_thread is None and self._zeroconf is None:
+                return
+
+        # Wait for any in-flight register thread to finish before tearing
+        # down: registering with the old name and immediately unregistering
+        # would race the zeroconf cache.
+        if self._register_thread is not None:
+            self._register_thread.join(timeout=10.0)
+            self._register_thread = None
+
+        if self._zeroconf is not None and self._info is not None:
+            try:
+                t = threading.Thread(target=self._do_unregister, daemon=True)
+                t.start()
+                t.join(timeout=5.0)
+            except Exception:
+                logger.warning(
+                    "Failed to unregister mDNS service before rename", exc_info=True
+                )
+
+        # Re-register under the new name. ``register`` itself spawns a
+        # background thread so it's safe to call from any context.
+        self.register()
 
     def _do_register(self) -> None:
         try:
@@ -157,7 +206,9 @@ class _RobotCollector(ServiceListener):
 
         addresses = [socket.inet_ntoa(addr) for addr in info.addresses]
         props = {
-            k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else str(v)
+            k.decode() if isinstance(k, bytes) else k: v.decode()
+            if isinstance(v, bytes)
+            else str(v)
             for k, v in info.properties.items()
         }
 
@@ -361,8 +412,15 @@ def _filter_alive(robots: List[DiscoveredRobot]) -> List[DiscoveredRobot]:
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Discover Reachy Mini robots on the local network.")
-    parser.add_argument("--timeout", type=float, default=5.0, help="Discovery timeout in seconds (default: 5.0)")
+    parser = argparse.ArgumentParser(
+        description="Discover Reachy Mini robots on the local network."
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Discovery timeout in seconds (default: 5.0)",
+    )
     args = parser.parse_args()
 
     robots = find_robots(timeout=args.timeout)

--- a/tests/unit_tests/test_central_signaling_heartbeat.py
+++ b/tests/unit_tests/test_central_signaling_heartbeat.py
@@ -1,0 +1,248 @@
+"""Heartbeat re-emission tests for ``CentralSignalingRelay``.
+
+The daemon must keep refreshing its central lease via real
+``setPeerStatus`` POSTs, even when the meta payload is identical to the
+last one sent. Without this, the central's TTL sweeper would evict an
+idle-but-online producer (server-pushed SSE keepalives are NOT a
+liveness signal - see ``reachy_mini/docs/SIGNALING.md``).
+
+These tests poke ``update_producer_meta()`` directly without spinning
+up the real network stack: we build a relay, force it into
+``CONNECTED`` state, replace ``_send_to_central`` with an awaitable
+spy, and observe which calls actually go out.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from reachy_mini.daemon.peer_health import PeerHealth
+from reachy_mini.media.central_signaling_relay import (
+    HEARTBEAT_INTERVAL_SECONDS,
+    CentralSignalingRelay,
+    RelayState,
+)
+
+
+def _make_connected_relay(
+    *, health: PeerHealth | None = None
+) -> CentralSignalingRelay:
+    """Construct a relay short-circuited into ``CONNECTED`` state.
+
+    Real network bring-up touches aiohttp + websockets which we don't
+    want in a unit test. Setting the state attributes directly is
+    enough for ``update_producer_meta`` whose only liveness gate is
+    ``self._state == CONNECTED and self._central_peer_id is not None``.
+    """
+    relay = CentralSignalingRelay(
+        central_uri="https://test.invalid",
+        local_uri="ws://127.0.0.1:0",
+        hf_token="dummy",
+        robot_name="testbot",
+        install_id="0" * 32,
+        kind="robot",
+        wireless_version=True,
+        version="0.0.0-test",
+        capabilities=["motion"],
+        health_provider=(
+            lambda: (health or PeerHealth(health="ok", error_code=None))
+        ),
+    )
+    relay._state = RelayState.CONNECTED
+    relay._central_peer_id = "fake-peer-id"
+    return relay
+
+
+@pytest.mark.asyncio
+async def test_first_call_sends_setpeerstatus():  # noqa: D103
+    relay = _make_connected_relay()
+
+    sent: list[dict] = []
+
+    async def _capture(msg):
+        sent.append(msg)
+
+    with patch.object(relay, "_send_to_central", side_effect=_capture):
+        emitted = await relay.update_producer_meta()
+
+    assert emitted is True
+    assert len(sent) == 1
+    assert sent[0]["type"] == "setPeerStatus"
+    assert sent[0]["roles"] == ["producer"]
+    assert relay._last_published_at is not None
+
+
+@pytest.mark.asyncio
+async def test_identical_meta_in_quick_succession_does_not_resend():  # noqa: D103
+    relay = _make_connected_relay()
+
+    sent: list[dict] = []
+
+    async def _capture(msg):
+        sent.append(msg)
+
+    with patch.object(relay, "_send_to_central", side_effect=_capture):
+        await relay.update_producer_meta()  # initial send
+        for _ in range(5):
+            await relay.update_producer_meta()
+
+    # Only the first call should have hit the wire: subsequent ticks
+    # see identical meta and the heartbeat is not yet due.
+    assert len(sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_re_emits_after_interval_with_unchanged_meta():
+    """Re-emit ``setPeerStatus`` once the heartbeat interval expires.
+
+    Even when the meta payload is byte-for-byte identical, the relay
+    MUST re-emit so central can refresh ``last_seen``. This is the
+    central's only liveness signal for a steady-state robot.
+    """
+    relay = _make_connected_relay()
+
+    sent: list[dict] = []
+
+    async def _capture(msg):
+        sent.append(msg)
+
+    with patch.object(relay, "_send_to_central", side_effect=_capture):
+        await relay.update_producer_meta()
+        assert len(sent) == 1
+
+        # Pretend the last send happened a full heartbeat ago. We
+        # rewind the cached timestamp instead of sleeping for the
+        # full interval - tests must run fast.
+        relay._last_published_at = (
+            time.monotonic() - HEARTBEAT_INTERVAL_SECONDS - 0.1
+        )
+
+        emitted = await relay.update_producer_meta()
+        assert emitted is True
+        assert len(sent) == 2
+
+        # And the second send carries the same meta as the first.
+        assert sent[0]["meta"] == sent[1]["meta"]
+
+
+@pytest.mark.asyncio
+async def test_meta_change_re_emits_immediately_without_waiting_heartbeat():
+    """Propagate meta changes on the very next status tick.
+
+    Health going from ``ok`` to ``degraded`` must propagate without
+    waiting on the heartbeat interval - users can't be left looking
+    at a stale row for 20 s.
+    """
+    health_box = {"value": PeerHealth(health="ok", error_code=None)}
+    relay = CentralSignalingRelay(
+        central_uri="https://test.invalid",
+        local_uri="ws://127.0.0.1:0",
+        hf_token="dummy",
+        robot_name="testbot",
+        install_id="0" * 32,
+        kind="robot",
+        wireless_version=True,
+        version="0.0.0-test",
+        capabilities=["motion"],
+        health_provider=lambda: health_box["value"],
+    )
+    relay._state = RelayState.CONNECTED
+    relay._central_peer_id = "fake-peer-id"
+
+    sent: list[dict] = []
+
+    async def _capture(msg):
+        sent.append(msg)
+
+    with patch.object(relay, "_send_to_central", side_effect=_capture):
+        await relay.update_producer_meta()
+        assert len(sent) == 1
+        assert sent[0]["meta"]["health"] == "ok"
+
+        # Simulate a transition to ``degraded``. The heartbeat clock
+        # is barely advanced, so the only reason to re-emit is the
+        # meta delta.
+        health_box["value"] = PeerHealth(
+            health="degraded", error_code="audio_unavailable"
+        )
+
+        emitted = await relay.update_producer_meta()
+        assert emitted is True
+        assert len(sent) == 2
+        assert sent[1]["meta"]["health"] == "degraded"
+        assert sent[1]["meta"]["error_code"] == "audio_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_no_send_when_relay_not_connected():
+    """Reject sends from non-CONNECTED states.
+
+    A relay still in CONNECTING / CLOSED state has no peer id central
+    would associate the message with, so it must short-circuit.
+    """
+    relay = _make_connected_relay()
+    relay._state = RelayState.CONNECTING
+    relay._central_peer_id = None
+
+    with patch.object(
+        relay, "_send_to_central", side_effect=AssertionError("must not send")
+    ):
+        emitted = await relay.update_producer_meta()
+    assert emitted is False
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_resets_after_send():
+    """Restart the heartbeat clock after each emission.
+
+    Otherwise we would keep re-emitting on every subsequent tick once
+    the interval was exceeded once.
+    """
+    relay = _make_connected_relay()
+
+    async def _noop(_msg):
+        return None
+
+    with patch.object(relay, "_send_to_central", side_effect=_noop):
+        await relay.update_producer_meta()
+
+        relay._last_published_at = (
+            time.monotonic() - HEARTBEAT_INTERVAL_SECONDS - 0.1
+        )
+        await relay.update_producer_meta()  # heartbeat re-emit
+
+        # Next tick: timer was reset, no further send.
+        emitted = await relay.update_producer_meta()
+        assert emitted is False
+
+
+# ----------------------------------------------------------------------
+# withdraw() resets heartbeat bookkeeping
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_withdraw_clears_heartbeat_timer():
+    """Reset bookkeeping on withdraw so a future re-register sends.
+
+    ``withdraw()`` is followed (later) by a fresh registration. We
+    must NOT short-circuit that re-registration's first
+    ``setPeerStatus`` because of a stale ``_last_published_meta``.
+    """
+    relay = _make_connected_relay()
+
+    async def _noop(_msg):
+        return None
+
+    with patch.object(relay, "_send_to_central", side_effect=_noop):
+        await relay.update_producer_meta()
+        assert relay._last_published_meta is not None
+        assert relay._last_published_at is not None
+
+        await relay.withdraw(timeout=0.05)
+
+    assert relay._last_published_meta is None
+    assert relay._last_published_at is None

--- a/tests/unit_tests/test_central_signaling_heartbeat.py
+++ b/tests/unit_tests/test_central_signaling_heartbeat.py
@@ -22,6 +22,8 @@ import pytest
 from reachy_mini.daemon.peer_health import PeerHealth
 from reachy_mini.media.central_signaling_relay import (
     HEARTBEAT_INTERVAL_SECONDS,
+    MAX_HEARTBEAT_INTERVAL_SECONDS,
+    MIN_HEARTBEAT_INTERVAL_SECONDS,
     CentralSignalingRelay,
     RelayState,
 )
@@ -222,6 +224,93 @@ async def test_heartbeat_resets_after_send():
 # ----------------------------------------------------------------------
 # withdraw() resets heartbeat bookkeeping
 # ----------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------
+# Welcome-driven heartbeat negotiation
+# ----------------------------------------------------------------------
+#
+# The relay reads ``recommended_heartbeat_interval_seconds`` from each
+# ``welcome`` SSE frame so server operators can re-tune the liveness
+# contract by changing one env var on the central, without redeploying
+# the fleet. These tests pin the contract so a future refactor that
+# accidentally drops the override (or fails to clamp it) breaks loud.
+
+
+def test_apply_welcome_overrides_heartbeat_interval():
+    relay = _make_connected_relay()
+    relay._apply_welcome_negotiation(
+        {
+            "type": "welcome",
+            "peerId": "p",
+            "lease_seconds": 30.0,
+            "recommended_heartbeat_interval_seconds": 10.0,
+        }
+    )
+    assert relay._heartbeat_interval_seconds == 10.0
+    assert relay._central_lease_seconds == 30.0
+
+
+def test_apply_welcome_without_hint_keeps_default():
+    relay = _make_connected_relay()
+    relay._heartbeat_interval_seconds = 999.0  # poison so we'd notice
+    relay._apply_welcome_negotiation(
+        {"type": "welcome", "peerId": "p", "username": "alice"}
+    )
+    assert relay._heartbeat_interval_seconds == HEARTBEAT_INTERVAL_SECONDS
+    assert relay._central_lease_seconds is None
+
+
+def test_apply_welcome_clamps_below_minimum():
+    relay = _make_connected_relay()
+    relay._apply_welcome_negotiation(
+        {"recommended_heartbeat_interval_seconds": 0.1}
+    )
+    assert relay._heartbeat_interval_seconds == MIN_HEARTBEAT_INTERVAL_SECONDS
+
+
+def test_apply_welcome_clamps_above_maximum():
+    relay = _make_connected_relay()
+    relay._apply_welcome_negotiation(
+        {"recommended_heartbeat_interval_seconds": 9999.0}
+    )
+    assert relay._heartbeat_interval_seconds == MAX_HEARTBEAT_INTERVAL_SECONDS
+
+
+def test_apply_welcome_ignores_non_numeric_hint():
+    relay = _make_connected_relay()
+    relay._apply_welcome_negotiation(
+        {"recommended_heartbeat_interval_seconds": "five"}
+    )
+    assert relay._heartbeat_interval_seconds == HEARTBEAT_INTERVAL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_negotiated_heartbeat_drives_re_emit_window():
+    """End-to-end: a welcome with a smaller interval must shorten the
+    re-emit window seen by ``update_producer_meta``.
+    """
+    relay = _make_connected_relay()
+    relay._apply_welcome_negotiation(
+        {"recommended_heartbeat_interval_seconds": 2.0}
+    )
+
+    sent: list[dict] = []
+
+    async def _capture(msg):
+        sent.append(msg)
+
+    with patch.object(relay, "_send_to_central", side_effect=_capture):
+        await relay.update_producer_meta()
+        # At t=1.5s (under the 2s negotiated interval), no re-emit.
+        relay._last_published_at = time.monotonic() - 1.5
+        emitted = await relay.update_producer_meta()
+        assert emitted is False
+        # At t=2.1s (over), re-emit.
+        relay._last_published_at = time.monotonic() - 2.1
+        emitted = await relay.update_producer_meta()
+        assert emitted is True
+    assert len(sent) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_peer_health.py
+++ b/tests/unit_tests/test_peer_health.py
@@ -1,0 +1,178 @@
+"""Truth table for ``reachy_mini.daemon.peer_health.compute``.
+
+The relay exposes only what this function returns to listeners, so any
+regression here shows up immediately as wrong badges in the mobile app
+(or worse, auto-connect to a dead robot). Keep this file exhaustive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from reachy_mini.daemon.peer_health import (
+    ERR_BACKEND_NOT_READY,
+    ERR_DAEMON_FATAL,
+    ERR_MEDIA,
+    ERR_MOTOR_COMM,
+    ERR_NO_BACKEND,
+    compute,
+)
+from reachy_mini.io.protocol import (
+    DaemonState,
+    DaemonStatus,
+    MotorControlMode,
+    RobotBackendStatus,
+)
+
+
+def _backend(ready: bool, error: str | None = None) -> RobotBackendStatus:
+    """Build a minimal RobotBackendStatus for the truth table.
+
+    The control loop fields are required by the pydantic model but
+    ``compute()`` doesn't read them, so we keep them at trivial values.
+    """
+    return RobotBackendStatus(
+        ready=ready,
+        motor_control_mode=MotorControlMode.Enabled,
+        last_alive=None,
+        control_loop_stats={},
+        error=error,
+    )
+
+
+def _status(
+    state: DaemonState,
+    backend: RobotBackendStatus | None = None,
+    no_media: bool = False,
+    camera_specs_name: str = "wireless",
+) -> DaemonStatus:
+    return DaemonStatus(
+        robot_name="reachy_mini",
+        install_id="x" * 32,
+        state=state,
+        wireless_version=False,
+        desktop_app_daemon=False,
+        simulation_enabled=None,
+        mockup_sim_enabled=None,
+        no_media=no_media,
+        camera_specs_name=camera_specs_name,
+        backend_status=backend,
+        error=None,
+    )
+
+
+# ----------------------------------------------------------------------
+# Fatal daemon states short-circuit everything else
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state",
+    [DaemonState.STOPPING, DaemonState.STOPPED],
+)
+def test_stopping_and_stopped_are_error_daemon_fatal(state):  # noqa: D103
+    s = _status(state, backend=_backend(ready=True))
+    h = compute(s)
+    assert h.health == "error"
+    assert h.error_code == ERR_DAEMON_FATAL
+
+
+def test_error_state_with_motor_error_reports_motor_comm():  # noqa: D103
+    s = _status(DaemonState.ERROR, backend=_backend(ready=True, error="bus 0 timeout"))
+    h = compute(s)
+    assert h.health == "error"
+    assert h.error_code == ERR_MOTOR_COMM
+
+
+def test_error_state_with_no_backend_reports_no_backend():  # noqa: D103
+    s = _status(DaemonState.ERROR, backend=None)
+    h = compute(s)
+    assert h.health == "error"
+    assert h.error_code == ERR_NO_BACKEND
+
+
+def test_error_state_with_ready_backend_no_error_falls_back_to_daemon_fatal():  # noqa: D103
+    s = _status(DaemonState.ERROR, backend=_backend(ready=True))
+    h = compute(s)
+    assert h.health == "error"
+    assert h.error_code == ERR_DAEMON_FATAL
+
+
+# ----------------------------------------------------------------------
+# Non-fatal states - the backend decides
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state",
+    [DaemonState.NOT_INITIALIZED, DaemonState.STARTING, DaemonState.RUNNING],
+)
+def test_no_backend_in_non_fatal_state_is_no_backend_error(state):  # noqa: D103
+    s = _status(state, backend=None)
+    h = compute(s)
+    assert h.health == "error"
+    assert h.error_code == ERR_NO_BACKEND
+
+
+def test_backend_present_but_not_ready_is_backend_not_ready():  # noqa: D103
+    s = _status(DaemonState.STARTING, backend=_backend(ready=False))
+    h = compute(s)
+    assert h.health == "error"
+    assert h.error_code == ERR_BACKEND_NOT_READY
+
+
+def test_ready_backend_with_recoverable_error_is_degraded():  # noqa: D103
+    # Backend is up and accepting commands, but logged a transient
+    # serial error. We still let the user connect (degraded), we just
+    # surface a warning so they know.
+    s = _status(DaemonState.RUNNING, backend=_backend(ready=True, error="transient blip"))
+    h = compute(s)
+    assert h.health == "degraded"
+    assert h.error_code == ERR_MOTOR_COMM
+
+
+def test_ready_backend_no_error_is_ok():  # noqa: D103
+    s = _status(DaemonState.RUNNING, backend=_backend(ready=True))
+    h = compute(s)
+    assert h.health == "ok"
+    assert h.error_code is None
+
+
+def test_no_media_does_not_count_as_degraded_when_explicitly_disabled():  # noqa: D103
+    # ``--no-media`` is a deliberate choice, not a failure.
+    s = _status(
+        DaemonState.RUNNING,
+        backend=_backend(ready=True),
+        no_media=True,
+        camera_specs_name="",
+    )
+    h = compute(s)
+    assert h.health == "ok"
+    assert h.error_code is None
+
+
+def test_media_failure_is_degraded_not_error():  # noqa: D103
+    # Media was requested (no_media=False) but the camera/audio init
+    # never set ``camera_specs_name``. Treat as degraded so the user
+    # can still drive the robot but knows audio/video is missing.
+    s = _status(
+        DaemonState.RUNNING,
+        backend=_backend(ready=True),
+        no_media=False,
+        camera_specs_name="",
+    )
+    h = compute(s)
+    assert h.health == "degraded"
+    assert h.error_code == ERR_MEDIA
+
+
+# ----------------------------------------------------------------------
+# Frozen-dataclass guarantees - prevent accidental mutation
+# ----------------------------------------------------------------------
+
+
+def test_peer_health_is_immutable():  # noqa: D103
+    s = _status(DaemonState.RUNNING, backend=_backend(ready=True))
+    h = compute(s)
+    with pytest.raises(Exception):
+        h.health = "error"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Draft integration branch for the Reachy Mini **mobile app** daemon work. This is the line we use day-to-day locally and on robots; it supersedes the older umbrella branch `integration/mobile-app-daemon` in breadth (extra signaling, health, BLE TLV, central URL default, tray-on-central, etc.).

**Not intended for merge as-is without review split** — this PR exists so Pollen can see the full diff, run CI, and decide how to land it (cherry-picks vs smaller PRs).

## Scope (high level)

- WebRTC DataChannel `http_proxy` / `ws_proxy` for unified transport
- HF auth: token bridging, refresh-relay, tray + lite registering on central
- BLE: Wi-Fi provisioning commands, `WIFI_PROBE`, TLV advert (`install_id`, `central_peer_id`, `network_mode`), pairing disabled on adapter
- Central signaling: heartbeat from welcome, producer meta / peer health, default `REACHY_CENTRAL_URL` alignment
- Stable `install_id`, `/api/daemon/identity`, macOS GStreamer DeviceMonitor guard
- Docs: `docs/known-issues/libnice-session-reuse-crash.md`

## Related

- Umbrella / tracking: #1049 (`integration/mobile-app-daemon`) — child PRs there are subsets of this line.
- Smaller upstream PRs still open: #1045–#1048, #1038, #1050–#1052, #1029 (likely superseded by TLV advert).

## Notes

- Branch: `dev/mobile-app-integration` (pushed on `origin`).
- Rebase onto `main` will be needed before any non-draft merge (branch is behind `main` by some commits).


Made with [Cursor](https://cursor.com)