### PR TITLE
feat(daemon): make central URL configurable via REACHY_CENTRAL_URL

### DIFF
--- a/docs/source/SDK/javascript-sdk.md
+++ b/docs/source/SDK/javascript-sdk.md
@@ -179,7 +179,7 @@ robot.logout();              // clear HF credentials
 
 ```js
 new ReachyMini({
-    signalingUrl: "https://cduss-reachy-mini-central.hf.space",  // default
+    signalingUrl: "https://tfrere-reachy-mini-central.hf.space",  // default
     enableMicrophone: true,  // default — request mic on startSession()
 })
 ```

--- a/js/reachy-mini.js
+++ b/js/reachy-mini.js
@@ -72,7 +72,7 @@
  * CONSTRUCTOR OPTIONS
  * ───────────────────
  *   new ReachyMini({
- *     signalingUrl:              string,   // default: "https://cduss-reachy-mini-central.hf.space"
+ *     signalingUrl:              string,   // default: "https://tfrere-reachy-mini-central.hf.space"
  *     enableMicrophone:          boolean,  // default: true  — acquire mic for bidirectional audio
  *     videoJitterBufferTargetMs: number,   // default: 0     — receiver-side jitter buffer hint, ms
  *                                          //                  0 = "render ASAP" (teleop). Spec range [0, 4000].
@@ -191,7 +191,7 @@ export class ReachyMini extends EventTarget {
     /** @param {{ signalingUrl?: string, enableMicrophone?: boolean, clientId?: string, appName?: string, videoJitterBufferTargetMs?: number }} [options] */
     constructor(options = {}) {
         super();
-        this._signalingUrl = options.signalingUrl || 'https://cduss-reachy-mini-central.hf.space';
+        this._signalingUrl = options.signalingUrl || 'https://tfrere-reachy-mini-central.hf.space';
         this._enableMicrophone = options.enableMicrophone !== false;
         this._clientId = options.clientId || null;
         this._appName = options.appName || 'unknown';

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -10,15 +10,17 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
 from reachy_mini.apps.sources import hf_auth
+from reachy_mini.media.central_signaling_relay import CENTRAL_SIGNALING_SERVER
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/hf-auth")
 
-# Central signaling server that tracks which robot is currently in use by
-# which remote JS app. We proxy its /api/robot-status endpoint so the
-# desktop frontend never needs to see the raw HF token.
-CENTRAL_ROBOT_STATUS_URL = "https://cduss-reachy-mini-central.hf.space/api/robot-status"
+# We proxy the central /api/robot-status endpoint so the desktop frontend
+# never needs to see the raw HF token. Single source of truth for the
+# central base URL (and its REACHY_CENTRAL_URL override) is the relay
+# module — importing it here keeps the default in lock-step.
+CENTRAL_ROBOT_STATUS_URL = f"{CENTRAL_SIGNALING_SERVER}/api/robot-status"
 CENTRAL_ROBOT_STATUS_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -41,7 +41,7 @@ class RelayState(Enum):
 # Central signaling server URL. Override via the REACHY_CENTRAL_URL env
 # var at startup to point at a fork (test Space, staging, etc.).
 CENTRAL_SIGNALING_SERVER = os.getenv(
-    "REACHY_CENTRAL_URL", "https://cduss-reachy-mini-central.hf.space"
+    "REACHY_CENTRAL_URL", "https://tfrere-reachy-mini-central.hf.space"
 )
 LOCAL_GSTREAMER_SIGNALING = "ws://127.0.0.1:8443"
 

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -12,6 +12,7 @@ The relay automatically:
 import asyncio
 import json
 import logging
+import os
 import threading
 import time
 from enum import Enum
@@ -37,8 +38,11 @@ class RelayState(Enum):
     ERROR = "error"
 
 
-# Central signaling server URL
-CENTRAL_SIGNALING_SERVER = "https://cduss-reachy-mini-central.hf.space"
+# Central signaling server URL. Override via the REACHY_CENTRAL_URL env
+# var at startup to point at a fork (test Space, staging, etc.).
+CENTRAL_SIGNALING_SERVER = os.getenv(
+    "REACHY_CENTRAL_URL", "https://cduss-reachy-mini-central.hf.space"
+)
 LOCAL_GSTREAMER_SIGNALING = "ws://127.0.0.1:8443"
 
 # Reconnection settings


### PR DESCRIPTION
## Summary

Stacked on top of #1069 (`mobile-app-integration-light`). Two cherry-picks from `dev/mobile-app-integration` that together make the central signaling server URL configurable and align the daemon + JS SDK defaults.

- **`feat(daemon): make central URL configurable via REACHY_CENTRAL_URL`** - replaces the hardcoded `https://cduss-reachy-mini-central.hf.space` constant in `central_signaling_relay.py` with an `os.getenv("REACHY_CENTRAL_URL", ...)` lookup. The `hf_auth` router now imports `CENTRAL_SIGNALING_SERVER` from the relay instead of duplicating the URL, so there is a single source of truth for both the SSE relay and the proxied `/api/robot-status` calls.
- **`chore(central): point default REACHY_CENTRAL_URL at tfrere instance`** - aligns the daemon default and the JS SDK default on `https://tfrere-reachy-mini-central.hf.space` so daemons booted with no env override publish to the same store the mobile app polls. Production overrides via `REACHY_CENTRAL_URL` still take precedence.

No behavior change for callers that already export `REACHY_CENTRAL_URL` at service startup; the env var path was already supported by the JS SDK constructor option.

## Files touched

- `src/reachy_mini/media/central_signaling_relay.py` (env override + new default)
- `src/reachy_mini/daemon/app/routers/hf_auth.py` (import the canonical URL)
- `js/reachy-mini.js` + `docs/source/SDK/javascript-sdk.md` (JS SDK default kept in sync)

## Test plan

- [ ] Boot the daemon without `REACHY_CENTRAL_URL` and confirm it registers against `tfrere-reachy-mini-central.hf.space` (existing tray + mobile app discovery flow).
- [ ] Boot with `REACHY_CENTRAL_URL=https://example.invalid` and confirm both the SSE relay and `GET /api/robot-status` proxy hit `example.invalid` (relay should fail gracefully, no leak to the cduss URL).
- [ ] `import { ReachyMini } from 'js/reachy-mini.js'`, default-construct, confirm `_signalingUrl === "https://tfrere-reachy-mini-central.hf.space"`.

## Notes

- Carved out of the umbrella draft #1070 so the central URL change can be reviewed and merged into #1069 without dragging in unrelated structured-logging / BLE / TLV work.
- Cherry-picked commits: `84d259de` and `d550572a` (rebased onto `mobile-app-integration-light`, the trivial conflict on `kv_log` from the unrelated structured-logging PR was dropped).


Made with [Cursor](https://cursor.com)