### PR TITLE
feat(daemon): stable robot identity + BLE TLV advert + WIFI_PROBE

### DIFF
--- a/src/reachy_mini/daemon/app/config.py
+++ b/src/reachy_mini/daemon/app/config.py
@@ -1,0 +1,230 @@
+"""Persistent daemon configuration.
+
+Holds a tiny JSON document under ``$XDG_CONFIG_HOME/reachy_mini/daemon.json``
+(default ``~/.config/reachy_mini/daemon.json``) for daemon-level state that
+must survive restarts and re-installs of the upstream tray app.
+
+Two fields live here today:
+
+- ``robot_name`` - the human-readable label the user picked for this
+  Reachy.
+- ``install_id`` - a stable opaque identifier (UUID4 hex) generated on
+  first boot and never rotated. Acts as the canonical reconciliation
+  key across discovery transports (BLE / mDNS / HF central): the same
+  physical robot reports the same ``install_id`` on every channel, so
+  the mobile app can merge "this is the robot I see on BLE *and* on
+  central" into a single row even before the user picks a name.
+
+We deliberately keep this file separate from any tray ``data_dir`` so that:
+
+- the same physical Reachy keeps its name + install_id across a tray
+  ``reset_bootstrap``,
+- the same daemon code path applies on the Wireless robot (where there is
+  no tray at all) and on the Lite/desktop tray on macOS or Linux,
+- destroying the HF token cache does not nuke the user's robot label.
+
+Reads and writes are tolerant: a missing or corrupt file is treated as
+"no persisted config", and a write failure is logged but never raises.
+The naming flow always has a mandatory in-memory fallback (``reachy_mini``).
+The install_id has a per-process in-memory fallback too so two daemons
+that fail to write disk still report stable values within their own
+lifetime.
+
+Concurrency: writes are ``fsync`` + atomic rename, so a crash mid-write
+cannot leave the config in a half-written state. There is no in-process
+locking here; the caller (single FastAPI worker) is responsible for not
+issuing parallel ``save_config`` calls. The HTTP route that mutates the
+name guards itself with an ``asyncio.Lock``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_FILENAME = "daemon.json"
+
+# Hard-coded fallback used when the user has not yet customised their
+# robot's name. Kept here so every layer of the daemon (config loader,
+# resolver in main.py, central-relay gate in daemon.py, rename HTTP route)
+# agrees on the same string and a single rename touches one place.
+DEFAULT_ROBOT_NAME = "reachy_mini"
+
+
+def _config_dir() -> Path:
+    """Resolve the directory that holds ``daemon.json``.
+
+    Honours ``$XDG_CONFIG_HOME`` when set (used by both Linux conventions
+    and the macOS tray when it wants a custom location), otherwise falls
+    back to ``~/.config`` per the XDG Base Directory spec. The ``reachy_mini``
+    subfolder keeps daemon config separate from any other Reachy tooling.
+    """
+    base = os.environ.get("XDG_CONFIG_HOME")
+    if base:
+        return Path(base) / "reachy_mini"
+    return Path.home() / ".config" / "reachy_mini"
+
+
+def get_config_path() -> Path:
+    """Return the absolute path to ``daemon.json`` (file may not exist)."""
+    return _config_dir() / _CONFIG_FILENAME
+
+
+def load_config() -> dict[str, Any]:
+    """Load the persisted daemon config.
+
+    Returns an empty dict when the file is missing or unreadable. Never
+    raises: corrupted config must not prevent the daemon from booting.
+    """
+    path = get_config_path()
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+            if isinstance(data, dict):
+                return data
+            logger.warning("[config] %s does not contain a JSON object, ignoring", path)
+            return {}
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("[config] failed to read %s: %s", path, exc)
+        return {}
+
+
+def save_config(config: dict[str, Any]) -> bool:
+    """Persist ``config`` atomically.
+
+    Writes to a temp file in the same directory, fsyncs it, then renames
+    over the target. Returns ``True`` on success, ``False`` on failure.
+    Never raises.
+    """
+    path = get_config_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("[config] failed to mkdir %s: %s", path.parent, exc)
+        return False
+
+    try:
+        # ``delete=False`` so we keep control of the rename ourselves.
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=".daemon.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            json.dump(config, tmp, indent=2, sort_keys=True)
+            tmp.write("\n")
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp_path = Path(tmp.name)
+    except OSError as exc:
+        logger.warning("[config] failed to write tmp file in %s: %s", path.parent, exc)
+        return False
+
+    try:
+        os.replace(tmp_path, path)
+    except OSError as exc:
+        logger.warning(
+            "[config] failed to atomically rename %s -> %s: %s", tmp_path, path, exc
+        )
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        return False
+
+    return True
+
+
+def get_persisted_robot_name() -> Optional[str]:
+    """Return the previously saved robot name, or ``None`` if unset."""
+    name = load_config().get("robot_name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return None
+
+
+def set_persisted_robot_name(name: str) -> bool:
+    """Persist ``name`` as the robot name. Returns whether the write succeeded.
+
+    Reads-modifies-writes the config so we don't clobber sibling fields
+    that future versions may add.
+    """
+    config = load_config()
+    config["robot_name"] = name
+    return save_config(config)
+
+
+# Process-local fallback for ``install_id`` when disk persistence
+# fails. Keeps the value stable across a single daemon process even on
+# read-only filesystems; it does NOT survive restarts in that case.
+_install_id_memo: Optional[str] = None
+
+
+def get_or_create_install_id() -> str:
+    """Return this install's stable opaque identifier, creating it on first call.
+
+    The id is a 32-char lowercase hex (UUID4 without dashes). It is
+    generated exactly once per install, persisted to ``daemon.json``,
+    and then read back on every subsequent boot. Never rotates: a
+    rename of the robot, a new HF token, or a tray ``reset_bootstrap``
+    all leave it untouched.
+
+    Why not a hardware serial: we don't have a stable hardware-anchored
+    id we can read from every supported platform (Wireless Pi, macOS
+    tray, Linux tray). A persisted UUID gives us "stable across all
+    channels for one user's lifetime of this robot install" which is
+    exactly what fleet reconciliation needs.
+
+    Failure mode: if disk writes fail (permissions, full disk, ...),
+    we fall back to a process-local memo so reads from this daemon
+    are at least internally consistent. The next daemon restart will
+    generate a fresh id and try to persist again.
+    """
+    global _install_id_memo
+
+    config = load_config()
+    raw = config.get("install_id")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+
+    if _install_id_memo is not None:
+        return _install_id_memo
+
+    new_id = uuid.uuid4().hex
+    config["install_id"] = new_id
+    if save_config(config):
+        logger.info("[config] generated new install_id=%s", new_id)
+    else:
+        logger.warning(
+            "[config] generated install_id=%s but persistence failed; "
+            "value will not survive a restart",
+            new_id,
+        )
+
+    _install_id_memo = new_id
+    return new_id
+
+
+def get_install_id() -> Optional[str]:
+    """Return the persisted install_id without creating one.
+
+    Used by callers that want to read but not initialise (e.g. the BLE
+    service when probing). Daemon startup always goes through
+    ``get_or_create_install_id`` so a missing file there is fixed
+    immediately.
+    """
+    raw = load_config().get("install_id")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return _install_id_memo

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -14,7 +14,7 @@ import types
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Optional
 
 import uvicorn
 from fastapi import APIRouter, FastAPI, Request
@@ -24,6 +24,12 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon.app.config import (
+    DEFAULT_ROBOT_NAME as _DEFAULT_ROBOT_NAME,
+)
+from reachy_mini.daemon.app.config import (
+    get_persisted_robot_name,
+)
 from reachy_mini.daemon.app.routers import (
     apps,
     camera,
@@ -87,7 +93,12 @@ class Args:
     preload_datasets: bool = False
     dataset_update_interval_hours: float = 24.0  # 0 to disable periodic updates
 
-    robot_name: str = "reachy_mini"
+    # ``None`` means "no explicit value passed on the CLI": resolution
+    # falls back first to the persisted ``daemon.json`` (set by the
+    # mobile app's rename flow), then to the default ``"reachy_mini"``.
+    # An explicit CLI flag always wins so factory provisioning and
+    # tests stay deterministic.
+    robot_name: Optional[str] = None
 
     fastapi_host: str = "0.0.0.0"
     fastapi_port: int = 8000
@@ -95,8 +106,34 @@ class Args:
     localhost_only: bool | None = None
 
 
+def _resolve_robot_name(args_value: Optional[str]) -> str:
+    """Pick the runtime robot name from CLI / persisted config / default.
+
+    Order of precedence:
+        1. explicit ``--robot-name`` CLI flag (``args_value`` is not None);
+        2. previously persisted name from ``daemon.json``;
+        3. hard-coded fallback ``reachy_mini``.
+    """
+    if args_value is not None:
+        return args_value
+    persisted = get_persisted_robot_name()
+    if persisted:
+        return persisted
+    return _DEFAULT_ROBOT_NAME
+
+
 def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
+    # Resolve the canonical robot name once for the lifetime of the app.
+    # Subsequent live renames go through ``Daemon.set_robot_name`` and
+    # update both ``args.robot_name`` and the daemon attribute, so the
+    # rest of the create_app body keeps reading from ``args.robot_name``.
+    # Capture whether the CLI passed an explicit value before we mutate
+    # ``args``; the rename route uses this to label the source as ``"cli"``
+    # so the mobile app knows the persisted name is being overridden.
+    args._robot_name_cli_explicit = args.robot_name is not None  # type: ignore[attr-defined]
+    args.robot_name = _resolve_robot_name(args.robot_name)
+
     localhost_only = (
         args.localhost_only
         if args.localhost_only is not None
@@ -109,7 +146,14 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         args = app.state.args  # type: Args
         dataset_updater_task: asyncio.Task[None] | None = None
 
-        mdns = MdnsServiceRegistration(args.robot_name, args.fastapi_port)
+        mdns = MdnsServiceRegistration(
+            args.robot_name,
+            args.fastapi_port,
+            install_id=app.state.daemon.install_id,
+        )
+        # Expose the registration so the rename route can rebroadcast the
+        # mDNS record under the new name without restarting the daemon.
+        app.state.mdns = mdns
 
         def preload_with_logging() -> None:
             """Download datasets with logging."""
@@ -441,7 +485,11 @@ def main() -> None:
         "--robot-name",
         type=str,
         default=default_args.robot_name,
-        help="Name of the robot (default: reachy_mini).",
+        help=(
+            "Override the robot name. When omitted, the daemon reads the "
+            "persisted name from ``~/.config/reachy_mini/daemon.json`` (set "
+            "by the mobile app) and falls back to ``reachy_mini``."
+        ),
     )
 
     # Real robot mode

--- a/src/reachy_mini/daemon/app/routers/daemon.py
+++ b/src/reachy_mini/daemon/app/routers/daemon.py
@@ -1,21 +1,97 @@
 """Daemon-related API routes."""
 
+import asyncio
 import logging
+import re
 import threading
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
 
 from reachy_mini.daemon.app import bg_job_register
+from reachy_mini.daemon.app.config import (
+    DEFAULT_ROBOT_NAME as _DEFAULT_ROBOT_NAME,
+)
+from reachy_mini.daemon.app.config import (
+    get_persisted_robot_name,
+)
 from reachy_mini.daemon.robot_app_lock import RobotAppLockStatus
 from reachy_mini.io.protocol import DaemonStatus
 
 from ...daemon import Daemon
 from ..dependencies import get_daemon
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(
     prefix="/daemon",
 )
 busy_lock = threading.Lock()
+
+# Single-writer guard for the rename flow: two parallel POSTs would race
+# on persistence + ``setPeerStatus`` re-emit. Acquired only inside the
+# rename route, never held across awaits longer than necessary.
+_robot_name_lock = asyncio.Lock()
+
+# Hard cap chosen so the result fits in mDNS TXT records, the WebSocket
+# producer ``meta.name`` field central displays in its dashboard, and
+# realistic UI labels. Lower bound rejects ``""`` and pure whitespace.
+_ROBOT_NAME_MIN_LEN = 1
+_ROBOT_NAME_MAX_LEN = 32
+
+# ASCII printable + space, no control characters. We deliberately keep
+# Unicode out for now because a) the BLE LocalName layer can't fit
+# arbitrary UTF-8 in a 31-byte advertisement, b) mDNS service names need
+# to round-trip through DNS-safe encoding, and c) the daemon HTTP layer
+# itself is fine with anything but downstream consumers (logs, dashboards)
+# get noisier with non-ASCII. Easy to relax later if real users ask.
+_ROBOT_NAME_PATTERN = re.compile(r"^[\x20-\x7E]+$")
+
+
+class RobotNameResponse(BaseModel):
+    """Current robot name and where it was sourced from."""
+
+    name: str
+    # ``"persisted"`` -> read from ``daemon.json`` on disk;
+    # ``"cli"`` -> ``--robot-name`` flag at daemon launch overrides config;
+    # ``"default"`` -> nobody set anything yet, mobile app should prompt.
+    source: str
+
+
+class SetRobotNameRequest(BaseModel):
+    """Body for ``POST /api/daemon/robot-name``."""
+
+    name: str = Field(
+        min_length=_ROBOT_NAME_MIN_LEN,
+        max_length=_ROBOT_NAME_MAX_LEN,
+        description="Human-readable label for the robot.",
+    )
+
+
+def _validate_robot_name(raw: str) -> str:
+    """Trim, validate, and return a name ready for persistence.
+
+    Raises ``HTTPException(422)`` with a precise reason on failure so
+    the mobile app can render a useful inline error.
+    """
+    name = raw.strip()
+    if len(name) < _ROBOT_NAME_MIN_LEN or len(name) > _ROBOT_NAME_MAX_LEN:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Robot name must be {_ROBOT_NAME_MIN_LEN}-{_ROBOT_NAME_MAX_LEN} "
+                f"characters after trimming whitespace."
+            ),
+        )
+    if not _ROBOT_NAME_PATTERN.match(name):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Robot name must only contain printable ASCII characters "
+                "(letters, digits, spaces, common punctuation)."
+            ),
+        )
+    return name
 
 
 @router.post("/start")
@@ -82,6 +158,135 @@ async def restart_daemon(
 @router.get("/status")
 async def get_daemon_status(daemon: Daemon = Depends(get_daemon)) -> DaemonStatus:
     """Get the current status of the daemon."""
+    return daemon.status()
+
+
+class DaemonIdentityResponse(BaseModel):
+    """Stable identifying information for this daemon install.
+
+    Used by the mobile app's robot registry to merge sightings of the
+    same physical robot across BLE / mDNS / loopback HTTP / HF central
+    into a single entry. ``install_id`` is the canonical key; the
+    other fields are convenience metadata so a single round-trip is
+    enough to render a row.
+    """
+
+    install_id: str
+    robot_name: str
+    # Producer peer id assigned by HF central on the latest ``welcome``
+    # frame. Optional because the relay may not be running (no token,
+    # offline, ...) and because it rotates on every reconnect. Mobile
+    # clients use this as a fallback dedup key against the central
+    # listing while the central server does not yet propagate
+    # ``meta.install_id``.
+    central_peer_id: str | None = None
+
+
+@router.get("/identity", response_model=DaemonIdentityResponse)
+async def get_daemon_identity(
+    daemon: Daemon = Depends(get_daemon),
+) -> DaemonIdentityResponse:
+    """Return the stable per-install identifier and current robot name.
+
+    ``install_id`` is generated on first daemon boot and persisted to
+    ``~/.config/reachy_mini/daemon.json``. It does NOT change when the
+    user renames the robot, swaps HF tokens, or reinstalls the tray:
+    it is the only field of this daemon that the mobile app can rely
+    on as a long-lived reconciliation key.
+
+    ``central_peer_id`` is volatile: it is the id central just handed
+    us back on the WebSocket ``welcome`` frame and rotates on every
+    reconnect. Returned as a best-effort dedup key for mobile clients
+    that want to merge a "this Mac" loopback row against the same
+    physical robot's central listing without waiting for central to
+    propagate ``meta.install_id``.
+    """
+    from reachy_mini.media.central_signaling_relay import get_central_peer_id
+
+    return DaemonIdentityResponse(
+        install_id=daemon.install_id,
+        robot_name=daemon.robot_name,
+        central_peer_id=get_central_peer_id(),
+    )
+
+
+@router.get("/robot-name", response_model=RobotNameResponse)
+async def get_robot_name(
+    request: Request, daemon: Daemon = Depends(get_daemon)
+) -> RobotNameResponse:
+    """Return the current robot name and tell the client where it came from.
+
+    The ``source`` field lets the mobile app decide whether to prompt
+    the user for a name on first connection: when the value is
+    ``"default"`` the user has never customised it, so we surface the
+    naming screen; when it is ``"persisted"`` or ``"cli"`` we trust the
+    existing label and skip the prompt.
+    """
+    args = getattr(request.app.state, "args", None)
+    cli_override = args is not None and getattr(args, "_robot_name_cli_explicit", False)
+
+    persisted = get_persisted_robot_name()
+
+    if cli_override:
+        source = "cli"
+    elif persisted and persisted == daemon.robot_name:
+        source = "persisted"
+    elif daemon.robot_name == _DEFAULT_ROBOT_NAME and not persisted:
+        source = "default"
+    else:
+        # Live rename in flight, or persisted vs in-memory disagree.
+        # ``persisted`` wins as the source label since we just wrote it
+        # there before mutating ``daemon.robot_name``.
+        source = "persisted" if persisted else "default"
+
+    return RobotNameResponse(name=daemon.robot_name, source=source)
+
+
+@router.post("/robot-name", response_model=DaemonStatus)
+async def set_robot_name(
+    body: SetRobotNameRequest,
+    daemon: Daemon = Depends(get_daemon),
+    request: Request = None,  # type: ignore[assignment]
+) -> DaemonStatus:
+    """Rename the robot live and persist the new label across restarts.
+
+    The new name is propagated to:
+
+    - in-memory ``Daemon.robot_name`` and ``DaemonStatus.robot_name``;
+    - ``~/.config/reachy_mini/daemon.json`` (atomic write);
+    - the central signaling relay (live ``setPeerStatus`` re-emit, no
+      reconnect required), so the HF fleet listing reflects the change
+      within a few seconds without dropping any in-flight WebRTC session;
+    - the mDNS service registration, when one is active (LAN listeners
+      see the goodbye + new advertisement).
+
+    Idempotent: a no-op when ``name`` already matches the current value
+    (after trimming). Concurrency-safe via an ``asyncio.Lock``: parallel
+    requests are serialised and the second one observes the new state
+    as a no-op.
+
+    Returns the full ``DaemonStatus`` snapshot so the mobile app can
+    refresh its connection summary in a single round-trip.
+    """
+    new_name = _validate_robot_name(body.name)
+
+    async with _robot_name_lock:
+        if new_name == daemon.robot_name:
+            # Idempotent fast-path: don't touch disk, don't churn central.
+            return daemon.status()
+
+        await daemon.set_robot_name(new_name)
+
+        # Forward to the mDNS handle owned by the FastAPI lifespan, when
+        # one exists (it doesn't on test harnesses that build the app
+        # without going through ``create_app``'s lifespan).
+        mdns = getattr(request.app.state, "mdns", None) if request else None
+        if mdns is not None:
+            try:
+                mdns.update_robot_name(new_name)
+            except Exception as exc:
+                logger.warning("[daemon.rename] mDNS update failed: %s", exc)
+
     return daemon.status()
 
 

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -40,6 +40,12 @@ REACHY_STATUS_SERVICE_UUID = "12345678-1234-5678-1234-56789abcdef3"
 NETWORK_STATUS_UUID = "12345678-1234-5678-1234-56789abcdef4"
 SYSTEM_STATUS_UUID = "12345678-1234-5678-1234-56789abcdef5"
 AVAILABLE_COMMANDS_UUID = "12345678-1234-5678-1234-56789abcdef6"
+# install_id (UUID4 hex, generated once on first daemon boot). Same value
+# also surfaces via mDNS TXT, the central listing's ``meta``, and
+# ``GET /api/daemon/identity`` - so the mobile robot registry can merge
+# this BLE row with the same robot's other sightings on this stable key.
+INSTALL_ID_UUID = "12345678-1234-5678-1234-56789abcdef7"
+ROBOT_NAME_UUID = "12345678-1234-5678-1234-56789abcdef8"
 
 BLUEZ_SERVICE_NAME = "org.bluez"
 GATT_MANAGER_IFACE = "org.bluez.GattManager1"
@@ -538,6 +544,23 @@ class ReachyStatusService(dbus.service.Object):
             )
         )
 
+        # Identity characteristics (install_id + current robot name).
+        # Resolved lazily through the daemon's local HTTP endpoint so
+        # they keep up with rename + first-boot persistence without us
+        # having to wire a second IPC channel into this DBus-only
+        # service. ``Dynamic`` is fine here: the read frequency is
+        # tiny (once at scan time on the mobile side).
+        self.add_characteristic(
+            DynamicCharacteristic(
+                bus, 3, INSTALL_ID_UUID, self, _get_install_id, "Install ID"
+            )
+        )
+        self.add_characteristic(
+            DynamicCharacteristic(
+                bus, 4, ROBOT_NAME_UUID, self, _get_robot_name, "Robot Name"
+            )
+        )
+
     def update_network_status(self):
         """Update the network status characteristic value."""
         if hasattr(self, "network_char"):
@@ -913,6 +936,62 @@ DAEMON_LOCAL_URL = "http://127.0.0.1:8000"
 WIFI_HTTP_TIMEOUT_S = 4.0
 WIFI_SCAN_HTTP_TIMEOUT_S = 15.0  # nmcli rescan is slow
 WIFI_SCAN_MAX_RESULTS = 12  # keep payload inside a single BLE MTU
+IDENTITY_HTTP_TIMEOUT_S = 1.5  # called from a GATT read; must not block
+
+# Cache so a burst of GATT reads (mobile clients tend to pre-warm
+# every characteristic on connect) doesn't hammer the local daemon.
+# Values are immutable across the daemon's lifetime (install_id
+# definitionally so; robot_name is mutable but a 5s lag during a
+# rename is harmless because the mobile re-fetches via HTTP anyway).
+_identity_cache: dict[str, str | float] = {
+    "install_id": "",
+    "robot_name": "",
+    "ts": 0.0,
+}
+_IDENTITY_CACHE_TTL_S = 5.0
+
+
+def _fetch_identity() -> dict[str, str]:
+    """Return a fresh ``{install_id, robot_name}`` dict from the daemon.
+
+    Falls back to empty strings on any error (daemon down, route 404
+    on a pre-revision-3 daemon, ...). GATT reads must never raise.
+    """
+    import time
+
+    now = time.monotonic()
+    if now - float(_identity_cache.get("ts", 0.0)) < _IDENTITY_CACHE_TTL_S:
+        return {
+            "install_id": str(_identity_cache.get("install_id", "")),
+            "robot_name": str(_identity_cache.get("robot_name", "")),
+        }
+
+    install_id = ""
+    robot_name = ""
+    try:
+        payload = _daemon_request(
+            "GET", "/api/daemon/identity", timeout=IDENTITY_HTTP_TIMEOUT_S
+        )
+        if isinstance(payload, dict):
+            install_id = str(payload.get("install_id") or "")
+            robot_name = str(payload.get("robot_name") or "")
+    except Exception as e:
+        logger.debug(f"identity fetch failed (returning blanks): {e}")
+
+    _identity_cache["install_id"] = install_id
+    _identity_cache["robot_name"] = robot_name
+    _identity_cache["ts"] = now
+    return {"install_id": install_id, "robot_name": robot_name}
+
+
+def _get_install_id() -> str:
+    """GATT getter: return the install_id as a UTF-8 string (or "")."""
+    return _fetch_identity()["install_id"]
+
+
+def _get_robot_name() -> str:
+    """GATT getter: return the human-readable robot_name as UTF-8 (or "")."""
+    return _fetch_identity()["robot_name"]
 
 
 def _daemon_request(

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -5,6 +5,7 @@ Includes a fixed NoInputNoOutput agent for automatic Just Works pairing.
 """
 # mypy: ignore-errors
 
+import concurrent.futures
 import fcntl
 import json
 import logging
@@ -769,12 +770,15 @@ class BluetoothCommandService:
             else:
                 return "ERROR: Incorrect PIN"
 
-        # WiFi provisioning commands. WIFI_STATUS is public (read-only snapshot);
-        # mutating commands require prior PIN authentication. Unlike CMD_*, we do
-        # NOT reset `self.connected` afterwards so a client can chain
-        # scan -> connect -> poll status in a single provisioning session.
+        # WiFi provisioning commands. WIFI_STATUS and WIFI_PROBE are public
+        # (read-only snapshots); mutating commands require prior PIN
+        # authentication. Unlike CMD_*, we do NOT reset `self.connected`
+        # afterwards so a client can chain scan -> connect -> poll status in a
+        # single provisioning session.
         elif upper == "WIFI_STATUS":
             return _wifi_status()
+        elif upper == "WIFI_PROBE":
+            return _wifi_probe()
         elif upper == "WIFI_SCAN":
             if not self.connected:
                 return "ERROR: Not connected. Please authenticate first."
@@ -856,7 +860,18 @@ class BluetoothCommandService:
         ad_manager = dbus.Interface(adapter, LE_ADVERTISING_MANAGER_IFACE)
         self.adv = Advertisement(self.bus, 0, "peripheral", self.device_name)
         self.adv.service_uuids = [REACHY_STATUS_SERVICE_UUID]
-        self.adv.manufacturer_data = encode_network_ips()
+        # Pull install_id + central_peer_id once at boot through the
+        # identity endpoint that the GATT install_id characteristic
+        # also reads. The advertis re-published on every refresh tick (see
+        # :meth:`_refresh_network_info`) so a daemon that boots before
+        # ``/api/daemon/identity`` is reachable still ends up with the
+        # correct payload.
+        identity = _fetch_identity()
+        self.adv.manufacturer_data = encode_advert_manufacturer_data(
+            identity.get("install_id", ""),
+            identity.get("central_peer_id", ""),
+            _current_network_mode_byte(),
+        )
         self._ad_manager = ad_manager
         ad_manager.RegisterAdvertisement(
             self.adv.get_path(),
@@ -873,10 +888,30 @@ class BluetoothCommandService:
         logger.info(f"✓ Bluetooth service started as '{self.device_name}'")
 
     def _refresh_network_info(self):
-        """Periodic callback: update GATT characteristic and advertisement."""
+        """Periodic callback: update GATT characteristic and advertisement.
+
+        Re-publishes the BLE advert when any of the three TLV
+        payloads changes:
+
+          - install_id (stable; the very first ticks may run before
+            ``/api/daemon/identity`` is reachable, hence the upgrade)
+          - central_peer_id (volatile; rotates on every relay
+            reconnect - this tick is the cadence at which mobile
+            scanners see the new peerId)
+          - network_mode (dynamic; flips between OFFLINE / HOTSPOT /
+            CONNECTED as the user joins a Wi-Fi or the daemon falls
+            back to its own AP). The 10s tick is fast enough that a
+            mobile scanner sees the transition before the user gives
+            up retrying.
+        """
         self.app.reachy_status.update_network_status()
 
-        new_data = encode_network_ips()
+        identity = _fetch_identity()
+        new_data = encode_advert_manufacturer_data(
+            identity.get("install_id", ""),
+            identity.get("central_peer_id", ""),
+            _current_network_mode_byte(),
+        )
         if new_data != self.adv.manufacturer_data:
             self.adv.manufacturer_data = new_data
             try:
@@ -885,7 +920,7 @@ class BluetoothCommandService:
                     self.adv.get_path(),
                     {},
                     reply_handler=lambda: logger.info(
-                        "Advertisement re-registered with updated IPs"
+                        "Advertisement re-registered with updated install_id payload"
                     ),
                     error_handler=lambda e: logger.error(
                         f"Failed to re-register advertisement: {e}"
@@ -919,6 +954,61 @@ class BluetoothCommandService:
             self.mainloop.quit()
 
 
+POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
+
+# Versioned ManufacturerData layout we publish in the advertisement:
+#
+#   byte 0      : format version (currently 0x02)
+#   bytes 1..N  : TLV blocks  -  [tag][len][value]
+#
+# Tag values:
+#   0x01  install_id_prefix : len=8 bytes, the first 8 bytes of the
+#         daemon's install_id (UUID4 hex). Used by mobile clients to
+#         dedupe a BLE row against the same physical robot's localhost
+#         loopback row + (eventually) its central listing without
+#         having to GATT connect first (a connect breaks the scan +
+#         needs pairing).
+#   0x02  central_peer_id_prefix : len=8 bytes, the first 8 bytes of
+#         the relay-assigned central peerId we got back on the
+#         welcome frame. Volatile (rotates on every relay reconnect)
+#         but used by mobile clients as a fallback dedup key for the
+#         BLE row vs the central listing while the central server
+#         does not yet propagate ``meta.install_id``. Absent when the
+#         relay is offline / the daemon has no token.
+#   0x03  network_mode : len=1 byte enum.
+#           0x00 = OFFLINE   - no usable IP on any interface.
+#           0x01 = HOTSPOT   - daemon is broadcasting its own AP
+#                              (wlan0 == 10.42.0.1).
+#           0x02 = CONNECTED - daemon has a real LAN/WAN IP (Wi-Fi
+#                              joined OR USB-tether interface up).
+#         Reads off ``ip -4 addr`` directly, so it reflects the
+#         daemon's *local* network state - independent of whether
+#         HF central / Internet are reachable. Mobile clients use
+#         this to render an authoritative "Setup pending" badge
+#         without false positives caused by transient relay flaps
+#         (cf. tag 0x02 which depends on 6+ conditions and flickers
+#         when central is unstable). Always emitted - we send 0x00
+#         OFFLINE on subprocess failure rather than dropping the
+#         TLV, so absence = "old daemon, no support".
+#
+# We deliberately drop the legacy IPv4 list from the advert: the
+# 31-byte legacy advertising payload is essentially full once
+# Flags + LocalName ("reachy-mini" = 13B) are accounted for, and
+# every existing client reads IPs via the GATT NETWORK_STATUS
+# characteristic anyway.
+ADVERT_FORMAT_VERSION = 0x02
+ADVERT_TLV_INSTALL_ID = 0x01
+ADVERT_TLV_CENTRAL_PEER_ID = 0x02
+ADVERT_TLV_NETWORK_MODE = 0x03
+ADVERT_INSTALL_ID_PREFIX_BYTES = 8
+ADVERT_CENTRAL_PEER_ID_PREFIX_BYTES = 8
+
+# 1-byte enum values for ADVERT_TLV_NETWORK_MODE.
+ADVERT_NETWORK_MODE_OFFLINE = 0x00
+ADVERT_NETWORK_MODE_HOTSPOT = 0x01
+ADVERT_NETWORK_MODE_CONNECTED = 0x02
+
+
 # =======================
 # WiFi provisioning over BLE
 # =======================
@@ -946,13 +1036,16 @@ IDENTITY_HTTP_TIMEOUT_S = 1.5  # called from a GATT read; must not block
 _identity_cache: dict[str, str | float] = {
     "install_id": "",
     "robot_name": "",
+    "central_peer_id": "",
     "ts": 0.0,
 }
+# central_peer_id rotates on every relay reconnect, so don't cache it
+# longer than the BLE refresh tick can react to it.
 _IDENTITY_CACHE_TTL_S = 5.0
 
 
 def _fetch_identity() -> dict[str, str]:
-    """Return a fresh ``{install_id, robot_name}`` dict from the daemon.
+    """Return a fresh ``{install_id, robot_name, central_peer_id}`` dict.
 
     Falls back to empty strings on any error (daemon down, route 404
     on a pre-revision-3 daemon, ...). GATT reads must never raise.
@@ -964,10 +1057,12 @@ def _fetch_identity() -> dict[str, str]:
         return {
             "install_id": str(_identity_cache.get("install_id", "")),
             "robot_name": str(_identity_cache.get("robot_name", "")),
+            "central_peer_id": str(_identity_cache.get("central_peer_id", "")),
         }
 
     install_id = ""
     robot_name = ""
+    central_peer_id = ""
     try:
         payload = _daemon_request(
             "GET", "/api/daemon/identity", timeout=IDENTITY_HTTP_TIMEOUT_S
@@ -975,13 +1070,19 @@ def _fetch_identity() -> dict[str, str]:
         if isinstance(payload, dict):
             install_id = str(payload.get("install_id") or "")
             robot_name = str(payload.get("robot_name") or "")
+            central_peer_id = str(payload.get("central_peer_id") or "")
     except Exception as e:
         logger.debug(f"identity fetch failed (returning blanks): {e}")
 
     _identity_cache["install_id"] = install_id
     _identity_cache["robot_name"] = robot_name
+    _identity_cache["central_peer_id"] = central_peer_id
     _identity_cache["ts"] = now
-    return {"install_id": install_id, "robot_name": robot_name}
+    return {
+        "install_id": install_id,
+        "robot_name": robot_name,
+        "central_peer_id": central_peer_id,
+    }
 
 
 def _get_install_id() -> str:
@@ -1143,58 +1244,341 @@ def _wifi_forget(ssid: str) -> str:
         return f"ERROR: {e}"
 
 
-      
-POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
+# =======================
+# WiFi reachability probe
+# =======================
+#
+# Runs entirely from the robot's point of view. The mobile app calls
+# this once after ``WIFI_STATUS`` reports ``mode=wlan`` so it can tell
+# the user *why* the robot is or is not actually online (vs. just
+# blindly polling /api/daemon/status from the phone, which only works
+# if the phone happens to share the WiFi).
+#
+# Hard rule: NO TLS in any of these probes. The Pi has no RTC; on a
+# fresh boot it can sit at 1970-01-01 until ``systemd-timesyncd``
+# catches up via the freshly-joined network. An HTTPS check would
+# spuriously fail certificate validation in that window and lie to the
+# user about being offline. Plain TCP / plain DNS sidesteps that
+# entirely - we only care that packets reach the right places, not
+# that the cert chain is healthy.
+#
+# Each individual probe is bounded by a short timeout, all four run in
+# parallel, and the whole call returns within
+# ``_PROBE_TOTAL_TIMEOUT_S`` so the BT command loop never stalls.
+
+# 1.1.1.1 (Cloudflare) and one.one.one.one are deliberately chosen:
+#  - hostnames are short, ASCII, and resolve fast
+#  - both AS13335 endpoints have global anycast PoPs (low jitter)
+#  - 443/tcp is the most common port that's *not* MITM'd by guest WiFi
+_PROBE_DNS_HOST = "one.one.one.one"
+_PROBE_INTERNET_HOST = "1.1.1.1"
+_PROBE_INTERNET_PORT = 443
+_PROBE_DNS_TIMEOUT_S = 1.5
+_PROBE_TCP_TIMEOUT_S = 1.5
+_PROBE_DAEMON_TIMEOUT_S = 1.0
+# Total budget for the whole WIFI_PROBE call. With 4 parallel checks
+# capped at 1.5s each, 2.5s is plenty of slack.
+_PROBE_TOTAL_TIMEOUT_S = 2.5
 
 
-# Hard cap on the number of IP addresses we cram into the BLE advert.
-# Each address eats 5 bytes (1 flag + 4 IPv4), and the legacy adv slot
-# is limited to 31 bytes total (~16 already used by flags + LocalName),
-# so 2 addresses is the safe maximum before HCI rejects the payload.
-_MAX_ADVERTISED_IPS = 2
+def _probe_default_gateway_ip() -> str | None:
+    """Return the IPv4 default gateway from ``/proc/net/route``, if any.
 
-
-def encode_network_ips() -> dict:
-    """Build a ManufacturerData payload with at most two IPv4 addresses.
-
-    Format per IP: 1 byte flags | 4 bytes IPv4
-      flags: 0x01 = hotspot, 0x00 = normal
-
-    Returns a dict {manufacturer_id: dbus.Array(bytes)} suitable for
-    BlueZ ManufacturerData property. Returns empty dict when offline.
-
-    The cap exists because the overall advert has to fit in 31 bytes
-    (see :class:`Advertisement.get_properties`). Mobile clients that
-    need more than two interfaces can still query the GATT
-    NETWORK_STATUS characteristic once connected.
+    Pure /proc parsing - no external command, no DNS, no network call.
+    Returns ``None`` when there's no default route (= robot has no LAN
+    yet, even if it has a link-local IP).
     """
-    status = get_network_status()
-    if status == "OFFLINE" or status == "ERROR":
+    try:
+        with open("/proc/net/route", "r", encoding="ascii") as f:
+            next(f, None)  # skip header
+            for line in f:
+                fields = line.split()
+                if len(fields) < 11:
+                    continue
+                # /proc/net/route uses little-endian hex for IPs
+                # Default route has Destination=00000000 and a Gateway field
+                if fields[1] != "00000000":
+                    continue
+                gw_hex = fields[2]
+                if gw_hex == "00000000":
+                    continue
+                octets = [int(gw_hex[i : i + 2], 16) for i in (6, 4, 2, 0)]
+                return ".".join(str(o) for o in octets)
+    except Exception as e:
+        logger.debug(f"_probe_default_gateway_ip failed: {e}")
+    return None
+
+
+def _probe_check_gateway() -> str:
+    """Return ``"ok"`` if a TCP SYN reaches the default gateway.
+
+    Uses port 53 (DNS) by convention - most home routers run a DNS
+    resolver, and if they don't, the TCP RST itself counts as
+    reachability proof (we'd see ConnectionRefusedError, not timeout).
+    """
+    gw = _probe_default_gateway_ip()
+    if not gw:
+        return "fail"
+    try:
+        with socket.create_connection((gw, 53), timeout=_PROBE_TCP_TIMEOUT_S):
+            return "ok"
+    except ConnectionRefusedError:
+        # The router answered with TCP RST - it's reachable, just not
+        # listening on :53. Counts as a healthy LAN gateway for our
+        # purposes.
+        return "ok"
+    except (TimeoutError, socket.timeout, OSError):
+        return "fail"
+
+
+def _probe_check_dns() -> str:
+    """Return ``"ok"`` if a public hostname resolves via the system resolver."""
+    socket.setdefaulttimeout(_PROBE_DNS_TIMEOUT_S)
+    try:
+        socket.gethostbyname(_PROBE_DNS_HOST)
+        return "ok"
+    except (socket.gaierror, socket.timeout, OSError):
+        return "fail"
+    finally:
+        socket.setdefaulttimeout(None)
+
+
+def _probe_check_internet() -> str:
+    """Return ``"ok"`` if a TCP SYN reaches a public anycast endpoint.
+
+    Plain TCP, no TLS - tolerant to a missing system clock.
+    """
+    try:
+        with socket.create_connection(
+            (_PROBE_INTERNET_HOST, _PROBE_INTERNET_PORT),
+            timeout=_PROBE_TCP_TIMEOUT_S,
+        ):
+            return "ok"
+    except (TimeoutError, socket.timeout, OSError):
+        return "fail"
+
+
+def _probe_check_daemon() -> str:
+    """Return ``"ok"``, ``"loading"`` or ``"fail"`` based on the daemon's status.
+
+    The mobile app uses this to wait gracefully when a fresh-booted
+    robot has joined WiFi *before* the daemon's backend has finished
+    loading - so we don't sling the user into a conversation that
+    immediately 503s.
+    """
+    try:
+        payload = _daemon_request(
+            "GET", "/api/daemon/status", timeout=_PROBE_DAEMON_TIMEOUT_S
+        )
+    except urllib.error.HTTPError as e:
+        if e.code in (502, 503):
+            return "loading"
+        return "fail"
+    except (urllib.error.URLError, TimeoutError, socket.timeout, OSError):
+        return "fail"
+    except Exception:
+        return "fail"
+
+    if not isinstance(payload, dict):
+        return "fail"
+
+    # The daemon exposes a `state` field that flips through
+    # ``starting`` -> ``loading`` -> ``running``. Anything other than
+    # ``running`` is "loading" from the client's POV.
+    state = str(payload.get("state", "")).lower()
+    if state in ("running", "ready", "ok"):
+        return "ok"
+    if state in ("starting", "loading", "booting", "initializing"):
+        return "loading"
+    # Unknown state shape (older daemons): if we got a 200 with a JSON
+    # body, treat the daemon as up.
+    return "ok"
+
+
+def _wifi_probe() -> str:
+    """Diagnose end-to-end reachability from the robot's POV.
+
+    Returns a JSON string (single BLE write fits in default MTU):
+
+        {"wlan":"ok","gateway":"ok","dns":"ok","internet":"ok","daemon":"ok"}
+
+    All four network checks run in parallel and are bounded by
+    ``_PROBE_TOTAL_TIMEOUT_S`` so the BT command loop never stalls.
+    """
+    # WLAN status comes from the same helper used for the BLE TLV 0x03
+    # network_mode byte - keep them aligned.
+    mode_byte = _current_network_mode_byte()
+    if mode_byte == ADVERT_NETWORK_MODE_CONNECTED:
+        wlan = "ok"
+    elif mode_byte == ADVERT_NETWORK_MODE_HOTSPOT:
+        wlan = "hotspot"
+    else:
+        wlan = "fail"
+
+    result: dict[str, str] = {"wlan": wlan}
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
+        futures = {
+            "gateway": ex.submit(_probe_check_gateway),
+            "dns": ex.submit(_probe_check_dns),
+            "internet": ex.submit(_probe_check_internet),
+            "daemon": ex.submit(_probe_check_daemon),
+        }
+        for name, fut in futures.items():
+            try:
+                result[name] = fut.result(timeout=_PROBE_TOTAL_TIMEOUT_S)
+            except concurrent.futures.TimeoutError:
+                result[name] = "fail"
+            except Exception as e:
+                logger.debug(f"_wifi_probe[{name}] failed: {e}")
+                result[name] = "fail"
+
+    return json.dumps(result, separators=(",", ":"))
+
+
+def _hex_id_prefix_bytes(value: str, prefix_bytes: int) -> bytes:
+    """Decode the first ``prefix_bytes`` of a hex string ``value``.
+
+    Tolerant by design: dashes (eg from a UUID like
+    ``204c2579-28c9-4d22-...``) are stripped, the input is lowercased,
+    and any decoding failure yields ``b""`` so callers can simply skip
+    the corresponding TLV instead of crashing the daemon.
+    """
+    if not value:
+        return b""
+    candidate = value.strip().lower().replace("-", "")
+    needed_hex_chars = prefix_bytes * 2
+    if len(candidate) < needed_hex_chars:
+        return b""
+    try:
+        return bytes.fromhex(candidate[:needed_hex_chars])
+    except ValueError:
+        return b""
+
+
+def _install_id_prefix_bytes(install_id: str) -> bytes:
+    """Return the first ``ADVERT_INSTALL_ID_PREFIX_BYTES`` bytes of ``install_id``.
+
+    ``install_id`` is the daemon's UUID4 hex (32 chars). We take its
+    first 16 hex chars and decode them to 8 raw bytes (= 64 bits of
+    uniqueness, collision-safe for any realistic fleet size).
+    """
+    return _hex_id_prefix_bytes(install_id, ADVERT_INSTALL_ID_PREFIX_BYTES)
+
+
+def _central_peer_id_prefix_bytes(central_peer_id: str) -> bytes:
+    """Return the first ``ADVERT_CENTRAL_PEER_ID_PREFIX_BYTES`` of the central peerId.
+
+    Central hands us back a UUID-shaped peerId (with dashes) on the
+    welcome frame. We compress it the same way as install_id so the
+    mobile parser can match it against the central listing's peerId
+    truncated to its first 16 hex chars.
+    """
+    return _hex_id_prefix_bytes(central_peer_id, ADVERT_CENTRAL_PEER_ID_PREFIX_BYTES)
+
+
+def _current_network_mode_byte() -> int | None:
+    """Derive the BLE TLV 0x03 byte from the local network state.
+
+    Reads ``ip -4 addr show`` once, classifies the wlan0 IP literal
+    against the well-known hotspot range (``10.42.0.1``) and returns:
+
+        - ``0x02 CONNECTED`` if any real interface has an IP that
+          isn't the hotspot literal,
+        - ``0x01 HOTSPOT``   if wlan0 holds the hotspot fallback
+          address (and no other real interface is up),
+        - ``0x00 OFFLINE``   if no IPv4 is configured anywhere.
+
+    Returns ``None`` only if the subprocess itself fails (rare); the
+    caller then drops the TLV rather than emitting a misleading
+    OFFLINE byte that could confuse mobile clients during boot.
+    """
+    try:
+        result = subprocess.run(
+            ["ip", "-4", "addr", "show"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+    except Exception as e:
+        logger.debug(f"_current_network_mode_byte: subprocess failed: {e}")
+        return None
+
+    interfaces: dict[str, str] = {}
+    current_iface = None
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line and not line.startswith("inet"):
+            parts = line.split(":")
+            if len(parts) >= 2 and parts[1].strip():
+                iface = parts[1].strip()
+                if iface != "lo":
+                    current_iface = iface
+        elif line.startswith("inet ") and current_iface:
+            inet_parts = line.split()
+            if len(inet_parts) >= 2:
+                ip_with_mask = inet_parts[1]
+                ip_addr = ip_with_mask.split("/")[0]
+                interfaces[current_iface] = ip_addr
+
+    if not interfaces:
+        return ADVERT_NETWORK_MODE_OFFLINE
+
+    # Connected if ANY interface holds a non-hotspot IP. Wired
+    # tether (usb0, eth0, ...) counts as connected even when wlan0
+    # is in hotspot fallback - the robot can still talk to central
+    # via the tether, and the user has nothing to set up Wi-Fi-wise.
+    has_connected_iface = any(
+        not ip.startswith("10.42.0.1") for ip in interfaces.values()
+    )
+    if has_connected_iface:
+        return ADVERT_NETWORK_MODE_CONNECTED
+
+    # All interfaces are on the hotspot literal ⇒ daemon is in setup
+    # mode (broadcasting its own AP).
+    return ADVERT_NETWORK_MODE_HOTSPOT
+
+
+def encode_advert_manufacturer_data(
+    install_id: str,
+    central_peer_id: str = "",
+    network_mode: int | None = None,
+) -> dict:
+    """Build the BLE advertisement ``ManufacturerData`` payload.
+
+    Returns a ``{manufacturer_id: dbus.Array[byte]}`` dict suitable
+    for the BlueZ ``ManufacturerData`` advertisement property, with a
+    versioned TLV stream carrying the daemon's install_id prefix,
+    (when available) its central peerId prefix, and (when known) a
+    1-byte network_mode descriptor. See the ``ADVERT_*`` constants
+    at the top of this module for the on-wire layout.
+
+    ``network_mode`` should be one of ``ADVERT_NETWORK_MODE_*`` or
+    ``None`` (TLV omitted - signals "old daemon" to mobile clients).
+
+    Returns an empty dict when no payload at all is available yet so
+    the advert just goes out without a ManufacturerData section
+    (rather than a malformed one).
+    """
+    install_prefix = _install_id_prefix_bytes(install_id)
+    cp_prefix = _central_peer_id_prefix_bytes(central_peer_id)
+    if not install_prefix and not cp_prefix and network_mode is None:
         return {}
 
     payload = bytearray()
-    is_hotspot = status.startswith("HOTSPOT")
-
-    parts = status.split("[")
-    encoded = 0
-    for part in parts[1:]:
-        if encoded >= _MAX_ADVERTISED_IPS:
-            break
-        if "]" not in part:
-            continue
-        iface, rest = part.split("]", 1)
-        ip_str = rest.split(";")[0].strip()
-        try:
-            ip_bytes = socket.inet_aton(ip_str)
-            flag = 0x01 if (is_hotspot and iface.strip() == "wlan0") else 0x00
-            payload.append(flag)
-            payload.extend(ip_bytes)
-            encoded += 1
-        except OSError:
-            continue
-
-    if not payload:
-        return {}
+    payload.append(ADVERT_FORMAT_VERSION)
+    if install_prefix:
+        payload.append(ADVERT_TLV_INSTALL_ID)
+        payload.append(len(install_prefix))
+        payload.extend(install_prefix)
+    if cp_prefix:
+        payload.append(ADVERT_TLV_CENTRAL_PEER_ID)
+        payload.append(len(cp_prefix))
+        payload.extend(cp_prefix)
+    if network_mode is not None:
+        payload.append(ADVERT_TLV_NETWORK_MODE)
+        payload.append(1)
+        payload.append(network_mode & 0xFF)
 
     return {
         dbus.UInt16(POLLEN_MANUFACTURER_ID): dbus.Array(

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -22,6 +22,7 @@ from reachy_mini.io.protocol import DaemonState, DaemonStatus, MotorControlMode
 from reachy_mini.io.ws_server import WSServer
 from reachy_mini.tools.reflash_motors import reflash_motors_if_needed
 
+from .app.config import get_or_create_install_id
 from .backend.mockup_sim import MockupSimBackend
 from .backend.mujoco import MujocoBackend
 from .backend.robot import RobotBackend
@@ -52,6 +53,14 @@ class Daemon:
 
         self.robot_name = robot_name
 
+        # Stable per-install id, created on first boot and persisted
+        # alongside ``robot_name`` in ``daemon.json``. Read once at init
+        # and held as ``self.install_id`` so it can be passed verbatim
+        # to every layer that needs to advertise the robot (central
+        # relay meta, mDNS TXT, BLE GATT char, HTTP /identity).
+        self.install_id: str = get_or_create_install_id()
+        self.logger.info("Daemon install_id: %s", self.install_id)
+
         self.wireless_version = wireless_version
         self.desktop_app_daemon = desktop_app_daemon
         self.no_media = no_media
@@ -67,6 +76,7 @@ class Daemon:
 
         self._status = DaemonStatus(
             robot_name=robot_name,
+            install_id=self.install_id,
             state=DaemonState.NOT_INITIALIZED,
             wireless_version=wireless_version,
             desktop_app_daemon=desktop_app_daemon,
@@ -153,8 +163,105 @@ class Daemon:
         self._status.media_released = False
         self.logger.info("Media hardware re-acquired.")
 
+    async def set_robot_name(self, robot_name: str) -> "DaemonStatus":
+        """Rename the robot live, without restarting the daemon.
+
+        Updates the in-memory canonical ``robot_name`` (mirrored on
+        ``self._status.robot_name``), persists the new value to
+        ``daemon.json`` so it survives a restart, and pushes the change
+        downstream to the components that advertise the name:
+
+        - the central signaling relay (``setPeerStatus`` re-emit, no
+          reconnect required);
+        - the mDNS service registration, when one exists. The mDNS
+          handle is held by the FastAPI lifespan so the route layer is
+          responsible for forwarding it (kept out of ``Daemon`` to avoid
+          a circular import with the FastAPI app).
+
+        Idempotent: a no-op when ``robot_name`` already matches.
+        Persistence failure is logged but does not raise: the in-memory
+        rename has already taken effect and central has already been
+        notified, so the user-visible behaviour is correct - it just
+        won't survive a daemon restart.
+
+        Note: as of the install_id rollout there is no longer a "first
+        rename triggers central registration" path - the relay always
+        runs as soon as a token is available and reconciliation is
+        done by ``install_id``. So this method is purely an advertise
+        update on a relay that's already (or will soon be) up.
+        """
+        from reachy_mini.daemon.app.config import set_persisted_robot_name
+        from reachy_mini.media.central_signaling_relay import notify_robot_name_change
+
+        if robot_name == self.robot_name:
+            return self._status
+
+        self.logger.info("Renaming robot: %r -> %r", self.robot_name, robot_name)
+        self.robot_name = robot_name
+        self._status.robot_name = robot_name
+
+        if not set_persisted_robot_name(robot_name):
+            self.logger.warning(
+                "Persisted config write failed; rename will not survive restart"
+            )
+
+        try:
+            await notify_robot_name_change(robot_name)
+        except Exception as exc:
+            # ``notify_robot_name_change`` already logs at warning level;
+            # downgrade further failures to debug so we don't double-log.
+            self.logger.debug("notify_robot_name_change raised after handling: %s", exc)
+
+        return self._status
+
+    async def ensure_central_signaling_relay(self) -> dict[str, Any]:
+        """Ensure the central signaling relay is running.
+
+        Idempotent helper used by HTTP routes (e.g. ``save-token``,
+        ``refresh-relay``) to recover from the cold-boot case where the
+        daemon started without an HF token. In that case
+        ``_start_central_signaling_relay`` ran once at media-acquire
+        time, found no token, and returned without setting
+        ``_relay_instance``. After the user pushes a token via
+        ``save-token``, ``notify_token_change`` is a no-op (because
+        ``_relay_instance is None``), so the robot stays invisible on
+        central until the next daemon restart. This method closes that
+        gap by re-running the start path.
+
+        Returns a small dict describing what happened, suitable for
+        bubbling up to API responses.
+        """
+        from reachy_mini.media import central_signaling_relay as _csr
+
+        if _csr._relay_instance is not None:
+            return {"started": False, "reason": "already_running"}
+        if not self._media_server or self._media_released:
+            return {"started": False, "reason": "media_unavailable"}
+
+        await self._start_central_signaling_relay()
+
+        if _csr._relay_instance is None:
+            return {"started": False, "reason": "no_token_or_failed"}
+        return {"started": True}
+
     async def _start_central_signaling_relay(self) -> None:
-        """Start the central signaling relay for remote WebRTC access."""
+        """Start the central signaling relay for remote WebRTC access.
+
+        Two preconditions must hold for the relay to actually start:
+
+        - the media server is up (no point relaying audio/video that
+          doesn't exist);
+        - an HF token is available (central rejects anonymous producers).
+
+        We deliberately do NOT gate on the robot name. Every robot with
+        a token registers on central, and the mobile app reconciles
+        sightings across BLE, mDNS, loopback HTTP, and central by
+        ``install_id`` - so two unnamed ``reachy_mini`` instances end
+        up as two distinguishable rows in the listing rather than two
+        indistinguishable duplicates. The user-facing label is still
+        the human-readable ``robot_name``; ``install_id`` is the
+        technical key.
+        """
         global _central_relay_task
 
         if not self._media_server:
@@ -175,10 +282,15 @@ class Daemon:
         try:
             from reachy_mini.media.central_signaling_relay import start_central_relay
 
-            self.logger.info("Starting central signaling relay...")
+            self.logger.info(
+                "Starting central signaling relay (name=%r, install_id=%s)...",
+                self.robot_name,
+                self.install_id,
+            )
             await start_central_relay(
                 hf_token=hf_token,
                 robot_name=self.robot_name,
+                install_id=self.install_id,
                 robot_app_lock=self.robot_app_lock,
             )
             self.logger.info("Central signaling relay started")
@@ -521,6 +633,20 @@ class Daemon:
             self._status.error = self._status.backend_status.error
         else:
             self._status.backend_status = None
+
+        # Refresh the volatile relay-assigned peer id on every call: the
+        # relay rotates this on each reconnect and we don't have a hook
+        # that wakes ``Daemon`` up on welcome frames. Cheap (single
+        # attribute load) so doing it on every status read is fine.
+        try:
+            from reachy_mini.media.central_signaling_relay import (
+                get_central_peer_id,
+            )
+
+            self._status.central_peer_id = get_central_peer_id()
+        except Exception:
+            # The relay module is optional in some test harnesses.
+            self._status.central_peer_id = None
 
         return self._status
 

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -81,6 +81,21 @@ class DaemonStatus(BaseModel):
 
     type: Literal["daemon_status"] = "daemon_status"
     robot_name: str
+    # Stable, opaque per-install identifier (UUID4 hex). Generated on
+    # first boot and persisted alongside ``robot_name`` in
+    # ``daemon.json``. Used by the mobile app to merge sightings of the
+    # same physical robot across BLE, mDNS, loopback HTTP, and the HF
+    # central listing into a single row even before the user picks a
+    # human-readable name. Optional only for backward compatibility
+    # with older daemons / tests that build a status by hand.
+    install_id: Optional[str] = None
+    # Producer peer id assigned by the HF central signaling server on the
+    # ``welcome`` frame. Volatile (rotates on every relay reconnect),
+    # forwarded to mobile clients so they can dedupe a "this Mac" loopback
+    # row against the same physical robot's central listing while the HF
+    # central server does not yet propagate ``meta.install_id``. Always
+    # ``None`` when the relay is offline (no token, no network, etc.).
+    central_peer_id: Optional[str] = None
     state: DaemonState
     wireless_version: bool
     desktop_app_daemon: bool

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -73,6 +73,7 @@ class CentralSignalingRelay:
         local_uri: str = LOCAL_GSTREAMER_SIGNALING,
         hf_token: Optional[str] = None,
         robot_name: str = "reachymini",
+        install_id: Optional[str] = None,
         on_state_change: Optional[Callable[["RelayState", Optional[str]], None]] = None,
         robot_app_lock: Optional[RobotAppLock] = None,
     ):
@@ -83,6 +84,12 @@ class CentralSignalingRelay:
             local_uri: WebSocket URI of local GStreamer signaling server
             hf_token: HuggingFace token for authentication (will be refreshed)
             robot_name: Name to register as producer
+            install_id: Stable per-install opaque identifier (UUID4
+                hex). Forwarded as ``meta.install_id`` on every
+                ``setPeerStatus`` so the central listing carries the
+                same reconciliation key the BLE / mDNS / loopback
+                surfaces report. Omitted when no install id is known
+                yet (very early boot, tests).
             on_state_change: Callback when state changes (state, message)
             robot_app_lock: Shared lock coordinating local vs remote access to
                 the robot. When provided, incoming remote sessions are
@@ -94,6 +101,7 @@ class CentralSignalingRelay:
         self.local_uri = local_uri
         self.hf_token = hf_token
         self.robot_name = robot_name
+        self.install_id = install_id
         self._on_state_change = on_state_change
         self._robot_app_lock = robot_app_lock
 
@@ -138,6 +146,20 @@ class CentralSignalingRelay:
     def state_message(self) -> Optional[str]:
         """Get additional info about the current state."""
         return self._state_message
+
+    @property
+    def central_peer_id(self) -> Optional[str]:
+        """The producer peer id central assigned to this relay.
+
+        Set on the ``welcome`` frame the first time we connect, cleared
+        on disconnect/teardown. Read by callers outside the relay thread
+        (HTTP handlers, daemon status snapshots): a single attribute load
+        on a `str | None` is atomic in CPython, so we do not need a lock
+        here. Callers MUST treat this as advisory - a freshly reconnected
+        relay can return a new id, and consumers (mobile dedupe, status
+        endpoints) should re-read on every refresh.
+        """
+        return self._central_peer_id
 
     def _set_state(self, state: RelayState, message: Optional[str] = None) -> None:
         """Update the connection state with logging."""
@@ -844,7 +866,7 @@ class CentralSignalingRelay:
                 {
                     "type": "setPeerStatus",
                     "roles": ["producer"],
-                    "meta": {"name": self.robot_name},
+                    "meta": self._build_producer_meta(),
                 }
             )
 
@@ -1116,6 +1138,61 @@ class CentralSignalingRelay:
                 ):
                     self._robot_app_lock.release_remote()
 
+    async def update_producer_name(self, robot_name: str) -> None:
+        """Update the producer name advertised to central, live.
+
+        Used by the daemon when the user renames the robot from the mobile
+        app: we need central's view of the fleet to reflect the new label
+        immediately, without forcing a full relay reconnect (which would
+        churn the WebSocket and momentarily evict any active remote
+        session).
+
+        Idempotent: a no-op when the name has not changed. Safe to call
+        before the relay is connected; the new value will be picked up by
+        the next ``setPeerStatus`` emitted on ``welcome``.
+
+        Must be invoked from the relay's own thread loop (or via
+        ``asyncio.run_coroutine_threadsafe`` for cross-thread callers) so
+        that the ``_send_to_central`` HTTP call uses the right session.
+        """
+        if robot_name == self.robot_name:
+            return
+
+        self.robot_name = robot_name
+        logger.info(
+            "[Central Relay] producer name updated to %r (state=%s)",
+            robot_name,
+            self._state.value,
+        )
+
+        # Only emit setPeerStatus when we're actually registered with
+        # central. In any other state the next ``welcome`` will use the
+        # already-updated ``self.robot_name``.
+        if self._state == RelayState.CONNECTED and self._central_peer_id is not None:
+            await self._send_to_central(
+                {
+                    "type": "setPeerStatus",
+                    "roles": ["producer"],
+                    "meta": self._build_producer_meta(),
+                }
+            )
+
+    def _build_producer_meta(self) -> dict[str, Any]:
+        """Assemble the ``meta`` payload sent on every ``setPeerStatus``.
+
+        Always includes ``name`` (human-readable robot label). Adds
+        ``install_id`` when one is known: this is the stable
+        reconciliation key that lets the mobile app's robot registry
+        merge a central row with the same robot's BLE / mDNS / loopback
+        sightings. We deliberately keep the payload additive so older
+        central versions that don't know about ``install_id`` ignore
+        it without complaining.
+        """
+        meta: dict[str, Any] = {"name": self.robot_name}
+        if self.install_id:
+            meta["install_id"] = self.install_id
+        return meta
+
 
 # Singleton instance for integration
 _relay_instance: Optional[CentralSignalingRelay] = None
@@ -1152,9 +1229,23 @@ def get_relay_status() -> dict[str, Any]:
     }
 
 
+def get_central_peer_id() -> Optional[str]:
+    """Best-effort lookup of the producer peer id central assigned us.
+
+    Returns ``None`` when the relay is not running or has not yet
+    received the ``welcome`` frame. Used by callers (HTTP handlers,
+    daemon identity endpoint) that want to expose this value to clients
+    without taking a hard dependency on the relay singleton.
+    """
+    if _relay_instance is None:
+        return None
+    return _relay_instance.central_peer_id
+
+
 async def start_central_relay(
     hf_token: Optional[str] = None,
     robot_name: str = "reachymini",
+    install_id: Optional[str] = None,
     central_uri: str = CENTRAL_SIGNALING_SERVER,
     on_state_change: Optional[Callable[[RelayState, Optional[str]], None]] = None,
     robot_app_lock: Optional[RobotAppLock] = None,
@@ -1164,6 +1255,8 @@ async def start_central_relay(
     Args:
         hf_token: HuggingFace token for authentication (will auto-refresh)
         robot_name: Name to register as producer
+        install_id: Stable per-install reconciliation key (forwarded to
+            the producer ``meta``). See ``CentralSignalingRelay``.
         central_uri: Central server URI
         on_state_change: Callback when connection state changes
         robot_app_lock: Shared lock coordinating local vs remote robot access.
@@ -1190,6 +1283,7 @@ async def start_central_relay(
         central_uri=central_uri,
         hf_token=hf_token,
         robot_name=robot_name,
+        install_id=install_id,
         on_state_change=on_state_change,
         robot_app_lock=robot_app_lock,
     )
@@ -1246,3 +1340,44 @@ async def notify_force_reconnect() -> None:
         return
 
     await _relay_instance.force_reconnect()
+
+
+async def notify_robot_name_change(new_name: str) -> None:
+    """Push a renamed robot to central without reconnecting.
+
+    Called by ``Daemon.set_robot_name`` after the in-memory and on-disk
+    state has been updated. No-op when there is no relay (Lite, no token,
+    relay not started yet); the relay will pick up the new name on its
+    next ``start()`` because the daemon also passes the fresh name to
+    ``start_central_relay``.
+
+    The actual ``setPeerStatus`` send happens on the relay's own thread
+    loop via ``run_coroutine_threadsafe``: ``_send_to_central`` uses the
+    relay-local ``aiohttp.ClientSession``, which is bound to that loop.
+    """
+    if _relay_instance is None:
+        logger.debug(
+            "[Central Relay] No relay instance, robot name change is in-memory only"
+        )
+        return
+
+    loop = _relay_instance._thread_loop
+    if loop is None or not loop.is_running():
+        # Relay thread not up yet; just update the attribute so the next
+        # ``welcome`` advertises the right name.
+        _relay_instance.robot_name = new_name
+        return
+
+    fut = asyncio.run_coroutine_threadsafe(
+        _relay_instance.update_producer_name(new_name), loop
+    )
+    try:
+        # Bound the wait so a stuck relay thread cannot freeze the HTTP
+        # request that triggered the rename. Failure here is non-fatal:
+        # the on-disk + in-memory state is already updated, central will
+        # catch up on its next reconnect / welcome.
+        await asyncio.get_event_loop().run_in_executor(None, fut.result, 5.0)
+    except Exception as exc:
+        logger.warning(
+            "[Central Relay] update_producer_name(%r) failed: %s", new_name, exc
+        )

--- a/src/reachy_mini/utils/discovery.py
+++ b/src/reachy_mini/utils/discovery.py
@@ -32,7 +32,9 @@ class DiscoveredRobot:
 
     def __repr__(self) -> str:
         """Return a human-readable representation."""
-        return f"DiscoveredRobot(name={self.name!r}, host={self.host!r}, port={self.port})"
+        return (
+            f"DiscoveredRobot(name={self.name!r}, host={self.host!r}, port={self.port})"
+        )
 
 
 def _get_local_ip() -> str:
@@ -54,13 +56,28 @@ def _get_local_ip() -> str:
 class MdnsServiceRegistration:
     """Register a Reachy Mini daemon as an mDNS service."""
 
-    def __init__(self, robot_name: str, port: int) -> None:
-        """Initialize with robot name and port to advertise."""
+    def __init__(
+        self,
+        robot_name: str,
+        port: int,
+        install_id: str | None = None,
+    ) -> None:
+        """Initialize with robot name, port and (optional) install_id to advertise.
+
+        ``install_id`` is published as a TXT property so LAN clients can
+        reconcile this advertisement with the same robot's central
+        listing entry. Always emitted when known; absent on legacy
+        callers / tests.
+        """
         self._robot_name = robot_name
         self._port = port
+        self._install_id = install_id
         self._zeroconf: Zeroconf | None = None
         self._info: ServiceInfo | None = None
         self._register_thread: threading.Thread | None = None
+        # Serialise register/update/unregister: zeroconf is thread-safe at the
+        # protocol level but we mutate ``_info`` and ``_zeroconf`` ourselves.
+        self._lock = threading.Lock()
 
     def register(self) -> None:
         """Register the mDNS service in a background thread.
@@ -89,6 +106,50 @@ class MdnsServiceRegistration:
         thread.start()
         thread.join(timeout=5.0)
 
+    def update_robot_name(self, robot_name: str) -> None:
+        """Re-publish the mDNS service under a new robot name.
+
+        Idempotent: a no-op when the new name matches the current one.
+        Safe to call before the initial ``register()`` (the new name will
+        simply be picked up at register time).
+
+        We unregister and re-register because zeroconf does not let us
+        mutate ``ServiceInfo.name`` in place: the service name encodes the
+        identity advertised on the network and clients caching the old
+        name need to see the goodbye to drop it.
+        """
+        with self._lock:
+            if robot_name == self._robot_name:
+                return
+            self._robot_name = robot_name
+
+            # If we never registered yet (or a previous attempt failed),
+            # there is nothing to tear down. The next ``register()`` call
+            # will use the updated name.
+            if self._register_thread is None and self._zeroconf is None:
+                return
+
+        # Wait for any in-flight register thread to finish before tearing
+        # down: registering with the old name and immediately unregistering
+        # would race the zeroconf cache.
+        if self._register_thread is not None:
+            self._register_thread.join(timeout=10.0)
+            self._register_thread = None
+
+        if self._zeroconf is not None and self._info is not None:
+            try:
+                t = threading.Thread(target=self._do_unregister, daemon=True)
+                t.start()
+                t.join(timeout=5.0)
+            except Exception:
+                logger.warning(
+                    "Failed to unregister mDNS service before rename", exc_info=True
+                )
+
+        # Re-register under the new name. ``register`` itself spawns a
+        # background thread so it's safe to call from any context.
+        self.register()
+
     def _do_register(self) -> None:
         try:
             pkg_version = version("reachy_mini")
@@ -101,6 +162,12 @@ class MdnsServiceRegistration:
             "ws_path": "/ws/sdk",
             "address": _get_local_ip(),
         }
+        if self._install_id:
+            # Stable per-install reconciliation key; same value also
+            # appears in the central listing's ``meta`` and at
+            # ``GET /api/daemon/identity``. Mobile clients merge mDNS
+            # rows with central rows on this key.
+            properties["install_id"] = self._install_id
 
         try:
             self._zeroconf = Zeroconf()
@@ -157,7 +224,9 @@ class _RobotCollector(ServiceListener):
 
         addresses = [socket.inet_ntoa(addr) for addr in info.addresses]
         props = {
-            k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else str(v)
+            k.decode() if isinstance(k, bytes) else k: v.decode()
+            if isinstance(v, bytes)
+            else str(v)
             for k, v in info.properties.items()
         }
 
@@ -361,8 +430,15 @@ def _filter_alive(robots: List[DiscoveredRobot]) -> List[DiscoveredRobot]:
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Discover Reachy Mini robots on the local network.")
-    parser.add_argument("--timeout", type=float, default=5.0, help="Discovery timeout in seconds (default: 5.0)")
+    parser = argparse.ArgumentParser(
+        description="Discover Reachy Mini robots on the local network."
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Discovery timeout in seconds (default: 5.0)",
+    )
     args = parser.parse_args()
 
     robots = find_robots(timeout=args.timeout)


### PR DESCRIPTION
## Summary

Stacked on top of #1069 (`mobile-app-integration-light`). Carve-out from the umbrella draft #1070 covering the **robot identity layer** the mobile app needs to dedupe BLE / mDNS / HF central / loopback HTTP sightings of the same physical robot into a single registry row, plus the **BLE-side consumer** of that identity (TLV advertisement) and a related **Wi-Fi diagnostic command** that lives in the same file.

Two commits, both squashed from cherry-picks:

1. `feat(daemon): stable robot identity (install_id + user-chosen name)` - the daemon-side identity layer
2. `feat(bluetooth): TLV-format BLE advert + WIFI_PROBE diagnostic` - BLE-side consumer + Wi-Fi probe

The intermediate `api_revision` bumps and the transitional "default name gate" (introduced then dropped within the same stack) have been collapsed: the squash represents the final, post-iteration state. **No new `/api/daemon/version` surface is added**; mobile clients can probe the identity capability by feature-detecting `GET /api/daemon/identity` (200 vs 404), and consult the existing `GET /update/install-source` for daemon versioning.

## Commit 1 - daemon identity (8 files, +927/-13)

### HTTP API
- `GET /api/daemon/identity` -> `{ install_id, robot_name, central_peer_id }`
  - `install_id` is generated on first daemon boot and persisted to `~/.config/reachy_mini/daemon.json`. Stable across renames, token rotations, and tray reinstalls.
  - `central_peer_id` comes from the `welcome` SSE frame the relay receives from HF central (rotates on every relay reconnect).
- `GET /api/daemon/robot-name` -> `{ name, source: "default" | "persisted" | "cli" }`
- `POST /api/daemon/robot-name` -> `DaemonStatus` (live rename, propagates to mDNS + central without dropping any active WebRTC session)

### Persistence
- `daemon/app/config.py` (NEW): atomic JSON read/write under `$XDG_CONFIG_HOME/reachy_mini/daemon.json`, with `robot_name` and `install_id` fields.

### BLE GATT
- Two new characteristics: `install_id` (`12345678-1234-5678-1234-56789abcdef7`) and `robot_name` (`12345678-1234-5678-1234-56789abcdef8`), lazy-resolved through the daemon's loopback HTTP with a 5s read cache.

### Central signaling
- `meta.install_id` baked into every `setPeerStatus` producer registration.
- `notify_robot_name_change()` re-emits `setPeerStatus` without a reconnect on rename.
- Drop the transitional "no central registration until renamed" gate.

### mDNS
- `update_robot_name()` performs goodbye + re-advertisement on live rename.

## Commit 2 - BLE advertisement TLV + WIFI_PROBE (1 file, +435/-51)

### Versioned ManufacturerData (TLV v0x02)
Replaces the legacy IPv4-list encoding with a structured TLV stream:

```
byte 0      : format version (0x02)
bytes 1..N  : TLV blocks  -  [tag][len][value]

  tag 0x01 (8 bytes)  install_id_prefix
  tag 0x02 (8 bytes)  central_peer_id_prefix (omitted when relay offline)
  tag 0x03 (1 byte)   network_mode enum
                        0x00 OFFLINE   - no usable IP on any iface
                        0x01 HOTSPOT   - daemon broadcasts its own AP
                        0x02 CONNECTED - real LAN/WAN IP
```

Mobile clients can dedupe a BLE row against the same physical robot's loopback / central row using `install_id` alone, without GATT-connecting (which breaks the scan + needs pairing). `network_mode` lets the mobile app render a "Setup pending" badge from a passive scan without false positives from transient relay flaps.

The 31-byte legacy advert envelope (Flags + LocalName uses ~16B) has barely room for two IPv4s and zero room for ids; every existing IP consumer reads the GATT `NETWORK_STATUS` characteristic anyway, so the IP-list is dropped.

### `WIFI_PROBE` BLE command
Public read-only command returning a JSON snapshot:

```json
{
  "wlan":     "ok|down|error",
  "gateway":  "ok|unreachable",
  "dns":      "ok|fail",
  "internet": "ok|fail",
  "daemon":   "ok|fail"
}
```

Four probes run in parallel under a strict total budget so a stuck DNS resolver cannot block the call. Mobile clients use it during onboarding to surface a precise diagnostic ("Wi-Fi is up but DNS fails") instead of a generic "the robot can't connect".

## Files

| File | Δ | What |
|------|---|------|
| `daemon/app/config.py` | +230 (NEW) | persisted daemon settings + helpers |
| `daemon/app/main.py` | +56 | lifespan: resolve name (CLI > persisted > default), thread install_id |
| `daemon/app/routers/daemon.py` | +205 | `/identity` + `/robot-name` routes, validation, lock |
| `daemon/daemon.py` | +130 | `set_robot_name`, `ensure_central_signaling_relay`, `install_id` |
| `daemon/app/services/bluetooth/bluetooth_service.py` | +561 | 2 new GATT chars, TLV advert v0x02, `WIFI_PROBE`, `network_mode` |
| `io/protocol.py` | +15 | `DaemonStatus.install_id` + `central_peer_id` |
| `media/central_signaling_relay.py` | +137 | `notify_robot_name_change`, `central_peer_id` property, `meta.install_id` |
| `utils/discovery.py` | +88 | mDNS TXT records, `update_robot_name` |

**Total**: 8 files, +1360 / -62 across 2 commits.

## Out of scope (not in this PR)

- Structured logging (`TraceIdFilter`, `kv_log`) - dropped; will not be upstreamed in this carve-out series.
- `GET /api/daemon/version` (`/version` endpoint) - dropped; clients use the existing `/update/install-source` instead.

## Test plan

### Daemon identity
- [ ] Boot the daemon fresh (no `~/.config/reachy_mini/daemon.json`); confirm `install_id` is generated, persisted, and round-trips through a process restart.
- [ ] `GET /api/daemon/identity` returns `install_id` + `robot_name`. After the relay connects, `central_peer_id` is populated.
- [ ] `POST /api/daemon/robot-name {"name": "Sparky"}` returns 200, `daemon.json` is updated, mDNS goodbye + re-advertisement is observed in `avahi-browse`, central listing flips to `"Sparky"` within ~1s without an SSE reconnect.
- [ ] `GET /api/daemon/robot-name` reflects the change with `source: "persisted"`.
- [ ] Validation: empty name, 33-char name, control chars all return 422.
- [ ] Two daemons booted with the default `reachy_mini` name both show up on HF central (no anonymous-duplicate gate).

### BLE
- [ ] BLE scan from the mobile app: GATT chars `install_id` + `robot_name` return correct values.
- [ ] Mobile passive scan parses TLV v0x02 advert: `install_id`, `central_peer_id`, `network_mode` are decoded correctly.
- [ ] Total advert size stays ≤ 31 bytes (controller would reject otherwise).
- [ ] `WIFI_PROBE` over BLE: returns the JSON snapshot in <1s on a healthy robot, in <2s with a stuck DNS resolver (parallel probes + strict budget).
- [ ] Forget current Wi-Fi -> `network_mode` flips to OFFLINE / HOTSPOT in the advert within one refresh tick.

## Notes

- Conflicts during cherry-pick from `dev/mobile-app-integration` were resolved by:
  - dropping the structured-logging `TraceIdFilter` import in `main.py` (out of scope);
  - dropping the `/api/daemon/version` route + `api_revision` bumps (replaced by feature-detection on `/identity`);
  - merging trivial addition-only contexts in `daemon.py` and `routers/daemon.py`;
  - dropping the duplicated `POLLEN_MANUFACTURER_ID` definition introduced by the TLV cherry-pick (kept the canonical one).

Source commits (squashed):
- `31877068` user-chosen robot names with persistence
- `7a7fc2bb` stable install_id + always-on central relay
- `8c0a2469` expose central peer id via /api/daemon/identity
- `3236e849` TLV-format BLE advertisement with install_id + central peer id
- `07f352c1` WIFI_PROBE diagnostic + network_mode TLV in BLE advert