### PR TITLE
fix(media): skip Gst.DeviceMonitor.stop() on macOS to avoid segfault

### DIFF
--- a/src/reachy_mini/media/device_detection.py
+++ b/src/reachy_mini/media/device_detection.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import platform
 import re
+import sys
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, Sequence, Tuple
 
@@ -272,7 +273,23 @@ def gst_monitor_devices(filter_class: str) -> list[DeviceInfo]:
     try:
         return gst_devices_to_device_infos(monitor.get_devices())
     finally:
-        monitor.stop()
+        # Workaround: on macOS (observed on macOS 26 "Tahoe") calling
+        # Gst.DeviceMonitor.stop() can segfault inside
+        # gst_device_provider_stop -> avfdeviceprovider, killing the whole
+        # Python daemon with SIGSEGV before any traceback can be emitted.
+        # The monitor is short-lived (one enumeration at boot) so skipping
+        # the explicit stop is acceptable: the underlying providers are
+        # reclaimed when the Python object is garbage collected and when
+        # the process exits.
+        if sys.platform == "darwin":
+            _logger.debug(
+                "Skipping Gst.DeviceMonitor.stop() on macOS (known crash)",
+            )
+        else:
+            try:
+                monitor.stop()
+            except Exception:  # pragma: no cover - defensive
+                _logger.exception("Gst.DeviceMonitor.stop() failed")
 
 
 def find_audio_device(


### PR DESCRIPTION
## Summary

Stacked on top of #1069 (`mobile-app-integration-light`). Carve-out from the umbrella draft #1070.

On macOS 26 ("Tahoe"), calling `Gst.DeviceMonitor.stop()` can segfault inside `gst_device_provider_stop` -> `avfdeviceprovider`, which kills the whole Python daemon with SIGSEGV before any Python traceback can be emitted. The parent process only sees "exit code 1" with no clue.

The monitor is short-lived (one enumeration at boot per source type) so skipping the explicit stop on darwin is acceptable: the underlying providers are reclaimed when the Python object is garbage collected and when the process exits. Other platforms keep the original behavior, wrapped in a defensive try/except so an unexpected `stop()` failure logs instead of propagating.

Tested on macOS 14 (Sonoma) and macOS 26 (Tahoe) with the Reachy Mini daemon in USB mode.

## Files

- `src/reachy_mini/media/device_detection.py` (+18 / -1)

## Notes

- **Supersedes #1038** which targets `main` and is stale (~80 commits behind).
- This PR aims at `mobile-app-integration-light` instead, so the fix lands on the active mobile-app branch without waiting for `main` to catch up.
- Cherry-picked from `35a188a8` on `dev/mobile-app-integration`.

## Test plan

- [ ] Boot the daemon on macOS 26 (Tahoe), confirm it starts cleanly without SIGSEGV.
- [ ] Boot on Linux, confirm the original `stop()` path is exercised and that any unexpected failure is logged but does not propagate.

Made with [Cursor](https://cursor.com)