### PR TITLE
fix(api): dual-mount /wifi/* under /api/wifi/* so mobile RobotClient can reach them

### DIFF
--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -240,7 +240,12 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         app.include_router(cache.router)
         app.include_router(logs.router)
         app.include_router(update.router)
+        # Legacy mount at `/wifi/...` (used by the Bluetooth provisioning service
+        # and older first-boot tooling). Kept for backward compatibility.
         app.include_router(wifi_config.router)
+        # New mount under `/api/wifi/...` so the mobile app can reach it via
+        # the unified `RobotClient` (which prefixes everything with `/api`).
+        router.include_router(wifi_config.router)
 
     app.include_router(router)
     app.include_router(sdk_ws.router)


### PR DESCRIPTION
## Summary

Stacked on top of #1069 (`mobile-app-integration-light`). Carve-out from the umbrella draft #1070.

The mobile app's unified `RobotClient` prefixes all calls with `/api` (so it can swap LAN HTTP for the WebRTC HTTP-proxy data channel transparently). The `wifi_config` router was only mounted at `/wifi/*` (legacy first-boot tooling contract used by the Bluetooth provisioning service), which made the mobile app's `forgetCurrentNetwork` / status calls 404.

This PR dual-mounts the same router:

- `/wifi/*` stays as-is for the existing BLE provisioning flow and any first-boot tooling that already targets it.
- `/api/wifi/*` is the canonical path for everything that talks to the daemon through `RobotClient` (LAN HTTP and WebRTC `http_proxy`).

Both mounts point at the same router instance, so behavior is identical regardless of which prefix the client uses.

## Files

- `src/reachy_mini/daemon/app/main.py` (+5 / 0): adds `router.include_router(wifi_config.router)` next to the existing app-level mount, with comments explaining the legacy vs canonical paths.

## Test plan

- [ ] `curl http://reachy-mini.local:8000/wifi/status` returns 200 (legacy path still works).
- [ ] `curl http://reachy-mini.local:8000/api/wifi/status` returns 200 (new canonical path).
- [ ] BLE provisioning service still successfully forwards `WIFI_STATUS` / `WIFI_SCAN` / `WIFI_CONNECT` to the daemon (it uses the legacy `/wifi/*` path).
- [ ] Mobile app's `RobotClient.forgetCurrentNetwork()` no longer 404s.

## Notes

- Cherry-picked from `da70f5be` on `dev/mobile-app-integration`. No conflicts (auto-merge applied cleanly on top of the WiFi work already merged into #1069 via #1071).


Made with [Cursor](https://cursor.com)