### PR TITLE
feat(central-relay): heartbeat contract with central's TTL sweeper

### DIFF
--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -68,6 +68,19 @@ PRODUCER_HEALTH_CHECK_MAX_MISSES = (
     2  # consecutive missing-from-list polls before we self-trigger a force_reconnect
 )
 
+# Heartbeat: re-emit setPeerStatus periodically so central refreshes our
+# peer lease (it runs a TTL sweeper that evicts producers without recent
+# inbound traffic). Cadence is negotiated through the SSE welcome; these
+# fall back when central does not advertise one. Details in `_heartbeat_loop`.
+HEARTBEAT_DEFAULT_INTERVAL = 5.0  # fallback when central does not advertise
+HEARTBEAT_MIN_INTERVAL = 1.0  # sanity floor (prevents request storms)
+HEARTBEAT_MAX_INTERVAL = 60.0  # sanity ceiling
+
+
+def _clamp_heartbeat_interval(value: float) -> float:
+    """Clamp a candidate heartbeat interval to the [MIN, MAX] safety envelope."""
+    return max(HEARTBEAT_MIN_INTERVAL, min(HEARTBEAT_MAX_INTERVAL, value))
+
 
 class CentralSignalingRelay:
     """Relay signaling messages between central server (HTTP/SSE) and local GStreamer (WebSocket).
@@ -139,6 +152,13 @@ class CentralSignalingRelay:
         self._central_to_local_session: dict[
             str, str
         ] = {}  # central_session_id -> local_session_id
+
+        # Cadence at which `_heartbeat_loop` re-emits setPeerStatus
+        # to refresh central's peer lease. Negotiated from the SSE
+        # `welcome` message every reconnect; falls back to
+        # HEARTBEAT_DEFAULT_INTERVAL if central does not advertise
+        # one (pre-lifecycle-robustness deployments).
+        self._heartbeat_interval_seconds: float = HEARTBEAT_DEFAULT_INTERVAL
 
     @property
     def state(self) -> RelayState:
@@ -611,40 +631,40 @@ class CentralSignalingRelay:
                 )
                 raise
 
-            # Now connect to central server and run all handlers
-            # Use wait with FIRST_COMPLETED so we can reconnect if any handler exits
+            # Now connect to central server and run all handlers.
+            # Use wait with FIRST_COMPLETED so we can reconnect if any
+            # handler exits. The mapping documents one-to-one why each
+            # task is part of the race; adding a new reconnect trigger
+            # is a one-line change.
             self._set_state(RelayState.CONNECTING, "Connecting to central server...")
-            central_task = asyncio.create_task(self._handle_central_sse())
-            token_task = asyncio.create_task(self._watch_for_token_update())
-            health_task = asyncio.create_task(self._producer_health_loop())
-            tasks = {central_task, local_task, token_task, health_task}
+            relay_tasks: dict[asyncio.Task, str] = {
+                asyncio.create_task(
+                    self._handle_central_sse()
+                ): "Central SSE handler exited, will reconnect",
+                local_task: "Local WebSocket handler exited, will reconnect",
+                asyncio.create_task(
+                    self._watch_for_token_update()
+                ): "Token update triggered reconnect",
+                asyncio.create_task(
+                    self._producer_health_loop()
+                ): "Producer health check triggered reconnect",
+                asyncio.create_task(
+                    self._heartbeat_loop()
+                ): "Heartbeat loop exited unexpectedly, will reconnect",
+            }
 
             try:
                 done, pending = await asyncio.wait(
-                    tasks, return_when=asyncio.FIRST_COMPLETED
+                    relay_tasks.keys(), return_when=asyncio.FIRST_COMPLETED
                 )
 
-                # Log which task finished first
                 for task in done:
-                    if task == central_task:
-                        logger.info(
-                            "[Central Relay] Central SSE handler exited, will reconnect"
-                        )
-                    elif task == local_task:
-                        logger.info(
-                            "[Central Relay] Local WebSocket handler exited, will reconnect"
-                        )
-                    elif task == token_task:
-                        logger.info("[Central Relay] Token update triggered reconnect")
-                    elif task == health_task:
-                        logger.info(
-                            "[Central Relay] Producer health check triggered reconnect"
-                        )
-
-                    # Check for exceptions
+                    logger.info("[Central Relay] %s", relay_tasks[task])
                     if task.exception():
                         logger.warning(
-                            f"[Central Relay] Task {task.get_name()} raised: {task.exception()}"
+                            "[Central Relay] Task %s raised: %s",
+                            task.get_name(),
+                            task.exception(),
                         )
 
                 # Cancel remaining tasks
@@ -662,7 +682,7 @@ class CentralSignalingRelay:
                     )
             except asyncio.CancelledError:
                 # Cancel all tasks if we're cancelled
-                for task in tasks:
+                for task in relay_tasks:
                     task.cancel()
                 raise
         finally:
@@ -675,6 +695,105 @@ class CentralSignalingRelay:
             "[Central Relay] Token update signal received, closing connections"
         )
         await self._close_connections()
+
+    def _producer_status_payload(self) -> dict[str, Any]:
+        """Single source of truth for our ``setPeerStatus`` payload.
+
+        Used both by the post-welcome registration round-trip and by
+        the periodic heartbeat re-emission. Keeping them DRY ensures
+        a future field (e.g. ``install_id`` for the central's
+        last-writer-wins dedup, ``capabilities`` for app gating, ...)
+        can never go out of sync between the two paths.
+        """
+        return {
+            "type": "setPeerStatus",
+            "roles": ["producer"],
+            "meta": {"name": self.robot_name},
+        }
+
+    @staticmethod
+    def _negotiate_heartbeat_interval(welcome_msg: dict[str, Any]) -> float:
+        """Pick the cadence at which we re-emit setPeerStatus.
+
+        Priority order:
+          1. ``recommended_heartbeat_interval_seconds`` field from the
+             welcome (canonical signal: central advertises whatever
+             cadence its server-side ``LEASE_SECONDS`` env tunes to,
+             typically ``LEASE / 3``).
+          2. ``lease_seconds`` field from the welcome divided by 3
+             (older centrals that expose lease but not the recommended
+             cadence directly).
+          3. ``HEARTBEAT_DEFAULT_INTERVAL`` for pre-negotiation
+             centrals that expose neither.
+
+        Rungs 1 and 2 are passed through ``_clamp_heartbeat_interval``
+        so a misconfigured central can neither ask us to spam (say,
+        0.1 s) nor lull us into a cadence so slow we'd be evicted
+        before the next heartbeat fires (say, 600 s).
+        """
+        raw = welcome_msg.get("recommended_heartbeat_interval_seconds")
+        if isinstance(raw, (int, float)) and raw > 0:
+            return _clamp_heartbeat_interval(float(raw))
+        lease = welcome_msg.get("lease_seconds")
+        if isinstance(lease, (int, float)) and lease > 0:
+            return _clamp_heartbeat_interval(float(lease) / 3.0)
+        return HEARTBEAT_DEFAULT_INTERVAL
+
+    async def _heartbeat_loop(self) -> None:
+        """Re-emit setPeerStatus periodically to keep the central lease alive.
+
+        Central runs a TTL sweeper: a producer that does not generate
+        inbound traffic (POST /send) for more than ``LEASE_SECONDS`` is
+        evicted from its in-memory tables, even if the SSE channel is
+        perfectly healthy. Half-open sockets (Wi-Fi yanked, NAT
+        rebinding, captive portal sleep) are the prime offenders -
+        the local TCP stack absorbs server-pushed keepalives silently
+        for minutes and the daemon never realises it's already a ghost.
+
+        This loop is the daemon-side half of the contract:
+          * Cadence is set by ``_negotiate_heartbeat_interval`` from
+            the SSE welcome and stored on ``_heartbeat_interval_seconds``.
+            We snapshot it once on entry; the loop is restarted on
+            every reconnect, so a renegotiated lease is picked up at
+            that point.
+          * The ``await sleep(interval)`` happens BEFORE each re-emit,
+            so the first heartbeat fires one interval after the loop
+            starts (the post-welcome registration just refreshed
+            ``last_seen``; firing again immediately would be wasteful).
+          * Each re-emit reuses ``_producer_status_payload`` so we
+            stay byte-identical to the registration payload. Central
+            is idempotent under repeated setPeerStatus from the same peer.
+          * A failed heartbeat is logged at DEBUG, not ERROR: the
+            split-brain detector (``_producer_health_loop``) is the
+            authoritative recovery path. If central truly dropped us,
+            the next robot-status poll will notice and trigger a
+            ``force_reconnect()``; redundant teardown from this loop
+            would only fight that mechanism.
+          * Exits on cancellation when ``_connect_and_relay``'s
+            FIRST_COMPLETED race tears all sibling tasks down.
+        """
+        interval = self._heartbeat_interval_seconds
+        logger.info("[Central Relay] heartbeat loop running, interval=%.1fs", interval)
+
+        while self._running:
+            try:
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                raise
+
+            if self._state != RelayState.CONNECTED:
+                # Reconnecting / errored: nothing to refresh. Once we
+                # land back in CONNECTED, this loop has already been
+                # cancelled and respawned with a freshly negotiated
+                # interval.
+                continue
+
+            try:
+                await self._send_to_central(self._producer_status_payload())
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.debug("[Central Relay] heartbeat re-emit failed: %s", e)
 
     async def _is_listed_as_producer(self) -> Optional[bool]:
         """Ask central whether we are still a registered producer.
@@ -961,10 +1080,13 @@ class CentralSignalingRelay:
         if msg_type == "welcome":
             # Received our peer ID from central server
             self._central_peer_id = msg.get("peerId")
+            self._heartbeat_interval_seconds = self._negotiate_heartbeat_interval(msg)
             logger.info(
-                "[Central Relay] central welcome received peer_id=%s; registering as producer name=%r",
+                "[Central Relay] central welcome received peer_id=%s; "
+                "registering as producer name=%r, heartbeat=%.1fs",
                 self._central_peer_id,
                 self.robot_name,
+                self._heartbeat_interval_seconds,
             )
 
             # Register as producer FIRST, then flip to CONNECTED. If we
@@ -973,13 +1095,7 @@ class CentralSignalingRelay:
             # central does not yet know we are a producer for this user,
             # which produces the desync described in /refresh-relay's
             # docstring.
-            await self._send_to_central(
-                {
-                    "type": "setPeerStatus",
-                    "roles": ["producer"],
-                    "meta": {"name": self.robot_name},
-                }
-            )
+            await self._send_to_central(self._producer_status_payload())
 
             self._set_state(
                 RelayState.CONNECTED, f"Remote access enabled as '{self.robot_name}'"

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -753,9 +753,11 @@ class CentralSignalingRelay:
         This loop is the daemon-side half of the contract:
           * Cadence is set by ``_negotiate_heartbeat_interval`` from
             the SSE welcome and stored on ``_heartbeat_interval_seconds``.
-            We snapshot it once on entry; the loop is restarted on
-            every reconnect, so a renegotiated lease is picked up at
-            that point.
+            We re-read it on every iteration so the negotiated value
+            propagates as soon as the welcome lands, even though this
+            loop is spawned in parallel with the SSE handler that
+            processes welcome (the first iteration uses the default,
+            every subsequent one uses the negotiated value).
           * The ``await sleep(interval)`` happens BEFORE each re-emit,
             so the first heartbeat fires one interval after the loop
             starts (the post-welcome registration just refreshed
@@ -772,10 +774,14 @@ class CentralSignalingRelay:
           * Exits on cancellation when ``_connect_and_relay``'s
             FIRST_COMPLETED race tears all sibling tasks down.
         """
-        interval = self._heartbeat_interval_seconds
-        logger.info("[Central Relay] heartbeat loop running, interval=%.1fs", interval)
+        last_logged_interval: Optional[float] = None
 
         while self._running:
+            interval = self._heartbeat_interval_seconds
+            if interval != last_logged_interval:
+                logger.info("[Central Relay] heartbeat loop interval=%.1fs", interval)
+                last_logged_interval = interval
+
             try:
                 await asyncio.sleep(interval)
             except asyncio.CancelledError:

--- a/tests/unit_tests/test_central_signaling_relay.py
+++ b/tests/unit_tests/test_central_signaling_relay.py
@@ -1,0 +1,153 @@
+"""Unit tests for :mod:`reachy_mini.media.central_signaling_relay`.
+
+These tests cover only the pure helpers exposed on the relay module:
+the welcome-message negotiation logic that picks the heartbeat
+cadence. Anything that would require driving the asyncio loop, the
+local GStreamer websocket, or the central HTTP server is out of
+scope here (and is currently tracked as integration-test tech debt
+in the same way as the robot_app_lock test suite).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from reachy_mini.media.central_signaling_relay import (
+    HEARTBEAT_DEFAULT_INTERVAL,
+    HEARTBEAT_MAX_INTERVAL,
+    HEARTBEAT_MIN_INTERVAL,
+    CentralSignalingRelay,
+    _clamp_heartbeat_interval,
+)
+
+
+# ---------------------------------------------------------------------------
+# _clamp_heartbeat_interval
+# ---------------------------------------------------------------------------
+
+
+def test_clamp_passes_through_in_range_value() -> None:
+    """A value already inside [MIN, MAX] is returned unchanged."""
+    assert _clamp_heartbeat_interval(5.0) == 5.0
+
+
+def test_clamp_floors_below_min() -> None:
+    """A sub-floor value is raised to ``HEARTBEAT_MIN_INTERVAL``."""
+    assert _clamp_heartbeat_interval(0.1) == HEARTBEAT_MIN_INTERVAL
+
+
+def test_clamp_ceilings_above_max() -> None:
+    """An over-ceiling value is lowered to ``HEARTBEAT_MAX_INTERVAL``."""
+    assert _clamp_heartbeat_interval(600.0) == HEARTBEAT_MAX_INTERVAL
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat interval negotiation
+# ---------------------------------------------------------------------------
+#
+# The cascade is documented in `_negotiate_heartbeat_interval`'s
+# docstring. We assert each rung explicitly so a future refactor that
+# inverts priorities (or drops the clamp) trips a regression here
+# rather than at runtime against a real central deployment.
+
+
+def test_negotiate_uses_recommended_when_present() -> None:
+    """Rung 1: the canonical field wins over everything else."""
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {
+            "type": "welcome",
+            "peerId": "abc",
+            "recommended_heartbeat_interval_seconds": 4.0,
+            "lease_seconds": 30.0,  # would otherwise yield 10.0
+        }
+    )
+    assert result == 4.0
+
+
+def test_negotiate_falls_back_to_lease_over_three() -> None:
+    """Rung 2: an older central exposing only `lease_seconds` is honored."""
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {"type": "welcome", "peerId": "abc", "lease_seconds": 15.0}
+    )
+    assert result == pytest.approx(5.0)
+
+
+def test_negotiate_falls_back_to_default_when_no_negotiation() -> None:
+    """Rung 3: a pre-negotiation central gets the conservative default."""
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {"type": "welcome", "peerId": "abc"}
+    )
+    assert result == HEARTBEAT_DEFAULT_INTERVAL
+
+
+def test_negotiate_clamps_below_floor() -> None:
+    """Rung 1 is subject to the safety clamp on its lower bound."""
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {"recommended_heartbeat_interval_seconds": 0.1}
+    )
+    assert result == HEARTBEAT_MIN_INTERVAL
+
+
+def test_negotiate_clamps_above_ceiling() -> None:
+    """Rung 1 is subject to the safety clamp on its upper bound."""
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {"recommended_heartbeat_interval_seconds": 600.0}
+    )
+    assert result == HEARTBEAT_MAX_INTERVAL
+
+
+def test_negotiate_clamps_lease_derived_value() -> None:
+    """Rung 2 is also subject to the safety clamp."""
+    # lease=600s would derive 200s, well above the 60s ceiling.
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {"lease_seconds": 600.0}
+    )
+    assert result == HEARTBEAT_MAX_INTERVAL
+
+
+def test_negotiate_ignores_non_numeric_recommended() -> None:
+    """A garbled `recommended_*` field falls through to the next rung."""
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {
+            "recommended_heartbeat_interval_seconds": "soon",
+            "lease_seconds": 15.0,
+        }
+    )
+    # Must come from `lease_seconds / 3`, not from the bad string.
+    assert result == pytest.approx(5.0)
+
+
+def test_negotiate_ignores_non_positive_recommended() -> None:
+    """A zero / negative `recommended_*` value falls through to the next rung."""
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {
+            "recommended_heartbeat_interval_seconds": -1,
+            "lease_seconds": 15.0,
+        }
+    )
+    assert result == pytest.approx(5.0)
+
+
+def test_negotiate_ignores_non_positive_lease() -> None:
+    """A zero / negative `lease_seconds` falls through to the default."""
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {"lease_seconds": 0}
+    )
+    assert result == HEARTBEAT_DEFAULT_INTERVAL
+
+
+def test_negotiate_ignores_non_numeric_lease() -> None:
+    """A garbled `lease_seconds` value falls through to the default."""
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {"lease_seconds": "fifteen"}
+    )
+    assert result == HEARTBEAT_DEFAULT_INTERVAL
+
+
+def test_negotiate_accepts_int_recommended() -> None:
+    """JSON ``recommended_*`` may arrive as int (no decimal); we still accept it."""
+    result = CentralSignalingRelay._negotiate_heartbeat_interval(
+        {"recommended_heartbeat_interval_seconds": 5}
+    )
+    assert result == 5.0
+    assert isinstance(result, float)


### PR DESCRIPTION
## Why

The central server (commit [`9bf83c3`](https://huggingface.co/spaces/tfrere/reachy_mini_central/commit/9bf83c3) on `tfrere/reachy_mini_central`) runs a TTL sweeper that evicts producers whose `last_seen` has aged past `LEASE_SECONDS` (default: **15 s**). The daemon never honored its half of the contract - it sent a single `setPeerStatus` post-welcome and then went silent until a client connected. Result: **idle robots disappear from the central's robot list every 15 s** and only come back when the `_producer_health_loop` (added this morning) hauls them back, ~30-60 s later. From the mobile app's perspective, healthy robots flicker offline.

This PR adds the daemon-side heartbeat that closes the loop.

## What it does

- Co-spawns `_heartbeat_loop()` in `_connect_and_relay` next to the existing `central` / `local` / `token` / `health` tasks. Same cancellation semantics (FIRST_COMPLETED race tears it down on every reconnect).
- Re-emits the exact same `setPeerStatus` payload as the post-welcome registration. Idempotent on central's side, so this is just a "ping with metadata" that refreshes the lease.
- Cadence is **negotiated through the SSE welcome message**, not hardcoded:

  | Welcome contains... | Cadence picked |
  |---|---|
  | `recommended_heartbeat_interval_seconds` (canonical) | as advertised |
  | only `lease_seconds` (older centrals) | `lease / 3` |
  | neither (pre-negotiation centrals) | `HEARTBEAT_DEFAULT_INTERVAL = 5 s` |

  Both negotiation rungs go through `_clamp_heartbeat_interval` to land in `[1 s, 60 s]` - a misconfigured central can't trigger a request storm or lull the daemon into eviction.
- Factors out the `setPeerStatus` payload (`_producer_status_payload`) so the post-welcome and heartbeat paths are guaranteed in sync. Future fields (`install_id`, `capabilities`, ...) need to be added in only one place.

## Drive-by cleanup in `_connect_and_relay`

The reconnect race in `_connect_and_relay` was already accumulating "one task per reason to reconnect"; this PR would have pushed it from 4 to 5 entries with a matching `if/elif` chain 25 lines long. Replaced the chain with a `dict[asyncio.Task, str]` mapping each task to its log message:

```python
relay_tasks: dict[asyncio.Task, str] = {
    asyncio.create_task(self._handle_central_sse()): "Central SSE handler exited, will reconnect",
    local_task: "Local WebSocket handler exited, will reconnect",
    asyncio.create_task(self._watch_for_token_update()): "Token update triggered reconnect",
    asyncio.create_task(self._producer_health_loop()): "Producer health check triggered reconnect",
    asyncio.create_task(self._heartbeat_loop()): "Heartbeat loop exited unexpectedly, will reconnect",
}

for task in done:
    logger.info("[Central Relay] %s", relay_tasks[task])
```

Adding a new reconnect trigger is now a one-line change instead of three.

## Failure mode

A heartbeat failure logs at **DEBUG, not ERROR**, by design: the producer health check is the authoritative recovery path. If central truly dropped us, the next `/api/robot-status` poll triggers a `force_reconnect`. Redundant teardown from the heartbeat would only fight that mechanism.

## Backwards compatibility

A daemon shipping this code, talking to a pre-negotiation central (no `lease_seconds`, no `recommended_*`), gets the conservative 5 s default and works exactly as today. The central simply ignores the extra `POST /send` traffic. No migration needed.

## Tests

14 new pytest cases (style consistent with the repo's `test_robot_app_lock` - free functions, no class wrappers):

```
test_clamp_passes_through_in_range_value                            PASSED
test_clamp_floors_below_min                                         PASSED
test_clamp_ceilings_above_max                                       PASSED
test_negotiate_uses_recommended_when_present                        PASSED
test_negotiate_falls_back_to_lease_over_three                       PASSED
test_negotiate_falls_back_to_default_when_no_negotiation            PASSED
test_negotiate_clamps_below_floor                                   PASSED
test_negotiate_clamps_above_ceiling                                 PASSED
test_negotiate_clamps_lease_derived_value                           PASSED
test_negotiate_ignores_non_numeric_recommended                      PASSED
test_negotiate_ignores_non_positive_recommended                     PASSED
test_negotiate_ignores_non_positive_lease                           PASSED
test_negotiate_ignores_non_numeric_lease                            PASSED
test_negotiate_accepts_int_recommended                              PASSED
```

The async loop itself is intentionally not unit-tested here - same rationale as `test_robot_app_lock`: that requires mocking the relay's thread + event loop and is tracked as separate tech debt. Validation plan below covers it E2E.

## Audit checklist

| | Where to look |
|---|---|
| Single new task added to the relay's task set | `_connect_and_relay`, the `relay_tasks` dict |
| Cadence cascade is correct | `_negotiate_heartbeat_interval` (staticmethod, no side effects) |
| Clamp is shared between rungs | `_clamp_heartbeat_interval` (module-level helper) |
| Heartbeat respects relay state | `_heartbeat_loop` skips re-emit when `_state != CONNECTED` |
| Payload is DRY | Both call sites use `_producer_status_payload` |
| First heartbeat is correctly delayed | `await sleep(interval)` happens BEFORE each re-emit, so the first fires one interval after loop start (registration just refreshed `last_seen`) |
| Cancellation is propagated | `_heartbeat_loop` re-raises `CancelledError`, doesn't swallow it |
| Failure is silent (not loud) | `except Exception` -> `logger.debug` only |
| No new dependencies | check `pyproject.toml` (unchanged) |

## Test plan (E2E, post-merge)

- [ ] On the Wi-Fi robot: SSH, `git pull` + reinstall, restart daemon. Watch `journalctl -u reachy-mini-daemon -f` for `[Central Relay] heartbeat loop running, interval=5.0s` shortly after reconnect.
- [ ] Leave the robot idle for **30+ seconds** (no client session). Confirm `curl https://tfrere-reachy-mini-central.hf.space/api/robot-status` still lists the robot the whole time, with `last_seen_age_seconds < 6` between heartbeats.
- [ ] Tune `LEASE_SECONDS` env on the Space (e.g. to 30 s). Restart daemon. Confirm log line shows `interval=10.0s` after re-welcome (no daemon redeploy needed).
- [ ] Disconnect the Wi-Fi robot mid-session (yank cable). Confirm the post-mortem journalctl shows the heartbeat path failing silently (DEBUG only) and the `_producer_health_loop` triggering the actual `force_reconnect` after 2 misses.

## Out of scope

- `install_id` plumbing in the daemon-side `meta` dict (central already supports the dedup, but the daemon doesn't generate one yet). Tracked separately.
- TURN server (mobile/cellular WebRTC). Tracked separately.
- Multi-replica HF Space coordination. Tracked separately.