### PR TITLE
feat(central-relay): advertise meta.transport for USB/Wi-Fi tagging

### DIFF
--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -178,10 +178,21 @@ class Daemon:
         try:
             from reachy_mini.media.central_signaling_relay import start_central_relay
 
+            # ``transport`` reflects how a remote client physically
+            # reaches this daemon: a tray-spawned daemon means the robot
+            # is plugged into the user's desktop over USB; an autonomous
+            # Pi-side daemon (Wireless variant or Lite hosted on its own
+            # Pi) is reached over Wi-Fi (or LAN). We use ``desktop_app_daemon``
+            # as the discriminator since it is the single authoritative
+            # signal we already have on the daemon and it cannot lie:
+            # only the tray launches the daemon with that flag.
+            transport = "usb" if self.desktop_app_daemon else "wifi"
+
             self.logger.info("Starting central signaling relay...")
             await start_central_relay(
                 hf_token=hf_token,
                 robot_name=self.robot_name,
+                transport=transport,
                 robot_app_lock=self.robot_app_lock,
             )
             self.logger.info("Central signaling relay started")

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -100,6 +100,7 @@ class CentralSignalingRelay:
         local_uri: str = LOCAL_GSTREAMER_SIGNALING,
         hf_token: Optional[str] = None,
         robot_name: str = "reachymini",
+        transport: str = "wifi",
         on_state_change: Optional[Callable[["RelayState", Optional[str]], None]] = None,
         robot_app_lock: Optional[RobotAppLock] = None,
     ):
@@ -110,6 +111,16 @@ class CentralSignalingRelay:
             local_uri: WebSocket URI of local GStreamer signaling server
             hf_token: HuggingFace token for authentication (will be refreshed)
             robot_name: Name to register as producer
+            transport: How a client physically reaches this daemon,
+                advertised as ``meta.transport`` and forwarded verbatim
+                by central to listeners. ``"wifi"`` for an autonomous
+                Pi-side daemon (Wireless variant or any Lite with its
+                own network), ``"usb"`` for the desktop-tray daemon
+                spawned next to the user's machine and tethered to the
+                robot over USB. The mobile picker uses this to badge
+                cards "USB" vs "Wi-Fi" without round-tripping the daemon.
+                Free-form string so future fronts (``"ethernet"``,
+                ``"sim"``, ...) need no relay change.
             on_state_change: Callback when state changes (state, message)
             robot_app_lock: Shared lock coordinating local vs remote access to
                 the robot. When provided, incoming remote sessions are
@@ -121,6 +132,7 @@ class CentralSignalingRelay:
         self.local_uri = local_uri
         self.hf_token = hf_token
         self.robot_name = robot_name
+        self.transport = transport
         self._on_state_change = on_state_change
         self._robot_app_lock = robot_app_lock
 
@@ -696,6 +708,28 @@ class CentralSignalingRelay:
         )
         await self._close_connections()
 
+    def _build_producer_meta(self) -> dict[str, Any]:
+        """Assemble the ``meta`` dict advertised to central listeners.
+
+        Single source of truth for **what** we tell the world about
+        ourselves. Kept separate from ``_producer_status_payload`` so
+        future fields (``install_id``, ``capabilities``, ``health``,
+        ``version``, ...) extend this method without disturbing the
+        envelope shape; tests target this function directly.
+
+        Today's surface is intentionally minimal:
+
+          * ``name``: user-facing label (matches the central's
+            ``robotName`` field on ``/api/robot-status``).
+          * ``transport``: ``"usb"`` | ``"wifi"`` so the mobile picker
+            can badge a listing without introspecting via a separate
+            channel.
+        """
+        return {
+            "name": self.robot_name,
+            "transport": self.transport,
+        }
+
     def _producer_status_payload(self) -> dict[str, Any]:
         """Single source of truth for our ``setPeerStatus`` payload.
 
@@ -708,7 +742,7 @@ class CentralSignalingRelay:
         return {
             "type": "setPeerStatus",
             "roles": ["producer"],
-            "meta": {"name": self.robot_name},
+            "meta": self._build_producer_meta(),
         }
 
     @staticmethod
@@ -1410,6 +1444,7 @@ def get_relay_status() -> dict[str, Any]:
 async def start_central_relay(
     hf_token: Optional[str] = None,
     robot_name: str = "reachymini",
+    transport: str = "wifi",
     central_uri: str = CENTRAL_SIGNALING_SERVER,
     on_state_change: Optional[Callable[[RelayState, Optional[str]], None]] = None,
     robot_app_lock: Optional[RobotAppLock] = None,
@@ -1419,6 +1454,8 @@ async def start_central_relay(
     Args:
         hf_token: HuggingFace token for authentication (will auto-refresh)
         robot_name: Name to register as producer
+        transport: Producer ``meta.transport`` (``"usb"`` | ``"wifi"``).
+            See ``CentralSignalingRelay.__init__`` for semantics.
         central_uri: Central server URI
         on_state_change: Callback when connection state changes
         robot_app_lock: Shared lock coordinating local vs remote robot access.
@@ -1445,6 +1482,7 @@ async def start_central_relay(
         central_uri=central_uri,
         hf_token=hf_token,
         robot_name=robot_name,
+        transport=transport,
         on_state_change=on_state_change,
         robot_app_lock=robot_app_lock,
     )

--- a/tests/unit_tests/test_central_signaling_relay.py
+++ b/tests/unit_tests/test_central_signaling_relay.py
@@ -151,3 +151,75 @@ def test_negotiate_accepts_int_recommended() -> None:
     )
     assert result == 5.0
     assert isinstance(result, float)
+
+
+# ---------------------------------------------------------------------------
+# _build_producer_meta
+# ---------------------------------------------------------------------------
+#
+# These tests are the contract guard for the meta dict the daemon
+# advertises to central listeners. They lock down the exact wire shape
+# the mobile app reads. A future change extending the meta (install_id,
+# capabilities, ...) MUST add new tests here, not edit the existing
+# ones - listening clients at older versions rely on these fields not
+# disappearing.
+
+
+def _make_relay(robot_name: str = "reachymini", transport: str = "wifi") -> CentralSignalingRelay:
+    """Construct a relay without starting the asyncio plumbing.
+
+    The constructor only stores fields; ``start()`` is what binds to the
+    websocket and HTTP client. Calling ``__init__`` directly is therefore
+    safe for pure-function tests.
+    """
+    return CentralSignalingRelay(robot_name=robot_name, transport=transport)
+
+
+def test_meta_carries_robot_name() -> None:
+    relay = _make_relay(robot_name="Sparky")
+    assert relay._build_producer_meta()["name"] == "Sparky"
+
+
+def test_meta_carries_transport_wifi_by_default() -> None:
+    """The relay defaults to ``transport='wifi'`` when no override is
+    passed: this matches the Pi-side autonomous daemon, which is the
+    common case (the desktop tray is the one that has to opt in)."""
+    relay = _make_relay()
+    assert relay._build_producer_meta()["transport"] == "wifi"
+
+
+def test_meta_carries_transport_usb_when_set() -> None:
+    relay = _make_relay(transport="usb")
+    assert relay._build_producer_meta()["transport"] == "usb"
+
+
+def test_meta_forwards_unknown_transport_value_verbatim() -> None:
+    """``transport`` is intentionally a free-form string: future fronts
+    (``"ethernet"``, ``"sim"``, ``"mockup"``, ...) must propagate to
+    listeners without a relay change. Listeners that don't recognise
+    the value fall back to "Wi-Fi" by convention.
+    """
+    relay = _make_relay(transport="ethernet")
+    assert relay._build_producer_meta()["transport"] == "ethernet"
+
+
+def test_meta_shape_is_minimal() -> None:
+    """Lock the wire shape so a listener written today is not broken by
+    an accidental field rename. Add new keys, never remove or rename.
+    """
+    relay = _make_relay()
+    meta = relay._build_producer_meta()
+    assert set(meta.keys()) == {"name", "transport"}
+
+
+def test_meta_used_by_producer_status_payload() -> None:
+    """``_producer_status_payload`` MUST embed the meta verbatim: the
+    payload is the canonical envelope, ``_build_producer_meta`` is the
+    source of truth for the dict's content. Any divergence would cause
+    the heartbeat re-emission to drift from the initial registration.
+    """
+    relay = _make_relay(robot_name="r1", transport="usb")
+    payload = relay._producer_status_payload()
+    assert payload["type"] == "setPeerStatus"
+    assert payload["roles"] == ["producer"]
+    assert payload["meta"] == relay._build_producer_meta()


### PR DESCRIPTION
**Stacked on #1081** (heartbeat). Single-field addition to the producer ``meta`` so listeners can badge robots as USB or Wi-Fi from the central listing alone.

## Why

The mobile picker has three sections - **Local USB**, **BLE**, **Distant (Central)** - and the same physical robot can appear in two of them at once. A tray-spawned daemon also registers with HF central, so it shows up in *Distant* alongside *Local USB*. Today there is no way to tell those rows apart from central alone, and the picker either renders duplicates or has to cross-reference ``robotName`` (which collides on the default ``reachy_mini``).

``meta.transport`` is the smallest authoritative signal that closes the gap. The daemon already knows whether it was launched by the tray (via the ``--desktop-app-daemon`` CLI flag stored on ``self.desktop_app_daemon``); this PR plumbs that bit through to the producer ``meta`` so listeners see it without needing a side channel.

## Design

- **One field, free-form string.** ``meta.transport`` is ``\"usb\"`` for a tray-spawned daemon and ``\"wifi\"`` otherwise. Free-form rather than a typed enum so future fronts (``\"ethernet\"``, ``\"sim\"``, ``\"mockup\"``) reach listeners without a relay change. Listeners that don't recognise a value fall back to *Wi-Fi* by convention.
- **Single source of truth.** New ``_build_producer_meta()`` returns the dict; ``_producer_status_payload`` embeds it verbatim. Both the post-welcome registration round-trip and the periodic heartbeat re-emission go through this path, so a future field (``install_id``, ``capabilities``, ``health``, ``version``) cannot drift between the two.
- **Discriminator on the daemon side.** ``daemon.py`` maps ``self.desktop_app_daemon -> \"usb\" else \"wifi\"``. The relay itself stays transport-agnostic and forwards whatever the daemon decided.
- **Default ``\"wifi\"``.** A direct ``CentralSignalingRelay(...)`` call matches the autonomous Pi-side case (Wireless variant or Lite hosted on its own Pi). The desktop tray opts in to ``\"usb\"`` because it is the special case.

## Wire shape

Before:

\`\`\`json
{ \"type\": \"setPeerStatus\", \"roles\": [\"producer\"], \"meta\": {\"name\": \"reachymini\"} }
\`\`\`

After:

\`\`\`json
{
  \"type\": \"setPeerStatus\",
  \"roles\": [\"producer\"],
  \"meta\": {\"name\": \"reachymini\", \"transport\": \"usb\"}
}
\`\`\`

Central forwards ``meta`` verbatim already, so **no central change is needed**. Pre-feature daemons keep emitting ``{name}`` only and listeners must default ``transport=undefined -> \"wifi\"``.

## Files

| File | What |
|---|---|
| ``media/central_signaling_relay.py`` | New ``transport`` ctor arg, new ``_build_producer_meta()`` method, ``_producer_status_payload()`` calls it, ``start_central_relay`` factory forwards the param. |
| ``daemon/daemon.py`` | Compute ``\"usb\" if self.desktop_app_daemon else \"wifi\"`` and pass it to ``start_central_relay``. |
| ``tests/unit_tests/test_central_signaling_relay.py`` | 6 new tests guarding the wire shape. |

Total: **+122 / -1**.

## Tests

20 total (14 heartbeat + 6 new):

\`\`\`
test_meta_carries_robot_name                       PASSED
test_meta_carries_transport_wifi_by_default        PASSED
test_meta_carries_transport_usb_when_set           PASSED
test_meta_forwards_unknown_transport_value_verbatim PASSED
test_meta_shape_is_minimal                         PASSED
test_meta_used_by_producer_status_payload          PASSED
\`\`\`

The shape-locking test (``test_meta_shape_is_minimal``) is the contract guard: any future field addition forces a new test rather than silently editing this one.

## Test plan (E2E, post-merge)

- [ ] Tray daemon: launch with ``--desktop-app-daemon``, observe ``meta.transport == \"usb\"`` in central's ``/api/robot-status``.
- [ ] Pi-side daemon (Wi-Fi): no flag, observe ``meta.transport == \"wifi\"``.
- [ ] Mobile picker (separate change): badge cards from ``meta.transport``.

## Out of scope

This is the smallest sensible slice of the broader producer-meta contract drafted on ``dev/mobile-app-integration``. The remaining pieces each warrant their own PR with their own test plan and will land separately on top of this one:

- **Withdraw()** distinct from ``stop()`` for graceful exit (kills 30 s phantom on shutdown)
- **meta.health + error_code** with the ``peer_health.py`` truth table for visible degraded states
- **\"Tray with no hardware\"** 30 s watchdog → auto-withdraw on USB unplug
- **debounced ``update_producer_meta()``** for live state transitions

The new ``_build_producer_meta()`` is the extension point for those follow-ups: each future field is one line in that helper plus its own unit test.

Made with [Cursor](https://cursor.com)