### PR TITLE
feat(central-relay): advertise meta.hardware_id for stable cross-source identity

### DIFF
--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -22,6 +22,7 @@ import websockets
 from websockets.asyncio.client import ClientConnection
 
 from reachy_mini.daemon.robot_app_lock import RobotAppLock
+from reachy_mini.utils.hardware_id import get_hardware_id
 
 logger = logging.getLogger(__name__)
 
@@ -724,11 +725,26 @@ class CentralSignalingRelay:
           * ``transport``: ``"usb"`` | ``"wifi"`` so the mobile picker
             can badge a listing without introspecting via a separate
             channel.
+          * ``hardware_id`` (when available): SHA-256 prefix of the
+            Pollen audio device's USB serial - stable per physical
+            robot across OS reinstalls and renames. Lets the mobile
+            picker dedupe a central listing against the same robot's
+            BLE / loopback row, and serves as a short visible "robot
+            tag" the user can recognise across sessions (the bare
+            ``peerId`` rotates on every relay reconnect, so it is a
+            poor display key). Omitted when the daemon runs without a
+            Reachy attached (``get_hardware_id()`` returns ``None``);
+            consumers must treat ``undefined`` as "no stable id" and
+            fall back to whatever they already had.
         """
-        return {
+        meta: dict[str, Any] = {
             "name": self.robot_name,
             "transport": self.transport,
         }
+        hw = get_hardware_id()
+        if hw is not None:
+            meta["hardware_id"] = hw
+        return meta
 
     def _producer_status_payload(self) -> dict[str, Any]:
         """Single source of truth for our ``setPeerStatus`` payload.

--- a/tests/unit_tests/test_central_signaling_relay.py
+++ b/tests/unit_tests/test_central_signaling_relay.py
@@ -203,15 +203,6 @@ def test_meta_forwards_unknown_transport_value_verbatim() -> None:
     assert relay._build_producer_meta()["transport"] == "ethernet"
 
 
-def test_meta_shape_is_minimal() -> None:
-    """Lock the wire shape so a listener written today is not broken by
-    an accidental field rename. Add new keys, never remove or rename.
-    """
-    relay = _make_relay()
-    meta = relay._build_producer_meta()
-    assert set(meta.keys()) == {"name", "transport"}
-
-
 def test_meta_used_by_producer_status_payload() -> None:
     """``_producer_status_payload`` MUST embed the meta verbatim: the
     payload is the canonical envelope, ``_build_producer_meta`` is the
@@ -223,3 +214,67 @@ def test_meta_used_by_producer_status_payload() -> None:
     assert payload["type"] == "setPeerStatus"
     assert payload["roles"] == ["producer"]
     assert payload["meta"] == relay._build_producer_meta()
+
+
+# ---------------------------------------------------------------------------
+# meta.hardware_id (stable per-robot identity)
+# ---------------------------------------------------------------------------
+#
+# ``hardware_id`` is sourced via ``get_hardware_id()`` which reads the
+# Pollen audio device's USB serial from sysfs. We monkeypatch that
+# function so the tests exercise the relay's ``meta`` plumbing, not
+# the underlying serial-reading helper (which has its own coverage).
+
+
+def test_meta_includes_hardware_id_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``get_hardware_id()`` returns a string, the meta MUST
+    carry it under the ``hardware_id`` key. Listeners use this as the
+    stable cross-source identity (BLE GATT / central / loopback HTTP
+    all expose the same value)."""
+    import reachy_mini.media.central_signaling_relay as relay_module
+
+    monkeypatch.setattr(relay_module, "get_hardware_id", lambda: "abc123def456")
+    relay = _make_relay()
+    meta = relay._build_producer_meta()
+    assert meta["hardware_id"] == "abc123def456"
+
+
+def test_meta_omits_hardware_id_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When no Reachy is attached (``get_hardware_id() is None``) the
+    field MUST be absent from the meta - never serialised as ``null``
+    or as the literal ``"unknown"``. Consumers branch on
+    ``"hardware_id" in meta`` to decide whether to use the stable id
+    or fall back to ``peerId`` / BLE address.
+    """
+    import reachy_mini.media.central_signaling_relay as relay_module
+
+    monkeypatch.setattr(relay_module, "get_hardware_id", lambda: None)
+    relay = _make_relay()
+    meta = relay._build_producer_meta()
+    assert "hardware_id" not in meta
+
+
+def test_meta_shape_with_hardware_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lock the full set of keys when ``hardware_id`` is available so a
+    listener written today is not broken by an accidental field rename.
+    Add new keys, never remove or rename.
+    """
+    import reachy_mini.media.central_signaling_relay as relay_module
+
+    monkeypatch.setattr(relay_module, "get_hardware_id", lambda: "deadbeef00112233")
+    relay = _make_relay()
+    meta = relay._build_producer_meta()
+    assert set(meta.keys()) == {"name", "transport", "hardware_id"}
+
+
+def test_meta_shape_without_hardware_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """And the minimal key set when no Reachy is attached. Same lock
+    intent: a future PR adding a new field MUST extend both shape tests
+    rather than relax them.
+    """
+    import reachy_mini.media.central_signaling_relay as relay_module
+
+    monkeypatch.setattr(relay_module, "get_hardware_id", lambda: None)
+    relay = _make_relay()
+    meta = relay._build_producer_meta()
+    assert set(meta.keys()) == {"name", "transport"}


### PR DESCRIPTION
**Stacked on #1083** (``meta.transport``). Closes the loop on producer-meta tagging by exposing the **stable per-robot identity** (``hardware_id``) on the central listing - the last surface where it was missing.

## Why

The mobile picker today shows three sections - **Local USB**, **BLE**, **Distant (Central)** - and the same physical robot can appear in all three at once. To dedupe to a single card, the picker needs a key that is:

1. **Stable per hardware** (survives reboots, OS reinstalls, renames, token rotations)
2. **Available across all transports** (HTTP loopback, BLE GATT, central)

``hardware_id`` already satisfies (1) and is exposed via:

- ``GET /api/daemon/hardware-id``
- ``GET /api/daemon/status.hardware_id``
- ``{type: \"get_hardware_id\"}`` over the WebRTC datachannel
- BLE GATT ``HARDWARE_ID_UUID`` on ``REACHY_STATUS_SERVICE_UUID``

…**except** the central listing. This PR closes that gap. The visible side-effect for the picker UI is that the bare ``peerId`` (which rotates on every reconnect) can be replaced by a short ``hwid.slice(0, 5)`` tag the user recognises across sessions.

## Design

- **Optional, never null.** When ``get_hardware_id()`` returns ``None`` (developer machine, no Reachy attached) the field is *omitted* from the meta - never serialised as ``null`` or ``\"unknown\"``. Consumers branch on ``\"hardware_id\" in meta``.
- **One read per emission.** ``get_hardware_id()`` reads sysfs each time we build the meta. The audio device is hot-pluggable in principle, so we deliberately don't cache; the cost is one ``open()`` + a ~30-byte hash, dwarfed by the central round-trip.
- **No envelope change.** Same ``_build_producer_meta()`` extension point as #1083: one line added inside that helper, plus its tests.

## Wire shape

Before (#1083):

\`\`\`json
{ \"type\": \"setPeerStatus\", \"roles\": [\"producer\"], \"meta\": {\"name\": \"reachymini\", \"transport\": \"usb\"} }
\`\`\`

After:

\`\`\`json
{
  \"type\": \"setPeerStatus\",
  \"roles\": [\"producer\"],
  \"meta\": {
    \"name\": \"reachymini\",
    \"transport\": \"usb\",
    \"hardware_id\": \"a3f1e8d2c4b50678\"
  }
}
\`\`\`

## Files

| File | What |
|---|---|
| ``media/central_signaling_relay.py`` | Import ``get_hardware_id``, extend ``_build_producer_meta()`` to add the field when present (omit when ``None``). |
| ``tests/unit_tests/test_central_signaling_relay.py`` | 4 new tests: present / absent / shape-with / shape-without. The earlier ``test_meta_shape_is_minimal`` is split into the two shape variants so the absence on a hardware-less machine doesn't silently become a regression vector. |

Total: **+62 / -7**.

## Tests

23 total (14 heartbeat + 9 meta):

\`\`\`
test_meta_includes_hardware_id_when_available  PASSED
test_meta_omits_hardware_id_when_absent        PASSED
test_meta_shape_with_hardware_id               PASSED
test_meta_shape_without_hardware_id            PASSED
\`\`\`

## Test plan (E2E, post-merge)

- [ ] Pi-side daemon with a Reachy: observe ``meta.hardware_id`` in ``/api/robot-status`` matching ``GET /api/daemon/hardware-id``.
- [ ] Tray daemon without a Reachy: observe ``meta`` lacks the field entirely (no ``\"hardware_id\": null``).
- [ ] Cross-source parity: the same value on BLE GATT char read AND central listing.
- [ ] Mobile picker (separate change): unify the three sections into one card per robot using ``hardware_id`` as the dedup key.

## Out of scope

- Mobile-app consumption: the picker change is a follow-up that does not need a daemon-side PR (BLE GATT char and HTTP status field already exist).
- ``install_id`` (#1073's persistent UUID): orthogonal. ``hardware_id`` is hardware-bound (survives reflash), ``install_id`` would survive a hardware swap but get a new value on reflash. Not in scope here.

Made with [Cursor](https://cursor.com)