### PR TITLE
feat(bluetooth): TLV-format BLE advertisement with hardware_id

### DIFF
--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -852,7 +852,7 @@ class BluetoothCommandService:
         ad_manager = dbus.Interface(adapter, LE_ADVERTISING_MANAGER_IFACE)
         self.adv = Advertisement(self.bus, 0, "peripheral", self.device_name)
         self.adv.service_uuids = [REACHY_STATUS_SERVICE_UUID]
-        self.adv.manufacturer_data = encode_network_ips()
+        self.adv.manufacturer_data = encode_advert_payload(get_hardware_id())
         self._ad_manager = ad_manager
         ad_manager.RegisterAdvertisement(
             self.adv.get_path(),
@@ -863,7 +863,11 @@ class BluetoothCommandService:
             ),
         )
 
-        # Refresh both GATT network characteristic and advertisement payload
+        # Refresh both GATT network characteristic and advertisement payload.
+        # The advert payload only changes if the audio device is hot-(un)plugged,
+        # which is rare; the periodic re-emit is mostly for the GATT
+        # network char update + a re-register safety net in case BlueZ
+        # ever loses our advertisement.
         GLib.timeout_add_seconds(10, self._refresh_network_info)
 
         logger.info(f"✓ Bluetooth service started as '{self.device_name}'")
@@ -872,7 +876,7 @@ class BluetoothCommandService:
         """Periodic callback: update GATT characteristic and advertisement."""
         self.app.reachy_status.update_network_status()
 
-        new_data = encode_network_ips()
+        new_data = encode_advert_payload(get_hardware_id())
         if new_data != self.adv.manufacturer_data:
             self.adv.manufacturer_data = new_data
             try:
@@ -881,7 +885,7 @@ class BluetoothCommandService:
                     self.adv.get_path(),
                     {},
                     reply_handler=lambda: logger.info(
-                        "Advertisement re-registered with updated IPs"
+                        "Advertisement re-registered with updated payload"
                     ),
                     error_handler=lambda e: logger.error(
                         f"Failed to re-register advertisement: {e}"
@@ -1082,57 +1086,87 @@ def _wifi_forget(ssid: str) -> str:
         logger.exception("wifi_forget failed")
         return f"ERROR: {e}"
 
-      
+
 POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
 
 
-# Hard cap on the number of IP addresses we cram into the BLE advert.
-# Each address eats 5 bytes (1 flag + 4 IPv4), and the legacy adv slot
-# is limited to 31 bytes total (~16 already used by flags + LocalName),
-# so 2 addresses is the safe maximum before HCI rejects the payload.
-_MAX_ADVERTISED_IPS = 2
+# =====================================================================
+# BLE advertisement payload (TLV v0x02)
+# =====================================================================
+#
+# We publish a single ManufacturerData entry under POLLEN_MANUFACTURER_ID,
+# encoded as a TLV stream so the mobile picker can dedupe a BLE row
+# against the same robot's central / loopback listing **without** having
+# to GATT-connect (a connect breaks the scan + needs pairing on iOS).
+#
+# Wire layout::
+#
+#     byte 0      : format version (0x02)
+#     bytes 1..N  : TLV blocks  -  [tag][len][value]
+#
+#     tag 0x01 (8 bytes)  hardware_id_prefix
+#                          - first 8 bytes of the SHA-256 prefix that
+#                            ``get_hardware_id()`` exposes elsewhere
+#                            (16 hex chars = 8 binary bytes)
+#                          - omitted when no Reachy is attached
+#                            (``get_hardware_id()`` returns ``None``)
+#
+# Why TLV instead of the previous IPv4-list:
+#
+# - Mobile clients already have NETWORK_STATUS via a GATT char read
+#   (no scan-time benefit from advertising IPs).
+# - A stable per-robot identity is the actual scan-time win: it lets
+#   the picker UI render a single card per physical robot from the
+#   moment a beacon arrives, without forcing a GATT-connect.
+# - TLV leaves room to add fields (network_mode, capabilities, ...)
+#   without another wire-shape break.
+#
+# Budget. Legacy advert = 31 bytes. AD struct overhead per entry is
+# 2 bytes (length + type), Flags eats 3 bytes, LocalName "ReachyMini"
+# eats 12 bytes. ManufacturerData = 2 (id) + 1 (version) + 10 (one TLV
+# of 1 + 1 + 8) = 13 bytes payload, +2 AD overhead = 15 bytes. Total
+# advert = 30 bytes. Margin: 1 byte. A future tag MUST keep the AD
+# under 31 bytes total or BlueZ rejects the registration.
+
+_BLE_ADVERT_FORMAT_VERSION = 0x02
+_TLV_TAG_HARDWARE_ID_PREFIX = 0x01
+_TLV_HARDWARE_ID_PREFIX_LEN = 8
 
 
-def encode_network_ips() -> dict:
-    """Build a ManufacturerData payload with at most two IPv4 addresses.
+def encode_advert_payload(hardware_id_hex: str | None) -> dict:
+    """Build the ManufacturerData payload for the BLE advertisement.
 
-    Format per IP: 1 byte flags | 4 bytes IPv4
-      flags: 0x01 = hotspot, 0x00 = normal
+    Args:
+        hardware_id_hex: 16-hex-char SHA-256 prefix as returned by
+            ``get_hardware_id()``, or ``None`` when no Reachy is
+            attached. ``None`` and any malformed input both produce an
+            empty payload (no ManufacturerData), letting the
+            advertisement still register with just Flags + LocalName.
 
-    Returns a dict {manufacturer_id: dbus.Array(bytes)} suitable for
-    BlueZ ManufacturerData property. Returns empty dict when offline.
+    Returns:
+        ``{manufacturer_id: dbus.Array(bytes)}`` suitable for the
+        BlueZ ``ManufacturerData`` property, or ``{}`` when there is
+        nothing useful to advertise.
 
-    The cap exists because the overall advert has to fit in 31 bytes
-    (see :class:`Advertisement.get_properties`). Mobile clients that
-    need more than two interfaces can still query the GATT
-    NETWORK_STATUS characteristic once connected.
     """
-    status = get_network_status()
-    if status == "OFFLINE" or status == "ERROR":
-        return {}
+    payload = bytearray([_BLE_ADVERT_FORMAT_VERSION])
 
-    payload = bytearray()
-    is_hotspot = status.startswith("HOTSPOT")
-
-    parts = status.split("[")
-    encoded = 0
-    for part in parts[1:]:
-        if encoded >= _MAX_ADVERTISED_IPS:
-            break
-        if "]" not in part:
-            continue
-        iface, rest = part.split("]", 1)
-        ip_str = rest.split(";")[0].strip()
+    if hardware_id_hex and len(hardware_id_hex) >= _TLV_HARDWARE_ID_PREFIX_LEN * 2:
         try:
-            ip_bytes = socket.inet_aton(ip_str)
-            flag = 0x01 if (is_hotspot and iface.strip() == "wlan0") else 0x00
-            payload.append(flag)
-            payload.extend(ip_bytes)
-            encoded += 1
-        except OSError:
-            continue
+            hwid_bytes = bytes.fromhex(
+                hardware_id_hex[: _TLV_HARDWARE_ID_PREFIX_LEN * 2]
+            )
+        except ValueError:
+            hwid_bytes = b""
+        if len(hwid_bytes) == _TLV_HARDWARE_ID_PREFIX_LEN:
+            payload.append(_TLV_TAG_HARDWARE_ID_PREFIX)
+            payload.append(_TLV_HARDWARE_ID_PREFIX_LEN)
+            payload.extend(hwid_bytes)
 
-    if not payload:
+    # Only the bare format version byte left and nothing else? Skip
+    # publishing a header-only payload - it carries no information and
+    # eats AD bytes for free.
+    if len(payload) == 1:
         return {}
 
     return {

--- a/tests/unit_tests/test_bluetooth_advert.py
+++ b/tests/unit_tests/test_bluetooth_advert.py
@@ -1,0 +1,182 @@
+"""Unit tests for the BLE advertisement TLV encoder.
+
+Targets the pure-Python ``encode_advert_payload`` helper. The full BLE
+service is not exercised here (its dbus / glib bindings are
+integration-test territory); we only lock the wire shape so a future
+refactor cannot accidentally break the mobile picker's parser.
+
+The encoder lives in the system-Python ``bluetooth_service.py`` module
+that runs outside the daemon's venv. We import it directly with
+``importlib`` after stubbing the dbus / gi modules: their attributes
+on the helper paths we exercise here are reduced to ``UInt16``, ``Byte``
+and ``Array`` plumbing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "reachy_mini"
+    / "daemon"
+    / "app"
+    / "services"
+    / "bluetooth"
+    / "bluetooth_service.py"
+)
+
+
+def _stub_bus_modules() -> None:
+    """Install minimal stubs for ``dbus`` / ``gi`` so the module imports.
+
+    The encoder we test only touches ``dbus.UInt16``, ``dbus.Byte`` and
+    ``dbus.Array``; everything else used by the BLE service top-level
+    (Object, mainloop bindings, ...) is exposed as a no-op placeholder
+    so the import side-effects don't blow up.
+    """
+    stubs: dict[str, list[str]] = {
+        "dbus": ["service", "mainloop"],
+        "dbus.mainloop": ["glib"],
+        "dbus.service": [],
+        "dbus.mainloop.glib": [],
+        "dbus.exceptions": [],
+        "gi": [],
+        "gi.repository": ["GLib"],
+    }
+    for name, attrs in stubs.items():
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+        mod = sys.modules[name]
+        for attr in attrs:
+            full = f"{name}.{attr}"
+            if not hasattr(mod, attr):
+                child = types.ModuleType(full)
+                setattr(mod, attr, child)
+                sys.modules[full] = child
+
+    # Plumbing the encoder actually exercises.
+    sys.modules["dbus"].UInt16 = lambda x: int(x)
+    sys.modules["dbus"].Byte = lambda x: int(x) & 0xFF
+    sys.modules["dbus"].Array = lambda items, signature=None: list(items)
+    # Filler so other module-top-level statements don't crash.
+    sys.modules["dbus"].SystemBus = type("SystemBus", (), {})
+    sys.modules["dbus"].Interface = type("Interface", (), {})
+    sys.modules["dbus"].Dictionary = dict
+    sys.modules["dbus"].Boolean = lambda x: bool(x)
+    sys.modules["dbus"].String = str
+    sys.modules["dbus"].ObjectPath = str
+    sys.modules["dbus.service"].Object = type("Object", (), {})
+    sys.modules["dbus.service"].method = lambda *a, **k: (lambda f: f)
+    sys.modules["dbus.service"].signal = lambda *a, **k: (lambda f: f)
+    sys.modules["dbus.service"].BusName = type(
+        "BusName", (), {"__init__": lambda self, *a, **k: None}
+    )
+    sys.modules["dbus.exceptions"].DBusException = type(
+        "DBusException", (Exception,), {}
+    )
+    sys.modules["gi.repository"].GLib = type(
+        "GLib", (), {"MainLoop": lambda: None, "timeout_add_seconds": lambda *a: None}
+    )
+
+
+def _import_bt_service() -> types.ModuleType:
+    _stub_bus_modules()
+    spec = importlib.util.spec_from_file_location("bt_advert_test", _MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def bt():  # type: ignore[no-untyped-def]
+    return _import_bt_service()
+
+
+# ---------------------------------------------------------------------------
+# encode_advert_payload
+# ---------------------------------------------------------------------------
+
+
+def _decode_payload(bt, mfg_data: dict) -> list[int]:
+    """Pull the raw byte list out of the dbus-style ManufacturerData dict."""
+    if not mfg_data:
+        return []
+    assert list(mfg_data.keys()) == [bt.POLLEN_MANUFACTURER_ID]
+    return list(mfg_data[bt.POLLEN_MANUFACTURER_ID])
+
+
+def test_encode_emits_version_byte_then_hwid_tlv(bt) -> None:
+    """A canonical 16-hex-char hwid produces a 11-byte payload:
+    1 version byte + 1 tag + 1 len + 8 hwid bytes."""
+    payload = _decode_payload(bt, bt.encode_advert_payload("0123456789abcdef"))
+    assert payload == [
+        bt._BLE_ADVERT_FORMAT_VERSION,
+        bt._TLV_TAG_HARDWARE_ID_PREFIX,
+        bt._TLV_HARDWARE_ID_PREFIX_LEN,
+        0x01,
+        0x23,
+        0x45,
+        0x67,
+        0x89,
+        0xAB,
+        0xCD,
+        0xEF,
+    ]
+
+
+def test_encode_returns_empty_when_hwid_is_none(bt) -> None:
+    """No ``hardware_id`` -> no advertisement payload at all (the
+    advert still registers with just Flags + LocalName)."""
+    assert bt.encode_advert_payload(None) == {}
+
+
+def test_encode_returns_empty_on_short_hwid(bt) -> None:
+    """A truncated hex string is treated as missing rather than
+    silently advertising padding bytes."""
+    assert bt.encode_advert_payload("dead") == {}
+
+
+def test_encode_returns_empty_on_non_hex(bt) -> None:
+    """A non-hex string never reaches the wire as garbage bytes."""
+    assert bt.encode_advert_payload("not-a-hex-string-zzzzzzz") == {}
+
+
+def test_encode_uses_only_first_8_bytes_of_hwid(bt) -> None:
+    """``hardware_id`` is 16 hex chars by spec, but if a longer string
+    arrives we MUST take exactly the first 8 bytes (16 hex chars) and
+    drop the rest. This guards the budget: any extra byte would push
+    the advert past 31 bytes total once Flags + LocalName is counted."""
+    long_hwid = "0123456789abcdef" + "ff" * 16
+    payload = _decode_payload(bt, bt.encode_advert_payload(long_hwid))
+    assert payload[3:] == [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF]
+
+
+def test_encode_payload_total_size_under_budget(bt) -> None:
+    """Sanity bound: the manufacturer-specific bytes must fit inside
+    the 16-byte slot we reserved when sizing the advert (31 bytes -
+    Flags 3 - LocalName 12 = 16). A regression that pushes the payload
+    over this size will cause BlueZ to silently drop the advert."""
+    payload = _decode_payload(bt, bt.encode_advert_payload("a" * 16))
+    assert len(payload) <= 16
+
+
+def test_format_version_is_v0x02(bt) -> None:
+    """Wire-shape lock: any change here breaks every parser in the
+    fleet at once. Bump only with a coordinated client release."""
+    assert bt._BLE_ADVERT_FORMAT_VERSION == 0x02
+
+
+def test_hwid_tlv_tag_and_len_are_stable(bt) -> None:
+    """Same lock as the format version: the parser keys off these
+    constants byte-for-byte."""
+    assert bt._TLV_TAG_HARDWARE_ID_PREFIX == 0x01
+    assert bt._TLV_HARDWARE_ID_PREFIX_LEN == 8


### PR DESCRIPTION
**Stacked on #1084** (``meta.hardware_id``). Replaces the IPv4-list ManufacturerData with a TLV stream so mobile clients can dedupe BLE sightings against the same robot's Local USB / Distant rows **at scan time**, without GATT-connecting (a connect breaks the scan and needs pairing on iOS).

## Why

The mobile picker's three sections (Local USB, BLE, Distant) now all expose ``hardware_id`` *except* BLE pre-connect: the legacy advert encoded IPv4 addresses, which mobile clients never consumed (they read them from the GATT ``NETWORK_STATUS`` characteristic anyway). Without a stable id in the advert, the picker either renders duplicate cards or has to GATT-connect to every advertised peripheral just to learn its identity.

This PR repurposes the 16 manufacturer-data bytes the legacy IPv4 code already owned and ships ``hardware_id_prefix`` instead. A mobile parser consumes it from ``manufacturerData`` directly in the scan callback and assigns ``device.hardwareId`` synchronously - a single unified card per robot becomes possible from the moment a beacon arrives.

## Wire layout

\`\`\`
byte 0      : format version (0x02)
bytes 1..N  : TLV blocks  -  [tag][len][value]

  tag 0x01 (8 bytes)  hardware_id_prefix
                      first 8 bytes of the SHA-256 prefix that
                      get_hardware_id() exposes elsewhere
                      (16 hex chars = 8 binary bytes); omitted
                      when get_hardware_id() returns None.
\`\`\`

When no Reachy is attached, the manufacturer-data section is omitted entirely - the advert still registers with just Flags + LocalName.

## Budget

Legacy advert = 31 bytes total. Per AD struct: 2 bytes overhead (length + type) + payload.

| AD | Bytes |
|---|---:|
| Flags | 3 |
| Complete Local Name \"ReachyMini\" | 12 |
| ManufacturerData (mfg id 2 + version 1 + TLV 10) | 15 |
| **Total** | **30** |

Margin: **1 byte**. A future TLV tag MUST keep the AD under 31 bytes total or BlueZ silently drops the advert.

## Why drop the IPv4 list

- Every existing mobile / desktop consumer reads IPs from the GATT ``NETWORK_STATUS`` characteristic, not the advert.
- IP info is not stable per robot (changes on every Wi-Fi rejoin), so it adds churn to the advert-refresh loop without any scan-time consumer benefit.
- Reclaiming those 16 bytes is what makes room for a stable id.

## Files

| File | What |
|---|---|
| ``daemon/app/services/bluetooth/bluetooth_service.py`` | New ``encode_advert_payload(hardware_id_hex)``, two TLV constants, two ``adv.manufacturer_data`` call sites updated, legacy ``encode_network_ips()`` + ``_MAX_ADVERTISED_IPS`` removed. |
| ``tests/unit_tests/test_bluetooth_advert.py`` (NEW) | 8 tests locking the wire shape. |

Total: **+260 / -44** across 1 file modified + 1 file added.

## Tests

8 new pytest cases all green:

\`\`\`
test_encode_emits_version_byte_then_hwid_tlv          PASSED
test_encode_returns_empty_when_hwid_is_none           PASSED
test_encode_returns_empty_on_short_hwid               PASSED
test_encode_returns_empty_on_non_hex                  PASSED
test_encode_uses_only_first_8_bytes_of_hwid           PASSED
test_encode_payload_total_size_under_budget           PASSED
test_format_version_is_v0x02                          PASSED
test_hwid_tlv_tag_and_len_are_stable                  PASSED
\`\`\`

The shape-locking constants (``_BLE_ADVERT_FORMAT_VERSION``, ``_TLV_TAG_HARDWARE_ID_PREFIX``, ``_TLV_HARDWARE_ID_PREFIX_LEN``) are asserted explicitly so a future refactor cannot silently break every parser in the fleet.

## Test plan (E2E, post-merge)

- [ ] Pi-side daemon with Reachy attached: ``hcitool lescan -d`` shows manufacturer data ``02 01 08 <8-byte hwid>``.
- [ ] Hex-decode the 8 bytes: must match the first 16 chars of ``GET /api/daemon/hardware-id``.
- [ ] Disconnect the audio device at runtime: next 10 s refresh tick drops the manufacturer data entry from the advert.
- [ ] Mobile picker (separate change): a single BLE card per robot with ``id:<5 hex chars>`` matching the same robot's Distant / Local USB cards.

## Backwards compatibility

- Daemon shipping this code + mobile client that does not parse TLV yet -> BLE list shows no hwid (same as pre-PR state).
- Pre-PR daemon + TLV-aware mobile client -> ``device.hardwareId = null``, picker falls back to whatever it had before.

No coordinated rollout needed.

## Out of scope

- **Mobile-app TLV parser**: lives in the consuming app, not in this PR.
- **Additional TLV tags** (``network_mode``, ``capabilities``, ...): the format is designed for them, but adding any pushes past the 1-byte budget margin. Tracked separately.

Made with [Cursor](https://cursor.com)