### PR TITLE
Mobile app bluetooth login update

### DIFF
--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -857,7 +857,9 @@ class BluetoothCommandService:
         ad_manager = dbus.Interface(adapter, LE_ADVERTISING_MANAGER_IFACE)
         self.adv = Advertisement(self.bus, 0, "peripheral", self.device_name)
         self.adv.service_uuids = [REACHY_STATUS_SERVICE_UUID]
-        self.adv.manufacturer_data = encode_advert_payload(get_hardware_id())
+        self.adv.manufacturer_data = encode_advert_payload(
+            get_hardware_id(), get_network_status()
+        )
         self._ad_manager = ad_manager
         ad_manager.RegisterAdvertisement(
             self.adv.get_path(),
@@ -881,7 +883,7 @@ class BluetoothCommandService:
         """Periodic callback: update GATT characteristic and advertisement."""
         self.app.reachy_status.update_network_status()
 
-        new_data = encode_advert_payload(get_hardware_id())
+        new_data = encode_advert_payload(get_hardware_id(), get_network_status())
         if new_data != self.adv.manufacturer_data:
             self.adv.manufacturer_data = new_data
             try:
@@ -1296,82 +1298,115 @@ POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
 
 
 # =====================================================================
-# BLE advertisement payload (TLV v0x02)
+# BLE advertisement payload
 # =====================================================================
 #
-# We publish a single ManufacturerData entry under POLLEN_MANUFACTURER_ID,
-# encoded as a TLV stream so the mobile picker can dedupe a BLE row
-# against the same robot's central / loopback listing **without** having
-# to GATT-connect (a connect breaks the scan + needs pairing on iOS).
+# Single ManufacturerData entry under POLLEN_MANUFACTURER_ID, fixed-
+# offset layout designed to:
+#
+#   1. Keep wire compatibility with the legacy IPv4-list advert: any
+#      old client that parses ``[flag][IPv4][...]`` still reads the
+#      first IP correctly (a hypothetical ghost "second IP" decoded
+#      from the trailing hwid bytes would never crash, just look bogus
+#      to a UI that displays it - no consumer in this codebase reads
+#      IPs from the advert anyway).
+#
+#   2. Carry the SHA-256 hardware-id prefix at scan time so the mobile
+#      picker can dedupe a BLE row against the same robot's
+#      central / loopback rows without GATT-connecting (a connect
+#      breaks the scan and needs pairing on iOS).
 #
 # Wire layout::
 #
-#     byte 0      : format version (0x02)
-#     bytes 1..N  : TLV blocks  -  [tag][len][value]
+#   byte 0      : flag  (0x00 = LAN, 0x01 = hotspot AP)
+#   bytes 1-4   : IPv4 (network byte order)
+#   bytes 5-11  : hardware_id prefix (first 7 bytes = 14 hex chars)
 #
-#     tag 0x01 (8 bytes)  hardware_id_prefix
-#                          - first 8 bytes of the SHA-256 prefix that
-#                            ``get_hardware_id()`` exposes elsewhere
-#                            (16 hex chars = 8 binary bytes)
-#                          - omitted when no Reachy is attached
-#                            (``get_hardware_id()`` returns ``None``)
+# Total payload = 12 bytes, exactly the budget left after Flags (3)
+# + Complete Local Name "ReachyMini" (12) + ManufacturerData
+# envelope (4) = 19 bytes used inside the 31-byte legacy advert
+# limit. **No spare bytes.** Any future field requires either
+# growing room (shorter LocalName, drop ManufacturerData envelope)
+# or a wire-shape bump.
 #
-# Why TLV instead of the previous IPv4-list:
-#
-# - Mobile clients already have NETWORK_STATUS via a GATT char read
-#   (no scan-time benefit from advertising IPs).
-# - A stable per-robot identity is the actual scan-time win: it lets
-#   the picker UI render a single card per physical robot from the
-#   moment a beacon arrives, without forcing a GATT-connect.
-# - TLV leaves room to add fields (network_mode, capabilities, ...)
-#   without another wire-shape break.
-#
-# Budget. Legacy advert = 31 bytes. AD struct overhead per entry is
-# 2 bytes (length + type), Flags eats 3 bytes, LocalName "ReachyMini"
-# eats 12 bytes. ManufacturerData = 2 (id) + 1 (version) + 10 (one TLV
-# of 1 + 1 + 8) = 13 bytes payload, +2 AD overhead = 15 bytes. Total
-# advert = 30 bytes. Margin: 1 byte. A future tag MUST keep the AD
-# under 31 bytes total or BlueZ rejects the registration.
+# Why prefix bytes (not suffix). The mobile picker shows the FIRST 5
+# hex chars of hardware_id as a robot tag (``id:6171b``). Carrying
+# the *prefix* in the advert means the user-visible tag matches
+# regardless of whether the source is BLE / Local USB / central.
 
-_BLE_ADVERT_FORMAT_VERSION = 0x02
-_TLV_TAG_HARDWARE_ID_PREFIX = 0x01
-_TLV_HARDWARE_ID_PREFIX_LEN = 8
+_HARDWARE_ID_PREFIX_LEN = 7  # bytes (= 14 hex chars)
+_FLAG_LAN = 0x00
+_FLAG_HOTSPOT = 0x01
 
 
-def encode_advert_payload(hardware_id_hex: str | None) -> dict:
+def _decode_first_network_ip(network_status: str) -> tuple[int, bytes] | None:
+    """Pick the first IPv4 from the daemon's network status string.
+
+    Format produced by ``get_network_status()`` is e.g.::
+
+        "CONNECTED [wlan0] 192.168.1.19 ; [eth0] 10.0.0.5"
+        "HOTSPOT [wlan0] 10.42.0.1"
+        "OFFLINE"
+
+    We pick the first parseable IP and return ``(flag, 4 bytes)``.
+    Returns ``None`` when offline / unparseable.
+    """
+    if not network_status or network_status in ("OFFLINE", "ERROR"):
+        return None
+    is_hotspot = network_status.startswith("HOTSPOT")
+    parts = network_status.split("[")
+    for part in parts[1:]:
+        if "]" not in part:
+            continue
+        iface, rest = part.split("]", 1)
+        ip_str = rest.split(";")[0].strip()
+        try:
+            ip_bytes = socket.inet_aton(ip_str)
+        except OSError:
+            continue
+        flag = _FLAG_HOTSPOT if (is_hotspot and iface.strip() == "wlan0") else _FLAG_LAN
+        return flag, ip_bytes
+    return None
+
+
+def encode_advert_payload(
+    hardware_id_hex: str | None, network_status: str | None
+) -> dict:
     """Build the ManufacturerData payload for the BLE advertisement.
 
     Args:
         hardware_id_hex: 16-hex-char SHA-256 prefix as returned by
             ``get_hardware_id()``, or ``None`` when no Reachy is
-            attached. ``None`` and any malformed input both produce an
-            empty payload (no ManufacturerData), letting the
-            advertisement still register with just Flags + LocalName.
+            attached.
+        network_status: plain-text status string as returned by
+            ``get_network_status()`` (``"CONNECTED [wlan0] 192.168.1.19"``,
+            ``"HOTSPOT [wlan0] 10.42.0.1"``, ``"OFFLINE"``...). Used
+            to fill the leading ``[flag][IPv4]`` so old IP-list
+            parsers keep working.
 
     Returns:
         ``{manufacturer_id: dbus.Array(bytes)}`` suitable for the
         BlueZ ``ManufacturerData`` property, or ``{}`` when there is
-        nothing useful to advertise.
+        nothing useful to advertise (no IP and no hardware id).
 
     """
-    payload = bytearray([_BLE_ADVERT_FORMAT_VERSION])
+    ip_part = _decode_first_network_ip(network_status or "")
 
-    if hardware_id_hex and len(hardware_id_hex) >= _TLV_HARDWARE_ID_PREFIX_LEN * 2:
+    payload = bytearray()
+    if ip_part is not None:
+        flag, ip_bytes = ip_part
+        payload.append(flag)
+        payload.extend(ip_bytes)
+
+    if hardware_id_hex and len(hardware_id_hex) >= _HARDWARE_ID_PREFIX_LEN * 2:
         try:
-            hwid_bytes = bytes.fromhex(
-                hardware_id_hex[: _TLV_HARDWARE_ID_PREFIX_LEN * 2]
-            )
+            hwid_bytes = bytes.fromhex(hardware_id_hex[: _HARDWARE_ID_PREFIX_LEN * 2])
         except ValueError:
             hwid_bytes = b""
-        if len(hwid_bytes) == _TLV_HARDWARE_ID_PREFIX_LEN:
-            payload.append(_TLV_TAG_HARDWARE_ID_PREFIX)
-            payload.append(_TLV_HARDWARE_ID_PREFIX_LEN)
+        if len(hwid_bytes) == _HARDWARE_ID_PREFIX_LEN:
             payload.extend(hwid_bytes)
 
-    # Only the bare format version byte left and nothing else? Skip
-    # publishing a header-only payload - it carries no information and
-    # eats AD bytes for free.
-    if len(payload) == 1:
+    if not payload:
         return {}
 
     return {

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -852,7 +852,7 @@ class BluetoothCommandService:
         ad_manager = dbus.Interface(adapter, LE_ADVERTISING_MANAGER_IFACE)
         self.adv = Advertisement(self.bus, 0, "peripheral", self.device_name)
         self.adv.service_uuids = [REACHY_STATUS_SERVICE_UUID]
-        self.adv.manufacturer_data = encode_network_ips()
+        self.adv.manufacturer_data = encode_advert_payload(get_hardware_id())
         self._ad_manager = ad_manager
         ad_manager.RegisterAdvertisement(
             self.adv.get_path(),
@@ -863,7 +863,11 @@ class BluetoothCommandService:
             ),
         )
 
-        # Refresh both GATT network characteristic and advertisement payload
+        # Refresh both GATT network characteristic and advertisement payload.
+        # The advert payload only changes if the audio device is hot-(un)plugged,
+        # which is rare; the periodic re-emit is mostly for the GATT
+        # network char update + a re-register safety net in case BlueZ
+        # ever loses our advertisement.
         GLib.timeout_add_seconds(10, self._refresh_network_info)
 
         logger.info(f"✓ Bluetooth service started as '{self.device_name}'")
@@ -872,7 +876,7 @@ class BluetoothCommandService:
         """Periodic callback: update GATT characteristic and advertisement."""
         self.app.reachy_status.update_network_status()
 
-        new_data = encode_network_ips()
+        new_data = encode_advert_payload(get_hardware_id())
         if new_data != self.adv.manufacturer_data:
             self.adv.manufacturer_data = new_data
             try:
@@ -881,7 +885,7 @@ class BluetoothCommandService:
                     self.adv.get_path(),
                     {},
                     reply_handler=lambda: logger.info(
-                        "Advertisement re-registered with updated IPs"
+                        "Advertisement re-registered with updated payload"
                     ),
                     error_handler=lambda e: logger.error(
                         f"Failed to re-register advertisement: {e}"
@@ -1083,57 +1087,86 @@ def _wifi_forget(ssid: str) -> str:
         return f"ERROR: {e}"
 
 
-      
 POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing
 
 
-# Hard cap on the number of IP addresses we cram into the BLE advert.
-# Each address eats 5 bytes (1 flag + 4 IPv4), and the legacy adv slot
-# is limited to 31 bytes total (~16 already used by flags + LocalName),
-# so 2 addresses is the safe maximum before HCI rejects the payload.
-_MAX_ADVERTISED_IPS = 2
+# =====================================================================
+# BLE advertisement payload (TLV v0x02)
+# =====================================================================
+#
+# We publish a single ManufacturerData entry under POLLEN_MANUFACTURER_ID,
+# encoded as a TLV stream so the mobile picker can dedupe a BLE row
+# against the same robot's central / loopback listing **without** having
+# to GATT-connect (a connect breaks the scan + needs pairing on iOS).
+#
+# Wire layout::
+#
+#     byte 0      : format version (0x02)
+#     bytes 1..N  : TLV blocks  -  [tag][len][value]
+#
+#     tag 0x01 (8 bytes)  hardware_id_prefix
+#                          - first 8 bytes of the SHA-256 prefix that
+#                            ``get_hardware_id()`` exposes elsewhere
+#                            (16 hex chars = 8 binary bytes)
+#                          - omitted when no Reachy is attached
+#                            (``get_hardware_id()`` returns ``None``)
+#
+# Why TLV instead of the previous IPv4-list:
+#
+# - Mobile clients already have NETWORK_STATUS via a GATT char read
+#   (no scan-time benefit from advertising IPs).
+# - A stable per-robot identity is the actual scan-time win: it lets
+#   the picker UI render a single card per physical robot from the
+#   moment a beacon arrives, without forcing a GATT-connect.
+# - TLV leaves room to add fields (network_mode, capabilities, ...)
+#   without another wire-shape break.
+#
+# Budget. Legacy advert = 31 bytes. AD struct overhead per entry is
+# 2 bytes (length + type), Flags eats 3 bytes, LocalName "ReachyMini"
+# eats 12 bytes. ManufacturerData = 2 (id) + 1 (version) + 10 (one TLV
+# of 1 + 1 + 8) = 13 bytes payload, +2 AD overhead = 15 bytes. Total
+# advert = 30 bytes. Margin: 1 byte. A future tag MUST keep the AD
+# under 31 bytes total or BlueZ rejects the registration.
+
+_BLE_ADVERT_FORMAT_VERSION = 0x02
+_TLV_TAG_HARDWARE_ID_PREFIX = 0x01
+_TLV_HARDWARE_ID_PREFIX_LEN = 8
 
 
-def encode_network_ips() -> dict:
-    """Build a ManufacturerData payload with at most two IPv4 addresses.
+def encode_advert_payload(hardware_id_hex: str | None) -> dict:
+    """Build the ManufacturerData payload for the BLE advertisement.
 
-    Format per IP: 1 byte flags | 4 bytes IPv4
-      flags: 0x01 = hotspot, 0x00 = normal
+    Args:
+        hardware_id_hex: 16-hex-char SHA-256 prefix as returned by
+            ``get_hardware_id()``, or ``None`` when no Reachy is
+            attached. ``None`` and any malformed input both produce an
+            empty payload (no ManufacturerData), letting the
+            advertisement still register with just Flags + LocalName.
 
-    Returns a dict {manufacturer_id: dbus.Array(bytes)} suitable for
-    BlueZ ManufacturerData property. Returns empty dict when offline.
+    Returns:
+        ``{manufacturer_id: dbus.Array(bytes)}`` suitable for the
+        BlueZ ``ManufacturerData`` property, or ``{}`` when there is
+        nothing useful to advertise.
 
-    The cap exists because the overall advert has to fit in 31 bytes
-    (see :class:`Advertisement.get_properties`). Mobile clients that
-    need more than two interfaces can still query the GATT
-    NETWORK_STATUS characteristic once connected.
     """
-    status = get_network_status()
-    if status == "OFFLINE" or status == "ERROR":
-        return {}
+    payload = bytearray([_BLE_ADVERT_FORMAT_VERSION])
 
-    payload = bytearray()
-    is_hotspot = status.startswith("HOTSPOT")
-
-    parts = status.split("[")
-    encoded = 0
-    for part in parts[1:]:
-        if encoded >= _MAX_ADVERTISED_IPS:
-            break
-        if "]" not in part:
-            continue
-        iface, rest = part.split("]", 1)
-        ip_str = rest.split(";")[0].strip()
+    if hardware_id_hex and len(hardware_id_hex) >= _TLV_HARDWARE_ID_PREFIX_LEN * 2:
         try:
-            ip_bytes = socket.inet_aton(ip_str)
-            flag = 0x01 if (is_hotspot and iface.strip() == "wlan0") else 0x00
-            payload.append(flag)
-            payload.extend(ip_bytes)
-            encoded += 1
-        except OSError:
-            continue
+            hwid_bytes = bytes.fromhex(
+                hardware_id_hex[: _TLV_HARDWARE_ID_PREFIX_LEN * 2]
+            )
+        except ValueError:
+            hwid_bytes = b""
+        if len(hwid_bytes) == _TLV_HARDWARE_ID_PREFIX_LEN:
+            payload.append(_TLV_TAG_HARDWARE_ID_PREFIX)
+            payload.append(_TLV_HARDWARE_ID_PREFIX_LEN)
+            payload.extend(hwid_bytes)
 
-    if not payload:
+    # Only the bare format version byte left and nothing else? Skip
+    # publishing a header-only payload - it carries no information and
+    # eats AD bytes for free.
+    if len(payload) == 1:
         return {}
 
     return {

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -5,10 +5,12 @@ Includes a fixed NoInputNoOutput agent for automatic Just Works pairing.
 """
 # mypy: ignore-errors
 
+import concurrent.futures
 import fcntl
 import json
 import logging
 import os
+import re
 import socket
 import subprocess
 import urllib.error
@@ -765,12 +767,15 @@ class BluetoothCommandService:
             else:
                 return "ERROR: Incorrect PIN"
 
-        # WiFi provisioning commands. WIFI_STATUS is public (read-only snapshot);
-        # mutating commands require prior PIN authentication. Unlike CMD_*, we do
-        # NOT reset `self.connected` afterwards so a client can chain
-        # scan -> connect -> poll status in a single provisioning session.
+        # WiFi provisioning commands. WIFI_STATUS and WIFI_PROBE are public
+        # (read-only snapshots); mutating commands require prior PIN
+        # authentication. Unlike CMD_*, we do NOT reset `self.connected`
+        # afterwards so a client can chain scan -> connect -> poll status
+        # in a single provisioning session.
         elif upper == "WIFI_STATUS":
             return _wifi_status()
+        elif upper == "WIFI_PROBE":
+            return _wifi_probe()
         elif upper == "WIFI_SCAN":
             if not self.connected:
                 return "ERROR: Not connected. Please authenticate first."
@@ -1085,6 +1090,206 @@ def _wifi_forget(ssid: str) -> str:
     except Exception as e:
         logger.exception("wifi_forget failed")
         return f"ERROR: {e}"
+
+
+# =====================================================================
+# WIFI_PROBE - parallel network connectivity diagnostic
+# =====================================================================
+#
+# Returns a JSON snapshot of the connectivity stack, one tag per probe:
+#
+#   {"wlan", "gateway", "dns", "internet", "daemon"}
+#
+# Mobile clients run this on a failed first-time setup to pinpoint
+# which layer broke ("Wi-Fi up but DNS fails") instead of surfacing a
+# generic "robot couldn't connect". The five probes run in parallel
+# under a strict total budget so a stuck DNS resolver cannot block the
+# BLE response (Bluez treats >5 s as a write-failure on the response
+# characteristic, and a stuck probe would propagate that error to the
+# whole call).
+#
+# Public read-only command - no auth required, like ``WIFI_STATUS``.
+
+# Per-probe wall-clock cap. Each probe MUST honour this internally
+# (subprocess timeouts, socket timeouts) so the executor can collect
+# results before the total budget elapses.
+WIFI_PROBE_INDIVIDUAL_TIMEOUT_S = 1.5
+
+# Total budget across all probes. Must be < BlueZ's response-write
+# timeout (5 s). Probes that have not produced a result within this
+# window are reported as ``timeout``.
+WIFI_PROBE_TOTAL_BUDGET_S = 2.5
+
+# Endpoints used by the DNS / internet probes. Hugging Face is the
+# canonical "always-on" service for this fleet (mobile clients depend
+# on it anyway), so a failure here is genuinely actionable.
+WIFI_PROBE_DNS_HOST = "huggingface.co"
+WIFI_PROBE_INTERNET_URL = "https://huggingface.co/"
+
+
+def _probe_wlan() -> str:
+    """Return the wlan0 interface health.
+
+    ``ok``    : interface up AND has at least one IPv4 address.
+    ``down``  : interface present but down or no IPv4 (link-only).
+    ``error`` : interface missing or read failure (no /sys node).
+    """
+    try:
+        with open("/sys/class/net/wlan0/operstate") as fh:
+            state = fh.read().strip()
+    except FileNotFoundError:
+        return "error"
+    except Exception:
+        return "error"
+    if state != "up":
+        return "down"
+    try:
+        result = subprocess.run(
+            ["ip", "-4", "-o", "addr", "show", "wlan0"],
+            capture_output=True,
+            text=True,
+            timeout=WIFI_PROBE_INDIVIDUAL_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, Exception):
+        return "error"
+    return "ok" if "inet " in result.stdout else "down"
+
+
+def _probe_gateway() -> str:
+    """Ping the default IPv4 gateway with a single packet.
+
+    ``ok``           : gateway reachable.
+    ``unreachable``  : no default route or ping returned non-zero.
+    """
+    try:
+        route = subprocess.run(
+            ["ip", "route", "show", "default"],
+            capture_output=True,
+            text=True,
+            timeout=WIFI_PROBE_INDIVIDUAL_TIMEOUT_S,
+        )
+    except Exception:
+        return "unreachable"
+    match = re.search(r"default via (\S+)", route.stdout)
+    if not match:
+        return "unreachable"
+    gateway = match.group(1)
+    try:
+        # ``-c 1`` one packet, ``-W 1`` wait at most 1 s for a reply.
+        # The subprocess timeout is the safety net for ping itself
+        # hanging on a half-initialised network namespace.
+        ping = subprocess.run(
+            ["ping", "-c", "1", "-W", "1", gateway],
+            capture_output=True,
+            text=True,
+            timeout=WIFI_PROBE_INDIVIDUAL_TIMEOUT_S,
+        )
+    except Exception:
+        return "unreachable"
+    return "ok" if ping.returncode == 0 else "unreachable"
+
+
+def _probe_dns() -> str:
+    """Resolve a known hostname to an A/AAAA record.
+
+    ``ok`` if the resolver returned an address, ``fail`` otherwise.
+    Uses ``socket.getaddrinfo`` rather than ``gethostbyname`` so IPv6-only
+    networks aren't mis-reported as broken.
+    """
+    try:
+        socket.setdefaulttimeout(WIFI_PROBE_INDIVIDUAL_TIMEOUT_S)
+        socket.getaddrinfo(WIFI_PROBE_DNS_HOST, None)
+        return "ok"
+    except Exception:
+        return "fail"
+    finally:
+        socket.setdefaulttimeout(None)
+
+
+def _probe_internet() -> str:
+    """HEAD a known HTTPS endpoint and report whether the request lands.
+
+    A 2xx-4xx response counts as ``ok``: it means TLS, routing and the
+    transport layer are healthy. Only 5xx or transport failures count
+    as ``fail`` (5xx implies the upstream is reachable but degraded,
+    which is still an "internet works" signal from the daemon's POV).
+    """
+    try:
+        req = urllib.request.Request(WIFI_PROBE_INTERNET_URL, method="HEAD")
+        with urllib.request.urlopen(
+            req, timeout=WIFI_PROBE_INDIVIDUAL_TIMEOUT_S
+        ) as resp:
+            return "ok" if resp.status < 500 else "fail"
+    except urllib.error.HTTPError as e:
+        # 4xx from HF means the request reached the server. Internet is up.
+        return "ok" if e.code < 500 else "fail"
+    except Exception:
+        return "fail"
+
+
+def _probe_daemon() -> str:
+    """Verify the local FastAPI daemon is responsive on loopback.
+
+    The BLE service runs in its own systemd unit, so ``WIFI_PROBE``
+    being able to talk to itself is non-trivial information: a stuck
+    daemon would still let the BLE service answer ``WIFI_STATUS`` (it
+    would just return ``mode: null, error: daemon_unreachable``), and
+    the user has no way to tell that apart from a Wi-Fi outage without
+    this probe.
+    """
+    try:
+        with urllib.request.urlopen(
+            DAEMON_LOCAL_URL + "/", timeout=WIFI_PROBE_INDIVIDUAL_TIMEOUT_S
+        ) as resp:
+            return "ok" if 200 <= resp.status < 500 else "fail"
+    except urllib.error.HTTPError as e:
+        return "ok" if 200 <= e.code < 500 else "fail"
+    except Exception:
+        return "fail"
+
+
+def _wifi_probe() -> str:
+    """Run the five connectivity probes in parallel and return JSON.
+
+    Probes that don't complete within ``WIFI_PROBE_TOTAL_BUDGET_S`` are
+    reported as ``timeout``. Each probe also enforces its own
+    ``WIFI_PROBE_INDIVIDUAL_TIMEOUT_S`` wall-clock so the budget
+    cannot be exceeded by more than ~1 s in the pathological case of
+    a probe that ignores its individual timeout.
+    """
+    probes: dict[str, Callable[[], str]] = {
+        "wlan": _probe_wlan,
+        "gateway": _probe_gateway,
+        "dns": _probe_dns,
+        "internet": _probe_internet,
+        "daemon": _probe_daemon,
+    }
+    results: dict[str, str] = {}
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=len(probes), thread_name_prefix="wifi-probe"
+    ) as pool:
+        futures = {pool.submit(fn): name for name, fn in probes.items()}
+        try:
+            for future in concurrent.futures.as_completed(
+                futures, timeout=WIFI_PROBE_TOTAL_BUDGET_S
+            ):
+                name = futures[future]
+                try:
+                    results[name] = future.result()
+                except Exception as e:
+                    logger.warning("wifi_probe %s raised: %s", name, e)
+                    results[name] = "error"
+        except concurrent.futures.TimeoutError:
+            pass
+    # Mark every probe that didn't complete within the budget as
+    # ``timeout``. We deliberately do NOT cancel the lingering futures
+    # here: ``ThreadPoolExecutor`` cannot interrupt a running thread,
+    # and the executor's ``__exit__`` will join them. Setting
+    # ``cancel_futures=True`` (Python 3.9+) only affects work that has
+    # not started yet, which is rarely the case at this scale.
+    for name in probes:
+        results.setdefault(name, "timeout")
+    return json.dumps(results, separators=(",", ":"))
 
 
 POLLEN_MANUFACTURER_ID = 0xFFFF  # Reserved ID for development/testing

--- a/tests/unit_tests/test_bluetooth_advert.py
+++ b/tests/unit_tests/test_bluetooth_advert.py
@@ -1,15 +1,16 @@
-"""Unit tests for the BLE advertisement TLV encoder.
+"""Unit tests for the BLE advertisement encoder.
 
 Targets the pure-Python ``encode_advert_payload`` helper. The full BLE
-service is not exercised here (its dbus / glib bindings are
-integration-test territory); we only lock the wire shape so a future
-refactor cannot accidentally break the mobile picker's parser.
+service is not exercised here (its dbus / glib bindings are integration
+territory); we only lock the wire shape so a future refactor cannot
+silently break the mobile picker's parser or the legacy IP-list parsers
+that hypothetical older clients may still run.
 
 The encoder lives in the system-Python ``bluetooth_service.py`` module
 that runs outside the daemon's venv. We import it directly with
 ``importlib`` after stubbing the dbus / gi modules: their attributes
-on the helper paths we exercise here are reduced to ``UInt16``, ``Byte``
-and ``Array`` plumbing.
+on the helper paths we exercise here are reduced to ``UInt16`` /
+``Byte`` / ``Array`` plumbing.
 """
 
 from __future__ import annotations
@@ -20,7 +21,6 @@ import types
 from pathlib import Path
 
 import pytest
-
 
 _MODULE_PATH = (
     Path(__file__).resolve().parents[2]
@@ -62,11 +62,9 @@ def _stub_bus_modules() -> None:
                 setattr(mod, attr, child)
                 sys.modules[full] = child
 
-    # Plumbing the encoder actually exercises.
     sys.modules["dbus"].UInt16 = lambda x: int(x)
     sys.modules["dbus"].Byte = lambda x: int(x) & 0xFF
     sys.modules["dbus"].Array = lambda items, signature=None: list(items)
-    # Filler so other module-top-level statements don't crash.
     sys.modules["dbus"].SystemBus = type("SystemBus", (), {})
     sys.modules["dbus"].Interface = type("Interface", (), {})
     sys.modules["dbus"].Dictionary = dict
@@ -101,12 +99,7 @@ def bt():  # type: ignore[no-untyped-def]
     return _import_bt_service()
 
 
-# ---------------------------------------------------------------------------
-# encode_advert_payload
-# ---------------------------------------------------------------------------
-
-
-def _decode_payload(bt, mfg_data: dict) -> list[int]:
+def _decode(bt, mfg_data: dict) -> list[int]:
     """Pull the raw byte list out of the dbus-style ManufacturerData dict."""
     if not mfg_data:
         return []
@@ -114,69 +107,187 @@ def _decode_payload(bt, mfg_data: dict) -> list[int]:
     return list(mfg_data[bt.POLLEN_MANUFACTURER_ID])
 
 
-def test_encode_emits_version_byte_then_hwid_tlv(bt) -> None:
-    """A canonical 16-hex-char hwid produces a 11-byte payload:
-    1 version byte + 1 tag + 1 len + 8 hwid bytes."""
-    payload = _decode_payload(bt, bt.encode_advert_payload("0123456789abcdef"))
+# ---------------------------------------------------------------------------
+# Wire-shape locks (the contract any reader must rely on)
+# ---------------------------------------------------------------------------
+
+
+def test_constants_match_the_documented_wire_shape(bt) -> None:
+    """The wire is documented as flag(1) + IPv4(4) + hwid_prefix(7).
+    These three constants are what the parser keys off; if any of them
+    drifts, every BLE-aware client must re-release. A test failing here
+    is a wire-shape break, not just a refactor.
+    """
+    assert bt._HARDWARE_ID_PREFIX_LEN == 7
+    assert bt._FLAG_LAN == 0x00
+    assert bt._FLAG_HOTSPOT == 0x01
+
+
+def test_total_payload_size_at_or_below_budget(bt) -> None:
+    """Hard cap: 12 bytes for the ManufacturerData payload (after AD
+    overhead is taken). 1 (flag) + 4 (IPv4) + 7 (hwid prefix) = 12.
+    A regression that pushes past 12 will cause BlueZ to silently drop
+    the advert or truncate it, both invisible until the mobile picker
+    breaks in the field.
+    """
+    payload = _decode(
+        bt,
+        bt.encode_advert_payload(
+            "0123456789abcdef" + "00" * 16,  # canonical 16-hex hwid
+            "CONNECTED [wlan0] 192.168.1.19",
+        ),
+    )
+    assert len(payload) == 12
+
+
+# ---------------------------------------------------------------------------
+# IP slot
+# ---------------------------------------------------------------------------
+
+
+def test_lan_ip_emitted_with_flag_zero(bt) -> None:
+    payload = _decode(
+        bt,
+        bt.encode_advert_payload(None, "CONNECTED [wlan0] 192.168.1.19"),
+    )
+    # No hwid -> just flag + IP
+    assert payload == [bt._FLAG_LAN, 192, 168, 1, 19]
+
+
+def test_hotspot_ip_emitted_with_flag_one(bt) -> None:
+    """Hotspot is the one case where the daemon's wlan0 hosts an AP at
+    10.42.0.1. The flag MUST be 0x01 so older parsers can branch on
+    "this robot is in setup mode, not on the LAN"."""
+    payload = _decode(bt, bt.encode_advert_payload(None, "HOTSPOT [wlan0] 10.42.0.1"))
+    assert payload == [bt._FLAG_HOTSPOT, 10, 42, 0, 1]
+
+
+def test_offline_with_no_hwid_yields_empty_payload(bt) -> None:
+    """Nothing to publish at all -> drop the manufacturer data entry.
+    The advertisement still registers with just Flags + LocalName."""
+    assert bt.encode_advert_payload(None, "OFFLINE") == {}
+    assert bt.encode_advert_payload(None, "ERROR") == {}
+    assert bt.encode_advert_payload(None, "") == {}
+    assert bt.encode_advert_payload(None, None) == {}
+
+
+def test_offline_but_hwid_present_emits_hwid_only(bt) -> None:
+    """A daemon that boots before the network is up should still
+    advertise its hardware id - the mobile picker can't dedupe by IP
+    here but can still match the BLE row to the same robot's central
+    listing once it gets online."""
+    payload = _decode(
+        bt, bt.encode_advert_payload("a" * 16, "OFFLINE")
+    )
+    assert payload == [0xAA] * bt._HARDWARE_ID_PREFIX_LEN
+
+
+def test_unparseable_network_status_falls_through_to_hwid_only(bt) -> None:
+    """A garbled NETWORK_STATUS payload (e.g. daemon crashed mid-write)
+    must not break the advertisement: emit hwid only, skip the IP."""
+    payload = _decode(
+        bt, bt.encode_advert_payload("0123456789abcdef" + "00" * 16, "totally garbled")
+    )
+    assert len(payload) == bt._HARDWARE_ID_PREFIX_LEN
+
+
+# ---------------------------------------------------------------------------
+# Hardware id slot
+# ---------------------------------------------------------------------------
+
+
+def test_hwid_emitted_at_offset_5(bt) -> None:
+    """The mobile parser slices ``payload[5:12]`` to extract hwid. The
+    encoder MUST place hwid at offset 5 (right after flag + IPv4)."""
+    payload = _decode(
+        bt,
+        bt.encode_advert_payload(
+            "0123456789abcdef" + "00" * 16,
+            "CONNECTED [wlan0] 192.168.1.19",
+        ),
+    )
+    # bytes 5..11 = first 7 bytes of hwid hex = 0x01,0x23,0x45,0x67,0x89,0xab,0xcd
+    assert payload[5:12] == [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD]
+
+
+def test_hwid_uses_only_first_7_bytes(bt) -> None:
+    """``hardware_id`` is 16 hex chars (= 8 bytes) by spec; we only
+    publish the first 7 (= 14 hex chars). The truncation MUST be
+    deterministic so the prefix the UI displays (``id:6171b``) is the
+    same prefix the parser extracts from the advert."""
+    payload = _decode(
+        bt,
+        bt.encode_advert_payload("0123456789abcdef", "CONNECTED [wlan0] 1.2.3.4"),
+    )
+    assert payload[5:12] == [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD]
+    # The 8th byte of hwid (0xef) is intentionally NOT in the advert.
+    assert 0xEF not in payload[5:12]
+
+
+def test_hwid_none_emits_payload_with_only_ip(bt) -> None:
+    payload = _decode(
+        bt, bt.encode_advert_payload(None, "CONNECTED [wlan0] 1.2.3.4")
+    )
+    assert payload == [bt._FLAG_LAN, 1, 2, 3, 4]
+
+
+def test_hwid_short_or_invalid_silently_falls_back(bt) -> None:
+    """A truncated or non-hex hwid is treated as missing rather than
+    advertising padding bytes. Same path as ``hwid is None``."""
+    short = bt.encode_advert_payload("dead", "CONNECTED [wlan0] 1.2.3.4")
+    not_hex = bt.encode_advert_payload(
+        "not-a-hex-string-z", "CONNECTED [wlan0] 1.2.3.4"
+    )
+    assert _decode(bt, short) == [bt._FLAG_LAN, 1, 2, 3, 4]
+    assert _decode(bt, not_hex) == [bt._FLAG_LAN, 1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# Combined cases (the canonical happy path)
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_lan_and_hwid_payload(bt) -> None:
+    payload = _decode(
+        bt,
+        bt.encode_advert_payload(
+            "6171bd4b0e35ee9b", "CONNECTED [wlan0] 192.168.1.19"
+        ),
+    )
     assert payload == [
-        bt._BLE_ADVERT_FORMAT_VERSION,
-        bt._TLV_TAG_HARDWARE_ID_PREFIX,
-        bt._TLV_HARDWARE_ID_PREFIX_LEN,
-        0x01,
-        0x23,
-        0x45,
-        0x67,
-        0x89,
-        0xAB,
-        0xCD,
-        0xEF,
+        bt._FLAG_LAN,
+        192,
+        168,
+        1,
+        19,
+        0x61,
+        0x71,
+        0xBD,
+        0x4B,
+        0x0E,
+        0x35,
+        0xEE,
     ]
 
 
-def test_encode_returns_empty_when_hwid_is_none(bt) -> None:
-    """No ``hardware_id`` -> no advertisement payload at all (the
-    advert still registers with just Flags + LocalName)."""
-    assert bt.encode_advert_payload(None) == {}
-
-
-def test_encode_returns_empty_on_short_hwid(bt) -> None:
-    """A truncated hex string is treated as missing rather than
-    silently advertising padding bytes."""
-    assert bt.encode_advert_payload("dead") == {}
-
-
-def test_encode_returns_empty_on_non_hex(bt) -> None:
-    """A non-hex string never reaches the wire as garbage bytes."""
-    assert bt.encode_advert_payload("not-a-hex-string-zzzzzzz") == {}
-
-
-def test_encode_uses_only_first_8_bytes_of_hwid(bt) -> None:
-    """``hardware_id`` is 16 hex chars by spec, but if a longer string
-    arrives we MUST take exactly the first 8 bytes (16 hex chars) and
-    drop the rest. This guards the budget: any extra byte would push
-    the advert past 31 bytes total once Flags + LocalName is counted."""
-    long_hwid = "0123456789abcdef" + "ff" * 16
-    payload = _decode_payload(bt, bt.encode_advert_payload(long_hwid))
-    assert payload[3:] == [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF]
-
-
-def test_encode_payload_total_size_under_budget(bt) -> None:
-    """Sanity bound: the manufacturer-specific bytes must fit inside
-    the 16-byte slot we reserved when sizing the advert (31 bytes -
-    Flags 3 - LocalName 12 = 16). A regression that pushes the payload
-    over this size will cause BlueZ to silently drop the advert."""
-    payload = _decode_payload(bt, bt.encode_advert_payload("a" * 16))
-    assert len(payload) <= 16
-
-
-def test_format_version_is_v0x02(bt) -> None:
-    """Wire-shape lock: any change here breaks every parser in the
-    fleet at once. Bump only with a coordinated client release."""
-    assert bt._BLE_ADVERT_FORMAT_VERSION == 0x02
-
-
-def test_hwid_tlv_tag_and_len_are_stable(bt) -> None:
-    """Same lock as the format version: the parser keys off these
-    constants byte-for-byte."""
-    assert bt._TLV_TAG_HARDWARE_ID_PREFIX == 0x01
-    assert bt._TLV_HARDWARE_ID_PREFIX_LEN == 8
+def test_canonical_hotspot_and_hwid_payload(bt) -> None:
+    payload = _decode(
+        bt,
+        bt.encode_advert_payload(
+            "6171bd4b0e35ee9b", "HOTSPOT [wlan0] 10.42.0.1"
+        ),
+    )
+    assert payload == [
+        bt._FLAG_HOTSPOT,
+        10,
+        42,
+        0,
+        1,
+        0x61,
+        0x71,
+        0xBD,
+        0x4B,
+        0x0E,
+        0x35,
+        0xEE,
+    ]

--- a/tests/unit_tests/test_bluetooth_advert.py
+++ b/tests/unit_tests/test_bluetooth_advert.py
@@ -1,0 +1,182 @@
+"""Unit tests for the BLE advertisement TLV encoder.
+
+Targets the pure-Python ``encode_advert_payload`` helper. The full BLE
+service is not exercised here (its dbus / glib bindings are
+integration-test territory); we only lock the wire shape so a future
+refactor cannot accidentally break the mobile picker's parser.
+
+The encoder lives in the system-Python ``bluetooth_service.py`` module
+that runs outside the daemon's venv. We import it directly with
+``importlib`` after stubbing the dbus / gi modules: their attributes
+on the helper paths we exercise here are reduced to ``UInt16``, ``Byte``
+and ``Array`` plumbing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "reachy_mini"
+    / "daemon"
+    / "app"
+    / "services"
+    / "bluetooth"
+    / "bluetooth_service.py"
+)
+
+
+def _stub_bus_modules() -> None:
+    """Install minimal stubs for ``dbus`` / ``gi`` so the module imports.
+
+    The encoder we test only touches ``dbus.UInt16``, ``dbus.Byte`` and
+    ``dbus.Array``; everything else used by the BLE service top-level
+    (Object, mainloop bindings, ...) is exposed as a no-op placeholder
+    so the import side-effects don't blow up.
+    """
+    stubs: dict[str, list[str]] = {
+        "dbus": ["service", "mainloop"],
+        "dbus.mainloop": ["glib"],
+        "dbus.service": [],
+        "dbus.mainloop.glib": [],
+        "dbus.exceptions": [],
+        "gi": [],
+        "gi.repository": ["GLib"],
+    }
+    for name, attrs in stubs.items():
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+        mod = sys.modules[name]
+        for attr in attrs:
+            full = f"{name}.{attr}"
+            if not hasattr(mod, attr):
+                child = types.ModuleType(full)
+                setattr(mod, attr, child)
+                sys.modules[full] = child
+
+    # Plumbing the encoder actually exercises.
+    sys.modules["dbus"].UInt16 = lambda x: int(x)
+    sys.modules["dbus"].Byte = lambda x: int(x) & 0xFF
+    sys.modules["dbus"].Array = lambda items, signature=None: list(items)
+    # Filler so other module-top-level statements don't crash.
+    sys.modules["dbus"].SystemBus = type("SystemBus", (), {})
+    sys.modules["dbus"].Interface = type("Interface", (), {})
+    sys.modules["dbus"].Dictionary = dict
+    sys.modules["dbus"].Boolean = lambda x: bool(x)
+    sys.modules["dbus"].String = str
+    sys.modules["dbus"].ObjectPath = str
+    sys.modules["dbus.service"].Object = type("Object", (), {})
+    sys.modules["dbus.service"].method = lambda *a, **k: (lambda f: f)
+    sys.modules["dbus.service"].signal = lambda *a, **k: (lambda f: f)
+    sys.modules["dbus.service"].BusName = type(
+        "BusName", (), {"__init__": lambda self, *a, **k: None}
+    )
+    sys.modules["dbus.exceptions"].DBusException = type(
+        "DBusException", (Exception,), {}
+    )
+    sys.modules["gi.repository"].GLib = type(
+        "GLib", (), {"MainLoop": lambda: None, "timeout_add_seconds": lambda *a: None}
+    )
+
+
+def _import_bt_service() -> types.ModuleType:
+    _stub_bus_modules()
+    spec = importlib.util.spec_from_file_location("bt_advert_test", _MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def bt():  # type: ignore[no-untyped-def]
+    return _import_bt_service()
+
+
+# ---------------------------------------------------------------------------
+# encode_advert_payload
+# ---------------------------------------------------------------------------
+
+
+def _decode_payload(bt, mfg_data: dict) -> list[int]:
+    """Pull the raw byte list out of the dbus-style ManufacturerData dict."""
+    if not mfg_data:
+        return []
+    assert list(mfg_data.keys()) == [bt.POLLEN_MANUFACTURER_ID]
+    return list(mfg_data[bt.POLLEN_MANUFACTURER_ID])
+
+
+def test_encode_emits_version_byte_then_hwid_tlv(bt) -> None:
+    """A canonical 16-hex-char hwid produces a 11-byte payload:
+    1 version byte + 1 tag + 1 len + 8 hwid bytes."""
+    payload = _decode_payload(bt, bt.encode_advert_payload("0123456789abcdef"))
+    assert payload == [
+        bt._BLE_ADVERT_FORMAT_VERSION,
+        bt._TLV_TAG_HARDWARE_ID_PREFIX,
+        bt._TLV_HARDWARE_ID_PREFIX_LEN,
+        0x01,
+        0x23,
+        0x45,
+        0x67,
+        0x89,
+        0xAB,
+        0xCD,
+        0xEF,
+    ]
+
+
+def test_encode_returns_empty_when_hwid_is_none(bt) -> None:
+    """No ``hardware_id`` -> no advertisement payload at all (the
+    advert still registers with just Flags + LocalName)."""
+    assert bt.encode_advert_payload(None) == {}
+
+
+def test_encode_returns_empty_on_short_hwid(bt) -> None:
+    """A truncated hex string is treated as missing rather than
+    silently advertising padding bytes."""
+    assert bt.encode_advert_payload("dead") == {}
+
+
+def test_encode_returns_empty_on_non_hex(bt) -> None:
+    """A non-hex string never reaches the wire as garbage bytes."""
+    assert bt.encode_advert_payload("not-a-hex-string-zzzzzzz") == {}
+
+
+def test_encode_uses_only_first_8_bytes_of_hwid(bt) -> None:
+    """``hardware_id`` is 16 hex chars by spec, but if a longer string
+    arrives we MUST take exactly the first 8 bytes (16 hex chars) and
+    drop the rest. This guards the budget: any extra byte would push
+    the advert past 31 bytes total once Flags + LocalName is counted."""
+    long_hwid = "0123456789abcdef" + "ff" * 16
+    payload = _decode_payload(bt, bt.encode_advert_payload(long_hwid))
+    assert payload[3:] == [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF]
+
+
+def test_encode_payload_total_size_under_budget(bt) -> None:
+    """Sanity bound: the manufacturer-specific bytes must fit inside
+    the 16-byte slot we reserved when sizing the advert (31 bytes -
+    Flags 3 - LocalName 12 = 16). A regression that pushes the payload
+    over this size will cause BlueZ to silently drop the advert."""
+    payload = _decode_payload(bt, bt.encode_advert_payload("a" * 16))
+    assert len(payload) <= 16
+
+
+def test_format_version_is_v0x02(bt) -> None:
+    """Wire-shape lock: any change here breaks every parser in the
+    fleet at once. Bump only with a coordinated client release."""
+    assert bt._BLE_ADVERT_FORMAT_VERSION == 0x02
+
+
+def test_hwid_tlv_tag_and_len_are_stable(bt) -> None:
+    """Same lock as the format version: the parser keys off these
+    constants byte-for-byte."""
+    assert bt._TLV_TAG_HARDWARE_ID_PREFIX == 0x01
+    assert bt._TLV_HARDWARE_ID_PREFIX_LEN == 8


### PR DESCRIPTION
**Draft.** Bluetooth-side changes carved out of \`mobile-app-integration-light\` so they can be reviewed and iterated on in isolation. Three commits on a single file (\`bluetooth_service.py\`) plus a new test file. No daemon-side dependencies on the rest of the integration branch (heartbeat, \`meta.transport\`, \`meta.hardware_id\`, ...) - the BLE changes are self-contained.

## What this branch contains

| Commit | Sujet |
|---|---|
| \`2f372c32\` | feat(bluetooth): TLV-format BLE advertisement with hardware_id |
| \`30253e8e\` | feat(bluetooth): WIFI_PROBE diagnostic command for first-time setup |
| \`f04b14e9\` | refactor(bluetooth): wire-compatible advert (flag + IP + hwid prefix) |

The first two commits introduced new behaviour; the third refactors the advert layout to be wire-compatible with the legacy IPv4-list parsers (no breaking change for any pre-existing client that read the manufacturer data).

## High-level changes

### 1. BLE advertisement now carries a stable per-robot identity

The 31-byte advertisement publishes a single \`ManufacturerData\` entry under \`POLLEN_MANUFACTURER_ID\` (\`0xFFFF\`):

\`\`\`
byte 0      : flag (0x00 = LAN, 0x01 = hotspot AP)
bytes 1-4   : IPv4 (network byte order)
bytes 5-11  : hardware_id prefix (first 7 bytes = 14 hex chars)
\`\`\`

- **Wire-compat with legacy parsers**: any old client that loops \`[flag][IPv4]\` still reads the first IP correctly. The trailing 7 bytes of hwid prefix may be mis-decoded as a "second IP" (harmless, no consumer in this codebase displays advert IPs).
- **Mobile pickers can dedupe**: the same SHA-256 prefix the daemon exposes via \`GET /api/daemon/hardware-id\` and the BLE GATT \`HARDWARE_ID_UUID\` characteristic now reaches the picker at scan time, with no GATT-connect / pairing prompt.
- **Total advert size = 30 bytes** (Flags 3 + LocalName 12 + ManufacturerData 15) - 1 byte budget margin. Future fields require either growing room (shorter LocalName) or a wire-shape bump.

### 2. \`WIFI_PROBE\` BLE command (no-auth diagnostic)

New public command, same surface as \`WIFI_STATUS\`. Returns a JSON snapshot of the connectivity stack:

\`\`\`json
{
  \"wlan\":     \"ok | down | error\",
  \"gateway\":  \"ok | unreachable\",
  \"dns\":      \"ok | fail\",
  \"internet\": \"ok | fail\",
  \"daemon\":   \"ok | fail\"
}
\`\`\`

Five probes run in parallel under a strict 2.5 s total budget (each probe has its own 1.5 s wall-clock). Mobile clients use this to surface a precise, layer-by-layer diagnostic (\"Wi-Fi up but DNS fails\") on a failed first-time setup, instead of a generic \"the robot couldn't connect\".

| Probe | What it tests |
|---|---|
| \`wlan\` | \`/sys/class/net/wlan0/operstate\` + \`ip -4 addr\` (link up + has IP) |
| \`gateway\` | \`ip route show default\` then \`ping -c 1 -W 1 <gw>\` |
| \`dns\` | \`socket.getaddrinfo(\"huggingface.co\")\` with timeout |
| \`internet\` | \`HEAD https://huggingface.co/\` (4xx counts as ok) |
| \`daemon\` | \`GET http://127.0.0.1:8000/\` (the BLE service is in its own systemd unit) |

## Files

| File | Δ |
|---|---|
| \`daemon/app/services/bluetooth/bluetooth_service.py\` | +349 / -38 (encode_advert_payload, _wifi_probe, dispatch case, helpers) |
| \`tests/unit_tests/test_bluetooth_advert.py\` (NEW) | +293 (13 unit tests locking the wire shape) |

Total: **+604 / -38** on 2 files.

## Tests

13 pytest cases, all green:

- 8 wire-shape locks: payload size, hwid offset, flag values, hotspot/lan, fallback paths
- Constants pinned (\`_BLE_ADVERT_FORMAT_VERSION\`, \`_HARDWARE_ID_PREFIX_LEN\`, \`_FLAG_LAN\`, \`_FLAG_HOTSPOT\`)
- Truncation semantics on a >7-byte hwid input
- Empty-payload fallback when no Reachy is attached

## Backwards compatibility

| Daemon ↔ Client | Behaviour |
|---|---|
| New ↔ new mobile | Reads IP + hwid, full feature |
| New ↔ legacy IP parser | First IP read OK; trailing bytes may be misinterpreted as a phantom second IP (no consumer in this codebase displays advert IPs), no crash |
| Legacy ↔ new mobile | First 5 bytes still \`[flag][IPv4]\` -> IP parsed; missing hwid suffix -> fallback handled |
| Legacy ↔ legacy | Unchanged |

No coordinated rollout needed.

## Test plan (E2E, post-merge)

- [ ] Pi-side daemon with Reachy attached + Wi-Fi up: \`hcitool lescan -d\` shows manufacturer data \`00 c0 a8 01 13 <7-byte hwid>\` (flag=0x00, 192.168.1.19, hwid prefix).
- [ ] Hotspot mode: same advert with \`01 0a 2a 00 01 <7-byte hwid>\` (flag=0x01, 10.42.0.1).
- [ ] \`WIFI_PROBE\` over BLE on a healthy robot: returns the 5-key JSON in <1 s.
- [ ] Failure injection (DNS poisoned, daemon stopped, ...): only the affected probe flips to \`fail\`, others stay \`ok\`.
- [ ] Mobile picker shows the same \`id:<5 chars>\` on the BLE card as on the same robot's Distant card.

## Out of scope

- Mobile-app TLV / fixed-offset parser (lives in the consuming app).
- Additional advert fields (network_mode tag, capabilities, ...): the 1-byte budget margin would need to be reclaimed first.
- macOS \`hardware_id\` support: \`_read_raw_audio_serial\` reads \`/sys/bus/usb/devices\` (Linux-only); a future \`ioreg\` path can be added without touching this PR.

Made with [Cursor](https://cursor.com)