### PR TITLE
fix(hf-auth): force OAuth consent prompt to expose org grants

### DIFF
--- a/src/reachy_mini/apps/sources/hf_auth.py
+++ b/src/reachy_mini/apps/sources/hf_auth.py
@@ -122,9 +122,7 @@ def _cleanup_expired_sessions() -> None:
         del _oauth_sessions[sid]
 
 
-def get_oauth_redirect_uri(
-    wireless_version: bool, use_localhost: bool = False
-) -> str:
+def get_oauth_redirect_uri(wireless_version: bool, use_localhost: bool = False) -> str:
     """Get the appropriate OAuth redirect URI based on robot type.
 
     Args:
@@ -181,7 +179,17 @@ def create_oauth_session(
     )
     _oauth_sessions[state] = session
 
-    # Build HuggingFace OAuth authorization URL with PKCE
+    # Build HuggingFace OAuth authorization URL with PKCE.
+    #
+    # `prompt=consent` forces HuggingFace to re-display the consent screen on
+    # every login, even when the app has already been authorized. This matters
+    # for organization access: HF lets the user pick which orgs to grant the
+    # `read-repos` scope to during consent, and a user who skipped that step
+    # the first time has no in-app way to fix it without going to
+    # https://huggingface.co/settings/connected-applications and revoking the
+    # app manually. Forcing consent makes "Logout + Login" enough to (re-)opt
+    # an org in or out, which is what we want for users who joined an org
+    # after their first login (e.g. private apps from `pollen-robotics`).
     from urllib.parse import urlencode
 
     params = {
@@ -192,6 +200,7 @@ def create_oauth_session(
         "state": state,
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",
+        "prompt": "consent",
     }
     auth_url = f"https://huggingface.co/oauth/authorize?{urlencode(params)}"
 
@@ -247,7 +256,9 @@ async def exchange_code_for_token(
         session.error_message = "OAuth not configured"
         return {"status": "error", "message": "OAuth not configured"}
 
-    redirect_uri = get_oauth_redirect_uri(session.wireless_version, session.use_localhost)
+    redirect_uri = get_oauth_redirect_uri(
+        session.wireless_version, session.use_localhost
+    )
 
     # Exchange code for token using PKCE
     token_url = "https://huggingface.co/oauth/token"


### PR DESCRIPTION
## Context

Reported by a user who is a member of `pollen-robotics`: he sees his **own** private Spaces tagged `reachy_mini_python_app` in the app catalog, but **never** the private ones from `pollen-robotics`. The desktop app's catalog (which calls `HfApi.list_spaces(filter=..., token=token)` from the daemon) returns user-private repos correctly, so auth and tagging are fine. The blocker is HF-side: the OAuth token does not have org-level grants.

## Root cause

Per [HF OAuth docs](https://huggingface.co/docs/hub/oauth#accessing-organization-resources):

> By default, the oauth app does not need to access organization resources.
> But some scopes like `read-repos` or `read-billing` apply to organizations as well.
> **The user can select which organizations to grant access to when authorizing the app.**

Our `read-repos` scope is already sufficient. The user just has to tick `pollen-robotics` (or any other org) in the HF consent screen during the OAuth flow. The problem: the consent screen is only displayed on the **first** authorization. A user who skipped the org checkbox initially (or joined the org afterwards) has no in-app way to fix it, short of manually revoking the app at https://huggingface.co/settings/connected-applications.

## Change

Add `prompt=consent` to the HuggingFace authorization URL in `create_oauth_session`. This is a standard OIDC parameter that forces the consent screen to be redisplayed on every login, even when the app has already been authorized. The user can then (re-)pick which orgs to grant access to, without having to revoke anything by hand.

The OAuth scopes are **unchanged**.

## What this does NOT fix

Two things still need to be checked org-side:

- The `pollen-robotics` org admins must have authorized the OAuth app `71146982-8184-45a2-b05a-d561b3cd701d` for the org (Settings -> Connected applications). Without this, even consent + tick won't work.
- Private Spaces inside the org must carry the `reachy_mini_python_app` tag in their README, otherwise they won't pass the `filter=` query against `/api/spaces`.

## Test plan

- [ ] On a robot with an existing HF login, click "Sign out" then "Sign in" again -> consent screen is shown (instead of being silently skipped) -> org checkboxes are visible -> after ticking the org, private org Spaces tagged `reachy_mini_python_app` show up in the catalog.
- [ ] On a fresh robot (no prior HF login), the flow still works (consent shown as before).
- [ ] No regression on the lite / wireless variants of the redirect URI.

## Made-with: Cursor

Made with [Cursor](https://cursor.com)