### PR TITLE
feat(sdk): expose robot.preselectedRobotId from URL hint

### DIFF
--- a/js/reachy-mini.js
+++ b/js/reachy-mini.js
@@ -94,6 +94,12 @@
  *   .micSupported     boolean           — true if robot offers bidirectional audio
  *   .micMuted         boolean           — your microphone mute state
  *   .audioMuted       boolean           — robot speaker mute state (local)
+ *   .preselectedRobotId string | null   — peer id from `?robot_peer_id=` /
+ *                                          `#robot_peer_id=`; null if absent.
+ *                                          Use it to skip your robot picker
+ *                                          when a host iframe (e.g. the
+ *                                          Reachy Mini mobile shell) embeds
+ *                                          this app.
  *
  *
  * EVENTS  (EventTarget — use addEventListener)
@@ -247,6 +253,52 @@ function consumeFragmentCredentials() {
     try { window.history.replaceState(null, '', cleanUrl); } catch (_e) {}
 }
 
+/**
+ * Pick up a preselected robot peer id from the URL.
+ *
+ * Looked up in this order:
+ *   1. URL fragment   (`#robot_peer_id=<peerId>`)
+ *   2. URL query      (`?robot_peer_id=<peerId>`)
+ *
+ * Both spellings are accepted because:
+ *   - the Reachy Mini mobile shell sends it in the query today,
+ *   - the vibe-coder preview / future hosts may prefer the fragment for
+ *     symmetry with `consumeFragmentCredentials`,
+ *   - the value is NOT a secret (peer ids are public on the central
+ *     signaling server's robot listing) so query is fine.
+ *
+ * Returns `null` when no peer id is found in either location, when there
+ * is no `window` (SSR / Worker context), or on parse error. Unlike
+ * credentials, we do NOT strip the param from the URL: the value is
+ * harmless to keep visible and removing it would break tools that read
+ * the URL for context.
+ *
+ * @returns {string|null}
+ */
+function readPreselectedRobotIdFromUrl() {
+    if (typeof window === 'undefined') return null;
+    // 1. Fragment (`#robot_peer_id=…`).
+    if (window.location.hash) {
+        const raw = window.location.hash.startsWith('#')
+            ? window.location.hash.slice(1)
+            : window.location.hash;
+        try {
+            const params = new URLSearchParams(raw);
+            const fromHash = params.get('robot_peer_id');
+            if (fromHash) return fromHash;
+        } catch (_e) { /* malformed fragment — fall through */ }
+    }
+    // 2. Query (`?robot_peer_id=…`).
+    if (window.location.search) {
+        try {
+            const params = new URLSearchParams(window.location.search);
+            const fromQuery = params.get('robot_peer_id');
+            if (fromQuery) return fromQuery;
+        } catch (_e) { /* malformed query — fall through */ }
+    }
+    return null;
+}
+
 /** Check if the audio m= section of an SDP has a=sendrecv (bidirectional audio). */
 function sdpHasAudioSendRecv(sdp) {
     const lines = sdp.split('\r\n');
@@ -279,6 +331,18 @@ export class ReachyMini extends EventTarget {
         this._state = 'disconnected';                 // 'disconnected' | 'connected' | 'streaming'
         this._robots = [];                             // latest robot list from signaling
         this._robotState = {};                         // populated from daemon state events (wire shape)
+
+        // Preselected robot peer id read from the URL at construction
+        // time. When a host iframe (typically the Reachy Mini mobile
+        // shell) embeds an SDK consumer, it appends the peer id of the
+        // robot it's already connected to via
+        // `?robot_peer_id=…` (or `#robot_peer_id=…`). Apps can read
+        // `robot.preselectedRobotId` and call `startSession(id)`
+        // directly to skip their robot picker. Captured ONCE at
+        // construction so subsequent URL changes (history navigation,
+        // hash mutations from `consumeFragmentCredentials`) don't move
+        // the target out from under the consumer.
+        this._preselectedRobotId = readPreselectedRobotIdFromUrl();
 
         // Auth
         this._token = null;
@@ -361,6 +425,25 @@ export class ReachyMini extends EventTarget {
 
     /** @returns {boolean} */
     get audioMuted() { return this._audioMuted; }
+
+    /**
+     * Peer id of the robot the embedding host wants this session to
+     * target, captured from the URL at construction time. Apps that
+     * want to support iframe-embedding without forcing the user to
+     * re-pick a robot read this and pass it straight to
+     * `startSession()` once `connect()` resolves:
+     *
+     *     await robot.connect();
+     *     await robot.startSession(robot.preselectedRobotId ?? pickedId);
+     *
+     * Returns `null` when the URL carries no `robot_peer_id` (typical
+     * standalone Space load). The value is also exposed on the
+     * "robotsChanged" payload via the `meta` sidecar for
+     * convenience, but the most direct read is right here.
+     *
+     * @returns {string|null}
+     */
+    get preselectedRobotId() { return this._preselectedRobotId; }
 
     // ─── Auth ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Pairs with the credential hand-off shipped in #1093. When an iframe host (typically the Reachy Mini mobile shell) embeds an SDK consumer, it can now ALSO tell the consumer which robot to target so the user does not get bounced through a redundant robot picker after we silently logged them in via the URL fragment.

## What changes

\`js/reachy-mini.js\`

- New private helper \`readPreselectedRobotIdFromUrl()\` (next to \`consumeFragmentCredentials\`) which tries
  1. the URL fragment (\`#robot_peer_id=…\`),
  2. the URL query (\`?robot_peer_id=…\`),
  3. otherwise returns \`null\`.

- Constructor stores the result on \`this._preselectedRobotId\` once, at instantiation. Subsequent URL mutations (\`consumeFragmentCredentials()\` strips the auth keys, history navigation, in-app routing) do not move the target out from under the consumer.

- Public read-only getter \`robot.preselectedRobotId\` returning \`string | null\`.

- Top-of-file READ-ONLY PROPERTIES JSDoc updated.

## Usage

Apps opt in with two lines after \`authenticate()\` succeeds:

\`\`\`js
if (await robot.authenticate()) await robot.connect();
await robot.startSession(robot.preselectedRobotId ?? pickedId);
\`\`\`

That is enough to skip the robot picker entirely when a host has already chosen a target.

## Why query AND fragment

The peer id is NOT a secret — the central signaling server publishes it on its public robot listing — so a query param is fine. The Reachy Mini mobile shell already emits \`?robot_peer_id=…\` today via [\`buildEmbedUrl.ts\`](https://github.com/pollen-robotics/reachy_mini_mobile_app/blob/main/src/apps/buildEmbedUrl.ts) and remains unchanged. Hosts that prefer the fragment for symmetry with #1093's credentials hand-off get identical behaviour. Both reads are tolerant of malformed input — we fall through to \`null\` rather than throwing.

## Pairs with

- #1093 (credential URL-fragment hand-off, already merged).
- A follow-up on \`reachy_mini_minimal_conversation\`'s \`src/main.ts\`: read \`robot.preselectedRobotId\` after \`authenticate()\`, set \`selectedRobotId\` directly, skip the picker. (Will land separately so SDK and app cycles are independent.)

## Test plan

- [ ] Standalone Space load (no \`robot_peer_id\` anywhere in URL) → \`robot.preselectedRobotId === null\`, picker behaviour unchanged.
- [ ] Mobile-shell embed with \`?robot_peer_id=abc123\` → \`robot.preselectedRobotId === 'abc123'\`.
- [ ] Hosts using \`#robot_peer_id=abc123\` (fragment-only) → same.
- [ ] Both query and fragment present → fragment wins (consistent with the credentials hand-off precedence).
- [ ] Malformed query / fragment → no throw, \`preselectedRobotId\` is \`null\`.


Made with [Cursor](https://cursor.com)