### PR TITLE
fix(sdk): skip empty ICE candidates so Safari / iOS WKWebView stops throwing

### DIFF
--- a/js/reachy-mini.js
+++ b/js/reachy-mini.js
@@ -1307,7 +1307,17 @@ export class ReachyMini extends EventTarget {
                 }
             }
             if (msg.ice) {
-                await this._pc.addIceCandidate(new RTCIceCandidate(msg.ice));
+                // Safari (and the iOS WKWebView Tauri ships on) rejects
+                // empty candidate strings with `OperationError: Expect
+                // line: candidate:<candidate-str>`. The signaling
+                // server uses an empty string as the end-of-candidates
+                // marker (legal per the WebRTC spec but optional).
+                // Chrome / Firefox swallow it silently; we mirror that
+                // here so the iOS WebView stops surfacing the noise as
+                // a robot-side WebRTC error event.
+                if (msg.ice.candidate) {
+                    await this._pc.addIceCandidate(new RTCIceCandidate(msg.ice));
+                }
             }
         } catch (e) {
             console.error('WebRTC error:', e);


### PR DESCRIPTION
## Summary

The signaling server uses an empty candidate string as the end-of-candidates marker (legal per the WebRTC spec but optional). Chrome and Firefox swallow it silently. Safari, and the iOS WKWebView Tauri ships on, rejects it with:

\`\`\`
OperationError: Expect line: candidate:<candidate-str>
\`\`\`

The error fires on every iOS robot session right after the real candidates are exchanged. It's non-fatal — the connection completes fine — but it pollutes consumer logs and triggers the SDK's \`'error'\` event with a misleading \`'webrtc'\` source, which apps tend to surface as a generic 'something went wrong'.

## What changes

\`js/reachy-mini.js\`'s \`_handlePeerMessage\` now matches Chrome / Firefox: skip the \`addIceCandidate\` call when the candidate string is empty. Real candidates still go through; only the end-of-candidates sentinel is dropped.

\`\`\`js
if (msg.ice.candidate) {
    await this._pc.addIceCandidate(new RTCIceCandidate(msg.ice));
}
\`\`\`

## Why this matters now

Reported by the Reachy Mini mobile app (iOS WKWebView). Logs were full of:

\`\`\`
[Error] WebRTC error: OperationError: Expect line: candidate:<candidate-str>
[Error] [robot:webrtc] – OperationError: Expect line: candidate:<candidate-str>
\`\`\`

even though the session was up and the data channel happily replying to \`get_volume\` etc. The misleading \`error\` event was getting surfaced by the host as a fatal WebRTC failure.

## Test plan

- [ ] iOS WKWebView (Reachy Mini mobile app dev build) — empty-candidate noise is gone, real candidates still flow.
- [ ] Chrome desktop — no behaviour change (same code path, the branch is just an additional gate).
- [ ] Firefox desktop — same as Chrome.


Made with [Cursor](https://cursor.com)