### PR TITLE
fix(sdk): default signalingUrl to tfrere-reachy-mini-central

### DIFF
--- a/js/reachy-mini.js
+++ b/js/reachy-mini.js
@@ -72,7 +72,7 @@
  * CONSTRUCTOR OPTIONS
  * ───────────────────
  *   new ReachyMini({
- *     signalingUrl:              string,   // default: "https://cduss-reachy-mini-central.hf.space"
+ *     signalingUrl:              string,   // default: "https://tfrere-reachy-mini-central.hf.space"
  *     enableMicrophone:          boolean,  // default: true  — acquire mic for bidirectional audio
  *     videoJitterBufferTargetMs: number,   // default: 0     — receiver-side jitter buffer hint, ms
  *                                          //                  0 = "render ASAP" (teleop). Spec range [0, 4000].
@@ -266,7 +266,15 @@ export class ReachyMini extends EventTarget {
     /** @param {{ signalingUrl?: string, enableMicrophone?: boolean, clientId?: string, appName?: string, videoJitterBufferTargetMs?: number }} [options] */
     constructor(options = {}) {
         super();
-        this._signalingUrl = options.signalingUrl || 'https://cduss-reachy-mini-central.hf.space';
+        // Production central. The legacy `cduss-reachy-mini-central`
+        // host predates the proper deployment and is no longer where
+        // any Reachy Mini daemon registers; pointing the SDK at it
+        // produces a successful `connect()` but an empty
+        // `robot.robots` list and a `startSession()` that hangs
+        // forever (the central can't route a peer id it doesn't know).
+        // Override via the `signalingUrl` option for staging /
+        // self-hosted setups.
+        this._signalingUrl = options.signalingUrl || 'https://tfrere-reachy-mini-central.hf.space';
         this._enableMicrophone = options.enableMicrophone !== false;
         this._clientId = options.clientId || null;
         this._appName = options.appName || 'unknown';


### PR DESCRIPTION
## Summary

The legacy \`cduss-reachy-mini-central.hf.space\` host predates the proper deployment and no Reachy Mini daemon registers there anymore. Pointing the SDK at it produces:

- a successful \`connect()\` (\`welcome\` SSE arrives)
- an empty \`robot.robots\` list (no daemons known)
- \`startSession(peerId)\` that hangs forever — the central can't route a peer id it doesn't know, no \`sessionRejected\`, no progress

The Reachy Mini mobile shell already overrode this via its own [\`config.ts\`](https://github.com/pollen-robotics/reachy_mini_mobile_app/blob/main/src/config.ts) (\`tfrere-reachy-mini-central\`). The minimal conversation app and any vibe-coder generated app inherited the broken default and silently hung at \`starting\`.

## What changes

\`js/reachy-mini.js\` — flip the constructor's default:

\`\`\`js
this._signalingUrl = options.signalingUrl || 'https://tfrere-reachy-mini-central.hf.space';
\`\`\`

JSDoc + top-of-file QUICK START example updated. Custom hosts (staging, self-hosted) keep working via the existing \`signalingUrl\` option.

## Test plan

- [ ] Standalone Space load (no \`signalingUrl\` option) → \`robot.robots\` populated, \`startSession\` succeeds.
- [ ] Mobile shell embed → unchanged (already overrides via \`signalingUrl\`).
- [ ] Custom \`signalingUrl\` → still respected.


Made with [Cursor](https://cursor.com)