### PR TITLE
js: prefer preferred_username over name for _username

### DIFF
--- a/js/reachy-mini.js
+++ b/js/reachy-mini.js
@@ -473,7 +473,7 @@ export class ReachyMini extends EventTarget {
             // 2. OAuth redirect callback.
             const result = await oauthHandleRedirectIfPresent();
             if (result) {
-                this._username = result.userInfo.name || result.userInfo.preferred_username;
+                this._username = result.userInfo.preferred_username || result.userInfo.name;
                 this._token = result.accessToken;
                 this._tokenExpires = result.accessTokenExpiresAt;
                 sessionStorage.setItem('hf_token', this._token);


### PR DESCRIPTION
The HF OAuth userInfo carries both `name` (display name, e.g. "Remi Fabre" -> may include spaces) and `preferred_username` (URL slug, e.g. "RemiFabre" -> guaranteed slug-shape).

Apps that consume `robot.username` as a path segment for `createRepo`/`uploadFiles` get 403s when the display name has spaces. Flipping the precedence picks the slug first; callers who specifically need the display name can still get it via `whoAmI()`.

Closes #1104.