### PR TITLE
fix(daemon): edge-driven Timer debounce for gpio-shutdown (#1109)

### DIFF
--- a/scripts/issue_1109/README.md
+++ b/scripts/issue_1109/README.md
@@ -1,0 +1,114 @@
+# Issue #1109 investigation tooling
+
+Two on-robot scripts to support the conversation on PR #1110:
+
+- `burst_characterization.py` — measure motor-EMI burst duration on GPIO23.
+- `hold_time_sweep.py` — sweep `HOLD_TIME` values, find the floor that
+  survives motor stress with zero spurious shutdowns.
+
+Both scripts run **on the Reachy Mini's Raspberry Pi**, not on the Mac.
+Copy with `scp -r scripts/issue_1109 pollen@reachy-mini.local:/home/pollen/`
+or equivalent.
+
+## Pre-conditions (both scripts)
+
+```sh
+# Take exclusive ownership of GPIO23 (otherwise the daemon's own monitor
+# will also fire callbacks, and may shut the robot down mid-test):
+sudo systemctl stop gpio-shutdown-daemon
+
+# The reachy-mini-daemon must be running for set_target to work:
+systemctl status reachy-mini-daemon
+
+# Do not touch the latch during these runs. We're characterizing
+# motor-EMI alone, so any deliberate latch pull would contaminate the
+# data.
+```
+
+Restore the daemon after testing:
+
+```sh
+sudo systemctl start gpio-shutdown-daemon
+```
+
+## Workflow
+
+### 1. Characterize EMI burst duration
+
+```sh
+# 5-minute run with 10 Hz set_target stress (matches #1109's reproducer)
+python3 burst_characterization.py --duration 300 --freq 10
+
+# Optional baseline: passive EMI floor (no motor activity)
+python3 burst_characterization.py --duration 60 --no-motor
+```
+
+Output: `logs/issue_1109/burst-<UTC>.jsonl` plus a stdout summary with
+burst duration p50 / p95 / p99 and inter-edge gap counts (<1 ms, <10 ms,
+<100 ms).
+
+**What the numbers tell us:** the production Timer cancels on any
+`when_pressed` edge during the hold window, so what matters is **the
+maximum gap between adjacent edges inside a single burst** —
+HOLD_TIME just needs to outlast one such gap. Burst durations from
+this script give us a measured upper bound to compare against the
+"sub-millisecond" claim in the PR description.
+
+### 2. Sweep HOLD_TIME to find the safe floor
+
+```sh
+# 6-value sweep at 2 min/step = ~12 min total
+python3 hold_time_sweep.py \
+    --hold-times 0.05 0.1 0.2 0.5 1.0 2.0 \
+    --duration-per-step 120 --freq 10
+
+# Quick smoke (narrower range, shorter duration)
+python3 hold_time_sweep.py \
+    --hold-times 0.1 0.2 0.5 \
+    --duration-per-step 60
+```
+
+Output: `logs/issue_1109/sweep-<UTC>.jsonl` plus a stdout table.
+
+**Pass criterion:** a HOLD_TIME passes if `n_timers_fired == 0` after
+its full step duration. The **floor** is the smallest passing value.
+The `pull_up=False` setting matches production
+`shutdown_monitor.py`, so the edge semantics are identical.
+
+The harness replaces `shutdown_now()` with a counter — your robot will
+not actually shut down regardless of HOLD_TIME or motor activity.
+
+### 3. Pick HOLD_TIME for the PR
+
+Bound the safe range from both directions:
+
+- **Floor** (from `hold_time_sweep.py`): smallest value with 0 spurious
+  fires during sustained motor stress.
+- **Ceiling** (from the review on PR #1110): ~2 s, after which the
+  Wireless latch-OUT power cut beats `shutdown_now()` to completion.
+
+### Empirical result on Reachy Mini Wireless (2026-05-12)
+
+`burst_characterization.py --duration 300 --freq 10` produced **0
+edges** across 2,887 motor commands. `hold_time_sweep.py
+--hold-times 0.05 0.1 0.2 0.5 1.0 2.0 --duration-per-step 120 --freq
+10` produced **0 spurious fires at every HOLD_TIME tested**. Total: 17
+minutes of stress, ~10,000 motor commands, zero GPIO23 edges.
+
+On this hardware the EMI condition described in #1109 is below the
+measurement floor, so the floor for HOLD_TIME is set by gesture-
+recognition UX, not EMI. **HOLD_TIME = 0.5 s** was chosen: 10× a typical
+e-stop tap (~50 ms), 4× headroom below the ~2 s power-rail cut.
+
+## Notes
+
+- Both scripts use `gpiozero.Button(23, pull_up=False)`, which matches
+  the production `shutdown_monitor.py` and defers pull configuration to
+  the kernel device tree.
+- The motor-stress loop drives `head` (sinusoidal yaw), `antennas`
+  (sweeping), and `body_yaw` (slow oscillation) simultaneously — heavier
+  than a single-joint loop, intended to maximize EMI per unit wall-clock.
+- These scripts are not part of the PR's deliverable; they live in
+  `scripts/issue_1109/` for the duration of the #1109 / #1110
+  investigation and can be removed before merge if Pierre prefers a
+  smaller diff.

--- a/scripts/issue_1109/burst_characterization.py
+++ b/scripts/issue_1109/burst_characterization.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""GPIO23 motor-EMI burst characterization for issue #1109.
+
+Runs ON the robot (Raspberry Pi inside Reachy Mini). Listens for raw
+GPIO23 edges with high-resolution monotonic timestamps while optionally
+driving the motors at a configurable cadence. Produces a JSONL edge log
+plus a stdout summary so we can answer "how long are the EMI bursts,
+actually?" with measured numbers instead of inference.
+
+Pre-conditions
+--------------
+* `sudo systemctl stop gpio-shutdown-daemon` (we need exclusive GPIO23
+  access; the daemon's own monitor would otherwise also fire callbacks
+  and may actually shut the robot down).
+* `reachy-mini-daemon` running (so `set_target` works). Use `--no-motor`
+  if you want a passive EMI-floor run without motor activity.
+* Run as the daemon user (typically `pollen`) — gpiozero needs hardware
+  access. `sudo` is fine too.
+
+What it measures
+----------------
+* Every `when_pressed` (rising edge) and `when_released` (falling edge)
+  with `time.monotonic_ns()` relative to start.
+* Burst clustering: a run of >=2 edges with inter-edge gap < 100 ms is
+  treated as one "burst" and reported as a duration.
+* Inter-edge gap distribution (count <1ms, count <10ms).
+
+The shutdown-monitor's edge-driven Timer cancels on ANY `when_pressed`
+edge during the hold window, so the **burst duration** is what matters
+for HOLD_TIME sizing: HOLD_TIME just needs to outlast a single burst
+without an intervening cancel-edge. Inter-edge gap distribution is what
+matters for "could a burst be wide enough that no cancel arrives in
+HOLD_TIME?"
+
+Output
+------
+* `logs/issue_1109/burst-<UTC>.jsonl` — one JSON object per edge plus a
+  session_meta header.
+* Stdout summary table (also written to the meta line).
+
+Usage
+-----
+    sudo systemctl stop gpio-shutdown-daemon
+    python3 scripts/issue_1109/burst_characterization.py \\
+        --duration 300 --freq 10
+
+    # baseline EMI floor (no motor stress):
+    python3 scripts/issue_1109/burst_characterization.py \\
+        --duration 60 --no-motor
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from gpiozero import Button  # type: ignore[import-untyped]
+
+
+def _motor_stress_loop(stop_event: threading.Event, freq_hz: float) -> None:
+    """Drive the head + antennas + body_yaw at `freq_hz` until stop_event."""
+    import math
+
+    import numpy as np
+    from reachy_mini import ReachyMini  # type: ignore[import-untyped]
+
+    period = 1.0 / freq_hz
+    n = 0
+    try:
+        with ReachyMini() as robot:
+            # Robot may be in sleep state — `set_target` is silently
+            # ignored until wake_up() transitions the daemon out of
+            # sleep. `enable_motors()` alone enables torque but the
+            # daemon ignores streamed targets while asleep.
+            # wake_up() plays a "toudoum" sound and wiggles the head;
+            # acceptable for a test run.
+            print("[motor] wake_up...", file=sys.stderr)
+            robot.wake_up()
+            print("[motor] awake; starting stress loop", file=sys.stderr)
+            try:
+                t0 = time.monotonic()
+                while not stop_event.is_set():
+                    t = time.monotonic() - t0
+                    # Small sinusoidal head yaw (~5 deg) + antenna sweep + body yaw
+                    # — enough motor activity to reproduce #1109 without large
+                    # excursions.
+                    yaw_rad = math.radians(5.0) * math.sin(2 * math.pi * 0.5 * t)
+                    head = np.eye(4, dtype=np.float64)
+                    head[0, 0] = math.cos(yaw_rad)
+                    head[0, 1] = -math.sin(yaw_rad)
+                    head[1, 0] = math.sin(yaw_rad)
+                    head[1, 1] = math.cos(yaw_rad)
+                    antenna_rad = math.radians(15.0) * math.sin(2 * math.pi * 0.7 * t)
+                    try:
+                        robot.set_target(
+                            head=head,
+                            antennas=[antenna_rad, -antenna_rad],
+                            body_yaw=math.radians(3.0) * math.sin(2 * math.pi * 0.3 * t),
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        print(f"[motor] set_target error at n={n}: {exc}", file=sys.stderr)
+                    n += 1
+                    # Use Event.wait so we exit promptly on stop.
+                    if stop_event.wait(timeout=period):
+                        break
+            finally:
+                try:
+                    robot.disable_motors()
+                    print("[motor] motors disabled", file=sys.stderr)
+                except Exception as exc:  # noqa: BLE001
+                    print(f"[motor] disable_motors error: {exc}", file=sys.stderr)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[motor] fatal: {exc}", file=sys.stderr)
+    finally:
+        print(f"[motor] stopped after {n} commands", file=sys.stderr)
+
+
+def _summarize(
+    edges: list[dict[str, Any]],
+    duration_s: float,
+    burst_gap_threshold_us: float = 100_000.0,
+) -> dict[str, Any]:
+    """Compute burst-cluster + inter-edge-gap statistics from the edge log."""
+    summary: dict[str, Any] = {
+        "n_edges": len(edges),
+        "duration_s": duration_s,
+        "burst_gap_threshold_us": burst_gap_threshold_us,
+    }
+    if len(edges) < 2:
+        return summary
+
+    pressed = [e for e in edges if e["edge"] == "pressed"]
+    released = [e for e in edges if e["edge"] == "released"]
+    summary["n_pressed"] = len(pressed)
+    summary["n_released"] = len(released)
+
+    gaps_us = [
+        (edges[i + 1]["monotonic_ns"] - edges[i]["monotonic_ns"]) / 1000.0
+        for i in range(len(edges) - 1)
+    ]
+    summary["inter_edge_gap_us"] = {
+        "min": min(gaps_us),
+        "p50": statistics.median(gaps_us),
+        "max": max(gaps_us),
+        "count_lt_1ms": sum(1 for g in gaps_us if g < 1_000),
+        "count_lt_10ms": sum(1 for g in gaps_us if g < 10_000),
+        "count_lt_100ms": sum(1 for g in gaps_us if g < 100_000),
+    }
+
+    # Cluster edges into bursts. A burst = >=2 edges separated by gaps <
+    # burst_gap_threshold_us. Burst duration = first→last edge in the run.
+    bursts: list[list[dict[str, Any]]] = []
+    current = [edges[0]]
+    for prev, nxt in zip(edges, edges[1:], strict=False):
+        gap_us = (nxt["monotonic_ns"] - prev["monotonic_ns"]) / 1000.0
+        if gap_us < burst_gap_threshold_us:
+            current.append(nxt)
+        else:
+            if len(current) > 1:
+                bursts.append(current)
+            current = [nxt]
+    if len(current) > 1:
+        bursts.append(current)
+
+    summary["n_bursts"] = len(bursts)
+    if bursts:
+        durs_us = [
+            (b[-1]["monotonic_ns"] - b[0]["monotonic_ns"]) / 1000.0 for b in bursts
+        ]
+        counts = [len(b) for b in bursts]
+        burst_stats: dict[str, Any] = {
+            "duration_us": {
+                "min": min(durs_us),
+                "p50": statistics.median(durs_us),
+                "max": max(durs_us),
+            },
+            "edge_count": {
+                "min": min(counts),
+                "p50": statistics.median(counts),
+                "max": max(counts),
+            },
+        }
+        if len(durs_us) >= 20:
+            burst_stats["duration_us"]["p95"] = statistics.quantiles(durs_us, n=20)[18]
+            burst_stats["duration_us"]["p99"] = statistics.quantiles(durs_us, n=100)[98]
+        summary["bursts"] = burst_stats
+
+    return summary
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--duration",
+        type=float,
+        default=300.0,
+        help="seconds to characterize (default: 300)",
+    )
+    ap.add_argument(
+        "--freq",
+        type=float,
+        default=10.0,
+        help="set_target frequency in Hz (default: 10 — matches #1109 reproducer)",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=Path("logs/issue_1109"),
+        help="output directory (default: logs/issue_1109/)",
+    )
+    ap.add_argument(
+        "--gpio",
+        type=int,
+        default=23,
+        help="GPIO pin to monitor (default: 23)",
+    )
+    ap.add_argument(
+        "--no-motor",
+        action="store_true",
+        help="skip motor stress (passive EMI floor check)",
+    )
+    args = ap.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    out_path = args.out / f"burst-{ts}.jsonl"
+    print(f"[main] logging to {out_path}", file=sys.stderr)
+
+    edges: list[dict[str, Any]] = []
+    edges_lock = threading.Lock()
+    t0_ns = time.monotonic_ns()
+
+    # pull_up=False matches production shutdown_monitor.py — defers to the
+    # kernel device-tree pull configuration.
+    button = Button(args.gpio, pull_up=False)
+
+    def _record(edge: str) -> None:
+        with edges_lock:
+            edges.append(
+                {
+                    "edge": edge,
+                    "monotonic_ns": time.monotonic_ns() - t0_ns,
+                    "wall_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                }
+            )
+
+    button.when_pressed = lambda: _record("pressed")
+    button.when_released = lambda: _record("released")
+
+    initial = "pressed (HIGH/latched-in)" if button.is_pressed else "released (LOW/latched-out)"
+    print(f"[main] initial GPIO{args.gpio} state: {initial}", file=sys.stderr)
+    print(
+        f"[main] starting {args.duration:.0f}s run | freq={args.freq} Hz | motor={not args.no_motor}",
+        file=sys.stderr,
+    )
+
+    stop_event = threading.Event()
+    motor_thread: threading.Thread | None = None
+    if not args.no_motor:
+        motor_thread = threading.Thread(
+            target=_motor_stress_loop, args=(stop_event, args.freq), daemon=True
+        )
+        motor_thread.start()
+
+    try:
+        stop_event.wait(timeout=args.duration)
+    except KeyboardInterrupt:
+        print("[main] interrupted - flushing", file=sys.stderr)
+    finally:
+        stop_event.set()
+        if motor_thread is not None:
+            motor_thread.join(timeout=2.0)
+
+    with edges_lock:
+        snapshot = list(edges)
+
+    summary = _summarize(snapshot, args.duration)
+    summary["pin_initial_state"] = initial
+    summary["motor_stress"] = not args.no_motor
+    summary["freq_hz"] = args.freq
+
+    with out_path.open("w") as f:
+        f.write(json.dumps({"event": "session_meta", **summary}) + "\n")
+        for e in snapshot:
+            f.write(json.dumps(e) + "\n")
+
+    # Pretty-print summary to stderr.
+    print("", file=sys.stderr)
+    print("=== summary ===", file=sys.stderr)
+    print(json.dumps(summary, indent=2, default=str), file=sys.stderr)
+    print(f"\n[main] JSONL: {out_path}", file=sys.stderr)
+
+    button.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/issue_1109/hold_time_sweep.py
+++ b/scripts/issue_1109/hold_time_sweep.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""HOLD_TIME floor sweep for issue #1109 (PR #1110 follow-up).
+
+Reproduces the production edge-driven Timer logic from
+`reachy_mini.daemon.app.services.gpio_shutdown.shutdown_monitor` in-process
+with HOLD_TIME parameterized, replaces `shutdown_now` with a counter,
+and runs the #1109 reproducer (10 Hz `set_target` motor stress) for a
+configurable duration per HOLD_TIME value. Reports per-HOLD_TIME spurious
+firings so we can establish the minimum value that survives motor EMI
+with zero false positives — the floor of the safe range. Pierre's
+~2 s latch→power-rail-cut bound (review on PR #1110) is the ceiling.
+
+Pre-conditions
+--------------
+* `sudo systemctl stop gpio-shutdown-daemon` — exclusive GPIO23 access.
+* `reachy-mini-daemon` running.
+* Do NOT touch the latch during a sweep. We're measuring spurious
+  firings from EMI alone; a deliberate latch pull would be a true
+  positive and contaminate the floor estimate.
+
+What it tests
+-------------
+For each HOLD_TIME in the sweep:
+  1. Reset Timer state.
+  2. Start motor stress at `--freq` Hz.
+  3. Listen for GPIO23 edges; falling edge schedules
+     `Timer(HOLD_TIME, _fake_shutdown)`, rising edge cancels it.
+  4. Run for `--duration-per-step` seconds.
+  5. Tally: scheduled timers, cancelled timers, fires (= spurious
+     shutdowns), edge counts.
+
+A PASS for a HOLD_TIME value is **0 fires**. The floor is the smallest
+HOLD_TIME that passes. The PR's claim that EMI bursts are
+"sub-millisecond" predicts that even HOLD_TIME = 50 ms should pass;
+this harness verifies or falsifies that prediction with measurements.
+
+Output
+------
+* `logs/issue_1109/sweep-<UTC>.jsonl` — per-step result row + a final
+  summary row. One JSON object per line.
+* Stdout table.
+
+Usage
+-----
+    sudo systemctl stop gpio-shutdown-daemon
+    python3 scripts/issue_1109/hold_time_sweep.py \\
+        --hold-times 50 100 200 500 1000 2000 \\
+        --duration-per-step 120 --freq 10
+
+A 6-value sweep at 120 s/step = ~12 min of robot time. Start with a
+narrower sweep if you want a quick smoke (e.g. `--hold-times 200 500`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from gpiozero import Button  # type: ignore[import-untyped]
+
+
+class TimerDebounce:
+    """In-process clone of production shutdown_monitor.py's Timer logic.
+
+    Keeps the same semantics: `when_released` schedules
+    `Timer(hold_time, shutdown_cb)`; `when_pressed` cancels any pending
+    Timer. `shutdown_cb` is replaced with a counter for sweep purposes
+    so the robot does not actually shut down.
+    """
+
+    def __init__(self, hold_time: float, shutdown_cb: Callable[[], None]) -> None:
+        self.hold_time = hold_time
+        self._shutdown_cb = shutdown_cb
+        self._lock = threading.Lock()
+        self._pending: threading.Timer | None = None
+        self.n_scheduled = 0
+        self.n_cancelled = 0
+        self.n_fired = 0
+
+    def on_released(self) -> None:
+        with self._lock:
+            if self._pending is not None:
+                self._pending.cancel()
+                self.n_cancelled += 1
+            timer = threading.Timer(self.hold_time, self._fire)
+            timer.daemon = True
+            self._pending = timer
+            self.n_scheduled += 1
+            timer.start()
+
+    def on_pressed(self) -> None:
+        with self._lock:
+            if self._pending is not None:
+                self._pending.cancel()
+                self._pending = None
+                self.n_cancelled += 1
+
+    def _fire(self) -> None:
+        with self._lock:
+            self.n_fired += 1
+            self._pending = None
+        self._shutdown_cb()
+
+    def shutdown(self) -> None:
+        with self._lock:
+            if self._pending is not None:
+                self._pending.cancel()
+                self._pending = None
+
+
+def _motor_stress_loop(robot: Any, stop_event: threading.Event, freq_hz: float) -> None:
+    """Drive head + antennas + body_yaw at `freq_hz` (reproduces #1109 scenario c).
+
+    Caller owns the ReachyMini context. We run continuously for the whole
+    sweep; per-step wake_up cycling crashes the GStreamer pipeline used
+    by the sound playback in wake_up().
+    """
+    period = 1.0 / freq_hz
+    n = 0
+    t0 = time.monotonic()
+    while not stop_event.is_set():
+        t = time.monotonic() - t0
+        yaw_rad = math.radians(5.0) * math.sin(2 * math.pi * 0.5 * t)
+        head = np.eye(4, dtype=np.float64)
+        head[0, 0] = math.cos(yaw_rad)
+        head[0, 1] = -math.sin(yaw_rad)
+        head[1, 0] = math.sin(yaw_rad)
+        head[1, 1] = math.cos(yaw_rad)
+        antenna_rad = math.radians(15.0) * math.sin(2 * math.pi * 0.7 * t)
+        try:
+            robot.set_target(
+                head=head,
+                antennas=[antenna_rad, -antenna_rad],
+                body_yaw=math.radians(3.0) * math.sin(2 * math.pi * 0.3 * t),
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"[motor] set_target error at n={n}: {exc}", file=sys.stderr)
+        n += 1
+        if stop_event.wait(timeout=period):
+            break
+    print(f"[motor] stopped after {n} commands", file=sys.stderr)
+
+
+def _run_step(
+    hold_time: float,
+    duration_s: float,
+    freq_hz: float,
+    gpio_pin: int,
+) -> dict[str, Any]:
+    """Run one HOLD_TIME value; return its result dict.
+
+    Caller must already be running the motor stress thread continuously.
+    """
+    n_pressed = 0
+    n_released = 0
+    n_pressed_lock = threading.Lock()
+
+    debounce = TimerDebounce(hold_time, shutdown_cb=lambda: None)
+    # pull_up=False matches production.
+    button = Button(gpio_pin, pull_up=False)
+
+    def _pressed() -> None:
+        nonlocal n_pressed
+        with n_pressed_lock:
+            n_pressed += 1
+        debounce.on_pressed()
+
+    def _released() -> None:
+        nonlocal n_released
+        with n_pressed_lock:
+            n_released += 1
+        debounce.on_released()
+
+    button.when_pressed = _pressed
+    button.when_released = _released
+
+    initial_pressed = button.is_pressed
+    print(
+        f"\n[step] HOLD_TIME={hold_time:.3f}s | duration={duration_s:.0f}s | "
+        f"initial_state={'pressed' if initial_pressed else 'released'}",
+        file=sys.stderr,
+    )
+
+    t_start = time.monotonic()
+    try:
+        # Block for duration_s while motors stress in the background.
+        time.sleep(duration_s)
+    except KeyboardInterrupt:
+        print("[step] interrupted", file=sys.stderr)
+    finally:
+        # Give any pending Timer hold_time + 100ms to fire before tearing
+        # down; otherwise we'd under-count fires in the last hold_time
+        # window.
+        time.sleep(hold_time + 0.1)
+        debounce.shutdown()
+        button.close()
+
+    elapsed = time.monotonic() - t_start
+    result = {
+        "hold_time_s": hold_time,
+        "duration_s": duration_s,
+        "elapsed_s": elapsed,
+        "freq_hz": freq_hz,
+        "initial_pressed": initial_pressed,
+        "n_pressed_edges": n_pressed,
+        "n_released_edges": n_released,
+        "n_timers_scheduled": debounce.n_scheduled,
+        "n_timers_cancelled": debounce.n_cancelled,
+        "n_timers_fired": debounce.n_fired,
+        "pass": debounce.n_fired == 0,
+    }
+    print(
+        f"[step] pressed={n_pressed} released={n_released} "
+        f"scheduled={debounce.n_scheduled} cancelled={debounce.n_cancelled} "
+        f"fired={debounce.n_fired} -> {'PASS' if result['pass'] else 'FAIL'}",
+        file=sys.stderr,
+    )
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--hold-times",
+        type=float,
+        nargs="+",
+        default=[0.05, 0.1, 0.2, 0.5, 1.0, 2.0],
+        help="HOLD_TIME values to sweep, in seconds (default: 0.05 0.1 0.2 0.5 1.0 2.0)",
+    )
+    ap.add_argument(
+        "--duration-per-step",
+        type=float,
+        default=120.0,
+        help="seconds per HOLD_TIME value (default: 120)",
+    )
+    ap.add_argument(
+        "--freq",
+        type=float,
+        default=10.0,
+        help="set_target frequency in Hz (default: 10 — matches #1109 reproducer)",
+    )
+    ap.add_argument(
+        "--gpio",
+        type=int,
+        default=23,
+        help="GPIO pin (default: 23)",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=Path("logs/issue_1109"),
+        help="output directory (default: logs/issue_1109/)",
+    )
+    args = ap.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    out_path = args.out / f"sweep-{ts}.jsonl"
+    print(f"[main] logging to {out_path}", file=sys.stderr)
+
+    print(
+        f"[main] sweep: {len(args.hold_times)} values x {args.duration_per_step:.0f}s "
+        f"= ~{len(args.hold_times) * args.duration_per_step / 60:.1f} min total",
+        file=sys.stderr,
+    )
+
+    results: list[dict[str, Any]] = []
+    meta = {
+        "event": "session_meta",
+        "hold_times_s": args.hold_times,
+        "duration_per_step_s": args.duration_per_step,
+        "freq_hz": args.freq,
+        "gpio": args.gpio,
+        "started_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+    # Single ReachyMini context + single wake_up + continuous motor stress
+    # thread for the whole sweep. Per-step wake_up was crashing GStreamer.
+    from reachy_mini import ReachyMini  # type: ignore[import-untyped]
+
+    motor_stop = threading.Event()
+    with out_path.open("w") as f:
+        f.write(json.dumps(meta) + "\n")
+        with ReachyMini() as robot:
+            # Gentle wake — no chime, no 20deg wiggle. wake_up() is violent
+            # AND its play_sound() crashes the GStreamer pipeline on
+            # repeat calls; use the enable+goto path which is proven
+            # reliable and quiet.
+            print("[main] gentle wake (enable_motors + slow goto)...", file=sys.stderr)
+            robot.enable_motors()
+            time.sleep(0.2)
+            robot.goto_target(
+                np.eye(4), antennas=[-0.1745, 0.1745], duration=2.0
+            )
+            time.sleep(2.3)
+            print("[main] awake; starting continuous motor stress", file=sys.stderr)
+            motor_thread = threading.Thread(
+                target=_motor_stress_loop,
+                args=(robot, motor_stop, args.freq),
+                daemon=True,
+            )
+            motor_thread.start()
+            try:
+                for hold_time in args.hold_times:
+                    try:
+                        result = _run_step(
+                            hold_time=hold_time,
+                            duration_s=args.duration_per_step,
+                            freq_hz=args.freq,
+                            gpio_pin=args.gpio,
+                        )
+                    except KeyboardInterrupt:
+                        print("[main] sweep interrupted", file=sys.stderr)
+                        break
+                    results.append(result)
+                    f.write(json.dumps({"event": "step_result", **result}) + "\n")
+                    f.flush()
+            finally:
+                motor_stop.set()
+                motor_thread.join(timeout=2.0)
+                try:
+                    robot.disable_motors()
+                except Exception as exc:  # noqa: BLE001
+                    print(f"[main] disable_motors error: {exc}", file=sys.stderr)
+
+        floor: float | None = None
+        for r in sorted(results, key=lambda x: x["hold_time_s"]):
+            if r["pass"]:
+                floor = r["hold_time_s"]
+                break
+        summary = {
+            "event": "sweep_summary",
+            "n_steps": len(results),
+            "floor_s": floor,
+            "all_results": results,
+            "ended_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        f.write(json.dumps(summary) + "\n")
+
+    # Pretty-print summary table.
+    print("\n=== sweep summary ===", file=sys.stderr)
+    print(
+        f"{'HOLD_TIME (s)':>14} {'pressed':>8} {'released':>9} "
+        f"{'scheduled':>10} {'cancelled':>10} {'fired':>6} {'verdict':>8}",
+        file=sys.stderr,
+    )
+    for r in results:
+        print(
+            f"{r['hold_time_s']:>14.3f} {r['n_pressed_edges']:>8} {r['n_released_edges']:>9} "
+            f"{r['n_timers_scheduled']:>10} {r['n_timers_cancelled']:>10} "
+            f"{r['n_timers_fired']:>6} {'PASS' if r['pass'] else 'FAIL':>8}",
+            file=sys.stderr,
+        )
+    if floor is not None:
+        print(f"\n[main] floor: HOLD_TIME >= {floor:.3f}s passed with 0 fires", file=sys.stderr)
+    else:
+        print("\n[main] NO value in sweep passed (all had spurious fires)", file=sys.stderr)
+    print(f"[main] JSONL: {out_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/reachy_mini/daemon/app/services/gpio_shutdown/shutdown_monitor.py
+++ b/src/reachy_mini/daemon/app/services/gpio_shutdown/shutdown_monitor.py
@@ -1,28 +1,99 @@
-"""Monitor GPIO24 for shutdown signal."""
+"""Monitor GPIO23 for the body shutdown-button signal.
 
-import time
+Hardware: GPIO23 is wired to a soft-power latch on the robot body. The
+latch sits IN during normal operation (pin HIGH, ``is_pressed=True``);
+the user signals "shutdown" by popping the latch OUT (pin LOW,
+``is_pressed=False``) and leaving it OUT for at least :data:`HOLD_TIME`
+seconds. Briefly popping the latch out and back in is NOT a shutdown
+gesture.
+
+``pull_up=False`` keeps gpiozero from overriding the kernel-side pull
+configured in the device tree.
+
+Issue #1109: motor-coil EMI couples brief LOW spikes onto GPIO23 during
+sustained ``set_target`` activity. The previous busy-wait debounce in
+PR #505 polls ``is_pressed`` on a 1 ms schedule for 200 ms after each
+``when_released``; sub-millisecond EMI spikes can pass between samples,
+so the poll never observes the pin returning HIGH and a spurious release
+becomes a real shutdown.
+
+This module replaces the busy-wait with an edge-driven design:
+
+* ``when_released`` (falling edge) starts a
+  ``threading.Timer(HOLD_TIME, shutdown_now)``.
+* ``when_pressed`` (rising edge) cancels any pending Timer.
+
+Because gpiozero's edge handlers are interrupt-style (kernel GPIO events,
+not sampled polls), even sub-millisecond HIGH spikes that flip the pin
+HIGH→LOW→HIGH cancel the pending Timer. A deliberate :data:`HOLD_TIME`-
+second release with no intervening HIGH spikes still fires
+:func:`shutdown_now`.
+
+Tradeoffs:
+
+* ``Timer.cancel()`` is best-effort. If the worker thread has already
+  begun executing the callback when ``cancel()`` is called, the shutdown
+  proceeds. This race window is sub-millisecond and acceptable for a
+  shutdown gesture.
+* HIGH spikes superimposed on an already-LOW pin during a real user
+  release also cancel the Timer. That matches PR #505's "bounce, ignore"
+  behaviour (no regression versus current main), but heavy motor
+  activity can theoretically delay or suppress an intentional shutdown
+  gesture. Not observed empirically.
+"""
+
+from __future__ import annotations
+
+import threading
 from signal import pause
 from subprocess import call
 
 from gpiozero import Button
 
+#: Sustained-release duration (seconds) before the shutdown handler fires.
+#: Longer than any motor-EMI burst observed in #1109; still a natural gesture.
+HOLD_TIME: float = 2.0
+
 shutdown_button = Button(23, pull_up=False)
 
+_pending_timer: threading.Timer | None = None
+_state_lock = threading.Lock()
 
-def released() -> None:
-    """Handle shutdown button released."""
-    for _ in range(200):
-        time.sleep(0.001)
 
-        if shutdown_button.is_pressed:
-            # probably just a bounce, ignore
-            return
-
-    print("Shutdown button released, shutting down...")
+def shutdown_now() -> None:
+    """Issue ``sudo shutdown -h now``. Invoked by the hold-detection Timer."""
+    print("Shutdown button held in released state, shutting down...")
     call(["sudo", "shutdown", "-h", "now"])
 
 
-shutdown_button.when_released = released
+def _schedule_shutdown() -> None:
+    """Falling-edge handler. Start (or restart) the hold-detection Timer."""
+    global _pending_timer
+    with _state_lock:
+        if _pending_timer is not None:
+            _pending_timer.cancel()
+        # Lambda defers the ``shutdown_now`` lookup to fire-time so tests
+        # can ``monkeypatch.setattr(module, "shutdown_now", ...)`` after
+        # the Timer is scheduled.
+        timer = threading.Timer(HOLD_TIME, lambda: shutdown_now())
+        timer.daemon = True
+        _pending_timer = timer
+        timer.start()
 
-print("Monitoring GPIO23 for shutdown signal...")
-pause()
+
+def _cancel_shutdown() -> None:
+    """Rising-edge handler. Cancel any pending hold-detection Timer."""
+    global _pending_timer
+    with _state_lock:
+        if _pending_timer is not None:
+            _pending_timer.cancel()
+            _pending_timer = None
+
+
+shutdown_button.when_released = _schedule_shutdown
+shutdown_button.when_pressed = _cancel_shutdown
+
+
+if __name__ == "__main__":
+    print(f"Monitoring GPIO23 for {HOLD_TIME}s sustained release...")
+    pause()

--- a/src/reachy_mini/daemon/app/services/gpio_shutdown/shutdown_monitor.py
+++ b/src/reachy_mini/daemon/app/services/gpio_shutdown/shutdown_monitor.py
@@ -40,6 +40,18 @@ Tradeoffs:
   behaviour (no regression versus current main), but heavy motor
   activity can theoretically delay or suppress an intentional shutdown
   gesture. Not observed empirically.
+
+HOLD_TIME sizing:
+
+EMI bursts are filtered by the cancel-on-press edge, not by HOLD_TIME --
+any rising edge during the hold window cancels the pending Timer
+independent of HOLD_TIME's value. HOLD_TIME is therefore a UX /
+gesture-recognition parameter, not an EMI filter parameter. Its only
+hard upper bound is that ``shutdown_now()`` plus the systemd shutdown
+dispatch must complete before the Wireless's latch-OUT-cuts-power-rail
+deadline (~2 s, per review on PR #1110); the lower bound is "long
+enough to distinguish a deliberate latch pull from an incidental
+brush". 0.5 s sits comfortably inside that window.
 """
 
 from __future__ import annotations
@@ -51,8 +63,11 @@ from subprocess import call
 from gpiozero import Button
 
 #: Sustained-release duration (seconds) before the shutdown handler fires.
-#: Longer than any motor-EMI burst observed in #1109; still a natural gesture.
-HOLD_TIME: float = 2.0
+#: UX / gesture-recognition parameter; not an EMI filter (the cancel-on-press
+#: edge handles EMI orthogonally). Must complete shutdown_now() before the
+#: Wireless's ~2 s latch-OUT power-rail cut; long enough to distinguish a
+#: deliberate latch pull from an incidental brush.
+HOLD_TIME: float = 0.5
 
 shutdown_button = Button(23, pull_up=False)
 

--- a/tests/unit_tests/test_shutdown_monitor.py
+++ b/tests/unit_tests/test_shutdown_monitor.py
@@ -9,7 +9,7 @@ test).
 Drives ``gpiozero`` via its ``MockFactory`` so the tests run on any host
 — no real GPIO required. Each test reloads the module under the mock
 factory and patches :data:`HOLD_TIME` to 0.3 s so the suite stays fast;
-the production constant ``HOLD_TIME = 2.0`` is verified separately by
+the production constant ``HOLD_TIME = 0.5`` is verified separately by
 ``test_module_constants_match_design``.
 
 Pin-state setup pattern: ``Button(pull_up=False)`` resets the
@@ -66,9 +66,11 @@ def shutdown_module(monkeypatch):
     at import time, capturing whatever ``Device.pin_factory`` is then. Tests
     must swap to ``MockFactory`` first.
 
-    Why monkeypatch ``HOLD_TIME``: the production constant is 2.0 s, which
-    would make the suite painfully slow. ``_schedule_shutdown`` reads
-    ``HOLD_TIME`` at fire-time, so patching after import works.
+    Why monkeypatch ``HOLD_TIME``: 0.3 s is faster than the production
+    value and is short enough that the "brief release < HOLD_TIME"
+    gestures the suite simulates run inside CI's wall-clock budget.
+    ``_schedule_shutdown`` reads ``HOLD_TIME`` at fire-time, so patching
+    after import works.
     """
     previous = Device.pin_factory
     Device.pin_factory = MockFactory()
@@ -109,12 +111,20 @@ def _wait_until(predicate, timeout: float = 2.0, poll: float = 0.01) -> bool:
 
 
 def test_module_constants_match_design():
-    """Production HOLD_TIME stays at 2.0 s (#1109 acceptance criterion)."""
+    """Production HOLD_TIME = 0.5 s.
+
+    Bounded above by the Wireless's ~2 s latch-OUT-to-power-rail-cut
+    deadline (per review on PR #1110: ``shutdown_now()`` must dispatch
+    inside that window); bounded below by gesture-recognition UX (long
+    enough to distinguish a deliberate latch pull from an incidental
+    brush). EMI bursts are filtered by the cancel-on-press edge,
+    independent of HOLD_TIME.
+    """
     from reachy_mini.daemon.app.services.gpio_shutdown.shutdown_monitor import (
         HOLD_TIME,
     )
 
-    assert HOLD_TIME == 2.0
+    assert HOLD_TIME == 0.5
 
 
 def test_brief_release_then_press_does_not_fire_shutdown(shutdown_module):

--- a/tests/unit_tests/test_shutdown_monitor.py
+++ b/tests/unit_tests/test_shutdown_monitor.py
@@ -33,12 +33,29 @@ gpiozero = pytest.importorskip("gpiozero")
 from gpiozero import Device  # noqa: E402
 from gpiozero.pins.mock import MockFactory  # noqa: E402
 
-# Bind a MockFactory for the test session BEFORE any test imports the
-# ``shutdown_monitor`` module. The module constructs ``Button(23,
-# pull_up=False)`` at import time; without a pin_factory pre-set, gpiozero
-# attempts to auto-detect one and raises ``BadPinFactory`` on hosts without
-# Linux GPIO (CI runners, dev macOS / Windows).
-Device.pin_factory = MockFactory()
+
+@pytest.fixture(autouse=True, scope="session")
+def _bind_mock_pin_factory_for_session():
+    """Bind a session-scoped ``MockFactory`` and restore the previous value.
+
+    The ``shutdown_monitor`` module constructs ``Button(23, pull_up=False)``
+    at import time; without a pin_factory pre-set, gpiozero attempts to
+    auto-detect one and raises ``BadPinFactory`` on hosts without Linux
+    GPIO (CI runners, dev macOS / Windows). Setting the factory at session
+    start ensures the per-test ``shutdown_module`` fixture always finds a
+    valid factory when it reloads the module.
+
+    Capturing+restoring (rather than mutating ``Device.pin_factory`` at
+    module-import time) means importing this test file does NOT leak a
+    MockFactory into other test modules that may rely on the default
+    pin-factory auto-detect behaviour.
+    """
+    previous = Device.pin_factory
+    Device.pin_factory = MockFactory()
+    try:
+        yield
+    finally:
+        Device.pin_factory = previous
 
 
 @pytest.fixture
@@ -73,6 +90,22 @@ def shutdown_module(monkeypatch):
 def _settle() -> None:
     """Yield briefly so gpiozero's edge-dispatch thread runs handlers."""
     time.sleep(0.02)
+
+
+def _wait_until(predicate, timeout: float = 2.0, poll: float = 0.01) -> bool:
+    """Poll ``predicate`` until True or ``timeout`` elapses.
+
+    Returns the final ``predicate()`` value (True if it became true within
+    the window, False if it never did). Used to make Timer-fire assertions
+    robust against scheduling delay on slow / loaded CI runners — see
+    Copilot review feedback on PR #1110.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(poll)
+    return predicate()
 
 
 def test_module_constants_match_design():
@@ -120,12 +153,11 @@ def test_sustained_release_fires_shutdown_once(shutdown_module):
     _settle()
 
     with patch(monkey_target, side_effect=lambda: fired.append(True)):
-        pin.drive_low()   # release at t=0.
-        time.sleep(0.5)   # 0.5 > 0.3 — Timer fires at t=0.3.
-
-    assert fired == [True], (
-        f"sustained release did not fire shutdown_now exactly once: fired={fired}"
-    )
+        pin.drive_low()   # release at t=0; Timer scheduled to fire at t=HOLD_TIME.
+        # Poll for fire instead of fixed sleep — robust to slow / loaded CI runners.
+        assert _wait_until(lambda: fired == [True], timeout=2.0), (
+            f"sustained release did not fire shutdown_now within 2s: fired={fired}"
+        )
 
 
 def test_emi_burst_during_release_cancels_pending_timer(shutdown_module):
@@ -159,11 +191,10 @@ def test_emi_burst_during_release_cancels_pending_timer(shutdown_module):
             f"fired={fired}"
         )
 
-        # At t≈0.50 — past Timer #2's deadline (t≈0.4).
-        time.sleep(0.15)
-        assert fired == [True], (
-            f"Timer #2 did not fire after the EMI burst (or fired more than once): "
-            f"fired={fired}"
+        # Timer #2's deadline is t≈0.4; poll for fire instead of fixed sleep
+        # so the test is robust to scheduling delay on slow / loaded CI runners.
+        assert _wait_until(lambda: fired == [True], timeout=2.0), (
+            f"Timer #2 did not fire after the EMI burst within 2s: fired={fired}"
         )
 
 
@@ -177,3 +208,26 @@ def test_shutdown_now_invokes_shutdown_command():
     with patch(target) as mock_call:
         shutdown_now()
     mock_call.assert_called_once_with(["sudo", "shutdown", "-h", "now"])
+
+
+def test_scheduled_timer_is_daemon_thread(shutdown_module):
+    """Pending Timer must be ``daemon=True`` so process exit isn't blocked.
+
+    Critical safety property: if the Python process exits while a Timer is
+    pending, the Timer thread must not keep the process alive (which would
+    hang the SDK shutdown sequence). The fix is the explicit
+    ``timer.daemon = True`` in :func:`shutdown_monitor._schedule_shutdown`;
+    this regression test pins that behaviour.
+    """
+    pin = Device.pin_factory.pin(23)
+    pin.drive_high()  # latch IN.
+    _settle()
+    pin.drive_low()  # release schedules a pending Timer.
+    _settle()
+
+    assert shutdown_module._pending_timer is not None, (
+        "release must schedule a pending Timer"
+    )
+    assert shutdown_module._pending_timer.daemon is True, (
+        "scheduled Timer must be daemon=True to prevent process hang on exit"
+    )

--- a/tests/unit_tests/test_shutdown_monitor.py
+++ b/tests/unit_tests/test_shutdown_monitor.py
@@ -33,6 +33,13 @@ gpiozero = pytest.importorskip("gpiozero")
 from gpiozero import Device  # noqa: E402
 from gpiozero.pins.mock import MockFactory  # noqa: E402
 
+# Bind a MockFactory for the test session BEFORE any test imports the
+# ``shutdown_monitor`` module. The module constructs ``Button(23,
+# pull_up=False)`` at import time; without a pin_factory pre-set, gpiozero
+# attempts to auto-detect one and raises ``BadPinFactory`` on hosts without
+# Linux GPIO (CI runners, dev macOS / Windows).
+Device.pin_factory = MockFactory()
+
 
 @pytest.fixture
 def shutdown_module(monkeypatch):

--- a/tests/unit_tests/test_shutdown_monitor.py
+++ b/tests/unit_tests/test_shutdown_monitor.py
@@ -1,0 +1,172 @@
+"""Unit tests for the GPIO23 shutdown-button monitor.
+
+Regression coverage for issue #1109: motor-coil EMI on GPIO23 must not
+fire :func:`shutdown_now` (HIGH-burst-during-release suppression test)
+while a deliberate sustained release still must (long-hold test). Brief
+release+press gestures must also not fire shutdown_now (gesture-cancel
+test).
+
+Drives ``gpiozero`` via its ``MockFactory`` so the tests run on any host
+— no real GPIO required. Each test reloads the module under the mock
+factory and patches :data:`HOLD_TIME` to 0.3 s so the suite stays fast;
+the production constant ``HOLD_TIME = 2.0`` is verified separately by
+``test_module_constants_match_design``.
+
+Pin-state setup pattern: ``Button(pull_up=False)`` resets the
+MockFactory pin to LOW at construction. After the module reload, drive
+HIGH to establish the "latch IN / running normally" state, then drive
+LOW to simulate the user popping the latch OUT.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from unittest.mock import patch
+
+import pytest
+
+# gpiozero is a Linux-only optional dep in pyproject.toml; on macOS / Windows
+# the wheel may be installable but pin operations require a backend. Skip
+# this module if gpiozero is unimportable rather than failing the suite.
+gpiozero = pytest.importorskip("gpiozero")
+from gpiozero import Device  # noqa: E402
+from gpiozero.pins.mock import MockFactory  # noqa: E402
+
+
+@pytest.fixture
+def shutdown_module(monkeypatch):
+    """Reload the module under a fresh ``MockFactory`` with a fast hold_time.
+
+    Why reload: the module wires ``shutdown_button = Button(23, pull_up=False)``
+    at import time, capturing whatever ``Device.pin_factory`` is then. Tests
+    must swap to ``MockFactory`` first.
+
+    Why monkeypatch ``HOLD_TIME``: the production constant is 2.0 s, which
+    would make the suite painfully slow. ``_schedule_shutdown`` reads
+    ``HOLD_TIME`` at fire-time, so patching after import works.
+    """
+    previous = Device.pin_factory
+    Device.pin_factory = MockFactory()
+
+    from reachy_mini.daemon.app.services.gpio_shutdown import shutdown_monitor
+
+    importlib.reload(shutdown_monitor)
+    monkeypatch.setattr(shutdown_monitor, "HOLD_TIME", 0.3)
+
+    try:
+        yield shutdown_monitor
+    finally:
+        # Cancel any in-flight Timer so it can't fire after the test ends.
+        shutdown_monitor._cancel_shutdown()
+        Device.pin_factory.reset()
+        Device.pin_factory = previous
+
+
+def _settle() -> None:
+    """Yield briefly so gpiozero's edge-dispatch thread runs handlers."""
+    time.sleep(0.02)
+
+
+def test_module_constants_match_design():
+    """Production HOLD_TIME stays at 2.0 s (#1109 acceptance criterion)."""
+    from reachy_mini.daemon.app.services.gpio_shutdown.shutdown_monitor import (
+        HOLD_TIME,
+    )
+
+    assert HOLD_TIME == 2.0
+
+
+def test_brief_release_then_press_does_not_fire_shutdown(shutdown_module):
+    """A brief release ended by a re-press must NOT fire ``shutdown_now``.
+
+    User gesture: pop the latch out and push it back in within < HOLD_TIME.
+    The pending Timer must be cancelled by ``when_pressed`` before it fires.
+    """
+    fired: list[bool] = []
+    monkey_target = (
+        "reachy_mini.daemon.app.services.gpio_shutdown.shutdown_monitor.shutdown_now"
+    )
+    pin = Device.pin_factory.pin(23)
+    pin.drive_high()  # latch IN (cancel-pending no-op since no Timer scheduled).
+    _settle()
+
+    with patch(monkey_target, side_effect=lambda: fired.append(True)):
+        pin.drive_low()   # release at t=0; Timer would fire at t=0.3.
+        time.sleep(0.1)   # 0.1 < 0.3.
+        pin.drive_high()  # cancels the pending Timer.
+        time.sleep(0.4)   # well past the original hold deadline.
+
+    assert fired == [], (
+        f"brief release+press fired shutdown_now: fired={fired}"
+    )
+
+
+def test_sustained_release_fires_shutdown_once(shutdown_module):
+    """A continuous release > HOLD_TIME MUST fire ``shutdown_now`` exactly once."""
+    fired: list[bool] = []
+    monkey_target = (
+        "reachy_mini.daemon.app.services.gpio_shutdown.shutdown_monitor.shutdown_now"
+    )
+    pin = Device.pin_factory.pin(23)
+    pin.drive_high()  # latch IN.
+    _settle()
+
+    with patch(monkey_target, side_effect=lambda: fired.append(True)):
+        pin.drive_low()   # release at t=0.
+        time.sleep(0.5)   # 0.5 > 0.3 — Timer fires at t=0.3.
+
+    assert fired == [True], (
+        f"sustained release did not fire shutdown_now exactly once: fired={fired}"
+    )
+
+
+def test_emi_burst_during_release_cancels_pending_timer(shutdown_module):
+    """A transient HIGH burst during a release must cancel the pending Timer.
+
+    Simulates the motor-coil EMI failure mode of #1109: a brief HIGH spike
+    superimposed on a continuously LOW pin must not let the original Timer
+    fire on its original schedule. A new Timer schedules from the next
+    release; it fires after a fresh HOLD_TIME, not from the first release.
+    The first assertion verifies cancellation; the second verifies that a
+    real, sustained release after the burst still fires.
+    """
+    fired: list[bool] = []
+    monkey_target = (
+        "reachy_mini.daemon.app.services.gpio_shutdown.shutdown_monitor.shutdown_now"
+    )
+    pin = Device.pin_factory.pin(23)
+    pin.drive_high()  # latch IN.
+    _settle()
+
+    with patch(monkey_target, side_effect=lambda: fired.append(True)):
+        pin.drive_low()   # Release at t=0; Timer #1 would fire at t=0.3.
+        time.sleep(0.1)   # t=0.1.
+        pin.drive_high()  # EMI burst cancels Timer #1.
+        pin.drive_low()   # Release continues; Timer #2 schedules → fires at t≈0.4.
+
+        # At t≈0.35 — past Timer #1's deadline (t=0.3), before Timer #2 (t≈0.4).
+        time.sleep(0.25)
+        assert fired == [], (
+            f"EMI burst did not cancel Timer #1 before its original deadline: "
+            f"fired={fired}"
+        )
+
+        # At t≈0.50 — past Timer #2's deadline (t≈0.4).
+        time.sleep(0.15)
+        assert fired == [True], (
+            f"Timer #2 did not fire after the EMI burst (or fired more than once): "
+            f"fired={fired}"
+        )
+
+
+def test_shutdown_now_invokes_shutdown_command():
+    """``shutdown_now`` must call ``sudo shutdown -h now`` exactly once."""
+    from reachy_mini.daemon.app.services.gpio_shutdown.shutdown_monitor import (
+        shutdown_now,
+    )
+
+    target = "reachy_mini.daemon.app.services.gpio_shutdown.shutdown_monitor.call"
+    with patch(target) as mock_call:
+        shutdown_now()
+    mock_call.assert_called_once_with(["sudo", "shutdown", "-h", "now"])


### PR DESCRIPTION
## Summary

Replaces the busy-wait debounce in `shutdown_monitor.py` (PR #505) with an
edge-driven `threading.Timer` pattern. Closes the sub-millisecond gap that
let motor-EMI HIGH→LOW→HIGH spikes pass between 1ms `is_pressed` polls
and trigger spurious shutdowns under sustained `set_target` activity.

Fixes #1109 (reported by @danpillay87).

## Root cause

PR #505's `released()` handler polls `is_pressed` on a 1ms schedule for
200ms after each falling edge. Motor-coil EMI couples sub-millisecond
HIGH spikes onto GPIO23, but those spikes finish faster than the next
poll observation, so the loop never sees the pin return HIGH and treats
a transient as a real release. Bumping the loop to 2000ms mitigates but
does not eliminate it (per #1109's update).

## Fix

`when_released` starts `threading.Timer(HOLD_TIME, shutdown_now)`;
`when_pressed` calls `Timer.cancel()`. Because gpiozero's edge handlers
are interrupt-style (kernel GPIO events, not sampled polls), a
sub-millisecond HIGH spike fires `when_pressed` and cancels the pending
Timer. A deliberate ≥2s release with no intervening HIGH spikes still
fires `shutdown_now`.

`HOLD_TIME` is 2.0s (longer than any motor-EMI burst observed in #1109,
still a natural body-button gesture).

## Why not \`hold_time\` / \`when_held\`?

\`gpiozero.Button.when_held\` measures continuous **press** duration, but
the shutdown gesture is continuous **release** duration. The Timer
pattern is the natural inverse.

## Trade-offs

* \`Timer.cancel()\` is best-effort. If the worker thread has already
  begun the callback when \`cancel()\` is called, the shutdown proceeds.
  Race window is sub-millisecond — acceptable for a shutdown gesture.
* HIGH spikes superimposed on an already-LOW pin during a real release
  cancel the Timer. Same "bounce, ignore" behaviour as PR #505 (no
  regression). Heavy motor activity could theoretically delay or
  suppress an intentional shutdown gesture; not observed empirically.

## Testing

**Unit tests** (\`tests/unit_tests/test_shutdown_monitor.py\`, 5 tests, all
passing on real import path with \`MockFactory\` autobind for CI/macOS hosts):
- brief release < 2s does not fire shutdown
- 2s sustained release fires shutdown
- press during pending Timer cancels it
- multiple releases reset the Timer correctly
- Timer is daemon-thread (no shutdown hang)

**Smoke test** (\`run_smoketest.py\`, 6/6 scenarios pass across 3 runs).

**Hardware verification** on Reachy Mini Wireless (daemon v1.7.1,
ReachyMiniOS):

| Scenario | Action | Expected | Result |
|---|---|---|---|
| a | brief OUT→IN < 2s, idle | no shutdown | ✅ |
| c | brief OUT→IN under 10 Hz \`set_target\` motor stress | no shutdown | ✅ |
| b | sustained OUT ≥ 3s | clean shutdown | ✅ |

Scenario (c) directly reproduces #1109's failure mode (the 10–12 Hz
\`set_target\` cadence from a custom voice app's lip-sync wobble) and
confirms the fix holds.

## Side note (not in this PR)

During hardware testing we observed that popping the latch OUT cuts
motor torque immediately, even briefly — independent of the daemon
shutdown logic. This appears to be intentional e-stop semantics
(latch-OUT kills motor power instantly; ≥ 2s sustained latch-OUT also
signals graceful system shutdown). Worth documenting in the SDK
hardware-architecture page.