### PR TITLE
Instrument daemon motor and readiness lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,7 +232,7 @@ __marimo__/
 __MACOSX/
 .AppleDouble
 .LSOverride
-Icon[]
+Icon\[\]
 
 # General for Linux
 *~

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ Reachy Mini robots are sold as kits and generally take **2 to 3 hours** to assem
 
 Encountering an issue? 👉 **[Check the Troubleshooting & FAQ Guide](https://huggingface.co/docs/reachy_mini/troubleshooting)**
 
+### Daemon instrumentation
+
+The daemon supports feature-flagged structured logs through `REACHY_DAEMON_INSTRUMENT`:
+
+```bash
+REACHY_DAEMON_INSTRUMENT=basic reachy-mini-daemon --log-file /tmp/reachy-daemon.jsonl
+REACHY_DAEMON_INSTRUMENT=trace reachy-mini-daemon --log-level DEBUG --log-file /tmp/reachy-daemon.jsonl
+```
+
+Modes are `off`, `basic` (default), `trace`, and `remote` (reserved for exporter work). Structured modes write one JSON object per line, which is friendly to tools like `jq`.
+
 <br>
 
 ## 🤝 Community & Contributing

--- a/docs/source/SDK/apps.md
+++ b/docs/source/SDK/apps.md
@@ -335,8 +335,33 @@ sudo journalctl -u reachy-mini-daemon --since '5 min ago' | grep -v "uvicorn\|GE
 | Problem | Solution |
 |---------|----------|
 | "An app is already running" | Stop the current app first: `curl -X POST http://localhost:8000/api/apps/stop-current-app` |
-| Daemon in a bad state | Restart it: `sudo systemctl restart reachy-mini-daemon` (wait ~30s before starting an app) |
+| Daemon in a bad state | Restart it: `sudo systemctl restart reachy-mini-daemon` |
 | App not picking up code changes | Restart the app. If you deployed manually, also clear bytecode: `rm -rf __pycache__` |
+
+### Waiting for daemon readiness on Wireless
+
+On Wireless units, `reachy-mini-daemon.service` uses systemd readiness
+notifications. `systemctl start reachy-mini-daemon.service` and units ordered
+after it do not proceed until FastAPI is serving and daemon autostart has
+completed.
+
+For Robot Comic or another systemd-launched companion service, depend on the
+daemon instead of adding fixed sleeps:
+
+```ini
+[Unit]
+Requires=reachy-mini-daemon.service
+After=reachy-mini-daemon.service
+```
+
+For scripts that are not launched by systemd, poll the daemon API and wait for
+`state` to be `running`:
+
+```bash
+until curl -sf http://reachy-mini.local:8000/api/daemon/status | grep -q '"state":"running"'; do
+  sleep 1
+done
+```
 
 ### Tip: log everything at startup
 

--- a/src/reachy_mini/daemon/app/dashboard/static/js/autostart.js
+++ b/src/reachy_mini/daemon/app/dashboard/static/js/autostart.js
@@ -1,0 +1,114 @@
+// Reachy Mini dashboard — Autostart section
+// Talks to /api/autostart/* endpoints. Vanilla JS, no framework.
+
+(() => {
+  "use strict";
+
+  const $ = (id) => document.getElementById(id);
+
+  const fb = (msg, kind) => {
+    const el = $("autostartFeedback");
+    if (!el) return;
+    el.className = "small mb-3 " + (
+      kind === "ok"   ? "text-success" :
+      kind === "err"  ? "text-danger"  :
+      kind === "warn" ? "text-warning" : "text-muted"
+    );
+    el.textContent = msg || "";
+  };
+
+  async function loadConfig() {
+    const r = await fetch("/api/autostart/config");
+    if (!r.ok) {
+      fb(`Failed to load config (${r.status})`, "err");
+      return;
+    }
+    const cfg = await r.json();
+    $("autostartEnabled").checked = !!cfg.app_autostart_enabled;
+    $("appModule").value = cfg.app_module || "";
+    $("appArgs").value = (cfg.app_args || []).join(" ");
+  }
+
+  async function loadInstalledApps() {
+    const r = await fetch("/api/autostart/installed_apps");
+    const dl = $("installedApps");
+    dl.innerHTML = "";
+    if (!r.ok) return;
+    const data = await r.json();
+    for (const app of data.apps || []) {
+      const opt = document.createElement("option");
+      opt.value = app.suggested_module;
+      opt.label = `${app.name} ${app.version}`;
+      dl.appendChild(opt);
+    }
+  }
+
+  async function loadStatus() {
+    try {
+      const [s, d] = await Promise.all([
+        fetch("/api/autostart/service_status").then(r => r.json()),
+        fetch("/api/autostart/daemon_autostart_status").then(r => r.json()),
+      ]);
+      $("serviceActive").textContent  = s.active  || "unknown";
+      $("serviceEnabled").textContent = s.enabled || "unknown";
+      $("daemonEnabled").textContent  = d.enabled || "unknown";
+    } catch (e) {
+      $("serviceActive").textContent  = "error";
+      $("serviceEnabled").textContent = "error";
+      $("daemonEnabled").textContent  = "error";
+    }
+  }
+
+  async function save() {
+    const moduleVal = $("appModule").value.trim();
+    const argsVal   = $("appArgs").value.trim();
+    const enabled   = $("autostartEnabled").checked;
+
+    // Friendly client-side guard: enabling autostart with no module is
+    // almost certainly a mistake.
+    if (enabled && !moduleVal) {
+      fb("Enable autostart but no app module specified — pick or type one.", "warn");
+      return;
+    }
+
+    const cfg = {
+      app_autostart_enabled: enabled,
+      app_module: moduleVal || null,
+      app_args:   argsVal ? argsVal.split(/\s+/) : [],
+    };
+
+    fb("Saving…");
+    const r = await fetch("/api/autostart/config", {
+      method:  "POST",
+      headers: { "Content-Type": "application/json" },
+      body:    JSON.stringify(cfg),
+    });
+
+    if (!r.ok) {
+      const text = await r.text();
+      fb(`Save failed: ${text}`, "err");
+      return;
+    }
+    fb("Saved. Will take effect on the next boot.", "ok");
+    await loadStatus();
+  }
+
+  async function init() {
+    // Only run if the autostart section is present
+    if (!$("autostartEnabled")) return;
+    await Promise.all([loadInstalledApps(), loadConfig(), loadStatus()]);
+
+    $("autostartSave").addEventListener("click", save);
+    $("autostartReload").addEventListener("click", async () => {
+      fb("Reloading…");
+      await Promise.all([loadConfig(), loadStatus()]);
+      fb("Reloaded.", "ok");
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/src/reachy_mini/daemon/app/dashboard/templates/index.html
+++ b/src/reachy_mini/daemon/app/dashboard/templates/index.html
@@ -7,6 +7,7 @@
     {% include "sections/apps.html" %}
     {% include "sections/appstore.html" %}
     {% include "sections/notification.html" %}
+    {% include "sections/autostart.html" %}
 </div>
 {% endblock %}
 

--- a/src/reachy_mini/daemon/app/dashboard/templates/sections/autostart.html
+++ b/src/reachy_mini/daemon/app/dashboard/templates/sections/autostart.html
@@ -1,0 +1,94 @@
+{# src/reachy_mini/daemon/app/dashboard/templates/sections/autostart.html
+   Include from the main dashboard template alongside other sections. #}
+
+<section class="card autostart-section" id="section-autostart">
+  <header class="card-header">
+    <h3>App Autostart</h3>
+    <p class="text-muted small">
+      Have a chosen app launch automatically when the robot powers on.
+      Changes take effect on the next boot.
+    </p>
+  </header>
+
+  <div class="card-body">
+
+    <div class="form-check form-switch mb-3">
+      <input class="form-check-input" type="checkbox" id="autostartEnabled">
+      <label class="form-check-label" for="autostartEnabled">
+        Auto-start an app at boot
+      </label>
+    </div>
+
+    <div class="mb-3">
+      <label for="appModule" class="form-label">App to start</label>
+      <input list="installedApps"
+             class="form-control"
+             id="appModule"
+             autocomplete="off"
+             spellcheck="false"
+             placeholder="e.g. reachy_mini_conversation_app.main">
+      <datalist id="installedApps"></datalist>
+      <div class="form-text">
+        Python module path. The launcher runs
+        <code>/venvs/apps_venv/bin/python -u -m &lt;module&gt;</code>.
+      </div>
+    </div>
+
+    <div class="mb-3">
+      <label for="appArgs" class="form-label">Arguments <span class="text-muted">(optional)</span></label>
+      <input class="form-control"
+             id="appArgs"
+             autocomplete="off"
+             spellcheck="false"
+             placeholder="--no-camera --gradio">
+      <div class="form-text">Space-separated. No shell quoting.</div>
+    </div>
+
+    <div class="d-flex gap-2 mb-3">
+      <button class="btn btn-primary" id="autostartSave" type="button">Save</button>
+      <button class="btn btn-outline-secondary" id="autostartReload" type="button"
+              title="Reload config from disk">
+        Reload
+      </button>
+    </div>
+
+    <div id="autostartFeedback" class="small mb-3" aria-live="polite"></div>
+
+    <hr>
+
+    <div class="autostart-status small text-muted">
+      <div>
+        Autostart service:
+        <code id="serviceActive">…</code>
+        <span class="mx-1">·</span>
+        <code id="serviceEnabled">…</code>
+      </div>
+      <div>
+        Daemon autostart:
+        <code id="daemonEnabled">…</code>
+      </div>
+    </div>
+
+    <details class="mt-3">
+      <summary class="text-muted small">
+        Disable daemon autostart (advanced — out-of-the-box mode)
+      </summary>
+      <div class="small mt-2">
+        <p>
+          To return the robot to factory boot behavior (no daemon, no apps),
+          SSH in and run:
+        </p>
+        <pre><code>sudo systemctl disable reachy-mini-daemon.service</code></pre>
+        <p>Re-enable with:</p>
+        <pre><code>sudo systemctl enable --now reachy-mini-daemon.service</code></pre>
+        <p class="text-muted">
+          We do not expose this as a UI toggle because disabling the daemon
+          also disables this dashboard.
+        </p>
+      </div>
+    </details>
+
+  </div>
+</section>
+
+<script src="/static/js/autostart.js" defer></script>

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -10,6 +10,7 @@ managing the robot's state.
 import argparse
 import asyncio
 import logging
+import sys
 import types
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -26,7 +27,6 @@ from fastapi.templating import Jinja2Templates
 from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.app.routers import (
     apps,
-    autostart,
     camera,
     daemon,
     hf_auth,
@@ -40,6 +40,7 @@ from reachy_mini.daemon.app.routers import (
     volume,
 )
 from reachy_mini.daemon.daemon import Daemon
+from reachy_mini.daemon.instrumentation import configure_daemon_logging, timing_event
 from reachy_mini.daemon.utils import SimulationMode
 from reachy_mini.media.audio_utils import (
     check_reachymini_asoundrc,
@@ -151,23 +152,31 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
             )
 
         try:
-            if args.autostart:
-                await app.state.daemon.start(
-                    serialport=args.serialport,
-                    sim=args.sim,
-                    mockup_sim=args.mockup_sim,
-                    scene=args.scene,
-                    headless=args.headless,
-                    use_audio=not args.no_media,
-                    kinematics_engine=args.kinematics_engine,
-                    check_collision=args.check_collision,
-                    wake_up_on_start=args.wake_up_on_start,
-                    localhost_only=localhost_only,
-                    hardware_config_filepath=args.hardware_config_filepath,
-                )
+            with timing_event(
+                "fastapi.lifespan.startup",
+                autostart=args.autostart,
+                wireless_version=args.wireless_version,
+                no_media=args.no_media,
+            ):
+                if args.autostart:
+                    with timing_event("daemon.autostart"):
+                        await app.state.daemon.start(
+                            serialport=args.serialport,
+                            sim=args.sim,
+                            mockup_sim=args.mockup_sim,
+                            scene=args.scene,
+                            headless=args.headless,
+                            use_audio=not args.no_media,
+                            kinematics_engine=args.kinematics_engine,
+                            check_collision=args.check_collision,
+                            wake_up_on_start=args.wake_up_on_start,
+                            localhost_only=localhost_only,
+                            hardware_config_filepath=args.hardware_config_filepath,
+                        )
 
-            # Register mDNS service only after the daemon is ready
-            mdns.register()
+                # Register mDNS service only after the daemon is ready
+                with timing_event("daemon.mdns.register", robot_name=args.robot_name):
+                    mdns.register()
 
             yield
         finally:
@@ -237,7 +246,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
     router.include_router(volume.router)
 
     if args.wireless_version:
-        from .routers import cache, update, wifi_config, autostart
+        from .routers import autostart, cache, update, wifi_config
 
         app.include_router(autostart.router)
         app.include_router(cache.router)
@@ -293,18 +302,9 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
 
 def run_app(args: Args) -> None:
     """Run the FastAPI app with Uvicorn."""
-    # Configure logging to ensure all logs go to stderr (captured by systemd)
-    import sys
-
+    # Configure logging to ensure all logs go to stderr (captured by systemd).
+    configure_daemon_logging(args.log_level, args.log_file)
     root_logger = logging.getLogger()
-    root_logger.setLevel(args.log_level)
-
-    # Create handler that writes to stderr with immediate flush
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setLevel(args.log_level)
-    handler.setFormatter(logging.Formatter("%(name)s - %(levelname)s - %(message)s"))
-    root_logger.handlers.clear()
-    root_logger.addHandler(handler)
 
     # Explicitly configure the apps.manager logger to ensure propagation
     apps_logger = logging.getLogger("reachy_mini.apps.manager")
@@ -617,14 +617,6 @@ def main() -> None:
     )
 
     args = parser.parse_args()
-
-    if args.log_file:
-        file_handler = logging.FileHandler(args.log_file, mode="a")
-        file_handler.setFormatter(
-            logging.Formatter("%(name)s - %(levelname)s - %(message)s")
-        )
-        logging.getLogger().addHandler(file_handler)
-        logging.getLogger().setLevel(args.log_level)
 
     if args.wireless_version:
         # Check and fix ownership of /venvs directory

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -41,7 +41,9 @@ from reachy_mini.daemon.app.routers import (
 )
 from reachy_mini.daemon.daemon import Daemon
 from reachy_mini.daemon.instrumentation import configure_daemon_logging, timing_event
+from reachy_mini.daemon.systemd import SystemdNotifier
 from reachy_mini.daemon.utils import SimulationMode
+from reachy_mini.io.protocol import DaemonState
 from reachy_mini.media.audio_utils import (
     check_reachymini_asoundrc,
     write_asoundrc_to_home,
@@ -97,7 +99,11 @@ class Args:
     localhost_only: bool | None = None
 
 
-def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> FastAPI:
+def create_app(
+    args: Args,
+    health_check_event: asyncio.Event | None = None,
+    systemd_notifier: SystemdNotifier | None = None,
+) -> FastAPI:
     """Create and configure the FastAPI application."""
     localhost_only = (
         args.localhost_only
@@ -159,6 +165,8 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                 no_media=args.no_media,
             ):
                 if args.autostart:
+                    if systemd_notifier:
+                        systemd_notifier.status("Starting Reachy Mini backend")
                     with timing_event("daemon.autostart"):
                         await app.state.daemon.start(
                             serialport=args.serialport,
@@ -175,12 +183,16 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                         )
 
                 # Register mDNS service only after the daemon is ready
+                if systemd_notifier:
+                    systemd_notifier.status("Registering Reachy Mini mDNS service")
                 with timing_event("daemon.mdns.register", robot_name=args.robot_name):
                     mdns.register()
 
             yield
         finally:
             # Cancel dataset updater task if running
+            if systemd_notifier:
+                systemd_notifier.stopping()
             if dataset_updater_task and not dataset_updater_task.done():
                 dataset_updater_task.cancel()
                 try:
@@ -305,6 +317,8 @@ def run_app(args: Args) -> None:
     # Configure logging to ensure all logs go to stderr (captured by systemd).
     configure_daemon_logging(args.log_level, args.log_file)
     root_logger = logging.getLogger()
+    systemd_notifier = SystemdNotifier.from_environment()
+    systemd_notifier.status("Starting Reachy Mini daemon process")
 
     # Explicitly configure the apps.manager logger to ensure propagation
     apps_logger = logging.getLogger("reachy_mini.apps.manager")
@@ -364,7 +378,7 @@ def run_app(args: Args) -> None:
         loop.set_exception_handler(asyncio_exception_handler)
 
         health_check_event = asyncio.Event()
-        app = create_app(args, health_check_event)
+        app = create_app(args, health_check_event, systemd_notifier)
 
         config = uvicorn.Config(
             app,
@@ -375,6 +389,8 @@ def run_app(args: Args) -> None:
         server = uvicorn.Server(config)
 
         health_check_task = None
+        readiness_task: asyncio.Task[None] | None = None
+        watchdog_task: asyncio.Task[None] | None = None
 
         async def health_check_timeout(timeout_seconds: float) -> None:
             while True:
@@ -393,6 +409,22 @@ def run_app(args: Args) -> None:
                     break
 
         try:
+            async def notify_when_serving() -> None:
+                while not server.started and not server.should_exit:
+                    await asyncio.sleep(0.05)
+                if server.started:
+                    daemon_status = app.state.daemon.status()
+                    if args.autostart and daemon_status.state != DaemonState.RUNNING:
+                        systemd_notifier.status(
+                            f"Daemon startup failed: {daemon_status.state.value}"
+                        )
+                        return
+                    systemd_notifier.ready(
+                        "FastAPI serving; Reachy Mini daemon startup complete"
+                    )
+
+            readiness_task = asyncio.create_task(notify_when_serving())
+            watchdog_task = asyncio.create_task(systemd_notifier.watchdog_loop())
             if args.timeout_health_check is not None:
                 health_check_task = asyncio.create_task(
                     health_check_timeout(args.timeout_health_check)
@@ -404,6 +436,14 @@ def run_app(args: Args) -> None:
             logger.exception(f"Error during server operation: {e}")
             raise
         finally:
+            systemd_notifier.stopping()
+            for task in (readiness_task, watchdog_task):
+                if task and not task.done():
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
             # Cancel health check task if it exists
             if health_check_task and not health_check_task.done():
                 health_check_task.cancel()
@@ -619,6 +659,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.wireless_version:
+        SystemdNotifier.from_environment().status("Running wireless startup checks")
         # Check and fix ownership of /venvs directory
         check_and_fix_venvs_ownership(custom_logger=logging.getLogger())
 

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -26,6 +26,7 @@ from fastapi.templating import Jinja2Templates
 from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.app.routers import (
     apps,
+    autostart,
     camera,
     daemon,
     hf_auth,
@@ -224,6 +225,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
 
     router = APIRouter(prefix="/api")
     router.include_router(apps.router)
+    #router.include_router(autostart.router)
     router.include_router(camera.router)
     router.include_router(daemon.router)
     router.include_router(hf_auth.router)
@@ -235,8 +237,9 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
     router.include_router(volume.router)
 
     if args.wireless_version:
-        from .routers import cache, update, wifi_config
+        from .routers import cache, update, wifi_config, autostart
 
+        app.include_router(autostart.router)
         app.include_router(cache.router)
         app.include_router(logs.router)
         app.include_router(update.router)

--- a/src/reachy_mini/daemon/app/routers/autostart.py
+++ b/src/reachy_mini/daemon/app/routers/autostart.py
@@ -1,0 +1,187 @@
+"""Autostart configuration router.
+
+Exposes a small REST surface for the dashboard to read/write the app
+autostart configuration and view related service status.
+
+Add to the daemon app:
+    from .routers import autostart
+    app.include_router(autostart.router)
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+
+CONFIG_PATH = Path("/etc/reachy-mini/autostart.json")
+APPS_VENV_PIP = "/venvs/apps_venv/bin/pip"
+APPS_VENV_PYTHON = "/venvs/apps_venv/bin/python"
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "app_autostart_enabled": False,
+    "app_module": None,
+    "app_args": [],
+}
+
+
+class AutostartConfig(BaseModel):
+    """Body for POST /api/autostart/config."""
+
+    app_autostart_enabled: bool
+    app_module: str | None = None
+    app_args: list[str] = Field(default_factory=list)
+
+    @field_validator("app_module")
+    @classmethod
+    def _validate_module(cls, v: str | None) -> str | None:
+        if v is None or v == "":
+            return None
+        # Defensive: allow only Python module path characters.
+        # No shell metachars, slashes, etc. — even though the launcher uses
+        # exec rather than shell, keeping this tight is a useful guardrail.
+        allowed = set(
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_."
+        )
+        if not all(ch in allowed for ch in v):
+            raise ValueError(
+                "app_module must contain only [A-Za-z0-9_.] (Python module path)"
+            )
+        return v
+
+
+router = APIRouter(prefix="/api/autostart", tags=["autostart"])
+
+
+def _read_config() -> dict[str, Any]:
+    if not CONFIG_PATH.exists():
+        return DEFAULT_CONFIG.copy()
+    try:
+        data = json.loads(CONFIG_PATH.read_text())
+    except json.JSONDecodeError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Autostart config is malformed: {e}",
+        )
+    # Merge over defaults so missing keys are filled in
+    merged = DEFAULT_CONFIG.copy()
+    merged.update(data)
+    return merged
+
+
+def _write_config(cfg: dict[str, Any]) -> None:
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = CONFIG_PATH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(cfg, indent=2) + "\n")
+    tmp.replace(CONFIG_PATH)
+
+
+def _systemctl(*args: str) -> tuple[int, str, str]:
+    """Run systemctl with the given args; never raises."""
+    if not shutil.which("systemctl"):
+        return 1, "", "systemctl not found"
+    try:
+        proc = subprocess.run(
+            ["systemctl", *args], capture_output=True, text=True, timeout=5
+        )
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 1, "", "systemctl timed out"
+
+
+# ─── endpoints ────────────────────────────────────────────────────────────
+
+@router.get("/config")
+def get_config() -> dict[str, Any]:
+    """Return the current autostart configuration."""
+    return _read_config()
+
+
+@router.post("/config")
+def set_config(cfg: AutostartConfig) -> dict[str, Any]:
+    """Write the autostart configuration. Takes effect on next boot."""
+    new = cfg.model_dump()
+    _write_config(new)
+    return new
+
+
+@router.get("/installed_apps")
+def list_installed_apps() -> dict[str, Any]:
+    """Best-effort enumeration of likely-Reachy-app packages in apps_venv.
+
+    Heuristic only: returns packages whose name contains 'reachy' or that
+    declare a dependency on `reachy_mini`. Users can also free-text any
+    Python module path via the dashboard.
+    """
+    if not Path(APPS_VENV_PIP).exists():
+        return {"apps": [], "error": f"{APPS_VENV_PIP} not found"}
+    try:
+        proc = subprocess.run(
+            [APPS_VENV_PIP, "list", "--format=json"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except subprocess.TimeoutExpired:
+        return {"apps": [], "error": "pip list timed out"}
+
+    if proc.returncode != 0:
+        return {"apps": [], "error": proc.stderr.strip()[:200]}
+
+    try:
+        all_pkgs = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {"apps": [], "error": "could not parse pip output"}
+
+    apps: list[dict[str, str]] = []
+    for p in all_pkgs:
+        name = p.get("name", "")
+        version = p.get("version", "")
+        lname = name.lower()
+        if "reachy" not in lname and "robot" not in lname:
+            continue
+        # Skip the SDK itself
+        if lname in ("reachy-mini", "reachy_mini"):
+            continue
+        # Best-guess module: package name with - → _
+        guessed_module = name.replace("-", "_")
+        apps.append(
+            {
+                "name": name,
+                "version": version,
+                "suggested_module": f"{guessed_module}.main",
+            }
+        )
+    return {"apps": apps}
+
+
+@router.get("/service_status")
+def service_status() -> dict[str, Any]:
+    """Active/enabled state of reachy-app-autostart.service."""
+    rc_active, active, _ = _systemctl("is-active", "reachy-app-autostart.service")
+    rc_enabled, enabled, _ = _systemctl(
+        "is-enabled", "reachy-app-autostart.service"
+    )
+    return {
+        "active": active,
+        "active_ok": rc_active == 0,
+        "enabled": enabled,
+        "enabled_ok": rc_enabled == 0,
+    }
+
+
+@router.get("/daemon_autostart_status")
+def daemon_autostart_status() -> dict[str, Any]:
+    """Whether reachy-mini-daemon.service is enabled at boot.
+
+    We expose this read-only — disabling the daemon is documented as an
+    SSH operation in the dashboard UI to avoid the footgun of disabling
+    the very service that serves the dashboard.
+    """
+    rc, enabled, _ = _systemctl("is-enabled", "reachy-mini-daemon.service")
+    return {"enabled": enabled, "ok": rc == 0}

--- a/src/reachy_mini/daemon/app/routers/motors.py
+++ b/src/reachy_mini/daemon/app/routers/motors.py
@@ -6,6 +6,7 @@ Provides endpoints to get and set the motor control mode.
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
+from reachy_mini.daemon.instrumentation import log_event, timing_event
 from reachy_mini.io.protocol import MotorControlMode
 
 from ....daemon.backend.abstract import Backend
@@ -38,6 +39,24 @@ async def set_motor_mode(
     backend: Backend = Depends(get_backend),
 ) -> dict[str, str]:
     """Set the motor control mode."""
-    backend.set_motor_control_mode(mode)
+    log_event(
+        "daemon.motor.mode.set.start",
+        source="rest",
+        endpoint="/api/motors/set_mode/{mode}",
+        mode=mode.value,
+    )
+    with timing_event(
+        "daemon.motor.mode.set",
+        source="rest",
+        endpoint="/api/motors/set_mode/{mode}",
+        mode=mode.value,
+    ):
+        backend.set_motor_control_mode(mode)
+    log_event(
+        "daemon.motor.mode.set.complete",
+        source="rest",
+        endpoint="/api/motors/set_mode/{mode}",
+        mode=mode.value,
+    )
 
     return {"status": f"motors changed to {mode} mode"}

--- a/src/reachy_mini/daemon/app/routers/move.py
+++ b/src/reachy_mini/daemon/app/routers/move.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisco
 from huggingface_hub.errors import RepositoryNotFoundError
 from pydantic import BaseModel
 
+from reachy_mini.daemon.instrumentation import log_event, timing_event
 from reachy_mini.motion.recorded_move import RecordedMoves
 from reachy_mini.utils.interpolation import InterpolationTechnique
 
@@ -152,13 +153,35 @@ async def goto(
 @router.post("/play/wake_up")
 async def play_wake_up(backend: Backend = Depends(get_backend)) -> MoveUUID:
     """Request the robot to wake up."""
-    return create_move_task(backend.wake_up())
+
+    async def instrumented_wake_up() -> None:
+        log_event("daemon.wake_up.start", source="rest")
+        try:
+            with timing_event("daemon.wake_up", source="rest"):
+                await backend.wake_up()
+        except Exception as e:
+            log_event("daemon.wake_up.error", source="rest", error=str(e))
+            raise
+        log_event("daemon.wake_up.complete", source="rest")
+
+    return create_move_task(instrumented_wake_up())
 
 
 @router.post("/play/goto_sleep")
 async def play_goto_sleep(backend: Backend = Depends(get_backend)) -> MoveUUID:
     """Request the robot to go to sleep."""
-    return create_move_task(backend.goto_sleep())
+
+    async def instrumented_goto_sleep() -> None:
+        log_event("daemon.goto_sleep.start", source="rest")
+        try:
+            with timing_event("daemon.goto_sleep", source="rest"):
+                await backend.goto_sleep()
+        except Exception as e:
+            log_event("daemon.goto_sleep.error", source="rest", error=str(e))
+            raise
+        log_event("daemon.goto_sleep.complete", source="rest")
+
+    return create_move_task(instrumented_goto_sleep())
 
 
 @router.get("/recorded-move-datasets/list/{dataset_name:path}")

--- a/src/reachy_mini/daemon/app/services/wireless/launcher.sh
+++ b/src/reachy_mini/daemon/app/services/wireless/launcher.sh
@@ -6,5 +6,6 @@ export PATH=$PATH:/opt/uv
 # Ensure WiFi is not soft-blocked (can happen after a crash or kernel module reload)
 sudo rfkill unblock wifi
 
-# Run Python in unbuffered mode (-u) to ensure logs are immediately forwarded to systemd
-python -u -m reachy_mini.daemon.app.main --wireless-version --no-wake-up-on-start
+# Run Python in unbuffered mode (-u) to ensure logs are immediately forwarded to systemd.
+# exec makes Python the systemd main process for Type=notify and watchdog heartbeats.
+exec python -u -m reachy_mini.daemon.app.main --wireless-version --no-wake-up-on-start

--- a/src/reachy_mini/daemon/app/services/wireless/reachy-mini-daemon.service
+++ b/src/reachy_mini/daemon/app/services/wireless/reachy-mini-daemon.service
@@ -4,10 +4,12 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
 ExecStart=/venvs/mini_daemon/lib/python3.12/site-packages/reachy_mini/daemon/app/services/wireless/launcher.sh
 Restart=on-failure
 RestartSec=3s
+WatchdogSec=30s
 User=pollen
 WorkingDirectory=/venvs/mini_daemon/lib/python3.12/site-packages/reachy_mini/daemon/app/services/wireless
 

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -22,6 +22,7 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.spatial.transform import Rotation as R
 
+from reachy_mini.daemon.instrumentation import log_event, timing_event
 from reachy_mini.io.protocol import (
     AnyCommand,
     AppendRecordCmd,
@@ -941,16 +942,46 @@ class Backend:
             send_response({"status": "ok", "command": "play_sound"})
 
         elif isinstance(cmd, SetMotorModeCmd):
-            self.set_motor_control_mode(MotorControlMode(cmd.mode))
+            mode = MotorControlMode(cmd.mode)
+            log_event(
+                "daemon.motor.mode.set.start",
+                source="command",
+                command="set_motor_mode",
+                mode=mode.value,
+            )
+            with timing_event(
+                "daemon.motor.mode.set",
+                source="command",
+                command="set_motor_mode",
+                mode=mode.value,
+            ):
+                self.set_motor_control_mode(mode)
+            log_event(
+                "daemon.motor.mode.set.complete",
+                source="command",
+                command="set_motor_mode",
+                mode=mode.value,
+            )
             send_response({"motor_mode": cmd.mode, "status": "ok"})
 
         elif isinstance(cmd, SetTorqueCmd):
+            requested_mode = None
             if cmd.ids is not None:
                 self.set_motor_torque_ids(cmd.ids, cmd.on)
             elif cmd.on:
+                requested_mode = MotorControlMode.Enabled
                 self.set_motor_control_mode(MotorControlMode.Enabled)
             else:
+                requested_mode = MotorControlMode.Disabled
                 self.set_motor_control_mode(MotorControlMode.Disabled)
+            log_event(
+                "daemon.motor.torque.set",
+                source="command",
+                command="set_torque",
+                ids=cmd.ids,
+                on=cmd.on,
+                mode=requested_mode.value if requested_mode else None,
+            )
             send_response({"status": "ok", "command": "set_torque"})
 
         elif isinstance(cmd, GetMotorModeCmd):
@@ -959,9 +990,28 @@ class Backend:
         elif isinstance(cmd, SetGravityCompensationCmd):
             try:
                 if cmd.enabled:
-                    self.set_motor_control_mode(MotorControlMode.GravityCompensation)
+                    mode = MotorControlMode.GravityCompensation
                 else:
-                    self.set_motor_control_mode(MotorControlMode.Enabled)
+                    mode = MotorControlMode.Enabled
+                log_event(
+                    "daemon.motor.mode.set.start",
+                    source="command",
+                    command="set_gravity_compensation",
+                    mode=mode.value,
+                )
+                with timing_event(
+                    "daemon.motor.mode.set",
+                    source="command",
+                    command="set_gravity_compensation",
+                    mode=mode.value,
+                ):
+                    self.set_motor_control_mode(mode)
+                log_event(
+                    "daemon.motor.mode.set.complete",
+                    source="command",
+                    command="set_gravity_compensation",
+                    mode=mode.value,
+                )
             except ValueError as e:
                 send_response({"error": str(e), "command": "set_gravity_compensation"})
                 return
@@ -1079,9 +1129,13 @@ class Backend:
     ) -> None:
         """Execute wake_up and send response when done."""
         try:
-            await self.wake_up()
+            log_event("daemon.wake_up.start", source="command")
+            with timing_event("daemon.wake_up", source="command"):
+                await self.wake_up()
+            log_event("daemon.wake_up.complete", source="command")
             send_response({"status": "ok", "command": "wake_up", "completed": True})
         except Exception as e:
+            log_event("daemon.wake_up.error", source="command", error=str(e))
             send_response({"error": str(e), "command": "wake_up"})
 
     async def _async_goto_sleep(
@@ -1089,9 +1143,13 @@ class Backend:
     ) -> None:
         """Execute goto_sleep and send response when done."""
         try:
-            await self.goto_sleep()
+            log_event("daemon.goto_sleep.start", source="command")
+            with timing_event("daemon.goto_sleep", source="command"):
+                await self.goto_sleep()
+            log_event("daemon.goto_sleep.complete", source="command")
             send_response({"status": "ok", "command": "goto_sleep", "completed": True})
         except Exception as e:
+            log_event("daemon.goto_sleep.error", source="command", error=str(e))
             send_response({"error": str(e), "command": "goto_sleep"})
 
     # ------------------------------------------------------------------

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -12,6 +12,7 @@ from importlib.metadata import PackageNotFoundError, version
 from threading import Event, Thread
 from typing import Any, Optional
 
+from reachy_mini.daemon.instrumentation import timing_event
 from reachy_mini.daemon.robot_app_lock import RobotAppLock
 from reachy_mini.daemon.utils import (
     SimulationMode,
@@ -261,80 +262,98 @@ class Daemon:
         self._status.state = DaemonState.STARTING
 
         try:
-            self.backend = self._setup_backend(
+            backend_mode = "mockup" if mockup_sim else "mujoco" if sim else "robot"
+            with timing_event(
+                "daemon.start",
+                backend_mode=backend_mode,
                 wireless_version=self.wireless_version,
-                sim=sim,
-                mockup_sim=mockup_sim,
-                serialport=serialport,
-                scene=scene,
-                check_collision=check_collision,
-                kinematics_engine=kinematics_engine,
-                headless=headless,
-                use_audio=effective_use_audio,
-                hardware_config_filepath=hardware_config_filepath,
-            )
-
-            self.ws_server = WSServer(backend=self.backend)
-            self.ws_server.start()
-            self._thread_publish_status = Thread(
-                target=self._publish_status, daemon=True
-            )
-            self._thread_publish_status.start()
-
-            def backend_wrapped_run() -> None:
-                assert self.backend is not None, (
-                    "Backend should be initialized before running."
+                no_media=self.no_media,
+                wake_up_on_start=wake_up_on_start,
+            ):
+                self.backend = self._setup_backend(
+                    wireless_version=self.wireless_version,
+                    sim=sim,
+                    mockup_sim=mockup_sim,
+                    serialport=serialport,
+                    scene=scene,
+                    check_collision=check_collision,
+                    kinematics_engine=kinematics_engine,
+                    headless=headless,
+                    use_audio=effective_use_audio,
+                    hardware_config_filepath=hardware_config_filepath,
                 )
 
-                try:
-                    self.backend.wrapped_run()
-                except Exception as e:
-                    self.logger.error(f"Backend encountered an error: {e}")
+                with timing_event("daemon.websocket.start", backend_mode=backend_mode):
+                    self.ws_server = WSServer(backend=self.backend)
+                    self.ws_server.start()
+                with timing_event("daemon.status_publisher.start"):
+                    self._thread_publish_status = Thread(
+                        target=self._publish_status, daemon=True
+                    )
+                    self._thread_publish_status.start()
+
+                def backend_wrapped_run() -> None:
+                    assert self.backend is not None, (
+                        "Backend should be initialized before running."
+                    )
+
+                    try:
+                        self.backend.wrapped_run()
+                    except Exception as e:
+                        self.logger.error(f"Backend encountered an error: {e}")
+                        self._status.state = DaemonState.ERROR
+                        self._status.error = str(e)
+                        if self.ws_server is not None:
+                            self.ws_server.stop()
+                        self.backend = None
+
+                with timing_event("daemon.backend.thread.start", backend_mode=backend_mode):
+                    self.backend_run_thread = Thread(target=backend_wrapped_run)
+                    self.backend_run_thread.start()
+
+                with timing_event("daemon.backend.ready.wait", backend_mode=backend_mode, timeout_s=2.0):
+                    backend_ready = self.backend.ready.wait(timeout=2.0)
+                if not backend_ready:
+                    self.logger.error(
+                        "Backend is not ready after 2 seconds. Some error occurred."
+                    )
                     self._status.state = DaemonState.ERROR
-                    self._status.error = str(e)
-                    if self.ws_server is not None:
-                        self.ws_server.stop()
-                    self.backend = None
-
-            self.backend_run_thread = Thread(target=backend_wrapped_run)
-            self.backend_run_thread.start()
-
-            if not self.backend.ready.wait(timeout=2.0):
-                self.logger.error(
-                    "Backend is not ready after 2 seconds. Some error occurred."
-                )
-                self._status.state = DaemonState.ERROR
-                self._status.error = self.backend.error
-                return self._status.state
-
-            if self._media_server and not self._media_released:
-                if self.backend is not None:
-                    self.backend.setup_media_server(self._media_server)
-                self._media_server.start()
-
-                # Start central signaling relay for remote WebRTC access
-                await self._start_central_signaling_relay()
-
-            if wake_up_on_start:
-                try:
-                    self.logger.info("Waking up Reachy Mini...")
-                    self.backend.set_motor_control_mode(MotorControlMode.Enabled)
-                    await self.backend.wake_up()
-                except Exception as e:
-                    self.logger.error(f"Error while waking up Reachy Mini: {e}")
-                    self._status.state = DaemonState.ERROR
-                    self._status.error = str(e)
-                    return self._status.state
-                except KeyboardInterrupt:
-                    self.logger.warning("Wake up interrupted by user.")
-                    self._status.state = DaemonState.STOPPING
+                    self._status.error = self.backend.error
                     return self._status.state
 
-            if self._status.state != DaemonState.ERROR:
-                self.logger.info("Daemon started successfully.")
-                self._status.state = DaemonState.RUNNING
-            else:
-                self.logger.error("Daemon started with errors.")
+                if self._media_server and not self._media_released:
+                    if self.backend is not None:
+                        with timing_event("daemon.media.attach", backend_mode=backend_mode):
+                            self.backend.setup_media_server(self._media_server)
+                    with timing_event("daemon.media.start", backend_mode=backend_mode):
+                        self._media_server.start()
+
+                    # Start central signaling relay for remote WebRTC access
+                    with timing_event("daemon.central_relay.start"):
+                        await self._start_central_signaling_relay()
+
+                if wake_up_on_start:
+                    try:
+                        self.logger.info("Waking up Reachy Mini...")
+                        with timing_event("daemon.motor.enable", reason="wake_up_on_start"):
+                            self.backend.set_motor_control_mode(MotorControlMode.Enabled)
+                        with timing_event("daemon.wake_up"):
+                            await self.backend.wake_up()
+                    except Exception as e:
+                        self.logger.error(f"Error while waking up Reachy Mini: {e}")
+                        self._status.state = DaemonState.ERROR
+                        self._status.error = str(e)
+                        return self._status.state
+                    except KeyboardInterrupt:
+                        self.logger.warning("Wake up interrupted by user.")
+                        self._status.state = DaemonState.STOPPING
+                        return self._status.state
+
+                if self._status.state != DaemonState.ERROR:
+                    self.logger.info("Daemon started successfully.")
+                    self._status.state = DaemonState.RUNNING
+                else:
+                    self.logger.error("Daemon started with errors.")
 
         except Exception as e:
             self._status.state = DaemonState.ERROR
@@ -551,22 +570,25 @@ class Daemon:
         reflash_motors_on_start: bool = True,
     ) -> "RobotBackend | MujocoBackend | MockupSimBackend":
         if mockup_sim:
-            return MockupSimBackend(
-                check_collision=check_collision,
-                kinematics_engine=kinematics_engine,
-                use_audio=use_audio,
-            )
+            with timing_event("daemon.backend.construct", backend_mode="mockup"):
+                return MockupSimBackend(
+                    check_collision=check_collision,
+                    kinematics_engine=kinematics_engine,
+                    use_audio=use_audio,
+                )
         elif sim:
-            return MujocoBackend(
-                scene=scene,
-                check_collision=check_collision,
-                kinematics_engine=kinematics_engine,
-                headless=headless,
-                use_audio=use_audio,
-            )
+            with timing_event("daemon.backend.construct", backend_mode="mujoco"):
+                return MujocoBackend(
+                    scene=scene,
+                    check_collision=check_collision,
+                    kinematics_engine=kinematics_engine,
+                    headless=headless,
+                    use_audio=use_audio,
+                )
         else:
             if serialport == "auto":
-                ports = find_serial_port(wireless_version=wireless_version)
+                with timing_event("daemon.serial_port.discover", wireless_version=wireless_version):
+                    ports = find_serial_port(wireless_version=wireless_version)
 
                 if len(ports) == 0:
                     raise RuntimeError(
@@ -588,14 +610,16 @@ class Daemon:
             )
 
             if reflash_motors_on_start:
-                reflash_motors_if_needed(serialport, dont_light_up=True)
+                with timing_event("daemon.motors.reflash_check"):
+                    reflash_motors_if_needed(serialport, dont_light_up=True)
 
-            return RobotBackend(
-                serialport=serialport,
-                log_level=self.log_level,
-                check_collision=check_collision,
-                kinematics_engine=kinematics_engine,
-                use_audio=use_audio,
-                wireless_version=wireless_version,
-                hardware_config_filepath=hardware_config_filepath,
-            )
+            with timing_event("daemon.backend.construct", backend_mode="robot"):
+                return RobotBackend(
+                    serialport=serialport,
+                    log_level=self.log_level,
+                    check_collision=check_collision,
+                    kinematics_engine=kinematics_engine,
+                    use_audio=use_audio,
+                    wireless_version=wireless_version,
+                    hardware_config_filepath=hardware_config_filepath,
+                )

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -12,7 +12,7 @@ from importlib.metadata import PackageNotFoundError, version
 from threading import Event, Thread
 from typing import Any, Optional
 
-from reachy_mini.daemon.instrumentation import timing_event
+from reachy_mini.daemon.instrumentation import log_event, timing_event
 from reachy_mini.daemon.robot_app_lock import RobotAppLock
 from reachy_mini.daemon.utils import (
     SimulationMode,
@@ -313,6 +313,13 @@ class Daemon:
 
                 with timing_event("daemon.backend.ready.wait", backend_mode=backend_mode, timeout_s=2.0):
                     backend_ready = self.backend.ready.wait(timeout=2.0)
+                log_event(
+                    "daemon.backend.ready",
+                    backend_mode=backend_mode,
+                    ready=backend_ready,
+                    timeout_s=2.0,
+                    error=self.backend.error,
+                )
                 if not backend_ready:
                     self.logger.error(
                         "Backend is not ready after 2 seconds. Some error occurred."
@@ -335,11 +342,37 @@ class Daemon:
                 if wake_up_on_start:
                     try:
                         self.logger.info("Waking up Reachy Mini...")
+                        log_event(
+                            "daemon.motor.enable.start",
+                            source="daemon.start",
+                            reason="wake_up_on_start",
+                        )
                         with timing_event("daemon.motor.enable", reason="wake_up_on_start"):
                             self.backend.set_motor_control_mode(MotorControlMode.Enabled)
+                        log_event(
+                            "daemon.motor.enable.complete",
+                            source="daemon.start",
+                            reason="wake_up_on_start",
+                        )
+                        log_event(
+                            "daemon.wake_up.start",
+                            source="daemon.start",
+                            reason="wake_up_on_start",
+                        )
                         with timing_event("daemon.wake_up"):
                             await self.backend.wake_up()
+                        log_event(
+                            "daemon.wake_up.complete",
+                            source="daemon.start",
+                            reason="wake_up_on_start",
+                        )
                     except Exception as e:
+                        log_event(
+                            "daemon.wake_up.error",
+                            source="daemon.start",
+                            reason="wake_up_on_start",
+                            error=str(e),
+                        )
                         self.logger.error(f"Error while waking up Reachy Mini: {e}")
                         self._status.state = DaemonState.ERROR
                         self._status.error = str(e)
@@ -410,10 +443,49 @@ class Daemon:
             if goto_sleep_on_stop:
                 try:
                     self.logger.info("Putting Reachy Mini to sleep...")
-                    self.backend.set_motor_control_mode(MotorControlMode.Enabled)
-                    await self.backend.goto_sleep()
-                    self.backend.set_motor_control_mode(MotorControlMode.Disabled)
+                    log_event(
+                        "daemon.motor.enable.start",
+                        source="daemon.stop",
+                        reason="goto_sleep_on_stop",
+                    )
+                    with timing_event("daemon.motor.enable", reason="goto_sleep_on_stop"):
+                        self.backend.set_motor_control_mode(MotorControlMode.Enabled)
+                    log_event(
+                        "daemon.motor.enable.complete",
+                        source="daemon.stop",
+                        reason="goto_sleep_on_stop",
+                    )
+                    log_event(
+                        "daemon.goto_sleep.start",
+                        source="daemon.stop",
+                        reason="goto_sleep_on_stop",
+                    )
+                    with timing_event("daemon.goto_sleep", reason="goto_sleep_on_stop"):
+                        await self.backend.goto_sleep()
+                    log_event(
+                        "daemon.goto_sleep.complete",
+                        source="daemon.stop",
+                        reason="goto_sleep_on_stop",
+                    )
+                    log_event(
+                        "daemon.motor.disable.start",
+                        source="daemon.stop",
+                        reason="goto_sleep_on_stop",
+                    )
+                    with timing_event("daemon.motor.disable", reason="goto_sleep_on_stop"):
+                        self.backend.set_motor_control_mode(MotorControlMode.Disabled)
+                    log_event(
+                        "daemon.motor.disable.complete",
+                        source="daemon.stop",
+                        reason="goto_sleep_on_stop",
+                    )
                 except Exception as e:
+                    log_event(
+                        "daemon.goto_sleep.error",
+                        source="daemon.stop",
+                        reason="goto_sleep_on_stop",
+                        error=str(e),
+                    )
                     self.logger.error(f"Error while putting Reachy Mini to sleep: {e}")
                     self._status.state = DaemonState.ERROR
                     self._status.error = str(e)

--- a/src/reachy_mini/daemon/instrumentation.py
+++ b/src/reachy_mini/daemon/instrumentation.py
@@ -105,6 +105,20 @@ def configure_daemon_logging(log_level: str, log_file: str | None = None) -> Ins
     return mode
 
 
+def log_event(name: str, message: str | None = None, **attrs: Any) -> None:
+    """Emit a structured instrumentation event unless instrumentation is off."""
+    if get_instrument_mode() is InstrumentMode.OFF:
+        return
+
+    logging.getLogger(__name__).info(
+        message or name,
+        extra={
+            "event": name,
+            "attrs": attrs,
+        },
+    )
+
+
 class timing_event:
     """Context manager that emits a trace timing event when trace mode is enabled."""
 

--- a/src/reachy_mini/daemon/instrumentation.py
+++ b/src/reachy_mini/daemon/instrumentation.py
@@ -1,0 +1,141 @@
+"""Feature-flagged daemon instrumentation helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+INSTRUMENT_ENV_VAR = "REACHY_DAEMON_INSTRUMENT"
+
+
+class InstrumentMode(str, Enum):
+    """Supported daemon instrumentation modes."""
+
+    OFF = "off"
+    BASIC = "basic"
+    TRACE = "trace"
+    REMOTE = "remote"
+
+
+def get_instrument_mode(raw: str | None = None) -> InstrumentMode:
+    """Return the configured instrumentation mode."""
+    value = (raw if raw is not None else os.getenv(INSTRUMENT_ENV_VAR, "basic")).strip().lower()
+    try:
+        return InstrumentMode(value)
+    except ValueError:
+        logging.getLogger(__name__).warning(
+            "Invalid %s=%r, falling back to basic",
+            INSTRUMENT_ENV_VAR,
+            value,
+        )
+        return InstrumentMode.BASIC
+
+
+def is_structured_mode(mode: InstrumentMode) -> bool:
+    """Return whether logs should be emitted as JSON records."""
+    return mode in {InstrumentMode.BASIC, InstrumentMode.TRACE, InstrumentMode.REMOTE}
+
+
+class JsonLogFormatter(logging.Formatter):
+    """Format log records as one compact JSON object per line."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format a logging record as JSON."""
+        payload: dict[str, Any] = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S%z"),
+            "level": record.levelname,
+            "logger": record.name,
+            "event": getattr(record, "event", record.getMessage()),
+            "message": record.getMessage(),
+            "attrs": getattr(record, "attrs", {}),
+        }
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def _make_handler(stream: Any, mode: InstrumentMode, log_level: str) -> logging.Handler:
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(log_level)
+    if is_structured_mode(mode):
+        handler.setFormatter(JsonLogFormatter())
+    else:
+        handler.setFormatter(logging.Formatter("%(name)s - %(levelname)s - %(message)s"))
+    return handler
+
+
+def configure_daemon_logging(log_level: str, log_file: str | None = None) -> InstrumentMode:
+    """Configure root daemon logging and return the selected instrumentation mode."""
+    mode = get_instrument_mode()
+    effective_level = "WARNING" if mode is InstrumentMode.OFF else log_level
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(effective_level)
+    root_logger.handlers.clear()
+    root_logger.addHandler(_make_handler(sys.stderr, mode, effective_level))
+
+    if log_file:
+        path = Path(log_file)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(path, mode="a")
+        file_handler.setLevel(effective_level)
+        if is_structured_mode(mode):
+            file_handler.setFormatter(JsonLogFormatter())
+        else:
+            file_handler.setFormatter(logging.Formatter("%(name)s - %(levelname)s - %(message)s"))
+        root_logger.addHandler(file_handler)
+
+    logging.getLogger(__name__).info(
+        "Daemon instrumentation configured",
+        extra={
+            "event": "instrumentation.configured",
+            "attrs": {
+                "mode": mode.value,
+                "log_level": effective_level,
+                "log_file": log_file,
+            },
+        },
+    )
+    return mode
+
+
+class timing_event:
+    """Context manager that emits a trace timing event when trace mode is enabled."""
+
+    def __init__(self, name: str, **attrs: Any) -> None:
+        """Create a timing event with a name and optional attributes."""
+        self.name = name
+        self.attrs = attrs
+        self.started = 0.0
+
+    def __enter__(self) -> "timing_event":
+        """Start timing."""
+        self.started = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        """Emit a completed timing event when trace mode is active."""
+        if get_instrument_mode() not in {InstrumentMode.TRACE, InstrumentMode.REMOTE}:
+            return
+        attrs = dict(self.attrs)
+        attrs["duration_ms"] = round((time.perf_counter() - self.started) * 1000, 3)
+        attrs["outcome"] = "error" if exc is not None else "ok"
+        if exc is not None:
+            attrs["error.type"] = type(exc).__name__
+            attrs["error.message"] = str(exc)
+        logging.getLogger(__name__).info(
+            self.name,
+            extra={
+                "event": "span.end",
+                "attrs": {
+                    "name": self.name,
+                    **attrs,
+                },
+            },
+        )

--- a/src/reachy_mini/daemon/systemd.py
+++ b/src/reachy_mini/daemon/systemd.py
@@ -1,0 +1,107 @@
+"""Small sd_notify helper for systemd-managed daemon launches."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SystemdNotifier:
+    """Best-effort client for systemd's notification socket."""
+
+    notify_socket: str | None
+    watchdog_usec: int | None = None
+
+    @classmethod
+    def from_environment(
+        cls,
+        env: Mapping[str, str] | None = None,
+    ) -> "SystemdNotifier":
+        """Create a notifier from systemd environment variables."""
+        values = env if env is not None else os.environ
+        watchdog_usec = cls._parse_watchdog_usec(values)
+        return cls(values.get("NOTIFY_SOCKET"), watchdog_usec)
+
+    @staticmethod
+    def _parse_watchdog_usec(values: Mapping[str, str]) -> int | None:
+        watchdog_pid = values.get("WATCHDOG_PID")
+        if watchdog_pid and watchdog_pid != str(os.getpid()):
+            return None
+
+        raw_usec = values.get("WATCHDOG_USEC")
+        if raw_usec is None:
+            return None
+
+        try:
+            watchdog_usec = int(raw_usec)
+        except ValueError:
+            logger.warning("Ignoring invalid WATCHDOG_USEC=%r", raw_usec)
+            return None
+
+        return watchdog_usec if watchdog_usec > 0 else None
+
+    @property
+    def enabled(self) -> bool:
+        """Whether sd_notify messages can be sent."""
+        return bool(self.notify_socket)
+
+    @property
+    def watchdog_interval_seconds(self) -> float | None:
+        """Return a conservative heartbeat interval, if watchdog is configured."""
+        if self.watchdog_usec is None:
+            return None
+        return max(self.watchdog_usec / 2_000_000, 1.0)
+
+    def status(self, message: str) -> None:
+        """Publish a human-readable service status message."""
+        self.notify(f"STATUS={message}")
+
+    def ready(self, message: str = "Reachy Mini daemon ready") -> None:
+        """Tell systemd the service has reached its intended ready point."""
+        self.notify(f"READY=1\nSTATUS={message}")
+
+    def stopping(self, message: str = "Stopping Reachy Mini daemon") -> None:
+        """Tell systemd the service is shutting down."""
+        self.notify(f"STOPPING=1\nSTATUS={message}")
+
+    def watchdog(self) -> None:
+        """Send one watchdog heartbeat."""
+        self.notify("WATCHDOG=1")
+
+    async def watchdog_loop(self) -> None:
+        """Send watchdog heartbeats until cancelled."""
+        interval = self.watchdog_interval_seconds
+        if interval is None or not self.enabled:
+            return
+
+        try:
+            while True:
+                self.watchdog()
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            raise
+
+    def notify(self, payload: str) -> None:
+        """Send a raw sd_notify payload, ignoring missing systemd support."""
+        if not self.notify_socket:
+            return
+
+        notify_socket = self.notify_socket
+        address: str | bytes
+        if notify_socket.startswith("@"):
+            address = b"\0" + notify_socket[1:].encode()
+        else:
+            address = notify_socket
+
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
+                sock.sendto(payload.encode(), address)
+        except OSError as exc:
+            logger.debug("Failed to notify systemd: %s", exc)

--- a/tests/unit_tests/test_daemon_instrumentation.py
+++ b/tests/unit_tests/test_daemon_instrumentation.py
@@ -10,13 +10,16 @@ from pathlib import Path
 import pytest
 
 from reachy_mini.daemon.daemon import Daemon
+from reachy_mini.daemon.backend.mockup_sim.backend import MockupSimBackend
 from reachy_mini.daemon.instrumentation import (
     INSTRUMENT_ENV_VAR,
     InstrumentMode,
     configure_daemon_logging,
     get_instrument_mode,
+    log_event,
     timing_event,
 )
+from reachy_mini.io.protocol import MotorControlMode, SetMotorModeCmd
 
 
 @pytest.fixture()
@@ -129,6 +132,51 @@ def test_trace_mode_writes_timing_event(
     assert payload["attrs"]["outcome"] == "ok"
 
 
+def test_log_event_writes_basic_structured_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    restore_root_logging: None,
+) -> None:
+    """Basic mode writes explicit lifecycle events."""
+    monkeypatch.setenv(INSTRUMENT_ENV_VAR, "basic")
+    log_file = tmp_path / "daemon.jsonl"
+
+    configure_daemon_logging("INFO", str(log_file))
+    log_event("daemon.test.event", phase="unit-test")
+
+    payload = json.loads(log_file.read_text().splitlines()[-1])
+    assert payload["event"] == "daemon.test.event"
+    assert payload["attrs"] == {"phase": "unit-test"}
+
+
+def test_process_command_motor_mode_writes_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    restore_root_logging: None,
+) -> None:
+    """WebRTC/WS motor-mode commands emit instrumentation events."""
+    monkeypatch.setenv(INSTRUMENT_ENV_VAR, "basic")
+    log_file = tmp_path / "daemon.jsonl"
+
+    configure_daemon_logging("INFO", str(log_file))
+    backend = MockupSimBackend(use_audio=False)
+    responses: list[dict[str, str]] = []
+
+    backend.process_command(
+        SetMotorModeCmd(mode=MotorControlMode.Disabled.value),
+        send_response=responses.append,
+    )
+
+    events = [json.loads(line) for line in log_file.read_text().splitlines()]
+    assert responses == [{"motor_mode": "disabled", "status": "ok"}]
+    assert any(
+        event["event"] == "daemon.motor.mode.set.complete"
+        and event["attrs"]["source"] == "command"
+        and event["attrs"]["mode"] == "disabled"
+        for event in events
+    )
+
+
 def test_mockup_backend_setup_writes_trace_span(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -162,4 +210,34 @@ def test_mockup_backend_setup_writes_trace_span(
         span["attrs"]["name"] == "daemon.backend.construct"
         and span["attrs"]["backend_mode"] == "mockup"
         for span in spans
+    )
+
+
+@pytest.mark.asyncio
+async def test_mockup_daemon_start_writes_backend_ready_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    restore_root_logging: None,
+) -> None:
+    """Daemon start records whether the backend became ready."""
+    monkeypatch.setenv(INSTRUMENT_ENV_VAR, "basic")
+    log_file = tmp_path / "daemon.jsonl"
+
+    configure_daemon_logging("INFO", str(log_file))
+    daemon = Daemon(no_media=True)
+    try:
+        await daemon.start(
+            mockup_sim=True,
+            wake_up_on_start=False,
+            use_audio=False,
+        )
+    finally:
+        await daemon.stop(goto_sleep_on_stop=False)
+
+    events = [json.loads(line) for line in log_file.read_text().splitlines()]
+    assert any(
+        event["event"] == "daemon.backend.ready"
+        and event["attrs"]["backend_mode"] == "mockup"
+        and event["attrs"]["ready"] is True
+        for event in events
     )

--- a/tests/unit_tests/test_daemon_instrumentation.py
+++ b/tests/unit_tests/test_daemon_instrumentation.py
@@ -1,0 +1,165 @@
+"""Tests for daemon instrumentation helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from reachy_mini.daemon.daemon import Daemon
+from reachy_mini.daemon.instrumentation import (
+    INSTRUMENT_ENV_VAR,
+    InstrumentMode,
+    configure_daemon_logging,
+    get_instrument_mode,
+    timing_event,
+)
+
+
+@pytest.fixture()
+def restore_root_logging() -> Generator[None, None, None]:
+    """Restore root logger handlers after instrumentation tests."""
+    root = logging.getLogger()
+    handlers = list(root.handlers)
+    level = root.level
+    yield
+    for handler in root.handlers:
+        handler.close()
+    root.handlers.clear()
+    root.handlers.extend(handlers)
+    root.setLevel(level)
+
+
+def test_get_instrument_mode_defaults_to_basic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default instrumentation mode is basic."""
+    monkeypatch.delenv(INSTRUMENT_ENV_VAR, raising=False)
+
+    assert get_instrument_mode() is InstrumentMode.BASIC
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("off", InstrumentMode.OFF),
+        ("basic", InstrumentMode.BASIC),
+        ("trace", InstrumentMode.TRACE),
+        ("remote", InstrumentMode.REMOTE),
+        (" TRACE ", InstrumentMode.TRACE),
+    ],
+)
+def test_get_instrument_mode_parses_known_modes(raw: str, expected: InstrumentMode) -> None:
+    """Known instrumentation mode values are normalized."""
+    assert get_instrument_mode(raw) is expected
+
+
+def test_get_instrument_mode_falls_back_to_basic() -> None:
+    """Unknown instrumentation modes fall back to basic."""
+    assert get_instrument_mode("surprise") is InstrumentMode.BASIC
+
+
+def test_configure_daemon_logging_writes_jsonl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    restore_root_logging: None,
+) -> None:
+    """Structured modes write JSONL log files."""
+    monkeypatch.setenv(INSTRUMENT_ENV_VAR, "basic")
+    log_file = tmp_path / "daemon.jsonl"
+
+    mode = configure_daemon_logging("INFO", str(log_file))
+    logging.getLogger("reachy_mini.test").info(
+        "hello daemon",
+        extra={
+            "event": "test.event",
+            "attrs": {"answer": 42},
+        },
+    )
+
+    assert mode is InstrumentMode.BASIC
+    lines = log_file.read_text().splitlines()
+    assert len(lines) == 2
+    payload = json.loads(lines[-1])
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "reachy_mini.test"
+    assert payload["event"] == "test.event"
+    assert payload["message"] == "hello daemon"
+    assert payload["attrs"] == {"answer": 42}
+
+
+def test_configure_daemon_logging_off_raises_level_to_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    restore_root_logging: None,
+) -> None:
+    """Off mode suppresses info logs and keeps plain warning output."""
+    monkeypatch.setenv(INSTRUMENT_ENV_VAR, "off")
+    log_file = tmp_path / "daemon.log"
+
+    mode = configure_daemon_logging("INFO", str(log_file))
+    logging.getLogger("reachy_mini.test").info("hidden")
+    logging.getLogger("reachy_mini.test").warning("visible")
+
+    assert mode is InstrumentMode.OFF
+    assert log_file.read_text().splitlines() == [
+        "reachy_mini.test - WARNING - visible",
+    ]
+
+
+def test_trace_mode_writes_timing_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    restore_root_logging: None,
+) -> None:
+    """Trace mode writes span-style timing events."""
+    monkeypatch.setenv(INSTRUMENT_ENV_VAR, "trace")
+    log_file = tmp_path / "daemon.jsonl"
+
+    configure_daemon_logging("INFO", str(log_file))
+    with timing_event("daemon.test", stage="unit-test"):
+        pass
+
+    payload = json.loads(log_file.read_text().splitlines()[-1])
+    assert payload["event"] == "span.end"
+    assert payload["attrs"]["name"] == "daemon.test"
+    assert payload["attrs"]["stage"] == "unit-test"
+    assert payload["attrs"]["duration_ms"] >= 0
+    assert payload["attrs"]["outcome"] == "ok"
+
+
+def test_mockup_backend_setup_writes_trace_span(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    restore_root_logging: None,
+) -> None:
+    """Mockup backend setup emits a startup trace span."""
+    monkeypatch.setenv(INSTRUMENT_ENV_VAR, "trace")
+    log_file = tmp_path / "daemon.jsonl"
+
+    configure_daemon_logging("INFO", str(log_file))
+    daemon = Daemon(no_media=True)
+    backend = daemon._setup_backend(
+        wireless_version=False,
+        sim=False,
+        mockup_sim=True,
+        serialport="auto",
+        scene="empty",
+        check_collision=False,
+        kinematics_engine="AnalyticalKinematics",
+        headless=True,
+        use_audio=False,
+    )
+    backend.close()
+
+    spans = [
+        json.loads(line)
+        for line in log_file.read_text().splitlines()
+        if json.loads(line).get("event") == "span.end"
+    ]
+    assert any(
+        span["attrs"]["name"] == "daemon.backend.construct"
+        and span["attrs"]["backend_mode"] == "mockup"
+        for span in spans
+    )

--- a/tests/unit_tests/test_systemd.py
+++ b/tests/unit_tests/test_systemd.py
@@ -1,0 +1,58 @@
+"""Tests for systemd notification helpers."""
+
+from __future__ import annotations
+
+import os
+import socket
+from pathlib import Path
+
+from reachy_mini.daemon.systemd import SystemdNotifier
+
+
+def test_notifier_is_disabled_without_notify_socket() -> None:
+    """Non-systemd launches should be a no-op."""
+    notifier = SystemdNotifier.from_environment({})
+
+    assert not notifier.enabled
+    assert notifier.watchdog_interval_seconds is None
+    notifier.ready()
+
+
+def test_notifier_sends_ready_status_and_watchdog(tmp_path: Path) -> None:
+    """Systemd payloads are sent to the configured Unix datagram socket."""
+    socket_path = tmp_path / "notify.sock"
+    receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    receiver.bind(str(socket_path))
+    receiver.settimeout(1.0)
+
+    try:
+        notifier = SystemdNotifier(str(socket_path), watchdog_usec=4_000_000)
+
+        notifier.status("Starting test daemon")
+        notifier.ready("Test daemon ready")
+        notifier.watchdog()
+
+        payloads = [receiver.recv(1024).decode() for _ in range(3)]
+    finally:
+        receiver.close()
+
+    assert payloads == [
+        "STATUS=Starting test daemon",
+        "READY=1\nSTATUS=Test daemon ready",
+        "WATCHDOG=1",
+    ]
+    assert notifier.watchdog_interval_seconds == 2.0
+
+
+def test_watchdog_is_ignored_for_a_different_pid() -> None:
+    """WATCHDOG_PID gates heartbeat support the same way systemd does."""
+    notifier = SystemdNotifier.from_environment(
+        {
+            "NOTIFY_SOCKET": "/tmp/systemd-notify.sock",
+            "WATCHDOG_USEC": "1000000",
+            "WATCHDOG_PID": str(os.getpid() + 1),
+        }
+    )
+
+    assert notifier.enabled
+    assert notifier.watchdog_interval_seconds is None


### PR DESCRIPTION
## Summary
- add structured daemon lifecycle events for backend readiness, motor mode changes, wake-up, and sleep
- add trace spans around REST/command-channel motor and wake/sleep paths
- cover instrumentation helpers, command motor mode events, and backend readiness logging in unit tests

## Live Reachy Mini validation
- restarted reachy-mini-daemon.service onto this editable checkout
- confirmed journal events: instrumentation.configured, daemon.backend.ready, daemon.motor.mode.set.*, daemon.wake_up.*, daemon.goto_sleep.*
- backend ready wait: 23.488 ms, backend construct: 149.484 ms, daemon.start: 367.42 ms
- REST motor enable accepted in 9.92 ms; motor disable accepted in 10.58 ms
- wake_up accepted in 10.35 ms; task completed in 2.49 s; span duration 2248.335 ms
- goto_sleep accepted in 18.36 ms; task completed in 4.163 s; span duration 4075.761 ms
- control loop stayed error-free; observed frequency range during movement ~43.0-49.6 Hz; final motors disabled

## Tests
- uv run pytest tests/unit_tests/test_daemon_instrumentation.py tests/unit_tests/test_process_command.py
- uv run ruff check src/reachy_mini/daemon/instrumentation.py src/reachy_mini/daemon/daemon.py src/reachy_mini/daemon/backend/abstract.py src/reachy_mini/daemon/app/routers/motors.py src/reachy_mini/daemon/app/routers/move.py
- git diff --check

Note: GitHub issue #3 is already closed and appears unrelated to this instrumentation task.