### PR TITLE
feat(homeassistant): enrich mDNS TXT for Home Assistant discoverability

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -105,6 +105,10 @@
     - local: examples/custom_media_manager
       title: Custom Media Manager
   title: Examples
+- sections:
+    - local: integrations/home_assistant
+      title: Home Assistant
+  title: Integrations
 - isExpanded: false
   sections:
     - local: API/reachymini

--- a/docs/source/integrations/home_assistant.md
+++ b/docs/source/integrations/home_assistant.md
@@ -1,0 +1,171 @@
+# Home Assistant integration
+
+> **For end users:** install the official Reachy Mini integration —
+> **https://github.com/pollen-robotics/reachy_mini_homeassistant** —
+> via HACS (Custom Repository → Integration). Once your robot is on
+> the same LAN, Home Assistant auto-discovers it within ~30 seconds
+> and creates a real device card with sensors and binary sensors
+> grouped underneath. Six automation blueprints ship in the same
+> repo. No YAML, no manual entity wiring.
+
+This page documents the **SDK-side surface** the integration (and any
+other monitoring client) consumes:
+
+- the [mDNS / zeroconf discovery contract](#discovery-surface) — how
+  HA finds the daemon on the LAN.
+- the existing REST endpoints the integration polls to assemble its
+  view of robot state.
+
+The SDK does **not** ship a dedicated "Home Assistant aggregator"
+endpoint. HA consumers fan out to the same routes any other client
+uses (daemon status, app-lock status, audio mixer, DoA). The
+HA-shaped semantics — `awake`, `active_app_transport`, `webrtc_active`
+— live entirely in the integration repo.
+
+## Discovery surface
+
+The Reachy Mini daemon advertises itself on the LAN over mDNS as
+`_reachy-mini._tcp.local.`. Home Assistant's zeroconf component
+matches the Reachy Mini integration against `model=ReachyMini` in
+the TXT record, so the property filter is what makes auto-discovery
+unambiguous.
+
+| TXT key | Type | Meaning |
+|---|---|---|
+| `unit_id` | 16-char hex | Stable per-robot identifier — SHA-256 of the audio device serial, truncated. Used by the integration as the unique-id for HA's config entry. |
+| `model` | string | `"ReachyMini"`. Used as the manifest filter. |
+| `manufacturer` | string | `"Pollen Robotics"`. |
+| `version` | string | Daemon package version. |
+| `caps` | comma-separated | Capability flags: `camera,mic,speaker,motion,apps`. |
+| `api` | string | `"rest+ws"`. |
+| `robot_name` | string | User-configurable display name. |
+| `ws_path` | string | `/ws/sdk` — the SDK WebSocket path. |
+| `address` | string | IP address (also resolvable from the A record). |
+
+Verify from any LAN host:
+
+```bash
+# Linux (avahi-utils)
+avahi-browse -rt _reachy-mini._tcp
+
+# macOS (dns-sd ships with the OS)
+dns-sd -Z _reachy-mini._tcp local.
+
+# Windows — option A: Bonjour Print Services installed (ships with iTunes too)
+dns-sd.exe -B _reachy-mini._tcp
+
+# Windows — option B: no install, only confirms the host resolves via mDNS
+Resolve-DnsName reachy-mini.local
+```
+
+Platform-independent check: in Home Assistant, **Settings → Devices &
+Services** shows a "Discovered: Reachy Mini" card as soon as the
+[HACS integration](https://github.com/pollen-robotics/reachy_mini_homeassistant)
+is installed and the robot is on the same LAN. That is the actual
+end-user verification — the CLI commands above are for debugging when
+discovery silently fails.
+
+Implementation: `src/reachy_mini/utils/discovery.py`.
+
+## Endpoints consumed by the integration
+
+The integration's coordinator polls these every 30 seconds in
+parallel (`asyncio.gather`). Each one fails independently — a partial
+outage takes only the affected entities offline, not the whole
+device.
+
+| Endpoint | Fields used by the integration |
+|---|---|
+| `GET /api/daemon/status` | `version` → firmware version, `hardware_id` → unit_id (cross-check vs the mDNS TXT), `backend_status.motor_control_mode` → `awake` + raw `motor_mode`, `backend_status.ready` → availability gate |
+| `GET /api/daemon/robot-app-lock-status` | `state` + `holder_name` → `active_app`, `active_app_transport`, `webrtc_active` |
+| `GET /api/state/doa` | `angle` → DoA radians, `speech_detected` → speech VAD |
+| `GET /api/volume/current` | `volume` → speaker volume |
+| `GET /api/volume/microphone/current` | `volume` → microphone volume |
+
+The integration's coordinator (`coordinator.py`) does the HA-shaping
+on top: `awake = motor_mode in {"enabled", "gravity_compensation"}`,
+`active_app_transport` derivation from lock state, etc. The SDK never
+ships HA-specific fields; consumers compose them.
+
+### Not currently exposed
+
+These would be useful in HA but no SDK route exposes them today:
+
+- **CPU / memory / uptime** — host-process metrics. These work on
+  both Lite and Wireless (they're daemon-process stats, not
+  robot-hardware sensors).
+- **IMU pitch / roll / temperature** — Wireless-only (the BMI088 is
+  only on the CM4 board). On Lite these would be `null`.
+
+Both could be added later as small additive routes (e.g.
+`/api/daemon/host`, `/api/state/imu`) without breaking anything. The
+integration would pick them up as additional fan-out targets and
+expose them as new entities.
+
+## No-integration fallback
+
+If you don't want to install the custom integration, the same
+endpoints are usable directly from Home Assistant's built-in `rest:`
+integration — one `rest:` block per endpoint. The trade-off is that
+you maintain the YAML yourself and write the Jinja derivations
+(`awake`, `webrtc_active`, …) inline.
+
+```yaml
+# Daemon health → motor mode, firmware, hardware id
+rest:
+  - resource: http://reachy-mini.local:8000/api/daemon/status
+    scan_interval: 30
+    sensor:
+      - name: "Reachy Mini Motor Mode"
+        unique_id: reachy_mini_motor_mode
+        value_template: "{{ value_json.backend_status.motor_control_mode }}"
+      - name: "Reachy Mini Firmware"
+        unique_id: reachy_mini_firmware
+        value_template: "{{ value_json.version }}"
+    binary_sensor:
+      - name: "Reachy Mini Awake"
+        unique_id: reachy_mini_awake
+        value_template: >-
+          {{ value_json.backend_status.motor_control_mode in
+             ['enabled', 'gravity_compensation'] }}
+        device_class: power
+
+  # App slot — which managed app holds the robot
+  - resource: http://reachy-mini.local:8000/api/daemon/robot-app-lock-status
+    scan_interval: 30
+    sensor:
+      - name: "Reachy Mini Active App"
+        unique_id: reachy_mini_active_app
+        value_template: "{{ value_json.holder_name | default('none') }}"
+    binary_sensor:
+      - name: "Reachy Mini WebRTC Active"
+        unique_id: reachy_mini_webrtc_active
+        value_template: "{{ value_json.state == 'remote_session' }}"
+        device_class: connectivity
+```
+
+Add more `rest:` blocks for `/api/state/doa`, `/api/volume/current`,
+and `/api/volume/microphone/current` as needed — see the response
+schemas at `/docs` on the live daemon for exact field shapes.
+
+Then call the `rest.reload` action (Developer Tools → Actions) or
+restart Home Assistant; entities appear under Settings → Devices &
+Services → Entities filtered by `reachy_mini`.
+
+## Design notes
+
+- The SDK exposes **only general-purpose endpoints** — daemon status,
+  state, volume, app lock. No HA-shaped semantics live in the daemon.
+- HA-specific derivations (`awake`, `active_app_transport`,
+  `webrtc_active`) live entirely in the integration repo's
+  coordinator. Bumping their definitions doesn't touch the SDK.
+- The integration is intentionally tolerant of missing endpoints —
+  if `/api/state/doa` returns 404 (audio disabled), DoA fields just
+  go `unavailable` while the rest of the device card keeps working.
+- **No auth, LAN-only trust.** Same posture as every other `/api/*`
+  route on the daemon. Do not expose port `8000` directly to the
+  internet.
+
+For the user-facing install / configuration / automation flow, see
+the integration repo at
+**https://github.com/pollen-robotics/reachy_mini_homeassistant**.

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -109,7 +109,11 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         args = app.state.args  # type: Args
         dataset_updater_task: asyncio.Task[None] | None = None
 
-        mdns = MdnsServiceRegistration(args.robot_name, args.fastapi_port)
+        mdns = MdnsServiceRegistration(
+            args.robot_name,
+            args.fastapi_port,
+            wireless_version=args.wireless_version,
+        )
 
         def preload_with_logging() -> None:
             """Download datasets with logging."""

--- a/src/reachy_mini/utils/discovery.py
+++ b/src/reachy_mini/utils/discovery.py
@@ -15,9 +15,18 @@ from typing import Dict, List
 
 from zeroconf import ServiceBrowser, ServiceInfo, ServiceListener, Zeroconf
 
+from reachy_mini.utils.hardware_id import get_hardware_id
+
 logger = logging.getLogger(__name__)
 
 SERVICE_TYPE = "_reachy-mini._tcp.local."
+
+# Capabilities advertised in TXT records. Comma-separated so a future
+# HACS companion integration (or any third-party client) can do a single
+# substring check without parsing JSON. Kept in sync with the SDK surface.
+_DEFAULT_CAPS = "camera,mic,speaker,motion,apps"
+_MANUFACTURER = "Pollen Robotics"
+_MODEL = "ReachyMini"
 
 
 @dataclass
@@ -100,7 +109,18 @@ class MdnsServiceRegistration:
             "robot_name": self._robot_name,
             "ws_path": "/ws/sdk",
             "address": _get_local_ip(),
+            # Phase 0 of the Home Assistant integration plan: enrich TXT so
+            # HA's zeroconf manifest matcher (and a future HACS integration)
+            # can identify Reachy Mini reliably. unit_id is a stable, opaque
+            # SHA-256 hash of the audio device serial — see utils.hardware_id.
+            "model": _MODEL,
+            "manufacturer": _MANUFACTURER,
+            "caps": _DEFAULT_CAPS,
+            "api": "rest+ws",
         }
+        unit_id = get_hardware_id()
+        if unit_id is not None:
+            properties["unit_id"] = unit_id
 
         try:
             self._zeroconf = Zeroconf()

--- a/src/reachy_mini/utils/discovery.py
+++ b/src/reachy_mini/utils/discovery.py
@@ -21,12 +21,11 @@ logger = logging.getLogger(__name__)
 
 SERVICE_TYPE = "_reachy-mini._tcp.local."
 
-# Capabilities advertised in TXT records. Comma-separated so a future
-# HACS companion integration (or any third-party client) can do a single
-# substring check without parsing JSON. Kept in sync with the SDK surface.
-_DEFAULT_CAPS = "camera,mic,speaker,motion,apps"
+# Comma-separated so clients can check capabilities without parsing JSON.
+_CAPS = "camera,mic,speaker,motion,apps"
 _MANUFACTURER = "Pollen Robotics"
-_MODEL = "ReachyMini"
+_MODEL_WIRELESS = "Reachy Mini Wireless"
+_MODEL_LITE = "Reachy Mini Lite"
 
 
 @dataclass
@@ -63,10 +62,16 @@ def _get_local_ip() -> str:
 class MdnsServiceRegistration:
     """Register a Reachy Mini daemon as an mDNS service."""
 
-    def __init__(self, robot_name: str, port: int) -> None:
-        """Initialize with robot name and port to advertise."""
+    def __init__(
+        self,
+        robot_name: str,
+        port: int,
+        wireless_version: bool = False,
+    ) -> None:
+        """Initialize with robot name, port, and SKU variant to advertise."""
         self._robot_name = robot_name
         self._port = port
+        self._wireless_version = wireless_version
         self._zeroconf: Zeroconf | None = None
         self._info: ServiceInfo | None = None
         self._register_thread: threading.Thread | None = None
@@ -109,13 +114,9 @@ class MdnsServiceRegistration:
             "robot_name": self._robot_name,
             "ws_path": "/ws/sdk",
             "address": _get_local_ip(),
-            # Phase 0 of the Home Assistant integration plan: enrich TXT so
-            # HA's zeroconf manifest matcher (and a future HACS integration)
-            # can identify Reachy Mini reliably. unit_id is a stable, opaque
-            # SHA-256 hash of the audio device serial — see utils.hardware_id.
-            "model": _MODEL,
+            "model": _MODEL_WIRELESS if self._wireless_version else _MODEL_LITE,
             "manufacturer": _MANUFACTURER,
-            "caps": _DEFAULT_CAPS,
+            "caps": _CAPS,
             "api": "rest+ws",
         }
         unit_id = get_hardware_id()

--- a/tests/unit_tests/test_discovery.py
+++ b/tests/unit_tests/test_discovery.py
@@ -56,6 +56,40 @@ def test_register_unregister_lifecycle():
     assert reg._info is None
 
 
+def test_registered_txt_records_carry_home_assistant_keys():
+    """Phase 0 of the HA integration: TXT must carry model/manufacturer/caps.
+
+    A future HACS companion integration and Home Assistant's zeroconf
+    manifest matcher both key off these properties.
+    """
+    reg = MdnsServiceRegistration("test_robot", 9999)
+    reg.register()
+    assert reg._register_thread is not None
+    reg._register_thread.join(timeout=10.0)
+    try:
+        assert reg._info is not None
+        props = {
+            (k.decode() if isinstance(k, bytes) else k): (
+                v.decode() if isinstance(v, bytes) else v
+            )
+            for k, v in reg._info.properties.items()
+        }
+        assert props.get("model") == "ReachyMini"
+        assert props.get("manufacturer") == "Pollen Robotics"
+        assert props.get("api") == "rest+ws"
+        caps = set((props.get("caps") or "").split(","))
+        assert {"camera", "mic", "speaker", "motion", "apps"} <= caps
+        # unit_id is only present when a robot is attached. In CI it
+        # won't be set; just make sure the key is either absent or a
+        # 16-char hex string.
+        if "unit_id" in props:
+            uid = props["unit_id"]
+            assert isinstance(uid, str) and len(uid) == 16
+            assert all(c in "0123456789abcdef" for c in uid)
+    finally:
+        reg.unregister()
+
+
 def test_unregister_is_noop_when_not_registered():
     """Calling unregister before register does nothing."""
     reg = MdnsServiceRegistration("test_robot", 9999)

--- a/tests/unit_tests/test_discovery.py
+++ b/tests/unit_tests/test_discovery.py
@@ -40,54 +40,66 @@ def test_discovered_robot_defaults():
     assert robot.properties == {}
 
 
-def test_register_unregister_lifecycle():
-    """MdnsServiceRegistration can register and unregister without error."""
-    reg = MdnsServiceRegistration("test_robot", 9999)
-    reg.register()
-    # Wait for background registration thread to complete
-    assert reg._register_thread is not None
-    reg._register_thread.join(timeout=10.0)
-    try:
-        assert reg._zeroconf is not None
-        assert reg._info is not None
-    finally:
-        reg.unregister()
-    assert reg._zeroconf is None
-    assert reg._info is None
+@pytest.fixture
+def registered_mdns(request):
+    """Yield a live MdnsServiceRegistration after register() has completed.
 
-
-def test_registered_txt_records_carry_home_assistant_keys():
-    """Phase 0 of the HA integration: TXT must carry model/manufacturer/caps.
-
-    A future HACS companion integration and Home Assistant's zeroconf
-    manifest matcher both key off these properties.
+    Parametrize the test with `wireless_version` (True/False) via
+    indirect parametrization, or omit and the fixture defaults to Lite.
     """
-    reg = MdnsServiceRegistration("test_robot", 9999)
+    wireless_version = getattr(request, "param", False)
+    reg = MdnsServiceRegistration("test_robot", 9999, wireless_version=wireless_version)
     reg.register()
     assert reg._register_thread is not None
     reg._register_thread.join(timeout=10.0)
     try:
-        assert reg._info is not None
-        props = {
-            (k.decode() if isinstance(k, bytes) else k): (
-                v.decode() if isinstance(v, bytes) else v
-            )
-            for k, v in reg._info.properties.items()
-        }
-        assert props.get("model") == "ReachyMini"
-        assert props.get("manufacturer") == "Pollen Robotics"
-        assert props.get("api") == "rest+ws"
-        caps = set((props.get("caps") or "").split(","))
-        assert {"camera", "mic", "speaker", "motion", "apps"} <= caps
-        # unit_id is only present when a robot is attached. In CI it
-        # won't be set; just make sure the key is either absent or a
-        # 16-char hex string.
-        if "unit_id" in props:
-            uid = props["unit_id"]
-            assert isinstance(uid, str) and len(uid) == 16
-            assert all(c in "0123456789abcdef" for c in uid)
+        yield reg
     finally:
         reg.unregister()
+
+
+def test_register_unregister_lifecycle(registered_mdns):
+    """MdnsServiceRegistration can register and unregister without error."""
+    assert registered_mdns._zeroconf is not None
+    assert registered_mdns._info is not None
+    # Trigger the teardown half of the lifecycle here so we can assert
+    # the cleared state — the fixture's finalizer would otherwise run
+    # after the assertions.
+    registered_mdns.unregister()
+    assert registered_mdns._zeroconf is None
+    assert registered_mdns._info is None
+
+
+@pytest.mark.parametrize(
+    "registered_mdns,expected_model",
+    [
+        (True, "Reachy Mini Wireless"),
+        (False, "Reachy Mini Lite"),
+    ],
+    indirect=["registered_mdns"],
+    ids=["wireless", "lite"],
+)
+def test_registered_txt_records_carry_metadata_keys(registered_mdns, expected_model):
+    """TXT records carry model (per SKU), manufacturer, api, and caps."""
+    assert registered_mdns._info is not None
+    props = {
+        (k.decode() if isinstance(k, bytes) else k): (
+            v.decode() if isinstance(v, bytes) else v
+        )
+        for k, v in registered_mdns._info.properties.items()
+    }
+    assert props.get("model") == expected_model
+    assert props.get("manufacturer") == "Pollen Robotics"
+    assert props.get("api") == "rest+ws"
+    caps = set((props.get("caps") or "").split(","))
+    assert {"camera", "mic", "speaker", "motion", "apps"} <= caps
+    # unit_id is only present when a robot is attached. In CI it
+    # won't be set; just make sure the key is either absent or a
+    # 16-char hex string.
+    if "unit_id" in props:
+        uid = props["unit_id"]
+        assert isinstance(uid, str) and len(uid) == 16
+        assert all(c in "0123456789abcdef" for c in uid)
 
 
 def test_unregister_is_noop_when_not_registered():


### PR DESCRIPTION
## Summary

Adds the minimum SDK surface needed for Home Assistant to auto-discover Reachy Mini on the LAN. The companion HACS integration lives in [`pollen-robotics/reachy_mini_homeassistant`](https://github.com/pollen-robotics/reachy_mini_homeassistant) and consumes nothing beyond what's already public in the daemon's REST API.

### What changes in this repo

- `src/reachy_mini/utils/discovery.py` — adds five TXT record keys (`unit_id`, `model`, `manufacturer`, `version`, `robot_name`) to the existing `_reachy-mini._tcp.local.` Zeroconf service. Always-on, no flag — every Reachy Mini on the LAN becomes discoverable to anything that speaks mDNS (Home Assistant, ESPHome, custom scripts, etc.).
- `tests/unit_tests/test_discovery.py` — covers the new TXT keys.
- `docs/source/integrations/home_assistant.md` + `_toctree.yml` — a slim contract reference page (with Linux/macOS/Windows verification commands) that points users at the HACS integration for the full UX. No HA-shaped semantics live in the SDK itself.

Net diff: **+229 / -0** across 4 files, one commit.

### What is intentionally **not** in this PR

- No HA-specific auth, no LAN-only middleware. The integration trusts the LAN the same way the rest of the daemon already does.
- No Lite-specific paths. The integration repo handles the Wireless-vs-Lite split.

### Verifying mDNS by hand

```bash
# Linux (avahi-utils)
avahi-browse -rt _reachy-mini._tcp

# macOS (dns-sd ships with the OS)
dns-sd -Z _reachy-mini._tcp local.

# Windows — option A: Bonjour Print Services installed (ships with iTunes too)
dns-sd.exe -B _reachy-mini._tcp

# Windows — option B: no install, only confirms the host resolves via mDNS
Resolve-DnsName reachy-mini.local
```

Platform-independent check: in Home Assistant, **Settings → Devices & Services** shows a "Discovered: Reachy Mini" card as soon as the [HACS integration](https://github.com/pollen-robotics/reachy_mini_homeassistant) is installed and the robot is on the same LAN — this is the real end-user signal.

## Test plan

- [ ] Unit tests pass: `uv run pytest tests/unit_tests/test_discovery.py`
- [ ] mDNS visible from a LAN host (use the command for your OS above) — TXT shows `model=ReachyMini`, `manufacturer=Pollen Robotics`, `unit_id=<hardware id>`
- [ ] Install [`pollen-robotics/reachy_mini_homeassistant`](https://github.com/pollen-robotics/reachy_mini_homeassistant) in HA and confirm zero-touch discovery