### PR TITLE
feat(webrtc): add restart_daemon DataChannel command

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -40,6 +40,7 @@ from reachy_mini.io.protocol import (
     MujocoBackendStatus,
     PlaySoundCmd,
     RecordedDataMsg,
+    RestartDaemonCmd,
     RobotBackendStatus,
     SetAntennasCmd,
     SetAutomaticBodyYawCmd,
@@ -218,6 +219,16 @@ class Backend:
         # cross-thread cleanup (peer disconnect fires from gstreamer's
         # GLib thread) can schedule cancellation correctly.
         self._log_loop: Optional["asyncio.AbstractEventLoop"] = None
+
+        # Synchronous callback that triggers a full daemon restart
+        # (motor controller, kinematics, media server, ...). Wired in
+        # by `Daemon` after `setup_media_server` so that the typed
+        # `restart_daemon` DataChannel command can recover from a
+        # broken backend (e.g. dead motor controller) without forcing
+        # an out-of-band `systemctl restart` or REST round-trip.
+        # Returns immediately - the actual restart runs on a fresh
+        # thread so the data channel can flush its ack first.
+        self._restart_daemon_callback: Optional[Callable[[], None]] = None
 
     # Life cycle methods
     def wrapped_run(self) -> None:
@@ -738,7 +749,9 @@ class Backend:
         1.0032234352772091,
     ]
 
-    INIT_ANTENNAS_JOINT_POSITIONS = np.array((-0.1745, 0.1745))  # ~10° offset to reduce shaking at vertical
+    INIT_ANTENNAS_JOINT_POSITIONS = np.array(
+        (-0.1745, 0.1745)
+    )  # ~10° offset to reduce shaking at vertical
     SLEEP_ANTENNAS_JOINT_POSITIONS = np.array((-3.05, 3.05))
     SLEEP_HEAD_POSE = np.array(
         [
@@ -797,7 +810,9 @@ class Backend:
             if dist_to_init_pose > 30:
                 # Move to the initial position
                 await self.goto_target(
-                    self.INIT_HEAD_POSE, antennas=self.INIT_ANTENNAS_JOINT_POSITIONS, duration=1
+                    self.INIT_HEAD_POSE,
+                    antennas=self.INIT_ANTENNAS_JOINT_POSITIONS,
+                    duration=1,
                 )
                 await asyncio.sleep(0.2)
 
@@ -1021,7 +1036,12 @@ class Backend:
 
         elif isinstance(
             cmd,
-            (SetVolumeCmd, GetVolumeCmd, SetMicrophoneVolumeCmd, GetMicrophoneVolumeCmd),
+            (
+                SetVolumeCmd,
+                GetVolumeCmd,
+                SetMicrophoneVolumeCmd,
+                GetMicrophoneVolumeCmd,
+            ),
         ):
             # Volume is a global robot setting, not per-session: a remote
             # change persists for the next connection. This matches the
@@ -1090,6 +1110,25 @@ class Backend:
         elif isinstance(cmd, UnsubscribeLogsCmd):
             self._cancel_log_subscription(peer_id)
 
+        elif isinstance(cmd, RestartDaemonCmd):
+            # Ack BEFORE triggering the restart: the WebRTC transport
+            # is torn down by `daemon.stop()` so any later send on
+            # this peer's channel would silently drop. The callback
+            # spawns its own thread and returns immediately.
+            if self._restart_daemon_callback is None:
+                send_response(
+                    {
+                        "error": "restart_daemon not supported by this backend host",
+                        "command": "restart_daemon",
+                    }
+                )
+                return
+            send_response({"status": "ok", "command": "restart_daemon"})
+            try:
+                self._restart_daemon_callback()
+            except Exception as e:
+                self.logger.error(f"restart_daemon callback failed: {e}")
+
     # ------------------------------------------------------------------
     # journalctl log streaming over the typed transport (subscribe_logs)
     # ------------------------------------------------------------------
@@ -1110,9 +1149,7 @@ class Backend:
         # is a no-op error rather than an exception so the consumer can
         # blindly call `subscribeLogs` on every reconnect.
         self._cancel_log_subscription(peer_id)
-        task = asyncio.create_task(
-            self._async_subscribe_logs(peer_id, send_response)
-        )
+        task = asyncio.create_task(self._async_subscribe_logs(peer_id, send_response))
         self._log_tasks[peer_id] = task
 
     def _cancel_log_subscription(self, peer_id: Optional[str]) -> None:
@@ -1173,9 +1210,7 @@ class Backend:
                     # journalctl -f shouldn't EOF except on shutdown;
                     # surface it so the consumer can decide to retry.
                     send_response(
-                        LogStreamErrorMsg(
-                            error="journalctl stream ended"
-                        ).model_dump()
+                        LogStreamErrorMsg(error="journalctl stream ended").model_dump()
                     )
                     return
                 line = raw.decode("utf-8", errors="replace").rstrip("\n")
@@ -1185,9 +1220,7 @@ class Backend:
                 ts, sep, rest = line.partition(" ")
                 if not sep:
                     ts, rest = "", line
-                send_response(
-                    LogLineMsg(timestamp=ts, line=rest).model_dump()
-                )
+                send_response(LogLineMsg(timestamp=ts, line=rest).model_dump())
         except asyncio.CancelledError:
             raise
         except Exception as e:
@@ -1248,6 +1281,17 @@ class Backend:
     # ------------------------------------------------------------------
     # WebRTC data channel interface (delegates to process_command)
     # ------------------------------------------------------------------
+
+    def set_restart_daemon_callback(self, callback: Callable[[], None]) -> None:
+        """Wire the synchronous trigger used by the ``restart_daemon`` cmd.
+
+        ``Daemon`` injects a callback that schedules ``daemon.restart()``
+        on a fresh background thread (mirroring what
+        ``bg_job_register.run_command`` does for the REST endpoint).
+        The callback MUST return promptly so ``process_command`` can
+        flush its ack on the about-to-be-torn-down DataChannel.
+        """
+        self._restart_daemon_callback = callback
 
     def setup_media_server(self, media_server: Any) -> None:
         """Connect the backend to the media server.

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -322,6 +322,7 @@ class Daemon:
             if self._media_server and not self._media_released:
                 if self.backend is not None:
                     self.backend.setup_media_server(self._media_server)
+                    self.backend.set_restart_daemon_callback(self._spawn_webrtc_restart)
                 self._media_server.start()
 
                 # Start central signaling relay for remote WebRTC access
@@ -518,6 +519,34 @@ class Daemon:
         raise NotImplementedError(
             "Restarting is only supported when the daemon is in RUNNING or ERROR state."
         )
+
+    def _spawn_webrtc_restart(self) -> None:
+        """Run ``self.restart()`` on a fresh thread.
+
+        Called from the backend's WebRTC ``restart_daemon`` handler to
+        recover from a broken backend state (e.g. a dead motor
+        controller) without forcing a ``systemctl restart`` or a REST
+        round-trip. Mirrors ``bg_job_register.run_command``: a daemon
+        thread starts its own asyncio loop, runs ``restart()``, then
+        exits. We can't reuse the FastAPI background-job registry from
+        here because the backend has no FastAPI ``Request`` context.
+
+        Returns immediately so the caller can flush its DataChannel
+        ack before the WebRTC stack is torn down.
+        """
+        if self._status.state == DaemonState.STOPPED:
+            self.logger.warning(
+                "Ignoring WebRTC restart_daemon: daemon already stopped."
+            )
+            return
+
+        def _run() -> None:
+            try:
+                asyncio.run(self.restart())
+            except Exception as e:
+                self.logger.error(f"WebRTC restart_daemon failed: {e}")
+
+        Thread(target=_run, daemon=True, name="webrtc-restart-daemon").start()
 
     def status(self) -> "DaemonStatus":
         """Get the current status of the Reachy Mini daemon."""

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -7,7 +7,8 @@ Client->Server command types:
     goto_target, wake_up, goto_sleep, play_sound,
     set_motor_mode, set_torque, get_motor_mode,
     set_gravity_compensation, set_automatic_body_yaw,
-    get_state, get_version, start_recording, stop_recording, append_record
+    get_state, get_version, start_recording, stop_recording, append_record,
+    subscribe_logs, unsubscribe_logs, restart_daemon
 
 Server->Client message types:
     joint_positions, head_pose, imu_data, recorded_data,
@@ -304,6 +305,30 @@ class UnsubscribeLogsCmd(BaseModel):
     type: Literal["unsubscribe_logs"] = "unsubscribe_logs"
 
 
+# ------------------------------------------------------------------
+# Daemon restart over the DataChannel.
+#
+# Mirrors `POST /api/daemon/restart`: rebuilds the backend (motor
+# controller, kinematics, media server, ...). The DataChannel itself
+# is torn down by the restart, so the daemon sends an ack BEFORE
+# kicking off the actual restart and the client is expected to
+# reconnect afterwards. Idempotent at the daemon level (the restart
+# coroutine already no-ops if the daemon is STOPPED).
+# ------------------------------------------------------------------
+
+
+class RestartDaemonCmd(BaseModel):
+    """Restart the daemon (rebuilds backend, motor controller, media server).
+
+    The WebRTC transport is torn down by the restart, so the daemon
+    sends a single ack response immediately (``{"status": "ok",
+    "command": "restart_daemon"}``) and the consumer is expected to
+    reconnect once the daemon is back up. There is no completion
+    message - the data channel is gone before the restart finishes.
+    """
+
+    type: Literal["restart_daemon"] = "restart_daemon"
+
 
 AnyCommand = Annotated[
     SetTargetCmd
@@ -331,7 +356,8 @@ AnyCommand = Annotated[
     | SetMicrophoneVolumeCmd
     | GetMicrophoneVolumeCmd
     | SubscribeLogsCmd
-    | UnsubscribeLogsCmd,
+    | UnsubscribeLogsCmd
+    | RestartDaemonCmd,
     Field(discriminator="type"),
 ]
 


### PR DESCRIPTION
## Summary

Adds a typed `restart_daemon` command to the WebRTC DataChannel protocol so remote SDK clients can trigger a full daemon restart (rebuilds backend, motor controller, kinematics, media server, ...) the same way `POST /api/daemon/restart` does locally.

## Why

The localhost-only REST endpoint isn't reachable from a remote consumer (relayed sessions, embedded apps behind the host bridge, ...). When the backend gets stuck in a half-broken state - typically a dead motor controller surfacing as a flood of `Motor controller not initialized or already closed` errors on the WebRTC `error` channel, with `motor_mode: \"enabled\"` reported back so the SDK's `ensureAwake()` skips `wakeUp()` - the only recovery today is `ssh` + `systemctl restart reachy-mini-daemon`. That's not viable for remote operators or non-technical users.

Exposing the same restart over the existing typed transport keeps the recovery in-band: the SDK can simply call a new `restartDaemon()` and the host UI can re-establish the session through its normal reconnect path.

## Changes

Three files, ~100 lines including doc:

- **`io/protocol.py`** - new `RestartDaemonCmd` (single `type: \"restart_daemon\"` literal, no payload), added to the `AnyCommand` discriminator union.
- **`daemon/backend/abstract.py`** - dispatch in `process_command`. The ack response is sent *before* triggering the restart because the DataChannel is torn down by `daemon.stop()`; any later send on the peer's channel would silently drop. If no host wired a callback the backend replies with an explicit error rather than silently no-op.
- **`daemon/daemon.py`** - registers a synchronous `_spawn_webrtc_restart` callback right after `setup_media_server`. The callback spawns a daemon `Thread` running `asyncio.run(self.restart())`, mirroring `bg_job_register.run_command`. We can't reuse the FastAPI bg-job registry directly here because the backend has no `Request` context.

## Behaviour

1. Client sends `{\"type\": \"restart_daemon\"}` on the DataChannel.
2. Daemon replies once with `{\"status\": \"ok\", \"command\": \"restart_daemon\"}`.
3. Daemon spawns a worker thread, returns from the handler.
4. Worker calls `self.restart()` -> `daemon.stop()` -> `daemon.start(**previous_params)`. Media server, motor controller and the WebRTC stack are torn down and re-created.
5. Client's WebRTC connection drops. The consumer reconnects via existing session-recovery logic.

There is **no completion message** - by design, the transport is gone before `restart()` finishes. The reconnect itself is the success signal. `daemon.restart()` is already idempotent: it no-ops if the daemon is `STOPPED`, and `_spawn_webrtc_restart` short-circuits the same way with a warning log.

## Notes

- No new dependencies, no protocol breaking changes - additive enum on the discriminator union.
- Other transports (HTTP/WebSocket through `process_command`) gain the same command for free.
- No JS-side changes in this PR - they'll land in the SDK / host PRs that consume the new command.

## Test plan

- [ ] Unit: validate `command_adapter.validate_json('{\"type\":\"restart_daemon\"}')` returns a `RestartDaemonCmd`.
- [ ] Manual on real robot: drive the robot into a known-broken motor-controller state, send `restart_daemon` via DataChannel, verify daemon journal shows `Restarting Reachy Mini daemon...` -> `STOPPED` -> `STARTING` -> `RUNNING`, motor controller reinitialised.
- [ ] Manual: confirm SDK client receives the ack response, then sees `iceconnectionstate: disconnected` shortly after, and can re-establish a session.
- [ ] Negative path: backend variant where `setup_media_server` was not called -> client receives `{\"error\": \"restart_daemon not supported by this backend host\", \"command\": \"restart_daemon\"}` instead of a silent drop.

Made with [Cursor](https://cursor.com)