### PR TITLE
ci(npm-publish): Node 24, PR dry-run trigger

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,6 +9,11 @@ on:
       - main
     paths:
       - "js/**"
+      - ".github/workflows/npm-publish.yml"
+  pull_request:
+    paths:
+      - "js/**"
+      - ".github/workflows/npm-publish.yml"
 
 jobs:
   publish:
@@ -23,10 +28,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"   # ships npm >= 11.5.1 — required for trusted publishing
           registry-url: "https://registry.npmjs.org"
-      - name: Upgrade npm (>=11.5.1 required for trusted publishing)
-        run: npm install -g npm@latest
 
       # Install workspace deps (root + sdk + host workspaces, hoisted
       # into js/node_modules/) so the host bundles can be built.
@@ -39,20 +42,30 @@ jobs:
         run: npm run build:host
 
       # pyproject.toml is the single source of truth for the version.
-      # Release  → publish <py_ver>            on the `latest` dist-tag.
-      # Push     → publish <py_ver>-main.<sha> on the `main`   dist-tag.
+      # Release       → publish <py_ver>            on the `latest` dist-tag.
+      # Push to main  → publish <py_ver>-main.<sha> on the `main`   dist-tag.
+      # Pull request  → dry-run only (no publish).
       - name: Compute and apply version from pyproject.toml
         run: |
           py_ver=$(grep -E '^version' ../pyproject.toml | head -1 | sed -E 's/version *= *"([^"]+)"/\1/')
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
             sha=$(echo "${{ github.sha }}" | cut -c1-7)
             ver="${py_ver}-main.${sha}"
           else
             ver="${py_ver}"
           fi
-          echo "Publishing version: $ver"
+          echo "Computed version: $ver (event=${{ github.event_name }})"
           npm version "$ver" --no-git-tag-version --workspace=sdk
           npm version "$ver" --no-git-tag-version --workspace=host
+
+      # PR: pack both workspaces to confirm the publish would succeed
+      # (tarball layout, manifest validity, no missing files) without
+      # actually publishing.
+      - name: Verify tarballs (PR dry-run)
+        if: github.event_name == 'pull_request'
+        run: |
+          npm pack --workspace=sdk --dry-run
+          npm pack --workspace=host --dry-run
 
       - name: Publish SDK (latest)
         if: github.event_name == 'release'


### PR DESCRIPTION
Two small follow-ups to the npm-publish workflow:

1. Bump runner Node from 22 → 24, which ships with npm 11.5.1+ out of the box. Drops the fragile `npm install -g npm@latest` step that crashed mid-upgrade with "Cannot find module 'promise-retry'".

2. Add a `pull_request` trigger (paths: js/**, workflow file) that reuses the install + build steps and runs `npm pack --workspace=sdk --dry-run` + the host equivalent. Catches manifest/tarball errors before merge. Existing publish steps stay gated by event_name so a PR never publishes.

Note: the PR introducing this trigger can't fire it on itself — the `pull_request` event reads the workflow from the base branch, which doesn't have the trigger yet. Future PRs will be checked.

Assisted-by: Claude:claude-opus-4-7