### PR TITLE
feat(media): detect and report stuck WebRTC sessions via watchdog

### DIFF
--- a/docs/source/SDK/gstreamer-installation.md
+++ b/docs/source/SDK/gstreamer-installation.md
@@ -75,7 +75,15 @@ To build and install the WebRTC plugin, run the following commands:
 # Clone the GStreamer Rust plugins repository
 git clone https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
 cd gst-plugins-rs
-git checkout 0.14.1
+# 0.14.5 ships a critical webrtcsink fix for a deadlock between
+# remote description and ICE handling that manifested on the
+# daemon as the historical "stuck at session" UX (the JS client
+# spinning forever because libnice never reached `connected`).
+# Older 0.14.x tags (0.14.1, 0.14.2, 0.14.3) do NOT carry this
+# fix; see the upstream CHANGELOG. The daemon-side negotiation
+# watchdog (`reachy_mini.media.media_server`) is the safety net,
+# but pinning to a fixed plugin means that net should rarely fire.
+git checkout 0.14.5
 
 # Install the cargo-c build tool
 cargo install cargo-c

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -187,13 +187,24 @@ class Daemon:
             transport = "wifi" if self.wireless_version else "usb"
 
             self.logger.info("Starting central signaling relay...")
-            await start_central_relay(
+            relay = await start_central_relay(
                 hf_token=hf_token,
                 robot_name=self.robot_name,
                 transport=transport,
                 robot_app_lock=self.robot_app_lock,
             )
             self.logger.info("Central signaling relay started")
+
+            # Wire the negotiation watchdog: when GstMediaServer
+            # detects a stuck WebRTC negotiation (typically libnice
+            # frozen mid-CHECKING), it forwards the failure to central
+            # via the relay so the JS client gets a typed
+            # ``endSession`` instead of a spinner-on-blank-page UX.
+            # See `media_server.set_session_failed_handler`.
+            if self._media_server is not None:
+                self._media_server.set_session_failed_handler(
+                    relay.notify_peer_session_failed
+                )
         except Exception as e:
             self.logger.warning(f"Failed to start central signaling relay: {e}")
 

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -407,6 +407,130 @@ class CentralSignalingRelay:
         """
         await self._reconnect_now(self.hf_token, reason="Forced relay reconnect")
 
+    def notify_peer_session_failed(
+        self,
+        peer_id: str,
+        reason: str,
+        diagnostic: dict[str, Any],
+    ) -> None:
+        """Forward a daemon-side WebRTC failure to central as ``endSession``.
+
+        Thread-safe entry point intended for callers running on the
+        GStreamer / GLib thread (e.g. ``GstMediaServer``'s negotiation
+        watchdog). It schedules the actual network send onto this
+        relay's own asyncio event loop via
+        ``asyncio.run_coroutine_threadsafe``, so the GStreamer thread
+        never blocks on aiohttp.
+
+        ``peer_id`` is the identifier surfaced by ``webrtcsink``'s
+        ``consumer-added`` signal. ``webrtcsink`` uses the same UUID
+        for the WebRTC consumer and the local GStreamer signaling
+        session, so ``peer_id`` is also the ``local_session_id`` we
+        use for the central <-> local session mapping.
+
+        Args:
+            peer_id: ``webrtcbin`` consumer id == local GStreamer
+                session id.
+            reason: Wire-level reason carried in the ``endSession``
+                envelope; matched against
+                ``SESSION_FAILED_REASON_*`` constants in
+                ``media_server.py``. The JS SDK switches on this to
+                pick a user-facing message (vs. silent retry).
+            diagnostic: Free-form dict (ICE / connection / signaling
+                state, elapsed seconds) included in the daemon log
+                line. Not forwarded over the wire to keep the
+                envelope size bounded; central operators can grep the
+                daemon log if they need detail on a specific failure.
+
+        """
+        if self._thread_loop is None or not self._thread_loop.is_running():
+            logger.debug(
+                "[Central Relay] notify_peer_session_failed: relay loop not running, "
+                "dropping notification (peer_id=%s, reason=%s)",
+                peer_id,
+                reason,
+            )
+            return
+        asyncio.run_coroutine_threadsafe(
+            self._notify_peer_session_failed(peer_id, reason, diagnostic),
+            self._thread_loop,
+        )
+
+    async def _notify_peer_session_failed(
+        self,
+        peer_id: str,
+        reason: str,
+        diagnostic: dict[str, Any],
+    ) -> None:
+        """Inner coroutine for ``notify_peer_session_failed``.
+
+        Runs on the relay's own thread loop. Looks up the mapping,
+        emits ``endSession`` to central, and clears the bookkeeping
+        for this session. Local GStreamer is intentionally NOT
+        notified here: ``webrtcbin`` already considers the peer dead
+        (that's what triggered the watchdog) and emitting
+        ``endSession`` to local would race ``consumer-removed``,
+        producing a confusing pair of "session ended" log lines for
+        the same UUID.
+        """
+        # Walk the mapping in one pass and capture the central id
+        # before mutating the dicts, so we can log a single coherent
+        # line even if a concurrent ``endSession`` from the other
+        # direction is racing us.
+        local_session_id = peer_id
+        central_session_id = self._local_to_central_session.get(local_session_id)
+        if central_session_id is None:
+            logger.warning(
+                "[Central Relay] notify_peer_session_failed: no central session "
+                "mapped for peer_id=%s (reason=%s, diagnostic=%s); session may "
+                "have already been torn down",
+                peer_id,
+                reason,
+                diagnostic,
+            )
+            return
+
+        logger.error(
+            "[Central Relay] daemon-side WebRTC failure: peer_id=%s -> "
+            "central_session=%s reason=%s diagnostic=%s",
+            peer_id,
+            central_session_id,
+            reason,
+            diagnostic,
+        )
+
+        try:
+            await self._send_to_central(
+                {
+                    "type": "endSession",
+                    "sessionId": central_session_id,
+                    "reason": reason,
+                }
+            )
+        except Exception:
+            logger.warning(
+                "[Central Relay] Failed to notify central of peer session failure",
+                exc_info=True,
+            )
+
+        # Clean up our half of the bookkeeping. ``_consumer_removed``
+        # on the GStreamer side will run shortly after and clean up
+        # the local-side mappings too, but we drop our entries
+        # eagerly to avoid an inconsistent window where central
+        # already considers the session done but the relay still has
+        # stale state.
+        self._local_to_central_session.pop(local_session_id, None)
+        self._central_to_local_session.pop(central_session_id, None)
+        self._session_to_local_peer.pop(central_session_id, None)
+        if central_session_id in self._pending_central_sessions:
+            self._pending_central_sessions.remove(central_session_id)
+        if (
+            self._robot_app_lock is not None
+            and not self._central_to_local_session
+            and not self._pending_central_sessions
+        ):
+            self._robot_app_lock.release_remote()
+
     async def _reconnect_now(self, token: Optional[str], reason: str) -> None:
         """Shared core of token-change and force-reconnect paths.
 

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -25,7 +25,9 @@ Example usage::
 import logging
 import os
 import platform
-from threading import Thread
+import time
+from dataclasses import dataclass, field
+from threading import Lock, Thread
 from typing import Any, Callable, Dict, Optional
 
 import gi
@@ -51,6 +53,65 @@ gi.require_version("Gst", "1.0")
 gi.require_version("GstApp", "1.0")
 
 from gi.repository import GLib, Gst  # noqa: E402
+
+# Hard cap on how long a freshly-added consumer is allowed to spend
+# before its `webrtcbin.connection-state` reaches "connected". In a
+# healthy run the negotiation completes in well under a second
+# (offer/answer + a few ICE candidate pairs). Past this deadline,
+# we conclude the negotiation is stuck — the typical culprit is
+# libnice frozen mid-`CHECKING` (a known crash mode of certain
+# libnice versions) or a downstream networking issue we can't see
+# from the daemon. We notify the central so the JS client gets a
+# clean rejection instead of a spinner-on-blank-page UX.
+#
+# 12 s is generous for a healthy negotiation and short enough that
+# the user sees the failure quickly. Tuned conservatively because
+# the daemon has no way to distinguish "slow ICE on a flaky
+# network" from "libnice frozen" — at this duration both are bad.
+ICE_NEGOTIATION_DEADLINE_S = 12
+
+# `reason` strings sent to central via the existing `endSession`
+# message. Picked to be parseable by the JS SDK so a user-facing
+# message can map to a precise cause. See
+# `central_signaling_relay.notify_peer_session_failed` for the
+# wire-level emission.
+SESSION_FAILED_REASON_ICE_TIMEOUT = "ice_negotiation_timeout"
+SESSION_FAILED_REASON_PC_FAILED = "peer_connection_failed"
+
+
+@dataclass
+class _PeerWebRTCState:
+    """Live state of a single WebRTC peer's negotiation.
+
+    Used by the watchdog to decide if the session is making progress.
+    Updated on every `notify::*-state` callback fired by webrtcbin.
+    Held under :attr:`GstMediaServer._peer_states_lock` because
+    GStreamer signals can fire on internal threads.
+    """
+
+    peer_id: str
+    ice_state: str = "new"
+    conn_state: str = "new"
+    signaling_state: str = "new"
+    added_at: float = field(default_factory=time.monotonic)
+    # GLib timer source ID (returned by `GLib.timeout_add_seconds`).
+    # Kept so the watchdog can be cancelled if the peer reaches a
+    # terminal state (connected, removed) before the deadline.
+    watchdog_source_id: Optional[int] = None
+    # Whether the failure callback has already fired for this peer.
+    # Prevents double-notification when both `connection-state ==
+    # failed` AND the deadline timer fire close together.
+    failure_notified: bool = False
+
+    def asdict(self) -> Dict[str, Any]:
+        """Build a serialisable snapshot for diagnostics in failure notifications."""
+        return {
+            "peer_id": self.peer_id,
+            "ice_state": self.ice_state,
+            "conn_state": self.conn_state,
+            "signaling_state": self.signaling_state,
+            "elapsed_s": round(time.monotonic() - self.added_at, 2),
+        }
 
 
 class GstMediaServer:
@@ -128,6 +189,23 @@ class GstMediaServer:
         # leaves; used by the backend to free per-peer resources such
         # as the journalctl subprocess for a `subscribe_logs` stream.
         self._on_peer_disconnect: Optional[Callable[[str], None]] = None
+        # Optional callback fired by the ICE negotiation watchdog when
+        # a peer's `webrtcbin` is stuck mid-negotiation (see
+        # `_check_negotiation_deadline`). Wired by the daemon to the
+        # central signaling relay so the JS client gets a typed
+        # `endSession` instead of a spinner. Signature:
+        # `(peer_id, reason, diagnostic_dict) -> None`.
+        self._on_session_failed: Optional[
+            Callable[[str, str, Dict[str, Any]], None]
+        ] = None
+        self._peer_states: Dict[str, _PeerWebRTCState] = {}
+        # GStreamer signals (`notify::*`) can fire on internal threads
+        # owned by webrtcbin / libnice, while consumer-added /
+        # consumer-removed run on the GLib main thread. The state
+        # dict is touched from both, so we take a lock around every
+        # mutation. The critical sections are tiny (a few field
+        # writes) so contention is negligible.
+        self._peer_states_lock = Lock()
         self._incoming_audio: Dict[str, Dict[str, Any]] = {}
         self._playbin: Optional[Gst.Element] = None
 
@@ -206,6 +284,12 @@ class GstMediaServer:
         # Listen for incoming audio pads from the browser (bidirectional audio)
         webrtcbin.connect("pad-added", self._on_consumer_pad_added, peer_id)
 
+        # Watchdog wiring: track ICE / connection / signaling state on
+        # this peer's webrtcbin so we can detect a stuck negotiation
+        # and report it (instead of letting the JS client spin
+        # forever). See `ICE_NEGOTIATION_DEADLINE_S`.
+        self._install_negotiation_watchdog(peer_id, webrtcbin)
+
     # GstWebRTCRTPTransceiverDirection enum values
     _WEBRTC_DIRECTION_SENDRECV = 4
 
@@ -241,6 +325,9 @@ class GstMediaServer:
     ) -> None:
         self._logger.info(f"consumer removed: {peer_id}")
         self._cleanup_incoming_audio(peer_id)
+        # Cancel any outstanding watchdog for this peer; the consumer
+        # is gone so there's nothing left to police.
+        self._teardown_negotiation_watchdog(peer_id)
         if self._on_peer_disconnect is not None:
             try:
                 self._on_peer_disconnect(peer_id)
@@ -1020,6 +1107,258 @@ class GstMediaServer:
         loop before touching shared state.
         """
         self._on_peer_disconnect = handler
+
+    def set_session_failed_handler(
+        self,
+        handler: Callable[[str, str, Dict[str, Any]], None],  # (peer_id, reason, diag)
+    ) -> None:
+        """Set a callback fired when the negotiation watchdog gives up on a peer.
+
+        The callback runs on the GStreamer/GLib thread (or the
+        webrtcbin internal thread for `connection-state == failed`),
+        so consumers must hop back to their own loop before doing I/O.
+        Typical wiring is to forward to the central signaling relay
+        which converts the call into an ``endSession`` message for
+        the JS client.
+
+        Args:
+            handler: ``(peer_id, reason, diagnostic_dict) -> None``.
+                ``reason`` is one of ``SESSION_FAILED_REASON_*``.
+                ``diagnostic_dict`` carries the snapshot of the
+                webrtcbin state at failure time, suitable for logs.
+
+        """
+        self._on_session_failed = handler
+
+    # ------------------------------------------------------------------
+    # ICE negotiation watchdog (see `ICE_NEGOTIATION_DEADLINE_S`).
+    # ------------------------------------------------------------------
+
+    def _install_negotiation_watchdog(
+        self, peer_id: str, webrtcbin: Gst.Element
+    ) -> None:
+        """Subscribe to webrtcbin's state notifications and start the deadline timer.
+
+        Runs on the GLib main thread (called from `_consumer_added`).
+        """
+        state = _PeerWebRTCState(peer_id=peer_id)
+        with self._peer_states_lock:
+            # In theory `consumer-added` fires once per peer_id, but
+            # webrtcsink has been seen to re-add a peer after a brief
+            # disconnect. Drop the previous watchdog if any to avoid
+            # leaking timers.
+            existing = self._peer_states.pop(peer_id, None)
+            if existing is not None and existing.watchdog_source_id is not None:
+                GLib.source_remove(existing.watchdog_source_id)
+            self._peer_states[peer_id] = state
+
+        # `notify::*-state` fires every time the named property
+        # changes, on whatever thread webrtcbin is using internally.
+        # We pass `peer_id` as user data so the handlers don't need
+        # to reverse-lookup the peer from the GObject.
+        webrtcbin.connect(
+            "notify::ice-connection-state",
+            self._on_ice_connection_state_change,
+            peer_id,
+        )
+        webrtcbin.connect(
+            "notify::connection-state",
+            self._on_connection_state_change,
+            peer_id,
+        )
+        webrtcbin.connect(
+            "notify::signaling-state",
+            self._on_signaling_state_change,
+            peer_id,
+        )
+
+        source_id = GLib.timeout_add_seconds(
+            ICE_NEGOTIATION_DEADLINE_S,
+            self._on_negotiation_deadline,
+            peer_id,
+        )
+        with self._peer_states_lock:
+            # The peer might have already been removed in the brief
+            # window above (rare but possible on flaky networks).
+            current = self._peer_states.get(peer_id)
+            if current is state:
+                current.watchdog_source_id = source_id
+            else:
+                # Peer is gone; cancel the timer we just scheduled.
+                GLib.source_remove(source_id)
+
+    def _teardown_negotiation_watchdog(self, peer_id: str) -> None:
+        """Cancel the watchdog timer for `peer_id` and forget its state.
+
+        Called from `_consumer_removed` (peer left cleanly) and from
+        `_check_negotiation_deadline` (we just notified failure).
+        Safe to call twice — the second call is a no-op.
+        """
+        with self._peer_states_lock:
+            state = self._peer_states.pop(peer_id, None)
+        if state is None:
+            return
+        if state.watchdog_source_id is not None:
+            try:
+                GLib.source_remove(state.watchdog_source_id)
+            except Exception:
+                # `source_remove` raises (or returns False, depending
+                # on the binding) if the source has already fired.
+                # That's fine; we just wanted to make sure it's gone.
+                pass
+
+    def _on_ice_connection_state_change(
+        self,
+        webrtcbin: Gst.Element,
+        _pspec: Any,
+        peer_id: str,
+    ) -> None:
+        new_state = self._read_state_nick(webrtcbin, "ice-connection-state")
+        with self._peer_states_lock:
+            state = self._peer_states.get(peer_id)
+            if state is None:
+                return
+            state.ice_state = new_state
+        self._logger.debug(
+            f"[watchdog] peer={peer_id} ice-connection-state -> {new_state}"
+        )
+
+    def _on_signaling_state_change(
+        self,
+        webrtcbin: Gst.Element,
+        _pspec: Any,
+        peer_id: str,
+    ) -> None:
+        new_state = self._read_state_nick(webrtcbin, "signaling-state")
+        with self._peer_states_lock:
+            state = self._peer_states.get(peer_id)
+            if state is None:
+                return
+            state.signaling_state = new_state
+        self._logger.debug(f"[watchdog] peer={peer_id} signaling-state -> {new_state}")
+
+    def _on_connection_state_change(
+        self,
+        webrtcbin: Gst.Element,
+        _pspec: Any,
+        peer_id: str,
+    ) -> None:
+        new_state = self._read_state_nick(webrtcbin, "connection-state")
+        snapshot: Optional[Dict[str, Any]] = None
+        should_notify_failure = False
+        with self._peer_states_lock:
+            state = self._peer_states.get(peer_id)
+            if state is None:
+                return
+            state.conn_state = new_state
+            # `failed` is the terminal "we tried and gave up" state
+            # webrtcbin reaches when ICE check pairs all fail. We
+            # report it eagerly without waiting for the deadline, so
+            # the JS client gets a fast rejection on bad networks.
+            if new_state == "failed" and not state.failure_notified:
+                state.failure_notified = True
+                snapshot = state.asdict()
+                should_notify_failure = True
+
+        self._logger.info(f"[watchdog] peer={peer_id} connection-state -> {new_state}")
+
+        if should_notify_failure and snapshot is not None:
+            self._dispatch_session_failed(
+                peer_id,
+                SESSION_FAILED_REASON_PC_FAILED,
+                snapshot,
+            )
+            self._teardown_negotiation_watchdog(peer_id)
+
+    def _on_negotiation_deadline(self, peer_id: str) -> bool:
+        """Run the watchdog deadline check for ``peer_id``.
+
+        Fired by GLib ``ICE_NEGOTIATION_DEADLINE_S`` seconds after
+        ``consumer-added``. Returns False so GLib drops the source
+        automatically.
+        """
+        snapshot: Optional[Dict[str, Any]] = None
+        is_stuck = False
+        with self._peer_states_lock:
+            state = self._peer_states.get(peer_id)
+            if state is None:
+                # Peer already cleaned up; nothing to do.
+                return False
+            # Connection is healthy if we're connected or completed.
+            # The completed state means ICE has finished checking and
+            # promoted a candidate pair.
+            if state.conn_state in ("connected",) or state.ice_state in (
+                "connected",
+                "completed",
+            ):
+                # All good, but mark the timer as gone so
+                # `_teardown_negotiation_watchdog` doesn't try to
+                # remove an already-fired source.
+                state.watchdog_source_id = None
+                return False
+            if state.failure_notified:
+                # `connection-state == failed` already ran the
+                # callback; don't double-fire.
+                state.watchdog_source_id = None
+                return False
+            state.failure_notified = True
+            state.watchdog_source_id = None
+            snapshot = state.asdict()
+            is_stuck = True
+
+        if is_stuck and snapshot is not None:
+            self._logger.error(
+                f"[watchdog] peer={peer_id} stuck mid-negotiation "
+                f"after {ICE_NEGOTIATION_DEADLINE_S}s, snapshot={snapshot}"
+            )
+            self._dispatch_session_failed(
+                peer_id,
+                SESSION_FAILED_REASON_ICE_TIMEOUT,
+                snapshot,
+            )
+            self._teardown_negotiation_watchdog(peer_id)
+        return False
+
+    def _dispatch_session_failed(
+        self,
+        peer_id: str,
+        reason: str,
+        diagnostic: Dict[str, Any],
+    ) -> None:
+        """Invoke the user-supplied session-failed callback safely.
+
+        Swallows exceptions so a misbehaving handler can't crash the
+        GStreamer bus thread.
+        """
+        handler = self._on_session_failed
+        if handler is None:
+            self._logger.warning(
+                f"[watchdog] peer={peer_id} reason={reason} but no "
+                "session-failed handler is wired; the JS client will "
+                "have to rely on its own timeout"
+            )
+            return
+        try:
+            handler(peer_id, reason, diagnostic)
+        except Exception as e:
+            self._logger.warning(f"session-failed handler raised for {peer_id}: {e}")
+
+    @staticmethod
+    def _read_state_nick(webrtcbin: Gst.Element, prop: str) -> str:
+        """Read a webrtcbin enum property as its short string nick.
+
+        Returns ``"connected"`` instead of
+        ``GstWebRTCICEConnectionState.connected``. Returns ``"unknown"``
+        if introspection fails - we never want a diagnostic helper to raise.
+        """
+        try:
+            value = webrtcbin.get_property(prop)
+            nick = getattr(value, "value_nick", None)
+            if isinstance(nick, str) and nick:
+                return nick
+            return str(value)
+        except Exception:
+            return "unknown"
 
     def send_data_message(self, peer_id: Optional[str], message: str) -> None:
         """Send a message to connected peers via data channel.

--- a/tests/unit_tests/test_central_signaling_relay.py
+++ b/tests/unit_tests/test_central_signaling_relay.py
@@ -10,6 +10,12 @@ in the same way as the robot_app_lock test suite).
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import threading
+import time
+from typing import Any
+
 import pytest
 
 from reachy_mini.media.central_signaling_relay import (
@@ -19,7 +25,6 @@ from reachy_mini.media.central_signaling_relay import (
     CentralSignalingRelay,
     _clamp_heartbeat_interval,
 )
-
 
 # ---------------------------------------------------------------------------
 # _clamp_heartbeat_interval
@@ -130,9 +135,7 @@ def test_negotiate_ignores_non_positive_recommended() -> None:
 
 def test_negotiate_ignores_non_positive_lease() -> None:
     """A zero / negative `lease_seconds` falls through to the default."""
-    result = CentralSignalingRelay._negotiate_heartbeat_interval(
-        {"lease_seconds": 0}
-    )
+    result = CentralSignalingRelay._negotiate_heartbeat_interval({"lease_seconds": 0})
     assert result == HEARTBEAT_DEFAULT_INTERVAL
 
 
@@ -165,7 +168,9 @@ def test_negotiate_accepts_int_recommended() -> None:
 # disappearing.
 
 
-def _make_relay(robot_name: str = "reachymini", transport: str = "wifi") -> CentralSignalingRelay:
+def _make_relay(
+    robot_name: str = "reachymini", transport: str = "wifi"
+) -> CentralSignalingRelay:
     """Construct a relay without starting the asyncio plumbing.
 
     The constructor only stores fields; ``start()`` is what binds to the
@@ -176,38 +181,45 @@ def _make_relay(robot_name: str = "reachymini", transport: str = "wifi") -> Cent
 
 
 def test_meta_carries_robot_name() -> None:
+    """The relay carries ``robot_name`` into ``meta.name`` verbatim."""
     relay = _make_relay(robot_name="Sparky")
     assert relay._build_producer_meta()["name"] == "Sparky"
 
 
 def test_meta_carries_transport_wifi_by_default() -> None:
-    """The relay defaults to ``transport='wifi'`` when no override is
-    passed: this matches the Pi-side autonomous daemon, which is the
-    common case (the desktop tray is the one that has to opt in)."""
+    """The relay defaults to ``transport='wifi'`` when no override is passed.
+
+    This matches the Pi-side autonomous daemon, which is the common
+    case (the desktop tray is the one that has to opt in).
+    """
     relay = _make_relay()
     assert relay._build_producer_meta()["transport"] == "wifi"
 
 
 def test_meta_carries_transport_usb_when_set() -> None:
+    """The relay forwards ``transport='usb'`` verbatim into ``meta``."""
     relay = _make_relay(transport="usb")
     assert relay._build_producer_meta()["transport"] == "usb"
 
 
 def test_meta_forwards_unknown_transport_value_verbatim() -> None:
-    """``transport`` is intentionally a free-form string: future fronts
-    (``"ethernet"``, ``"sim"``, ``"mockup"``, ...) must propagate to
-    listeners without a relay change. Listeners that don't recognise
-    the value fall back to "Wi-Fi" by convention.
+    """``transport`` is intentionally a free-form string.
+
+    Future fronts (``"ethernet"``, ``"sim"``, ``"mockup"``, ...) must
+    propagate to listeners without a relay change. Listeners that
+    don't recognise the value fall back to "Wi-Fi" by convention.
     """
     relay = _make_relay(transport="ethernet")
     assert relay._build_producer_meta()["transport"] == "ethernet"
 
 
 def test_meta_used_by_producer_status_payload() -> None:
-    """``_producer_status_payload`` MUST embed the meta verbatim: the
-    payload is the canonical envelope, ``_build_producer_meta`` is the
-    source of truth for the dict's content. Any divergence would cause
-    the heartbeat re-emission to drift from the initial registration.
+    """``_producer_status_payload`` MUST embed the meta verbatim.
+
+    The payload is the canonical envelope, ``_build_producer_meta``
+    is the source of truth for the dict's content. Any divergence
+    would cause the heartbeat re-emission to drift from the initial
+    registration.
     """
     relay = _make_relay(robot_name="r1", transport="usb")
     payload = relay._producer_status_payload()
@@ -226,11 +238,14 @@ def test_meta_used_by_producer_status_payload() -> None:
 # the underlying serial-reading helper (which has its own coverage).
 
 
-def test_meta_includes_hardware_id_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When ``get_hardware_id()`` returns a string, the meta MUST
-    carry it under the ``hardware_id`` key. Listeners use this as the
-    stable cross-source identity (BLE GATT / central / loopback HTTP
-    all expose the same value)."""
+def test_meta_includes_hardware_id_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``get_hardware_id()`` returns a string, the meta carries it.
+
+    Listeners use this as the stable cross-source identity (BLE GATT
+    / central / loopback HTTP all expose the same value).
+    """
     import reachy_mini.media.central_signaling_relay as relay_module
 
     monkeypatch.setattr(relay_module, "get_hardware_id", lambda: "abc123def456")
@@ -240,9 +255,11 @@ def test_meta_includes_hardware_id_when_available(monkeypatch: pytest.MonkeyPatc
 
 
 def test_meta_omits_hardware_id_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When no Reachy is attached (``get_hardware_id() is None``) the
-    field MUST be absent from the meta - never serialised as ``null``
-    or as the literal ``"unknown"``. Consumers branch on
+    """When no Reachy is attached, the ``hardware_id`` field is absent.
+
+    ``get_hardware_id() is None`` MUST result in the field being
+    omitted from the meta - never serialised as ``null`` or as the
+    literal ``"unknown"``. Consumers branch on
     ``"hardware_id" in meta`` to decide whether to use the stable id
     or fall back to ``peerId`` / BLE address.
     """
@@ -255,9 +272,10 @@ def test_meta_omits_hardware_id_when_absent(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_meta_shape_with_hardware_id(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Lock the full set of keys when ``hardware_id`` is available so a
-    listener written today is not broken by an accidental field rename.
-    Add new keys, never remove or rename.
+    """Lock the full set of keys when ``hardware_id`` is available.
+
+    A listener written today must not be broken by an accidental
+    field rename. Add new keys, never remove or rename.
     """
     import reachy_mini.media.central_signaling_relay as relay_module
 
@@ -268,9 +286,11 @@ def test_meta_shape_with_hardware_id(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_meta_shape_without_hardware_id(monkeypatch: pytest.MonkeyPatch) -> None:
-    """And the minimal key set when no Reachy is attached. Same lock
-    intent: a future PR adding a new field MUST extend both shape tests
-    rather than relax them.
+    """Lock the minimal key set when no Reachy is attached.
+
+    Same lock intent as ``test_meta_shape_with_hardware_id``: a
+    future PR adding a new field MUST extend both shape tests rather
+    than relax them.
     """
     import reachy_mini.media.central_signaling_relay as relay_module
 
@@ -278,3 +298,191 @@ def test_meta_shape_without_hardware_id(monkeypatch: pytest.MonkeyPatch) -> None
     relay = _make_relay()
     meta = relay._build_producer_meta()
     assert set(meta.keys()) == {"name", "transport"}
+
+
+# ---------------------------------------------------------------------------
+# notify_peer_session_failed (daemon-side WebRTC watchdog -> central)
+# ---------------------------------------------------------------------------
+#
+# These tests exercise the relay-side leg of the negotiation
+# watchdog (the GStreamer-side leg lives in
+# `test_media_server_watchdog.py`). The watchdog fires when libnice
+# (or any other piece of the WebRTC plumbing) leaves the peer
+# stuck mid-negotiation; the relay translates that into an
+# `endSession` message routed at the central session id, so the
+# JS client gets a typed rejection.
+#
+# We drive the inner coroutine `_notify_peer_session_failed`
+# directly with `asyncio.run` and replace `_send_to_central` with a
+# stub journal so we can assert on the wire-level shape without
+# spinning up an HTTP session.
+
+
+class _SendJournal:
+    """Capture ``_send_to_central`` calls for inspection in tests."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def __call__(self, msg: dict[str, Any]) -> None:
+        self.sent.append(msg)
+
+
+def _make_relay_with_session(
+    *,
+    local_session_id: str = "local-1",
+    central_session_id: str = "central-1",
+    client_peer_id: str = "client-peer-1",
+) -> tuple[CentralSignalingRelay, _SendJournal]:
+    """Build a relay with one in-flight session and a stubbed central send.
+
+    Mirrors the state shape produced by
+    ``_process_local_message("sessionStarted")`` plus
+    ``_process_central_message("startSession")``.
+    """
+    relay = _make_relay()
+    journal = _SendJournal()
+    relay._send_to_central = journal  # type: ignore[method-assign]
+    relay._local_to_central_session[local_session_id] = central_session_id
+    relay._central_to_local_session[central_session_id] = local_session_id
+    relay._session_to_local_peer[central_session_id] = client_peer_id
+    return relay, journal
+
+
+def test_notify_peer_session_failed_sends_endsession_to_central() -> None:
+    """The wire shape of the failure message uses the central session id."""
+    relay, journal = _make_relay_with_session()
+
+    asyncio.run(
+        relay._notify_peer_session_failed(
+            "local-1",
+            "ice_negotiation_timeout",
+            {"ice_state": "checking", "elapsed_s": 12.0},
+        )
+    )
+
+    assert len(journal.sent) == 1
+    msg = journal.sent[0]
+    assert msg["type"] == "endSession"
+    assert msg["sessionId"] == "central-1"
+    assert msg["reason"] == "ice_negotiation_timeout"
+
+
+def test_notify_peer_session_failed_clears_session_bookkeeping() -> None:
+    """Session bookkeeping is cleared after a failure is reported to central."""
+    relay, _journal = _make_relay_with_session(
+        local_session_id="local-x",
+        central_session_id="central-x",
+        client_peer_id="peer-x",
+    )
+
+    asyncio.run(relay._notify_peer_session_failed("local-x", "any-reason", {}))
+
+    assert "local-x" not in relay._local_to_central_session
+    assert "central-x" not in relay._central_to_local_session
+    assert "central-x" not in relay._session_to_local_peer
+
+
+def test_notify_peer_session_failed_drops_pending_central_session() -> None:
+    """A pending central session for the failed peer is dropped from the queue."""
+    relay, journal = _make_relay_with_session(
+        local_session_id="local-p",
+        central_session_id="central-p",
+    )
+    relay._pending_central_sessions.append("central-p")
+
+    asyncio.run(relay._notify_peer_session_failed("local-p", "any-reason", {}))
+
+    assert "central-p" not in relay._pending_central_sessions
+    assert journal.sent[0]["sessionId"] == "central-p"
+
+
+def test_notify_peer_session_failed_no_op_when_session_unknown() -> None:
+    """A watchdog firing for an untracked session is a clean no-op."""
+    relay = _make_relay()
+    journal = _SendJournal()
+    relay._send_to_central = journal  # type: ignore[method-assign]
+
+    asyncio.run(relay._notify_peer_session_failed("ghost", "any", {}))
+
+    assert journal.sent == []
+
+
+def test_notify_peer_session_failed_logs_diagnostic_in_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The diagnostic dict is serialised to the daemon log for grepping."""
+    relay, _journal = _make_relay_with_session()
+    diagnostic = {"ice_state": "checking", "conn_state": "new", "elapsed_s": 12.0}
+
+    with caplog.at_level(logging.ERROR):
+        asyncio.run(
+            relay._notify_peer_session_failed(
+                "local-1", "ice_negotiation_timeout", diagnostic
+            )
+        )
+
+    matching = [
+        rec
+        for rec in caplog.records
+        if "daemon-side WebRTC failure" in rec.getMessage()
+    ]
+    assert len(matching) == 1
+    msg = matching[0].getMessage()
+    assert "checking" in msg
+    assert "ice_negotiation_timeout" in msg
+
+
+def test_public_notify_no_op_without_running_loop(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The public entry point drops the call when the relay loop is gone."""
+    relay = _make_relay()
+    assert relay._thread_loop is None
+
+    with caplog.at_level(logging.DEBUG):
+        relay.notify_peer_session_failed("local-1", "any", {})
+
+    debug_lines = [
+        rec for rec in caplog.records if "relay loop not running" in rec.getMessage()
+    ]
+    assert len(debug_lines) == 1
+
+
+def test_public_notify_schedules_work_on_relay_loop() -> None:
+    """The public entry point hops failure handling onto the relay's loop."""
+    relay, journal = _make_relay_with_session()
+
+    loop = asyncio.new_event_loop()
+    stop = threading.Event()
+
+    async def _block_until(evt: threading.Event) -> None:
+        while not evt.is_set():
+            await asyncio.sleep(0.01)
+
+    def _runner() -> None:
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(_block_until(stop))
+        finally:
+            loop.close()
+
+    relay._thread_loop = loop
+    t = threading.Thread(target=_runner, daemon=True)
+    t.start()
+
+    try:
+        relay.notify_peer_session_failed(
+            "local-1", "ice_negotiation_timeout", {"ice_state": "checking"}
+        )
+        for _ in range(50):
+            if journal.sent:
+                break
+            time.sleep(0.02)
+    finally:
+        stop.set()
+        t.join(timeout=2.0)
+
+    assert len(journal.sent) == 1
+    assert journal.sent[0]["sessionId"] == "central-1"
+    assert journal.sent[0]["reason"] == "ice_negotiation_timeout"

--- a/tests/unit_tests/test_media_server_watchdog.py
+++ b/tests/unit_tests/test_media_server_watchdog.py
@@ -1,0 +1,427 @@
+"""Unit tests for the WebRTC negotiation watchdog.
+
+The watchdog (in :mod:`reachy_mini.media.media_server`) is the
+daemon-side fix for the historical "stuck at session" bug, where
+libnice (used by webrtcbin internally) freezes mid-CHECKING and
+the JS client spins forever waiting on an offer that will never
+complete. These tests focus on the pure logic of the watchdog:
+state tracking, deadline handling, and the failure notification
+fan-out. The webrtcbin / GLib edges are mocked so the suite runs
+without a live GStreamer pipeline.
+
+Out of scope (would belong to an integration test):
+
+* End-to-end signal connection (``notify::*-state``) firing on a
+  real ``webrtcbin``.
+* Real ``GLib`` timer scheduling.
+* Cross-thread interaction with the central signaling relay.
+"""
+
+from __future__ import annotations
+
+import logging
+from threading import Lock
+from typing import Any, Dict, List, Tuple, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini.media.media_server import (
+    ICE_NEGOTIATION_DEADLINE_S,
+    SESSION_FAILED_REASON_ICE_TIMEOUT,
+    SESSION_FAILED_REASON_PC_FAILED,
+    GstMediaServer,
+    _PeerWebRTCState,
+)
+
+# ---------------------------------------------------------------------------
+# _PeerWebRTCState helpers
+# ---------------------------------------------------------------------------
+
+
+def test_peer_state_default_is_all_new() -> None:
+    """A freshly-created state defaults all three webrtcbin states to ``"new"``."""
+    state = _PeerWebRTCState(peer_id="peer-1")
+
+    assert state.peer_id == "peer-1"
+    assert state.ice_state == "new"
+    assert state.conn_state == "new"
+    assert state.signaling_state == "new"
+    assert state.failure_notified is False
+    assert state.watchdog_source_id is None
+
+
+def test_peer_state_asdict_round_trip() -> None:
+    """``asdict`` returns the exact set of fields downstream code reads."""
+    state = _PeerWebRTCState(peer_id="peer-2")
+    state.ice_state = "checking"
+    state.conn_state = "connecting"
+    state.signaling_state = "have-local-offer"
+
+    snapshot = state.asdict()
+
+    assert set(snapshot.keys()) == {
+        "peer_id",
+        "ice_state",
+        "conn_state",
+        "signaling_state",
+        "elapsed_s",
+    }
+    assert snapshot["peer_id"] == "peer-2"
+    assert snapshot["ice_state"] == "checking"
+    assert snapshot["conn_state"] == "connecting"
+    assert snapshot["signaling_state"] == "have-local-offer"
+    assert isinstance(snapshot["elapsed_s"], float)
+
+
+def test_reason_constants_are_distinct_strings() -> None:
+    """The wire-level reason constants must be distinct strings."""
+    assert SESSION_FAILED_REASON_ICE_TIMEOUT != SESSION_FAILED_REASON_PC_FAILED
+    assert isinstance(SESSION_FAILED_REASON_ICE_TIMEOUT, str)
+    assert isinstance(SESSION_FAILED_REASON_PC_FAILED, str)
+
+
+def test_ice_negotiation_deadline_is_reasonable() -> None:
+    """The deadline constant sits inside a sane safety envelope."""
+    # A sub-2s deadline would false-positive on slow networks; a
+    # >30s deadline defeats the UX purpose (user has already given up).
+    assert 2 < ICE_NEGOTIATION_DEADLINE_S < 30
+
+
+# ---------------------------------------------------------------------------
+# Bare-bones stand-in for GstMediaServer
+# ---------------------------------------------------------------------------
+#
+# `GstMediaServer.__init__` calls `Gst.init([])` and starts a
+# pipeline, which is overkill for testing the watchdog in isolation.
+# We bypass `__init__` and only initialise the attributes the
+# watchdog code touches; same approach as the existing
+# `test_audio_gstreamer.py`.
+
+
+def _make_server() -> GstMediaServer:
+    """Build a minimal ``GstMediaServer`` instance without booting GStreamer."""
+    server = cast(GstMediaServer, object.__new__(GstMediaServer))
+    server._logger = logging.getLogger("test_watchdog")
+    server._peer_states = {}
+    server._peer_states_lock = Lock()
+    server._on_session_failed = None
+    # Stubs for `__del__` -> `close()`, which the destructor calls
+    # at GC time; without them we'd surface a noisy
+    # ``AttributeError`` ``unraisable`` warning during the test
+    # session teardown. Real instances have these set in
+    # ``__init__``; we're bypassing it on purpose.
+    server._loop = MagicMock()
+    server._bus_sender = MagicMock()
+    return server
+
+
+def _patch_glib(monkeypatch: pytest.MonkeyPatch) -> Dict[str, List[Any]]:
+    """Replace ``GLib.timeout_add_seconds`` / ``source_remove`` with stubs."""
+    journal: Dict[str, List[Any]] = {"added": [], "removed": []}
+    next_id = [1000]
+
+    def fake_add(secs: int, fn: Any, *args: Any) -> int:
+        source_id = next_id[0]
+        next_id[0] += 1
+        journal["added"].append((source_id, secs, fn, args))
+        return source_id
+
+    def fake_remove(source_id: int) -> bool:
+        journal["removed"].append(source_id)
+        return True
+
+    from reachy_mini.media import media_server as ms
+
+    monkeypatch.setattr(ms.GLib, "timeout_add_seconds", fake_add)
+    monkeypatch.setattr(ms.GLib, "source_remove", fake_remove)
+    return journal
+
+
+# ---------------------------------------------------------------------------
+# _install_negotiation_watchdog
+# ---------------------------------------------------------------------------
+
+
+def test_install_watchdog_tracks_state_and_schedules_timer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A freshly-added peer is tracked, signalled, and timer-armed."""
+    journal = _patch_glib(monkeypatch)
+    server = _make_server()
+    webrtcbin = MagicMock()
+
+    server._install_negotiation_watchdog("peer-1", webrtcbin)
+
+    assert "peer-1" in server._peer_states
+    state = server._peer_states["peer-1"]
+    assert state.peer_id == "peer-1"
+    assert state.watchdog_source_id == 1000
+
+    connected_signals = {call.args[0] for call in webrtcbin.connect.call_args_list}
+    assert connected_signals == {
+        "notify::ice-connection-state",
+        "notify::connection-state",
+        "notify::signaling-state",
+    }
+
+    assert len(journal["added"]) == 1
+    _source_id, secs, _fn, args = journal["added"][0]
+    assert secs == ICE_NEGOTIATION_DEADLINE_S
+    assert args == ("peer-1",)
+
+
+def test_install_watchdog_replaces_pre_existing_state_for_same_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A re-fired ``consumer-added`` for the same peer cancels the old timer.
+
+    Some webrtcsink builds re-fire ``consumer-added`` after a brief
+    disconnect; we must not stack watchdogs that would all fire.
+    """
+    journal = _patch_glib(monkeypatch)
+    server = _make_server()
+    webrtcbin = MagicMock()
+
+    server._install_negotiation_watchdog("peer-1", webrtcbin)
+    first_source_id = server._peer_states["peer-1"].watchdog_source_id
+
+    server._install_negotiation_watchdog("peer-1", webrtcbin)
+
+    assert first_source_id in journal["removed"], (
+        "the previous watchdog timer must be cancelled before the new one fires"
+    )
+    new_state = server._peer_states["peer-1"]
+    assert new_state.watchdog_source_id != first_source_id
+
+
+# ---------------------------------------------------------------------------
+# _teardown_negotiation_watchdog
+# ---------------------------------------------------------------------------
+
+
+def test_teardown_watchdog_drops_state_and_cancels_timer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_consumer_removed`` clears both the state dict and the GLib source."""
+    journal = _patch_glib(monkeypatch)
+    server = _make_server()
+    webrtcbin = MagicMock()
+    server._install_negotiation_watchdog("peer-1", webrtcbin)
+
+    server._teardown_negotiation_watchdog("peer-1")
+
+    assert "peer-1" not in server._peer_states
+    assert journal["removed"] == [1000]
+
+
+def test_teardown_watchdog_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Calling teardown twice must be a clean no-op."""
+    _patch_glib(monkeypatch)
+    server = _make_server()
+    webrtcbin = MagicMock()
+    server._install_negotiation_watchdog("peer-1", webrtcbin)
+
+    server._teardown_negotiation_watchdog("peer-1")
+    server._teardown_negotiation_watchdog("peer-1")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# State change handlers
+# ---------------------------------------------------------------------------
+
+
+def _fake_webrtcbin_with_state(prop_to_nick: Dict[str, str]) -> MagicMock:
+    """Build a webrtcbin mock whose ``get_property`` returns the chosen nick."""
+    webrtcbin = MagicMock()
+
+    def get_property(prop: str) -> Any:
+        nick = prop_to_nick.get(prop, "unknown")
+        return MagicMock(value_nick=nick)
+
+    webrtcbin.get_property.side_effect = get_property
+    return webrtcbin
+
+
+def test_ice_state_change_updates_tracked_state() -> None:
+    """A ``notify::ice-connection-state`` callback updates the tracked state."""
+    server = _make_server()
+    server._peer_states["peer-1"] = _PeerWebRTCState(peer_id="peer-1")
+    webrtcbin = _fake_webrtcbin_with_state({"ice-connection-state": "checking"})
+
+    server._on_ice_connection_state_change(webrtcbin, None, "peer-1")
+
+    assert server._peer_states["peer-1"].ice_state == "checking"
+
+
+def test_connection_state_failed_triggers_pc_failed_notification() -> None:
+    """``connection-state == failed`` notifies eagerly without waiting."""
+    received: List[Tuple[str, str, Dict[str, Any]]] = []
+    server = _make_server()
+    server._on_session_failed = lambda *args: received.append(args)
+    server._peer_states["peer-1"] = _PeerWebRTCState(peer_id="peer-1")
+    webrtcbin = _fake_webrtcbin_with_state({"connection-state": "failed"})
+
+    server._on_connection_state_change(webrtcbin, None, "peer-1")
+
+    assert len(received) == 1
+    peer_id, reason, _diag = received[0]
+    assert peer_id == "peer-1"
+    assert reason == SESSION_FAILED_REASON_PC_FAILED
+    # State was dropped after the notify path teared the watchdog down.
+    assert "peer-1" not in server._peer_states
+
+
+def test_connection_state_connecting_does_not_notify() -> None:
+    """Intermediate states like ``connecting`` must not trip the failure callback."""
+    received: List[Any] = []
+    server = _make_server()
+    server._on_session_failed = lambda *args: received.append(args)
+    server._peer_states["peer-1"] = _PeerWebRTCState(peer_id="peer-1")
+    webrtcbin = _fake_webrtcbin_with_state({"connection-state": "connecting"})
+
+    server._on_connection_state_change(webrtcbin, None, "peer-1")
+
+    assert received == []
+    assert server._peer_states["peer-1"].conn_state == "connecting"
+
+
+def test_connection_state_failed_only_fires_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated ``connection-state == failed`` must only emit one ``endSession``."""
+    _patch_glib(monkeypatch)
+    received: List[Tuple[str, str, Dict[str, Any]]] = []
+    server = _make_server()
+    server._on_session_failed = lambda *args: received.append(args)
+    server._peer_states["peer-1"] = _PeerWebRTCState(peer_id="peer-1")
+    webrtcbin = _fake_webrtcbin_with_state({"connection-state": "failed"})
+
+    server._on_connection_state_change(webrtcbin, None, "peer-1")
+    # Re-add stub state to simulate a second `failed` firing in a
+    # world where teardown is async.
+    server._peer_states["peer-1"] = _PeerWebRTCState(peer_id="peer-1")
+    server._peer_states["peer-1"].failure_notified = True
+    server._on_connection_state_change(webrtcbin, None, "peer-1")
+
+    assert len(received) == 1
+
+
+# ---------------------------------------------------------------------------
+# _on_negotiation_deadline
+# ---------------------------------------------------------------------------
+
+
+def test_deadline_fires_session_failed_when_stuck(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A peer still ``checking`` past the deadline reports ``ICE_TIMEOUT``."""
+    _patch_glib(monkeypatch)
+    received: List[Tuple[str, str, Dict[str, Any]]] = []
+    server = _make_server()
+    server._on_session_failed = lambda *args: received.append(args)
+    state = _PeerWebRTCState(peer_id="peer-1")
+    state.ice_state = "checking"
+    state.conn_state = "new"
+    state.watchdog_source_id = 999
+    server._peer_states["peer-1"] = state
+
+    keep = server._on_negotiation_deadline("peer-1")
+
+    assert keep is False, "GLib timer must not be re-scheduled"
+    assert len(received) == 1
+    peer_id, reason, diag = received[0]
+    assert peer_id == "peer-1"
+    assert reason == SESSION_FAILED_REASON_ICE_TIMEOUT
+    assert diag["ice_state"] == "checking"
+    assert "peer-1" not in server._peer_states
+
+
+def test_deadline_skips_when_connection_is_healthy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deadline firing on a connected peer must NOT report a failure."""
+    _patch_glib(monkeypatch)
+    received: List[Any] = []
+    server = _make_server()
+    server._on_session_failed = lambda *args: received.append(args)
+    state = _PeerWebRTCState(peer_id="peer-1")
+    state.ice_state = "connected"
+    state.conn_state = "connected"
+    state.watchdog_source_id = 999
+    server._peer_states["peer-1"] = state
+
+    keep = server._on_negotiation_deadline("peer-1")
+
+    assert keep is False
+    assert received == []
+    # Still tracked: `_consumer_removed` is the canonical cleanup path.
+    assert "peer-1" in server._peer_states
+    assert server._peer_states["peer-1"].watchdog_source_id is None
+
+
+def test_deadline_no_op_after_failure_already_notified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deadline firing after eager-notify must not double-fire the callback."""
+    _patch_glib(monkeypatch)
+    received: List[Any] = []
+    server = _make_server()
+    server._on_session_failed = lambda *args: received.append(args)
+    state = _PeerWebRTCState(peer_id="peer-1")
+    state.failure_notified = True
+    state.watchdog_source_id = 999
+    server._peer_states["peer-1"] = state
+
+    server._on_negotiation_deadline("peer-1")
+
+    assert received == []
+
+
+def test_deadline_for_unknown_peer_is_no_op() -> None:
+    """A timer firing after ``_consumer_removed`` already ran is a clean no-op."""
+    server = _make_server()
+    keep = server._on_negotiation_deadline("ghost-peer")
+    assert keep is False
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_session_failed
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_swallows_handler_exceptions() -> None:
+    """A misbehaving handler must not crash the watchdog or the bus thread."""
+    server = _make_server()
+
+    def bad_handler(*_args: Any) -> None:
+        raise RuntimeError("downstream is on fire")
+
+    server._on_session_failed = bad_handler
+
+    server._dispatch_session_failed("peer-1", "any-reason", {"foo": "bar"})
+
+
+def test_dispatch_no_op_when_handler_unwired() -> None:
+    """Without a wired handler, dispatching is a clean no-op."""
+    server = _make_server()
+    server._dispatch_session_failed("peer-1", "any-reason", {"foo": "bar"})
+
+
+# ---------------------------------------------------------------------------
+# set_session_failed_handler wiring
+# ---------------------------------------------------------------------------
+
+
+def test_set_session_failed_handler_records_callback() -> None:
+    """The setter is the daemon's wiring entry point for the relay handler."""
+    server = _make_server()
+    captured: List[Tuple[str, str, Dict[str, Any]]] = []
+
+    def handler(peer_id: str, reason: str, diag: Dict[str, Any]) -> None:
+        captured.append((peer_id, reason, diag))
+
+    server.set_session_failed_handler(handler)
+    server._dispatch_session_failed("peer-9", "x", {"a": 1})
+
+    assert captured == [("peer-9", "x", {"a": 1})]


### PR DESCRIPTION
## Summary

Daemon-side fix for the historical "stuck at session" UX bug, where libnice (used by `webrtcbin` internally) freezes mid-`CHECKING` and the JS client spins forever waiting on an offer that will never complete. The daemon used to be silent in that scenario; this PR makes it observe its own `webrtcbin` state and translate stuck negotiations into a typed `endSession` so the client can render a real error view instead of a blank screen.

## Watchdog flow

1. `GstMediaServer._consumer_added` subscribes to webrtcbin's `notify::ice-connection-state`, `notify::connection-state`, and `notify::signaling-state` for each peer, and starts a `GLib.timeout_add_seconds` deadline (12s).
2. `connection-state == failed` short-circuits the deadline and reports `peer_connection_failed` immediately so hard network failures get a fast rejection.
3. The deadline reports `ice_negotiation_timeout` if the peer is still negotiating after 12s (the canonical libnice-frozen symptom).
4. `CentralSignalingRelay.notify_peer_session_failed` is the thread-safe entry point (uses `asyncio.run_coroutine_threadsafe` because the GStreamer signal callbacks fire on internal threads while the relay lives on its own asyncio loop). It translates the failure into an `endSession` message routed at the central `sessionId`, then clears the per-session bookkeeping.
5. The mapping `media_server peer_id` -> `central_session_id` reuses the existing `_local_to_central_session` dict; no new wire shape on the central side.

## gst-plugins-rs bump (0.14.1 -> 0.14.5)

The upstream `gst-plugins-rs` [CHANGELOG](https://github.com/GStreamer/gst-plugins-rs/blob/main/CHANGELOG.md) explicitly lists between 0.14.1 and 0.14.5:

- `webrtcsink: Fix deadlock when recalculating latency.`
- `webrtcsink: Fix deadlock between remote description and ICE handling.` <- **this is the root cause this watchdog is designed to surface**
- `webrtc: Various minor fixes and improvements.`

I bumped the install guide accordingly. The watchdog remains the safety net (libnice itself can still misbehave at the OS-package level on some Debian builds), but pinning to 0.14.5 means it should rarely fire in practice.

## Files changed

| File | Why |
|------|-----|
| `src/reachy_mini/media/media_server.py` | Watchdog state, signal handlers, deadline timer, `set_session_failed_handler` setter |
| `src/reachy_mini/media/central_signaling_relay.py` | Public thread-safe `notify_peer_session_failed` + inner coroutine that emits `endSession` to central |
| `src/reachy_mini/daemon/daemon.py` | Wires `media_server.set_session_failed_handler(relay.notify_peer_session_failed)` after the relay starts |
| `docs/source/SDK/gstreamer-installation.md` | Bumps the documented `gst-plugins-rs` pin from `0.14.1` to `0.14.5` |
| `tests/unit_tests/test_media_server_watchdog.py` | 19 new unit tests covering state tracking, deadline behaviour, eager fail-fast, idempotent teardown, no-double-fire |
| `tests/unit_tests/test_central_signaling_relay.py` | 7 new unit tests covering `notify_peer_session_failed` wire shape, bookkeeping cleanup, no-op on unmapped peers, cross-thread scheduling |

## Test plan

- [x] `pytest tests/unit_tests/test_media_server_watchdog.py tests/unit_tests/test_central_signaling_relay.py` -> 49 passed locally
- [x] `ruff check` and `ruff format --check` clean on touched files
- [ ] CI green (pytest + lint workflows)
- [ ] Manual smoke test on a real Reachy Mini Wireless: trigger a WebRTC connect over a flaky network, observe `[watchdog]` log lines + `endSession` reaching the JS client within 12s
- [ ] Manual smoke test on Reachy Mini Lite: same as above; confirms the wiring also fires under the desktop tray daemon

## Out of scope (follow-ups)

- JS-side handling of the new `reason` strings (`ice_negotiation_timeout`, `peer_connection_failed`) so the user-facing message can be more specific than "session failed". The wire shape is already there; the JS SDK just needs to switch on it.
- Bumping libnice itself: depends on the OS image (Bookworm ships 0.1.21, latest upstream 0.1.22). The 0.14.5 plugin bump is the actionable lever from this repo.
- Integration test that exercises a real `webrtcbin` reaching `connection-state == failed`. Needs a mock WebRTC peer; tracked separately along with the same gap on `central_signaling_relay`.


Made with [Cursor](https://cursor.com)