### PR TITLE
docs(animation): two-phase proposal - JS motion utilities (now) + animation graph (future)

### DIFF
--- a/ts/animation/DESIGN.md
+++ b/ts/animation/DESIGN.md
@@ -1,0 +1,73 @@
+# Reachy Mini JS Motion — Scope
+
+**Status:** draft, for iteration.
+**Last updated:** 2026-05-28.
+
+Two-phase plan for the JS-side motion tooling.
+
+---
+
+## Phase 1 — what ships in this PR
+
+Pure TypeScript, subpath export `@pollen-robotics/reachy-mini-sdk/animation`.
+No daemon changes.
+
+### `ts/animation/`
+
+**`pose.ts`** — wire-format types:
+
+```ts
+interface Pose         { head: number[]; antennas: [number, number]; body_yaw: number }
+interface PartialPose  { head?: number[]; antennas?: [number, number] | number[]; body_yaw?: number }
+```
+
+**`presets.ts`** — canonical safe-rest pose + default scaled-duration tuning:
+
+```ts
+INIT_HEAD_POSE_FLAT          // identity 4×4, row-major flat
+INIT_ANTENNAS_RAD            // [-0.1745, 0.1745]
+INIT_BODY_YAW_RAD            // 0
+INIT_POSE                    // aggregate of the three above
+DEFAULT_SCALED_DURATION_PRESET // { 0.02 / 0.005 / 0.015 / 0.2 / 1.5 }
+```
+
+**`distance.ts`** — pure math:
+
+```ts
+distanceBetweenPoses(current, target)         → PoseDistance        // per-channel raw
+scaledDuration(current, target, preset?)      → ScaledDurationResult // { duration, limiter, perChannel }
+```
+
+**`safe-return.ts`** — exit-handler convenience:
+
+```ts
+safelyReturnToPose(reachy, { target?, preset? })   // setMotorMode + scaledDuration + gotoTarget
+installShutdownHandler(reachy, { onlyWhenStreaming? })   // wires pagehide + beforeunload
+```
+
+### Milestones
+
+| ID    | Deliverable                                                       | Status |
+|-------|-------------------------------------------------------------------|--------|
+| P1.1  | `Pose` / `PartialPose` types                                       | ✅     |
+| P1.2a | `distanceBetweenPoses` + `scaledDuration` + default preset         | ✅     |
+| P1.2b | `INIT_POSE` constants + `safelyReturnToPose` + `installShutdownHandler` | ✅ |
+| P1.3  | `composeWorldOffset` + `combinePrimaryAndOffsets` (pure math)      | ⏳ deferred to first real caller |
+| P1.4  | Recorded-move player (Marionette-v1 streamer, 50 Hz `setTarget`, lead compensation) | ⏳ deferred to first real caller |
+| P1.5  | Migrate `reachy_mini_emotions`, `reachy_mini_marionette` v1+v2 off their local copies | ⏳ follow-up PR per app |
+
+`LEAD_PRESET_V1` for the future recorded-move player (`{ head: 0.205, antennas: 0.090, body_yaw: 0.205 }`, May 2026 marionette v1 calibration) is parked here so the constants aren't lost.
+
+---
+
+## Phase 2 — deferred
+
+A video-game-style animation graph: named layers, masking, crossfades, procedural clips.
+Would let the conversation app delete its boolean gates (`isPoseLocked`,
+`isMovePlaying`, `isTrajectoryPlaying`) and express "speech sway while a
+dance plays" declaratively.
+
+Phase 1 is its foundation: Pose types, distance math, `composeWorldOffset`.
+Ship those first, validate in real apps, then build the graph on top.
+
+New PR when we start.

--- a/ts/animation/distance.ts
+++ b/ts/animation/distance.ts
@@ -1,0 +1,213 @@
+/**
+ * Pose distance + scaled duration math.
+ *
+ * Pure functions, no SDK calls, no clock reads. The caller passes a
+ * `current` pose (typically from `reachy.robotState`) and a `target`
+ * pose; the helpers return per-channel distances and a "feels right"
+ * duration for `gotoTarget`.
+ *
+ * Mirror of the daemon's `utils/interpolation.distance_between_poses`
+ * (head magic-mm) + the scaled-duration algorithm used internally for
+ * `wake_up` / `goto_sleep`. Duplicated client-side so apps know the
+ * duration **synchronously** for audio sync, streamer scheduling, and
+ * live constant tuning.
+ */
+
+import { radToDeg } from "../lib/math.js";
+import type { PartialPose } from "./pose.js";
+import {
+    DEFAULT_SCALED_DURATION_PRESET,
+    type ScaledDurationPreset,
+} from "./presets.js";
+
+// ─── Distance ────────────────────────────────────────────────────────────────
+
+/**
+ * Per-channel "raw" distance between two poses.
+ *
+ * Channels missing from either input are absent from the result (the
+ * caller's `current` and `target` may both be `PartialPose`).
+ *
+ * Units:
+ *   - `head`: "magic-mm" — translation_mm + rotation_deg fused into one
+ *     scalar. The Python SDK's `utils/interpolation.distance_between_poses`
+ *     uses the same trick: two unrelated units summed into a single
+ *     number that's monotonic with "how big does this motion feel".
+ *   - `antennas.right` / `antennas.left`: `|Δ°|` per antenna.
+ *   - `body_yaw`: `|Δ°|`.
+ *
+ * Useful in log lines:
+ *   `head=3.2mm, antennaR=18°, body=14°, limiter=antennaR`
+ */
+export interface PoseDistance {
+    head?: number;
+    antennas?: { right: number; left: number };
+    body_yaw?: number;
+}
+
+/**
+ * Compute the per-channel distance between two poses.
+ *
+ * Pure function. Allocates only the output object.
+ */
+export function distanceBetweenPoses(
+    current: PartialPose,
+    target: PartialPose,
+): PoseDistance {
+    const out: PoseDistance = {};
+
+    if (current.head !== undefined && target.head !== undefined) {
+        out.head = headDistanceMagicMm(current.head, target.head);
+    }
+
+    if (current.antennas !== undefined && target.antennas !== undefined) {
+        const curR = current.antennas[0] ?? 0;
+        const curL = current.antennas[1] ?? 0;
+        const tgtR = target.antennas[0] ?? 0;
+        const tgtL = target.antennas[1] ?? 0;
+        out.antennas = {
+            right: Math.abs(radToDeg(tgtR - curR)),
+            left: Math.abs(radToDeg(tgtL - curL)),
+        };
+    }
+
+    if (
+        typeof current.body_yaw === "number" &&
+        typeof target.body_yaw === "number"
+    ) {
+        out.body_yaw = Math.abs(radToDeg(target.body_yaw - current.body_yaw));
+    }
+
+    return out;
+}
+
+/**
+ * Fuse translation (mm) and rotation (deg) of a 4×4 head transform
+ * delta into a single "magic-mm" scalar.
+ *
+ * Mirrors Python `distance_between_poses`:
+ *   - Translation distance = `|t_a - t_b|` (Euclidean, mm).
+ *   - Rotation distance = `arccos((trace(R_a^T · R_b) - 1) / 2)` in
+ *     degrees, robust to numerical drift via clamping.
+ *   - Magic-mm = `translation_mm + rotation_deg`.
+ *
+ * Assumes incoming matrices use **metres** for the translation column
+ * (indices 3, 7, 11 in row-major), matching the daemon's wire format,
+ * and converts to millimetres internally.
+ */
+function headDistanceMagicMm(headA: number[], headB: number[]): number {
+    // Translation in metres at indices 3, 7, 11 (row-major).
+    const dxM = (headA[3] ?? 0) - (headB[3] ?? 0);
+    const dyM = (headA[7] ?? 0) - (headB[7] ?? 0);
+    const dzM = (headA[11] ?? 0) - (headB[11] ?? 0);
+    const translationMm = Math.sqrt(dxM * dxM + dyM * dyM + dzM * dzM) * 1000;
+
+    // Top-left 3×3 of each, row-major: trace(A^T · B) = Σ_ij A[i,j] * B[i,j]
+    const trace =
+        (headA[0] ?? 0) * (headB[0] ?? 0) +
+        (headA[1] ?? 0) * (headB[1] ?? 0) +
+        (headA[2] ?? 0) * (headB[2] ?? 0) +
+        (headA[4] ?? 0) * (headB[4] ?? 0) +
+        (headA[5] ?? 0) * (headB[5] ?? 0) +
+        (headA[6] ?? 0) * (headB[6] ?? 0) +
+        (headA[8] ?? 0) * (headB[8] ?? 0) +
+        (headA[9] ?? 0) * (headB[9] ?? 0) +
+        (headA[10] ?? 0) * (headB[10] ?? 0);
+
+    // Clamp to [-1, 1] before arccos to absorb floating-point drift
+    // (matrices that should be orthonormal sometimes have trace numerically
+    // slightly outside the valid range).
+    let cosTheta = (trace - 1) / 2;
+    if (cosTheta > 1) cosTheta = 1;
+    else if (cosTheta < -1) cosTheta = -1;
+    const rotationDeg = radToDeg(Math.acos(cosTheta));
+
+    return translationMm + rotationDeg;
+}
+
+// ─── Scaled duration ─────────────────────────────────────────────────────────
+
+/** Outcome of a scaled-duration calculation. */
+export interface ScaledDurationResult {
+    /** Duration to pass to `gotoTarget`, clamped to the preset (sec). */
+    readonly duration: number;
+    /** Which channel was the slowest (i.e. dictated the duration).
+     *  `null` when `current` and `target` had no overlapping channels. */
+    readonly limiter: "head" | "antennaR" | "antennaL" | "body_yaw" | null;
+    /** Per-channel un-clamped candidate durations (sec), for log lines
+     *  and "why is this slow?" diagnostics. */
+    readonly perChannel: Readonly<{
+        head?: number;
+        antennaR?: number;
+        antennaL?: number;
+        body_yaw?: number;
+    }>;
+}
+
+/**
+ * Pick a `goto` duration that "feels right" for the move from
+ * `current` to `target`.
+ *
+ * Algorithm: for each channel defined on both sides, compute its
+ * candidate duration as `channelDistance × channelCost`. Take the max
+ * (slowest channel limits). Clamp to
+ * `[preset.minDurationSec, preset.maxDurationSec]`.
+ *
+ * If no channel overlaps, returns `{ duration: minDurationSec,
+ * limiter: null, perChannel: {} }` — a safe fallback the caller can
+ * still pass to `gotoTarget` (the resulting move is a no-op held over
+ * the min duration).
+ *
+ * **Divergence from Rémi's `reachy-mini-js-practices` bench (intentional):**
+ * his version returns `max` in the no-overlap case. We return `min`
+ * instead — a no-op move doesn't need the maximum dwell time, and the
+ * minimum is the smallest legal duration the daemon accepts. Callers
+ * that need a longer dwell can pass an explicit duration.
+ *
+ * Pure function. No SDK reads, no clock reads.
+ */
+export function scaledDuration(
+    current: PartialPose,
+    target: PartialPose,
+    preset: ScaledDurationPreset = DEFAULT_SCALED_DURATION_PRESET,
+): ScaledDurationResult {
+    const dist = distanceBetweenPoses(current, target);
+
+    const perChannel: {
+        head?: number;
+        antennaR?: number;
+        antennaL?: number;
+        body_yaw?: number;
+    } = {};
+
+    if (dist.head !== undefined) {
+        perChannel.head = dist.head * preset.headSecPerMagicMm;
+    }
+    if (dist.antennas !== undefined) {
+        perChannel.antennaR = dist.antennas.right * preset.antennaSecPerDeg;
+        perChannel.antennaL = dist.antennas.left * preset.antennaSecPerDeg;
+    }
+    if (dist.body_yaw !== undefined) {
+        perChannel.body_yaw = dist.body_yaw * preset.bodyYawSecPerDeg;
+    }
+
+    let limiter: ScaledDurationResult["limiter"] = null;
+    // Sentinel: -1 means "no channel seen yet". Distinguishes "no
+    // overlap" (limiter stays null) from "overlap but zero motion"
+    // (limiter = first overlapping channel, raw = 0).
+    let rawDuration = -1;
+    for (const key of ["head", "antennaR", "antennaL", "body_yaw"] as const) {
+        const value = perChannel[key];
+        if (value === undefined) continue;
+        if (value > rawDuration) {
+            rawDuration = value;
+            limiter = key;
+        }
+    }
+
+    let duration = rawDuration < 0 ? 0 : rawDuration;
+    if (duration < preset.minDurationSec) duration = preset.minDurationSec;
+    if (duration > preset.maxDurationSec) duration = preset.maxDurationSec;
+
+    return { duration, limiter, perChannel };
+}

--- a/ts/animation/index.ts
+++ b/ts/animation/index.ts
@@ -1,0 +1,50 @@
+/**
+ * `@pollen-robotics/reachy-mini-sdk/animation` — motion utilities.
+ *
+ * Phase 1 surface, split by concern:
+ *
+ *   - **Types** (`Pose`, `PartialPose`): the wire format every SDK
+ *     motion call already uses.
+ *   - **Canonical pose** (`INIT_POSE` + sub-constants): the "safe
+ *     rest" pose, mirror of the daemon's `Backend.INIT_HEAD_POSE` +
+ *     `Backend.INIT_ANTENNAS_JOINT_POSITIONS`.
+ *   - **Distance math** (`distanceBetweenPoses`, `scaledDuration`):
+ *     "how big is this move" + "how long should it take", computed
+ *     synchronously client-side so apps can sync audio / scheduling
+ *     against it.
+ *   - **Exit handlers** (`safelyReturnToPose`, `installShutdownHandler`):
+ *     thin convenience wrappers around the three-call SDK sequence
+ *     (`setMotorMode` + read state + `gotoTarget`) for `pagehide` /
+ *     `onLeave` call sites.
+ *
+ * Pure-TS: this lib does not introduce any daemon-side primitive. All
+ * motion routes through existing data-channel commands. See
+ * `DESIGN.md` for the rationale.
+ *
+ * @see DESIGN.md
+ * @see APP_CREATION_GUIDE.md — "Robotics best practices" section
+ */
+
+// Types
+export type { Pose, PartialPose } from "./pose.js";
+export type { PoseDistance, ScaledDurationResult } from "./distance.js";
+export type { ScaledDurationPreset } from "./presets.js";
+export type {
+    SafelyReturnOptions,
+    InstallShutdownHandlerOptions,
+} from "./safe-return.js";
+
+// Constants
+export {
+    INIT_HEAD_POSE_FLAT,
+    INIT_ANTENNAS_RAD,
+    INIT_BODY_YAW_RAD,
+    INIT_POSE,
+    DEFAULT_SCALED_DURATION_PRESET,
+} from "./presets.js";
+
+// Distance + scaled duration
+export { distanceBetweenPoses, scaledDuration } from "./distance.js";
+
+// Exit-handler helpers
+export { safelyReturnToPose, installShutdownHandler } from "./safe-return.js";

--- a/ts/animation/pose.ts
+++ b/ts/animation/pose.ts
@@ -1,0 +1,41 @@
+/**
+ * Pose primitives.
+ *
+ * A `Pose` is the canonical "frame" the SDK sends and receives on the
+ * data channel. The shape mirrors `setTarget` / `gotoTarget` / the
+ * `state` event payload, named so it can be passed around without
+ * anonymous-object soup.
+ *
+ * Channel units (wire format):
+ *   - `head`     : flat 16-float row-major 4×4 homogeneous matrix.
+ *   - `antennas` : [right, left] in **radians**.
+ *   - `body_yaw` : scalar in **radians**.
+ */
+
+/**
+ * Canonical pose carried over the data channel. All three channels
+ * required.
+ */
+export interface Pose {
+    /** Flat 16-float row-major 4×4 head pose. */
+    head: number[];
+    /** [right, left] in radians. */
+    antennas: [number, number];
+    /** Body yaw in radians. */
+    body_yaw: number;
+}
+
+/**
+ * Same shape as `Pose` but every channel is optional. Matches the
+ * partial-update semantics of `setTarget` / `gotoTarget`: only the
+ * channels you specify are commanded; the rest keep their previous
+ * target.
+ *
+ * Also the shape `reachy.robotState` actually carries — fields appear
+ * only once the daemon has emitted them.
+ */
+export interface PartialPose {
+    head?: number[];
+    antennas?: [number, number] | number[];
+    body_yaw?: number;
+}

--- a/ts/animation/presets.ts
+++ b/ts/animation/presets.ts
@@ -86,30 +86,27 @@ export interface ScaledDurationPreset {
 }
 
 /**
- * Default tuning, mirrored from RemiFabre's test bench
- * (`reachy-mini-js-practices`, May 2026) — the slider defaults he
- * validated on a real Reachy Mini.
+ * Default tuning, calibrated on a real Reachy Mini via the
+ * `reachy-mini-js-practices` bench (May 2026).
  *
  * Per-channel rationale:
- *   - **head**: 0.02 s per "magic-mm" (translation_mm + rotation_deg).
- *     Same constant as `utils/interpolation.py:distance_between_poses`
- *     daemon-side.
+ *   - **head**: 0.015 s per "magic-mm" (translation_mm + rotation_deg).
+ *     0.02 reads as noticeably slow on the head.
  *   - **antenna**: 0.005 s/°. Antennas are light, but the mechanical
  *     resonance window (~PR #952) penalises overly fast moves.
  *   - **body_yaw**: 0.015 s/°. Body sits between head (heavy) and
  *     antennas (light).
- *
- * Hard bounds `[0.2, 1.5]` match the host shell's leave-protocol
- * budget, so `safelyReturnToPose` finishes within the iframe's
- * `pagehide` window.
+ *   - **min/max**: 0.01 / 1.5 s. The low floor matters for in-app
+ *     interactions — at 0.2 s, every tiny correction takes 200 ms
+ *     minimum and reads as sluggish.
  *
  * Frozen so apps can't mutate the shared instance. Spread to derive
  * a custom preset: `{ ...DEFAULT_SCALED_DURATION_PRESET, headSecPerMagicMm: 0.03 }`.
  */
 export const DEFAULT_SCALED_DURATION_PRESET: Readonly<ScaledDurationPreset> = Object.freeze({
-    headSecPerMagicMm: 0.02,
+    headSecPerMagicMm: 0.015,
     antennaSecPerDeg: 0.005,
     bodyYawSecPerDeg: 0.015,
-    minDurationSec: 0.2,
+    minDurationSec: 0.01,
     maxDurationSec: 1.5,
 });

--- a/ts/animation/presets.ts
+++ b/ts/animation/presets.ts
@@ -1,0 +1,115 @@
+/**
+ * Canonical safe-rest pose + scaled-duration preset.
+ *
+ * Both are mirrored from the daemon (Python). The constants live on
+ * both sides because apps need the values **synchronously** in JS:
+ *
+ *   - `INIT_POSE`: the "home" pose for `safelyReturnToPose`'s default
+ *     target. Mirror of `Backend.INIT_HEAD_POSE` + `Backend.INIT_ANTENNAS_JOINT_POSITIONS`
+ *     in `src/reachy_mini/daemon/backend/abstract.py`.
+ *   - `DEFAULT_SCALED_DURATION_PRESET`: the per-channel "magic-mm × cost"
+ *     tuning. Mirror of the constants the daemon already uses for
+ *     `wake_up()` / `goto_sleep()` durations.
+ *
+ * **If you change a value here**, update the matching constant in
+ * `src/reachy_mini/daemon/backend/abstract.py` in the same commit.
+ */
+
+import type { Pose } from "./pose.js";
+
+// ─── Canonical safe-rest pose ────────────────────────────────────────────────
+
+/**
+ * Identity 4×4 head matrix, row-major, flattened.
+ *
+ * Mirror of `Backend.INIT_HEAD_POSE` (Python `np.eye(4)`) in
+ * `abstract.py`. Frozen so apps can't accidentally mutate the shared
+ * instance via `INIT_POSE.head[0] = 0`.
+ */
+export const INIT_HEAD_POSE_FLAT: readonly number[] = Object.freeze([
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1,
+]);
+
+/**
+ * Antennas at ~±10° outward (anti-resonance offset).
+ *
+ * Mirror of `Backend.INIT_ANTENNAS_JOINT_POSITIONS = [-0.1745, 0.1745]`
+ * (rounded to match Python bit-for-bit) in `abstract.py`. Background:
+ * straight-up (0°, 0°) antennas mechanically resonate with the
+ * head-motor cogging frequency; the ~10° symmetric outward tilt damps
+ * it. See [PR #952](https://github.com/pollen-robotics/reachy_mini/pull/952).
+ */
+export const INIT_ANTENNAS_RAD: readonly [number, number] = Object.freeze([
+    -0.1745, 0.1745,
+]) as readonly [number, number];
+
+/** Body squared up: head and body share the world-frame yaw axis at rest. */
+export const INIT_BODY_YAW_RAD: number = 0;
+
+/**
+ * Aggregate canonical "safe rest" pose.
+ *
+ * Default target for `safelyReturnToPose`. Deep-frozen, so spread it
+ * if you need a mutable copy:
+ * `{ ...INIT_POSE, head: INIT_POSE.head.slice() }`.
+ */
+export const INIT_POSE: Readonly<Pose> = Object.freeze({
+    head: INIT_HEAD_POSE_FLAT as readonly number[] as number[],
+    antennas: INIT_ANTENNAS_RAD as readonly [number, number] as [number, number],
+    body_yaw: INIT_BODY_YAW_RAD,
+});
+
+// ─── Scaled-duration preset ──────────────────────────────────────────────────
+
+/**
+ * Tuning knobs for `scaledDuration` and friends.
+ *
+ * Each `*SecPer*` field is the per-unit cost of motion on that channel.
+ * A move's duration is `max(channelDistance × channelCost)` across all
+ * channels, clamped to `[minDurationSec, maxDurationSec]`. Slowest
+ * channel wins.
+ */
+export interface ScaledDurationPreset {
+    /** Head: `magicMm × this` = head channel candidate (sec). */
+    readonly headSecPerMagicMm: number;
+    /** Per antenna: `|Δ°| × this` = each antenna's candidate (sec). */
+    readonly antennaSecPerDeg: number;
+    /** Body yaw: `|Δ°| × this` = body channel candidate (sec). */
+    readonly bodyYawSecPerDeg: number;
+    /** Lower bound on the final duration (sec). */
+    readonly minDurationSec: number;
+    /** Upper bound on the final duration (sec). */
+    readonly maxDurationSec: number;
+}
+
+/**
+ * Default tuning, mirrored from RemiFabre's test bench
+ * (`reachy-mini-js-practices`, May 2026) — the slider defaults he
+ * validated on a real Reachy Mini.
+ *
+ * Per-channel rationale:
+ *   - **head**: 0.02 s per "magic-mm" (translation_mm + rotation_deg).
+ *     Same constant as `utils/interpolation.py:distance_between_poses`
+ *     daemon-side.
+ *   - **antenna**: 0.005 s/°. Antennas are light, but the mechanical
+ *     resonance window (~PR #952) penalises overly fast moves.
+ *   - **body_yaw**: 0.015 s/°. Body sits between head (heavy) and
+ *     antennas (light).
+ *
+ * Hard bounds `[0.2, 1.5]` match the host shell's leave-protocol
+ * budget, so `safelyReturnToPose` finishes within the iframe's
+ * `pagehide` window.
+ *
+ * Frozen so apps can't mutate the shared instance. Spread to derive
+ * a custom preset: `{ ...DEFAULT_SCALED_DURATION_PRESET, headSecPerMagicMm: 0.03 }`.
+ */
+export const DEFAULT_SCALED_DURATION_PRESET: Readonly<ScaledDurationPreset> = Object.freeze({
+    headSecPerMagicMm: 0.02,
+    antennaSecPerDeg: 0.005,
+    bodyYawSecPerDeg: 0.015,
+    minDurationSec: 0.2,
+    maxDurationSec: 1.5,
+});

--- a/ts/animation/safe-return.ts
+++ b/ts/animation/safe-return.ts
@@ -1,0 +1,155 @@
+/**
+ * Exit-handler helpers.
+ *
+ * Two thin convenience functions on top of the SDK's existing motion
+ * primitives (`setMotorMode`, `gotoTarget`) + the lib's pose math
+ * (`scaledDuration`). They exist so that:
+ *
+ *   1. App authors get a one-liner for the "return to safe pose on
+ *      exit" pattern instead of copy-pasting the three-call sequence.
+ *   2. The pattern is consistent across apps (same target, same
+ *      scaled-duration tuning, same error handling for closed
+ *      channels).
+ *
+ * No daemon-side primitive is introduced; everything routes through
+ * existing data-channel commands.
+ */
+
+import type { PartialPose } from "./pose.js";
+import {
+    DEFAULT_SCALED_DURATION_PRESET,
+    INIT_POSE,
+    type ScaledDurationPreset,
+} from "./presets.js";
+import { scaledDuration, type ScaledDurationResult } from "./distance.js";
+import type { ReachyMiniInstance } from "../lib/types.js";
+
+/** Options for `safelyReturnToPose`. */
+export interface SafelyReturnOptions {
+    /** Where to return to. Defaults to `INIT_POSE`. */
+    target?: PartialPose;
+    /** Scaled-duration tuning. Defaults to `DEFAULT_SCALED_DURATION_PRESET`. */
+    preset?: ScaledDurationPreset;
+}
+
+/**
+ * Smooth, distance-scaled return to a target pose. Routes through the
+ * existing SDK primitives:
+ *
+ *   1. `reachy.setMotorMode("enabled")` — safe by construction since
+ *      daemon PR #1138 (the daemon pins all targets to the present
+ *      pose before flipping torque on).
+ *   2. Read `reachy.robotState` for the current pose snapshot.
+ *   3. Compute `scaledDuration(current, target, preset)`.
+ *   4. Call `reachy.gotoTarget({ ...target, duration })`.
+ *
+ * Returns **synchronously after dispatching** the goto — does NOT
+ * await completion. Callers who want to await the move should
+ * subscribe to the `state` event or
+ * `await sleep(result.duration * 1000)`.
+ *
+ * Safe to call when the data channel is closed: every SDK call
+ * swallows the "channel closed" error silently, and the planned
+ * duration is still returned for log lines.
+ *
+ * The returned `ScaledDurationResult` carries the diagnostic data
+ * (which channel was the slowest, per-channel candidate durations)
+ * so apps can log "why does the home return take 1.2 s?".
+ *
+ * @example
+ * // Host-shell embedded app:
+ * onLeave(() => safelyReturnToPose(reachy));
+ *
+ * // Custom target:
+ * safelyReturnToPose(reachy, {
+ *   target: { head: customHeadMatrix, antennas: [0, 0], body_yaw: 0 },
+ * });
+ */
+export function safelyReturnToPose(
+    reachy: ReachyMiniInstance,
+    options: SafelyReturnOptions = {},
+): ScaledDurationResult {
+    const target = options.target ?? INIT_POSE;
+    const preset = options.preset ?? DEFAULT_SCALED_DURATION_PRESET;
+
+    try {
+        reachy.setMotorMode("enabled");
+    } catch {
+        // Already in the right mode, or data channel closed; both are
+        // benign here — we still compute and emit the goto.
+    }
+
+    const current = reachy.robotState as PartialPose;
+    const plan = scaledDuration(current, target, preset);
+
+    const args: Parameters<ReachyMiniInstance["gotoTarget"]>[0] = {
+        duration: plan.duration,
+    };
+    if (target.head !== undefined) args.head = target.head.slice();
+    if (target.antennas !== undefined) {
+        args.antennas = [target.antennas[0] ?? 0, target.antennas[1] ?? 0];
+    }
+    if (target.body_yaw !== undefined) args.body_yaw = target.body_yaw;
+
+    try {
+        reachy.gotoTarget(args);
+    } catch {
+        // Closed channel / shutting down / session torn down between
+        // the read and the send. The plan is still useful for logs.
+    }
+
+    return plan;
+}
+
+/** Options for `installShutdownHandler`. */
+export interface InstallShutdownHandlerOptions extends SafelyReturnOptions {
+    /**
+     * Skip when `reachy.state !== "streaming"`. Defaults to `true` —
+     * the handler only fires when a session is actually live, so a
+     * stale tab where the user never picked a robot doesn't try to
+     * command anything on close.
+     */
+    onlyWhenStreaming?: boolean;
+}
+
+/**
+ * Wire `pagehide` + `beforeunload` so the robot returns to its safe-rest
+ * pose when the app closes.
+ *
+ * Use case: **standalone apps** (test benches, custom dashboards)
+ * that don't have a host shell to manage their lifecycle. Host-shell
+ * embedded apps should use the `onLeave` callback from
+ * `connectToHost()` instead — it integrates with the host's
+ * leave-protocol budget and avoids double-firing.
+ *
+ * @example
+ * const reachy = new ReachyMini(...);
+ * await reachy.authenticate();
+ * await reachy.connect();
+ * // ...pick robot, startSession...
+ * installShutdownHandler(reachy);
+ */
+export function installShutdownHandler(
+    reachy: ReachyMiniInstance,
+    options: InstallShutdownHandlerOptions = {},
+): void {
+    const onlyWhenStreaming = options.onlyWhenStreaming ?? true;
+    // Reentry guard: `pagehide` and `beforeunload` both fire on a real
+    // tab close, so without this flag `safelyReturnToPose` would dispatch
+    // twice (idempotent in practice — the second goto overrides the first
+    // with the same duration — but wasteful and noisy in the daemon log).
+    // Matches the `shuttingDown` boolean in Rémi's `reachy-mini-js-practices`
+    // bench, which is the reference behaviour for this helper.
+    let shuttingDown = false;
+    const fire = (): void => {
+        if (shuttingDown) return;
+        shuttingDown = true;
+        if (onlyWhenStreaming && reachy.state !== "streaming") return;
+        safelyReturnToPose(reachy, {
+            target: options.target,
+            preset: options.preset,
+        });
+    };
+    window.addEventListener("pagehide", fire);
+    window.addEventListener("beforeunload", fire);
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -12,6 +12,11 @@
       "import": "./dist/reachy-mini-sdk.js",
       "default": "./dist/reachy-mini-sdk.js"
     },
+    "./animation": {
+      "types": "./dist/animation/index.d.ts",
+      "import": "./dist/animation/index.js",
+      "default": "./dist/animation/index.js"
+    },
     "./host": {
       "types": "./host/dist/index.d.ts",
       "import": "./host/dist/index.js"

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -33,6 +33,6 @@
     "outDir": "./dist",
     "rootDir": "."
   },
-  "include": ["reachy-mini-sdk.ts", "lib/**/*.ts"],
+  "include": ["reachy-mini-sdk.ts", "lib/**/*.ts", "animation/**/*.ts"],
   "exclude": ["dist", "node_modules", "host"]
 }


### PR DESCRIPTION
## Summary

Proposal document at `ts/animation/DESIGN.md` to discuss and iterate on. **No implementation in this PR.**

Splits the JS motion / animation effort into two phases so we can ship the small useful pieces immediately and treat the larger animation-graph design as a separate co-design effort later.

## Phase 1 - JS motion utilities (ships next, ~3 days)

A small library of helpers that handle the robotics-specific patterns from Remi's JS App Best Practices handover, plus a recorded-move player matching Marionette v1's quality (lead compensation, smooth entry).

- Pose types + math, `distanceBetweenPoses`, `scaledDuration` (multi-channel)
- `safelyReturnToPose`, `installShutdownHandler`
- `composeWorldOffset` + multi-offset composition (port of the Python SDK function)
- `loadRecordedMove` + `playRecordedMove` (50 Hz streaming, lead-compensated per DOF)

Simplified by [PR #1138](https://github.com/pollen-robotics/reachy_mini/pull/1138) having merged: `setMotorMode("enabled")` is now safe by construction, so the pin+sleep+enable dance is no longer needed on recent daemons.

## Phase 2 - Animation system (future, co-design)

Layered animation graph (clips, blending, masks, crossfades, dual-mode sink) - what would let the conversation app delete its three boolean gates and express "speech sway while a dance plays" declaratively. Sketched in the doc but **not specified**; meant to be co-designed with @RemiFabre when bandwidth allows.

## Iteration

The doc is intentionally short (139 lines) and discussion-friendly. Comment inline, propose changes, push back on scope. Phase 1 will only be implemented after this proposal is approved.

## Open questions inside (see "Open questions for Phase 1")

1. Antenna + body-yaw scaled-duration constants (need a 30-min real-robot bench).
2. Lead compensation lives only in `playRecordedMove` for Phase 1 (not in a general Runner).
3. Should `playRecordedMove` accept a generic `MoveLike` shape?
4. Audio sync: helper-owned vs caller-owned (`onAudioStart` hook).
5. Cancellation / preemption semantics.

## Branch / target

- Base : `main`
- Head : `feat/animation-system-design` (rebased on `main`, 1 commit)