### PR TITLE
js: stop calling getUserMedia in the SDK

### DIFF
--- a/js/reachy-mini-sdk.d.ts
+++ b/js/reachy-mini-sdk.d.ts
@@ -60,6 +60,13 @@ export interface RobotState {
 /** SDK constructor options. */
 export interface ReachyMiniOptions {
   signalingUrl?: string;
+  /**
+   * @deprecated The SDK no longer acquires the user's microphone. A silent
+   * placeholder audio sender is always set up so apps can `replaceTrack`
+   * their own audio (TTS, files, or — for teleop — the user's mic) onto
+   * it. This option is parsed for backward compatibility but has no
+   * effect.
+   */
   enableMicrophone?: boolean;
   clientId?: string;
   appName?: string;
@@ -156,8 +163,10 @@ export interface ReachyMiniInstance extends EventTarget {
   /** Underlying RTCPeerConnection. Apps can read it to inspect
    *  audio / video transceivers. */
   _pc: RTCPeerConnection | null;
-  /** Local microphone MediaStream acquired by the SDK on
-   *  `startSession()` when `enableMicrophone` is `true`. */
+  /** Silent placeholder MediaStream the SDK feeds the WebRTC audio
+   *  sender so robot-speaker output can negotiate sendrecv. Apps inject
+   *  their own audio (TTS, files, the user's mic for teleop) by calling
+   *  `replaceTrack()` on the audio sender from `_pc.getSenders()`. */
   _micStream: MediaStream | null;
 
   authenticate(): Promise<boolean>;

--- a/js/reachy-mini-sdk.js
+++ b/js/reachy-mini-sdk.js
@@ -385,6 +385,10 @@ export class ReachyMini extends EventTarget {
     constructor(options = {}) {
         super();
         this._signalingUrl = options.signalingUrl || 'https://pollen-robotics-reachy-mini-central.hf.space';
+        // Deprecated: SDK no longer acquires the user's microphone. Parsed
+        // for backward compat; has no effect. Apps that want to send the
+        // user's mic to the robot speaker do so explicitly via getUserMedia
+        // + replaceTrack on the audio sender from this._pc.
         this._enableMicrophone = options.enableMicrophone !== false;
         this._clientId = options.clientId || null;
         this._appName = options.appName || 'unknown';
@@ -440,7 +444,7 @@ export class ReachyMini extends EventTarget {
         this._selectedRobotId = null;
 
         // Audio
-        this._micStream = null;    // MediaStream from getUserMedia
+        this._micStream = null;    // Silent placeholder MediaStream; apps replaceTrack their own audio onto the sender
         this._micMuted = true;
         this._audioMuted = true;
         this._micSupported = false; // set after SDP negotiation
@@ -1039,41 +1043,30 @@ export class ReachyMini extends EventTarget {
         // don't get applied to a new RTCPeerConnection.
         this._pendingRemoteIce = [];
 
-        // Acquire mic eagerly so the browser permission prompt appears now,
-        // but tracks stay disabled (muted) until the user explicitly unmutes.
-        if (this._enableMicrophone) {
-            try {
-                this._micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-                this._micStream.getAudioTracks().forEach(t => { t.enabled = false; });
-                this._micMuted = true;
-            } catch (e) {
-                console.warn('Microphone not available:', e);
-                // Fall back to a silent placeholder track. We MUST add an
-                // audio track before createAnswer or the answer SDP comes
-                // back as recvonly for audio - which negotiates the audio
-                // SENDER side off the wire entirely. A host that wants to
-                // later inject a different audio source (e.g. a synthesised
-                // AI voice via replaceTrack on the sender) needs a live
-                // sendrecv slot, even if the initial track is silent.
-                try {
-                    const ctx = new (window.AudioContext || window.webkitAudioContext)();
-                    const dst = ctx.createMediaStreamDestination();
-                    // A muted oscillator keeps the track "alive" without
-                    // emitting any audible signal.
-                    const osc = ctx.createOscillator();
-                    const gain = ctx.createGain();
-                    gain.gain.value = 0;
-                    osc.connect(gain).connect(dst);
-                    osc.start();
-                    this._micStream = dst.stream;
-                    this._micStream.getAudioTracks().forEach(t => { t.enabled = false; });
-                    this._micMuted = true;
-                    this._silentMicFallback = { ctx, osc };
-                } catch (fallbackErr) {
-                    console.warn('Silent mic fallback failed:', fallbackErr);
-                    this._micStream = null;
-                }
-            }
+        // Silent placeholder audio track for the WebRTC audio sender.
+        // The SDK does NOT call navigator.mediaDevices.getUserMedia — the
+        // user's microphone is the app's responsibility. WebRTC needs a
+        // sendrecv audio sender for robot-speaker output to work, so we
+        // always set up a 0-gain oscillator → MediaStreamDestination as
+        // the initial track. Apps that want to send actual audio (TTS,
+        // prerecorded files, the user's mic for teleop, …) do so by
+        // calling sender.replaceTrack() on the audio sender exposed via
+        // this._pc after the `streaming` event fires.
+        try {
+            const ctx = new (window.AudioContext || window.webkitAudioContext)();
+            const dst = ctx.createMediaStreamDestination();
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            gain.gain.value = 0;
+            osc.connect(gain).connect(dst);
+            osc.start();
+            this._micStream = dst.stream;
+            this._micStream.getAudioTracks().forEach(t => { t.enabled = false; });
+            this._micMuted = true;
+            this._silentMicFallback = { ctx, osc };
+        } catch (e) {
+            console.warn('Audio sender placeholder setup failed:', e);
+            this._micStream = null;
         }
 
         this._pc = new RTCPeerConnection({


### PR DESCRIPTION
The SDK eagerly called navigator.mediaDevices.getUserMedia({audio: true}) inside startSession, popping the browser's microphone permission prompt on every connection. The track was then added to the WebRTC peer connection muted, used solely to satisfy sendrecv negotiation so apps could later replaceTrack() their own audio onto the sender.

This is the wrong default. The SDK's job is transport; audio source policy belongs to the app. Apps that want to send actual audio to the robot speaker — TTS, prerecorded files, or the user's mic for teleop — already do so explicitly via sender.replaceTrack() on the audio sender from _pc.getSenders(). Forcing every connection to ask for mic permission, even when no user mic is involved, was friction for no gain.

Always set up the silent oscillator → MediaStreamDestination placeholder (previously only reached as the getUserMedia-denied fallback). WebRTC still negotiates a sendrecv audio sender, replaceTrack still works, the permission prompt is gone.

enableMicrophone is marked @deprecated in the d.ts and kept parsed in the constructor for backward compatibility, but no longer has any effect.

Existing teleop apps that relied on the SDK acquiring the user's mic must now do so themselves (getUserMedia + replaceTrack onto the audio sender) — a five-line addition mirroring what TTS apps already do.

Assisted-by: Claude:claude-opus-4-7

Can be tested with : https://huggingface.co/spaces/pollen-robotics/bedtime-story-generator
You'll need to use reachy-mini-sdk.js locally (the one of this PR).
Then `npm run dev`, and `http://localhost:5173/#hf_token=hf_xxx&hf_username=xxx&hf_token_expires=2099-01-01T00:00:00Z`