### PR TITLE
ci(npm): route prerelease publishes to the `rc` dist-tag (fixes #1155)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,10 +48,13 @@ jobs:
         run: npm run build
 
       # pyproject.toml is the single source of truth for the version.
-      # Release       → publish <py_ver>            on the `latest` dist-tag.
-      # Push to main  → publish <py_ver>-main.<sha> on the `main`   dist-tag.
-      # Pull request  → dry-run only (no publish).
+      # Release (stable X.Y.Z)  → publish <py_ver>            on `latest`.
+      # Release (prerelease)    → publish <py_ver>            on `rc`
+      #                           (npm refuses prereleases on `latest`).
+      # Push to main            → publish <py_ver>-main.<sha> on `main`.
+      # Pull request            → dry-run only (no publish).
       - name: Compute and apply version from pyproject.toml
+        id: ver
         run: |
           py_ver=$(grep -E '^version' ../pyproject.toml | head -1 | sed -E 's/version *= *"([^"]+)"/\1/')
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -60,7 +63,13 @@ jobs:
           else
             ver="${py_ver}"
           fi
-          echo "Computed version: $ver (event=${{ github.event_name }})"
+          if [[ "$py_ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            release_tag="latest"
+          else
+            release_tag="rc"
+          fi
+          echo "Computed version: $ver (event=${{ github.event_name }}, release_tag=$release_tag)"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
           npm version "$ver" --no-git-tag-version
 
       # PR: pack to confirm the publish would succeed (tarball
@@ -70,9 +79,9 @@ jobs:
         if: github.event_name == 'pull_request'
         run: npm pack --dry-run
 
-      - name: Publish (latest)
+      - name: Publish (release)
         if: github.event_name == 'release'
-        run: npm publish
+        run: npm publish --tag "${{ steps.ver.outputs.release_tag }}"
 
       - name: Publish (main)
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
- The v1.8.0rc1 release publish failed ([run 26460095134](https://github.com/pollen-robotics/reachy_mini/actions/runs/26460095134)) with `npm error You must specify a tag using --tag when publishing a prerelease version.` — `npm publish` refuses prereleases on the default `latest` tag.
- In the *Compute and apply version* step, detect prereleases (any `pyproject.toml` version not matching strict `X.Y.Z`) and emit a `release_tag` step output: `latest` for stable, `rc` for everything else (`rcN`, `aN`, `bN`, `.devN`, …).
- The release publish step now does `npm publish --tag "$release_tag"`. Stable releases still land on `latest`; prereleases land on `rc`, opted into via `npm i @pollen-robotics/reachy-mini-sdk@rc`.
- `Publish (main)` path (uses `--tag main`) and PR dry-run path are unchanged.

Caveat: all prerelease channels (alpha/beta/rc/dev) share one `rc` tag. If we later want separate `@beta` vs `@rc` channels, map `aN`→`alpha`, `bN`→`beta`, etc. — two extra lines.

## Test plan
- [ ] Cut a new prerelease (e.g. `v1.8.0rc2`) and confirm the *Publish (release)* step runs `npm publish --tag rc` and succeeds.
- [ ] Verify `npm dist-tag ls @pollen-robotics/reachy-mini-sdk` shows the new version on `rc`.
- [ ] Verify `npm i @pollen-robotics/reachy-mini-sdk` still resolves the prior stable (`latest` untouched) and `@rc` resolves the new prerelease.
- [ ] Next stable release: confirm it routes back to `--tag latest`.

Closes #1155