### PR TITLE
ci(npm-publish): fetch LFS objects before building host bundles

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,7 +25,14 @@ jobs:
       run:
         working-directory: ts
     steps:
+      # `lfs: true` is required so Vite inlines the real binary content
+      # of host SVG/PNG assets (tracked via .gitattributes) instead of
+      # 130-byte LFS pointer text. Without it, the published bundle ends
+      # up containing `data:image/svg+xml,version https://git-lfs...`
+      # placeholders which render as broken images in consumer apps.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          lfs: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "24"   # ships npm >= 11.5.1 — required for trusted publishing
@@ -46,6 +53,18 @@ jobs:
       # tarball.
       - name: Build SDK and host bundles
         run: npm run build
+
+      # Guard against silently shipping a tarball where Vite has inlined
+      # LFS pointer text in place of the real binary assets (see
+      # `lfs: true` note on checkout). Fails the job loudly so the bug
+      # cannot regress unnoticed.
+      - name: Verify bundles contain no LFS pointers
+        run: |
+          if grep -RIn --binary-files=text 'git-lfs.github.com/spec' \
+              host/dist dist 2>/dev/null; then
+            echo "::error::LFS pointer text leaked into built bundles. Did checkout run without lfs: true?"
+            exit 1
+          fi
 
       # pyproject.toml is the single source of truth for the version.
       # Release (stable X.Y.Z)  → publish <py_ver>            on `latest`.


### PR DESCRIPTION
## Problem

The `npm-publish` workflow checks out the repo without fetching LFS
objects. Since all host assets (`ts/host/src/assets/*.svg`) are tracked
via `*.svg filter=lfs` in `.gitattributes`, Vite ends up inlining the
**130-byte LFS pointer text** instead of the real SVG content into
`ts/host/dist/chunks/mountHost-*.js`.

Consumer apps (`emotions`, `telepresence`, `minimal-conversation`
Spaces) render broken images inside the host shell, with `src`
attributes like:

```
data:image/svg+xml,version https://git-lfs.github.com/spec/v1
oid sha256:52379b77c3aa786d846dc121c61fbd8bb83166bd21b6826ec33aec5593209e1d
size 13043
```

## Repro on the currently-published `1.8.0-rc1`

```bash
npm pack @pollen-robotics/reachy-mini-sdk@1.8.0-rc1
tar -xzf pollen-robotics-reachy-mini-sdk-1.8.0-rc1.tgz
grep -oE 'git-lfs[^"'"'"']{0,200}' package/host/dist/chunks/mountHost-*.js
```

Yields 5 hits, one per asset under `ts/host/src/assets/`:

| OID (sha256, truncated) | Reported size |
|---|---|
| `7869d88f5994...` | 21029 |
| `52379b77c3aa...` | 13043 |
| `6272217469979...` | 121795 |
| `19c64c308bff...` | 81023 |
| `d035fb3db7eaa...` | 81040 |

## Fix

- Pass `lfs: true` to `actions/checkout` so the host SVGs are
  materialized on disk before `npm run build` runs.
- Add a post-build sanity check that greps `ts/host/dist` and
  `ts/dist` for the `git-lfs.github.com/spec` signature and fails the
  job loudly if the bug ever regresses. The check runs unconditionally
  (PR dry-run, push, release) so it catches the regression before any
  publish.

## Follow-up

This PR only fixes the pipeline; the already-published `1.8.0-rc1`
tarball on npm is still broken. A new `1.8.0-rc2` (or stable `1.8.0`)
release will be needed to ship clean bundles to consumers.

## Test plan

- [ ] CI on this PR runs `actions/checkout@v6` with `lfs: true`, then
      builds, then the new "Verify bundles contain no LFS pointers"
      step exits 0.
- [ ] After merging to `main`, the `-main.<sha>` tarball published to
      the `main` dist-tag no longer contains
      `git-lfs.github.com/spec` strings in `host/dist/chunks/*.js`.

Made with [Cursor](https://cursor.com)