### PR TITLE
fix(host): stop end-session button from shrinking mid-teardown

### DIFF
--- a/ts/host/src/components/TopBar.tsx
+++ b/ts/host/src/components/TopBar.tsx
@@ -164,22 +164,40 @@ export function TopBar({
             onClick={handleEndSession}
             disabled={isStopping}
             startIcon={
-              isStopping ? (
-                <CircularProgress
-                  size={14}
-                  thickness={5}
-                  sx={{ color: 'inherit' }}
-                />
-              ) : (
-                <PowerSettingsNewIcon sx={{ fontSize: 16 }} />
-              )
+              // Wrap both the icon and the spinner in a fixed 16x16
+              // slot so the button width does NOT shift by ~2px when
+              // we swap glyphs during teardown. `CircularProgress`
+              // and `PowerSettingsNewIcon` otherwise render at
+              // slightly different intrinsic sizes.
+              <Box
+                sx={{
+                  width: 16,
+                  height: 16,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                {isStopping ? (
+                  <CircularProgress
+                    size={14}
+                    thickness={5}
+                    sx={{ color: 'inherit' }}
+                  />
+                ) : (
+                  <PowerSettingsNewIcon sx={{ fontSize: 16 }} />
+                )}
+              </Box>
             }
             sx={{
               fontSize: 12.5,
               fontWeight: 600,
               py: 0.5,
               px: 1.25,
-              minWidth: 0,
+              // Lock the horizontal footprint to the widest label
+              // ("End session") so swapping in the shorter "Ending…"
+              // copy doesn't visibly shrink the chip mid-teardown.
+              minWidth: 116,
               borderRadius: 999,
               textTransform: 'none',
               lineHeight: 1.1,


### PR DESCRIPTION
## Summary

The destructive **End session** chip in the host `TopBar` visibly jittered the moment the user clicked it:

- The `startIcon` swap from `<PowerSettingsNewIcon fontSize={16}>` to `<CircularProgress size={14}>` shaved ~2px off the icon column.
- The label flip from `End session` (11 chars) to `Ending…` (7 chars) shaved more pixels off the text column.

Both deltas land on the very first frame after the click, which makes the chip feel like it "pops" smaller right while we're tearing the session down — exactly when the UI should feel stable.

## Fix

- Wrap the `startIcon` content in a fixed `16×16` `Box` so the spinner and the power glyph occupy the same footprint regardless of their intrinsic sizes.
- Lock `minWidth: 116` on the button so the shorter `Ending…` label can't shrink the chip horizontally.

Pure visual fix, no behavior change, no API change. The icon swap, spinner sizing, and copy are all preserved.

## Test plan

- [ ] Sign into the host shell, launch any app, click **End session**: the chip should keep the exact same width while the spinner is shown until teardown completes.
- [ ] Verify in both light and dark mode that the spinner stays centered in the 16×16 slot and looks unchanged otherwise.
- [ ] Sanity-check the chip footprint on narrow viewports (mobile) — the `minWidth: 116` shouldn't push the account chip off-screen since the parent `Stack` already lays out at desktop widths.


Made with [Cursor](https://cursor.com)