### PR TITLE
feat(audio): software AEC fallback when no XVF3800 board is present

### DIFF
--- a/src/reachy_mini/media/audio_aec.py
+++ b/src/reachy_mini/media/audio_aec.py
@@ -1,0 +1,264 @@
+"""Shared software acoustic echo cancellation (AEC) helpers.
+
+The Reachy Mini hardware path normally relies on the XVF3800 / XMOS audio
+board for acoustic echo cancellation: on Wireless robots through the
+``.asoundrc`` ALSA loopback, on Lite / desktop through the ReSpeaker USB
+dongle. When neither is in the audio path (typically simulation mode
+``--sim`` / ``--mockup-sim`` on a developer workstation), the
+conversation loop hears its own voice through the laptop speakers and
+collapses on feedback.
+
+This module centralises the detection logic and the GStreamer element
+chains used to insert ``webrtcdsp`` + ``webrtcechoprobe`` (from
+``gst-plugins-bad``) inline on the record / playback pipelines. Two
+backends consume these helpers:
+
+* :mod:`reachy_mini.media.audio_gstreamer` for the LOCAL Python SDK
+  audio backend (``MediaManager(backend=LOCAL)``).
+* :mod:`reachy_mini.media.media_server` for the WebRTC capture +
+  playback pipelines that bridge the daemon to remote clients (e.g.
+  the mobile conversation app).
+
+The ``webrtcdsp`` element on the recording side and the
+``webrtcechoprobe`` element on the playback side find each other
+through a process-wide registry keyed by the same shared name (see
+:data:`AEC_PROBE_NAME`). Both must agree on rate, channel count and
+sample format, hence :data:`AEC_SAMPLE_RATE` / :data:`AEC_CHANNELS`
+and :func:`make_aec_capsfilter`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+import gi
+
+from reachy_mini.media.audio_utils import has_reachymini_asoundrc
+from reachy_mini.media.device_detection import get_audio_device
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst  # noqa: E402
+
+AEC_PROBE_NAME = "reachymini_aec_probe"
+"""Shared name that pairs the recording-side ``webrtcdsp`` with the
+playback-side ``webrtcechoprobe``. Both elements communicate via a
+process-wide registry indexed by this string; the value just needs to
+be stable and unique within a process."""
+
+AEC_SAMPLE_RATE = 16_000
+"""Sample rate (Hz) the ``webrtcdsp`` / ``webrtcechoprobe`` pair share.
+16 kHz mono / stereo is the canonical voice rate WebRTC's AEC was
+trained on."""
+
+AEC_CHANNELS = 2
+"""Channel count for the AEC stage. The dsp and the probe MUST agree
+on channel count, so we canonicalise both sides to this value."""
+
+_AEC_ELEMENT_NAMES: Tuple[str, str] = ("webrtcdsp", "webrtcechoprobe")
+
+
+def resolve_sw_aec_enabled(logger: logging.Logger) -> bool:
+    """Decide whether to insert a ``webrtcdsp`` + ``webrtcechoprobe`` pair.
+
+    Pure auto-detection from the same audio device parsing the rest
+    of the backend uses. Returns ``True`` only when no hardware AEC
+    sits in the audio path and the matching ``gst-plugins-bad``
+    elements are actually packaged:
+
+    * ``has_reachymini_asoundrc()`` → Wireless XMOS does AEC, skip.
+    * ``get_audio_device("Source")`` → XVF3800 / ReSpeaker on USB
+      does AEC, skip.
+    * ``webrtcdsp`` or ``webrtcechoprobe`` missing → skip with a loud
+      warning so callers can install the missing plugin.
+
+    Anything else (typically ``--sim`` / ``--mockup-sim`` or a
+    developer workstation) gets the software AEC.
+
+    Args:
+        logger: Logger to use for diagnostic output. Each call to
+            ``resolve_sw_aec_enabled`` emits exactly one log line so
+            startup logs always tell the operator why the AEC stage
+            was or wasn't inserted.
+
+    Returns:
+        ``True`` when the software AEC stage should be added,
+        ``False`` otherwise.
+
+    """
+    if has_reachymini_asoundrc():
+        logger.info(
+            "Wireless `.asoundrc` detected - relying on XMOS "
+            "hardware AEC, skipping software AEC stage."
+        )
+        return False
+    if get_audio_device("Source") is not None:
+        logger.info(
+            "ReSpeaker / Reachy Mini Audio card detected - "
+            "relying on XVF3800 hardware AEC, skipping software "
+            "AEC stage."
+        )
+        return False
+
+    for name in _AEC_ELEMENT_NAMES:
+        if Gst.ElementFactory.find(name) is None:
+            logger.warning(
+                "No XVF3800 audio board detected AND GStreamer "
+                "element '%s' is unavailable in this build "
+                "(install gst-plugins-bad). Conversation audio "
+                "will loop back through the laptop mic - use a "
+                "headset to work around it.",
+                name,
+            )
+            return False
+
+    logger.warning(
+        "No XVF3800 audio board detected - enabling software AEC "
+        "(webrtcdsp + webrtcechoprobe). Quality is best-effort; "
+        "for production voice loops use the ReSpeaker USB dongle "
+        "or a Wireless robot with the XMOS AEC loopback."
+    )
+    return True
+
+
+def make_aec_capsfilter(
+    sample_rate: int = AEC_SAMPLE_RATE,
+    channels: int = AEC_CHANNELS,
+) -> Gst.Element:
+    """Force ``webrtcdsp``-friendly caps (S16LE interleaved).
+
+    ``webrtcdsp`` accepts ``S16LE/interleaved`` or
+    ``F32LE/non-interleaved``; most surrounding pipelines use
+    ``F32LE/interleaved``, so we pin S16LE on the AEC link and let
+    the surrounding ``audioconvert`` elements bridge the format gap
+    on both sides.
+
+    The dsp and the probe MUST agree on rate and channel count, so
+    callers should pass identical values on both sides of the AEC
+    chain. Defaults map to :data:`AEC_SAMPLE_RATE` /
+    :data:`AEC_CHANNELS`.
+    """
+    capsfilter = Gst.ElementFactory.make("capsfilter")
+    if capsfilter is None:
+        raise RuntimeError("Failed to create capsfilter element for AEC link")
+    capsfilter.set_property(
+        "caps",
+        Gst.Caps.from_string(
+            "audio/x-raw,"
+            "format=S16LE,"
+            "layout=interleaved,"
+            f"rate={sample_rate},"
+            f"channels={channels}"
+        ),
+    )
+    return capsfilter
+
+
+def build_aec_dsp_chain(
+    sample_rate: int = AEC_SAMPLE_RATE,
+    channels: int = AEC_CHANNELS,
+    probe_name: str = AEC_PROBE_NAME,
+) -> Tuple[Gst.Element, Gst.Element, Gst.Element]:
+    """Build the recording-side AEC chain.
+
+    Returns a (capsfilter, webrtcdsp, audioconvert) tuple. Callers
+    are expected to insert it between their existing
+    ``audioresample`` (or whatever produces float audio) and the
+    downstream sink. The ``audioconvert`` after the dsp converts the
+    canonical S16LE format back to whatever the rest of the pipeline
+    consumes.
+
+    Linking order::
+
+        upstream → capsfilter → webrtcdsp → audioconvert → downstream
+    """
+    capsfilter = make_aec_capsfilter(sample_rate=sample_rate, channels=channels)
+    dsp = Gst.ElementFactory.make("webrtcdsp")
+    ac_post_dsp = Gst.ElementFactory.make("audioconvert")
+    if not all([capsfilter, dsp, ac_post_dsp]):
+        raise RuntimeError("Failed to create AEC DSP elements (webrtcdsp chain)")
+    dsp.set_property("probe", probe_name)
+    dsp.set_property("delay-agnostic", True)
+    dsp.set_property("extended-filter", True)
+    return capsfilter, dsp, ac_post_dsp
+
+
+def make_aec_probe(probe_name: str = AEC_PROBE_NAME) -> Gst.Element:
+    """Create a standalone ``webrtcechoprobe`` element.
+
+    The probe registers itself in a process-wide registry keyed by its
+    ``name`` property as soon as the property is set. This means the
+    matching ``webrtcdsp`` can find it during its own
+    ``set_state(PLAYING)`` even before the probe is added to any
+    pipeline.
+
+    Callers can therefore pre-create the probe at startup, then add it
+    to an actual playback pipeline later (e.g. when a WebRTC peer
+    arrives). Reusing the same probe element across peer reconnects
+    keeps the registry entry stable.
+    """
+    probe = Gst.ElementFactory.make("webrtcechoprobe")
+    if probe is None:
+        raise RuntimeError("Failed to create webrtcechoprobe element")
+    probe.set_property("name", probe_name)
+    return probe
+
+
+def build_aec_probe_chain(
+    sample_rate: int = AEC_SAMPLE_RATE,
+    channels: int = AEC_CHANNELS,
+    probe_name: str = AEC_PROBE_NAME,
+    probe: Optional[Gst.Element] = None,
+) -> Tuple[Gst.Element, Gst.Element, Gst.Element]:
+    """Build the playback-side AEC chain.
+
+    Returns an (audioconvert, capsfilter, webrtcechoprobe) tuple.
+    Callers are expected to insert it between their decoded /
+    decompressed audio source and the speaker / tee branch. The
+    leading ``audioconvert`` converts whatever the upstream produced
+    to the canonical S16LE format the probe consumes.
+
+    Linking order::
+
+        upstream → audioconvert → capsfilter → webrtcechoprobe → downstream
+
+    The probe is a passthrough element data-wise: every speaker
+    sample is also handed to the matching ``webrtcdsp`` (paired by
+    :data:`AEC_PROBE_NAME`) as the reference signal it must subtract
+    from the mic stream.
+
+    Args:
+        sample_rate: Sample rate the probe will run at. Must match the
+            paired ``webrtcdsp``'s rate, hence the :data:`AEC_SAMPLE_RATE`
+            default.
+        channels: Channel count the probe will run at. Must match the
+            paired ``webrtcdsp``.
+        probe_name: Name used to pair the probe with its ``webrtcdsp``.
+        probe: Optional pre-created probe element to insert into the
+            chain instead of allocating a fresh one. Used by callers
+            that need the probe to exist before the playback pipeline
+            is ready (e.g. so the paired ``webrtcdsp`` finds it at
+            startup time).
+
+    """
+    ac_pre_probe = Gst.ElementFactory.make("audioconvert")
+    capsfilter_probe = make_aec_capsfilter(sample_rate=sample_rate, channels=channels)
+    if probe is None:
+        probe = make_aec_probe(probe_name=probe_name)
+    if not all([ac_pre_probe, capsfilter_probe, probe]):
+        raise RuntimeError(
+            "Failed to create AEC probe elements (webrtcechoprobe chain)"
+        )
+    return ac_pre_probe, capsfilter_probe, probe
+
+
+__all__ = [
+    "AEC_PROBE_NAME",
+    "AEC_SAMPLE_RATE",
+    "AEC_CHANNELS",
+    "resolve_sw_aec_enabled",
+    "make_aec_capsfilter",
+    "make_aec_probe",
+    "build_aec_dsp_chain",
+    "build_aec_probe_chain",
+]

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -25,6 +25,34 @@ Platform audio sources / sinks are discovered at runtime:
 The "Reachy Mini Audio" card is located by name via ``Gst.DeviceMonitor``.
 If no matching card is found the platform default is used instead.
 
+Software acoustic echo cancellation (no-board fallback)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When no XVF3800 audio board is in the audio path (no Wireless
+``~/.asoundrc`` AND no ReSpeaker USB dongle detected), the backend
+falls back to the platform default mic + speaker. Without the
+hardware AEC of the XMOS chip the OpenAI Realtime / conversation
+loop hears its own voice through the laptop speakers and collapses
+on feedback.
+
+To keep the simulation / dev workflow usable, this backend inserts
+a ``webrtcdsp`` + ``webrtcechoprobe`` pair (from
+``gst-plugins-bad``) on top of the record / playback pipelines in
+that case. Detection is automatic:
+
+* If ``has_reachymini_asoundrc()`` is true → no extra processing
+  (Wireless XMOS handles AEC).
+* If ``get_audio_device("Source")`` finds a ReSpeaker card → no
+  extra processing (USB XVF3800 handles AEC).
+* Otherwise → enable the software AEC stage.
+
+Two environment variables can be set to override the heuristic, for
+example to benchmark or troubleshoot:
+
+* ``REACHY_MINI_DISABLE_SW_AEC=1`` force-disables the fallback.
+* ``REACHY_MINI_FORCE_SW_AEC=1`` force-enables it (e.g. to compare
+  output against the hardware XVF3800 AEC on a board-equipped robot).
+
 Note:
     This class is typically used internally by ``MediaManager`` when the
     ``LOCAL`` backend is selected.  Direct usage is possible but usually
@@ -96,6 +124,12 @@ class GStreamerAudio(AudioBase):
     PLAYBACK_SINK_BUFFER_TIME_US = 50_000
     PLAYBACK_SINK_LATENCY_TIME_US = 5_000
 
+    # Shared name that ties the recording-side `webrtcdsp` to the
+    # playback-side `webrtcechoprobe`. Both elements communicate via
+    # a process-wide registry indexed by this string, so the value
+    # just needs to be stable and unique within the process.
+    _AEC_PROBE_NAME = "reachymini_aec_probe"
+
     def __init__(self, log_level: str = "INFO") -> None:
         """Initialize recording and playback pipelines.
 
@@ -114,6 +148,8 @@ class GStreamerAudio(AudioBase):
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()
 
+        self._sw_aec_enabled = self._resolve_sw_aec_enabled()
+
         self._pipeline_record = Gst.Pipeline.new("audio_recorder")
         self._init_pipeline_record(self._pipeline_record)
         self._bus_record = self._pipeline_record.get_bus()
@@ -128,6 +164,197 @@ class GStreamerAudio(AudioBase):
         self._bus_playback.add_watch(
             GLib.PRIORITY_DEFAULT, self._on_bus_message, self._pipeline_playback
         )
+
+    # ------------------------------------------------------------------
+    # Software AEC fallback
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _sw_aec_env_override() -> Optional[bool]:
+        """Return the env-var override for the software AEC, or None.
+
+        ``REACHY_MINI_DISABLE_SW_AEC`` takes precedence over
+        ``REACHY_MINI_FORCE_SW_AEC`` so an explicit disable always wins;
+        anything else falls back to the auto-detection heuristic.
+        """
+        truthy = {"1", "true", "yes", "on"}
+        if os.environ.get("REACHY_MINI_DISABLE_SW_AEC", "").lower() in truthy:
+            return False
+        if os.environ.get("REACHY_MINI_FORCE_SW_AEC", "").lower() in truthy:
+            return True
+        return None
+
+    def _resolve_sw_aec_enabled(self) -> bool:
+        """Decide whether to insert a `webrtcdsp` + `webrtcechoprobe` pair.
+
+        See the module docstring for the full rationale. Short version:
+        return ``True`` only when neither hardware AEC (Wireless XMOS
+        loopback via ``.asoundrc`` or USB XVF3800 dongle) is present,
+        unless an environment variable overrides the heuristic.
+
+        Also verifies that both AEC elements are actually present in
+        the running GStreamer build — packaging without
+        ``gst-plugins-bad`` would otherwise crash pipeline construction
+        with a cryptic ``Failed to create GStreamer elements``.
+        """
+        # Read via the class so tests can fake `self` with a plain
+        # `SimpleNamespace`; the helper is a `@staticmethod` and never
+        # depends on instance state.
+        override = GStreamerAudio._sw_aec_env_override()
+        if override is False:
+            self.logger.info("Software AEC disabled via REACHY_MINI_DISABLE_SW_AEC.")
+            return False
+
+        if override is True:
+            self.logger.warning(
+                "Software AEC force-enabled via REACHY_MINI_FORCE_SW_AEC. "
+                "If a hardware AEC (XMOS / XVF3800) is also active you "
+                "will likely double-process and end up with audible "
+                "artefacts — this knob is meant for A/B testing."
+            )
+        else:
+            # Auto-detection path. Bail out as soon as we find any
+            # hardware AEC in the audio path.
+            if has_reachymini_asoundrc():
+                self.logger.info(
+                    "Wireless `.asoundrc` detected — relying on XMOS "
+                    "hardware AEC, skipping software AEC stage."
+                )
+                return False
+            if get_audio_device("Source") is not None:
+                self.logger.info(
+                    "ReSpeaker / Reachy Mini Audio card detected — "
+                    "relying on XVF3800 hardware AEC, skipping software "
+                    "AEC stage."
+                )
+                return False
+
+        for name in ("webrtcdsp", "webrtcechoprobe"):
+            if Gst.ElementFactory.find(name) is None:
+                self.logger.warning(
+                    "Software AEC requested but GStreamer element '%s' "
+                    "is unavailable in this build (install "
+                    "gst-plugins-bad). Conversation audio will loop "
+                    "back through the laptop mic — use a headset to "
+                    "work around it.",
+                    name,
+                )
+                return False
+
+        self.logger.warning(
+            "No XVF3800 audio board detected — enabling software AEC "
+            "(webrtcdsp + webrtcechoprobe). Quality is best-effort; for "
+            "production voice loops use the ReSpeaker USB dongle or a "
+            "Wireless robot with the XMOS AEC loopback."
+        )
+        return True
+
+    def _make_aec_capsfilter(self) -> Gst.Element:
+        """Force ``webrtcdsp``-friendly caps (S16LE interleaved, 16 kHz).
+
+        `webrtcdsp` accepts either ``S16LE/interleaved`` or
+        ``F32LE/non-interleaved``; the rest of our pipeline uses
+        ``F32LE/interleaved``, so we pin S16LE on the AEC link and let
+        the surrounding ``audioconvert`` elements bridge the format
+        gap on both sides.
+        """
+        capsfilter = Gst.ElementFactory.make("capsfilter")
+        capsfilter.set_property(
+            "caps",
+            Gst.Caps.from_string(
+                "audio/x-raw,"
+                "format=S16LE,"
+                "layout=interleaved,"
+                f"rate={self.SAMPLE_RATE},"
+                f"channels={self.CHANNELS}"
+            ),
+        )
+        return capsfilter
+
+    def _append_aec_dsp(
+        self, pipeline: Gst.Pipeline, src_element: Gst.Element
+    ) -> Gst.Element:
+        """Append the recording-side AEC DSP chain to ``src_element``.
+
+        Inserts ``audioconvert → capsfilter(S16LE) → audiobuffersplit
+        (10 ms) → webrtcdsp(probe=..., delay-agnostic, extended-filter)
+        → audioconvert`` and returns the new tail element to which the
+        next downstream consumer should link.
+
+        ``audiobuffersplit`` is required because libwebrtc-audio-
+        processing operates on fixed 10 ms frames; without it the dsp
+        either rejects or stutters depending on the upstream buffer
+        cadence. ``delay-agnostic`` + ``extended-filter`` is the
+        recommended combo when the mic and reference clocks come from
+        different audio devices (which is exactly our case here:
+        record pipeline drives off the mic clock, playback pipeline
+        off the speaker clock).
+        """
+        ac_in = Gst.ElementFactory.make("audioconvert")
+        capsf = self._make_aec_capsfilter()
+        bsplit = Gst.ElementFactory.make("audiobuffersplit")
+        # `output-buffer-duration` is a GstFraction. PyGObject's
+        # set_property() segfaults when given a `Gst.Fraction(1, 100)`
+        # value, so we route through `Gst.util_set_object_arg` which
+        # accepts the same property as a string and constructs the
+        # underlying GValue C-side.
+        Gst.util_set_object_arg(bsplit, "output-buffer-duration", "1/100")
+        dsp = Gst.ElementFactory.make("webrtcdsp")
+        dsp.set_property("probe", self._AEC_PROBE_NAME)
+        dsp.set_property("delay-agnostic", True)
+        dsp.set_property("extended-filter", True)
+        ac_out = Gst.ElementFactory.make("audioconvert")
+
+        if not all([ac_in, capsf, bsplit, dsp, ac_out]):
+            raise RuntimeError("Failed to create AEC DSP elements")
+
+        for el in (ac_in, capsf, bsplit, dsp, ac_out):
+            pipeline.add(el)
+        src_element.link(ac_in)
+        ac_in.link(capsf)
+        capsf.link(bsplit)
+        bsplit.link(dsp)
+        dsp.link(ac_out)
+        return ac_out
+
+    def _attach_aec_probe(self, pipeline: Gst.Pipeline, tee: Gst.Element) -> None:
+        """Attach the playback-side AEC reference branch to ``tee``.
+
+        Adds a parallel branch: ``tee → queue → audioconvert →
+        capsfilter(S16LE) → audiobuffersplit(10 ms) → webrtcechoprobe
+        → fakesink``. The probe buffers reference frames internally
+        and the recording-side ``webrtcdsp`` pulls from it via the
+        shared name registered above.
+
+        The terminal ``fakesink`` uses ``sync=False, async=False`` so
+        the reference branch never throttles the rest of the playback
+        pipeline (the speaker branch already paces it).
+        """
+        queue_p = Gst.ElementFactory.make("queue")
+        ac_p = Gst.ElementFactory.make("audioconvert")
+        capsf_p = self._make_aec_capsfilter()
+        bsplit_p = Gst.ElementFactory.make("audiobuffersplit")
+        # See note on the record-side bsplit: GstFraction setter
+        # segfaults from Python; use the string-based helper instead.
+        Gst.util_set_object_arg(bsplit_p, "output-buffer-duration", "1/100")
+        probe = Gst.ElementFactory.make("webrtcechoprobe")
+        probe.set_property("name", self._AEC_PROBE_NAME)
+        fakesink_p = Gst.ElementFactory.make("fakesink")
+        fakesink_p.set_property("sync", False)
+        fakesink_p.set_property("async", False)
+        fakesink_p.set_property("enable-last-sample", False)
+
+        if not all([queue_p, ac_p, capsf_p, bsplit_p, probe, fakesink_p]):
+            raise RuntimeError("Failed to create AEC probe elements")
+
+        for el in (queue_p, ac_p, capsf_p, bsplit_p, probe, fakesink_p):
+            pipeline.add(el)
+        tee.link(queue_p)
+        queue_p.link(ac_p)
+        ac_p.link(capsf_p)
+        capsf_p.link(bsplit_p)
+        bsplit_p.link(probe)
+        probe.link(fakesink_p)
 
     def _init_pipeline_record(self, pipeline: Gst.Pipeline) -> None:
         self._appsink_audio = Gst.ElementFactory.make("appsink")
@@ -180,7 +407,15 @@ class GStreamerAudio(AudioBase):
         audiosrc.link(queue)
         queue.link(audioconvert)
         audioconvert.link(audioresample)
-        audioresample.link(self._appsink_audio)
+        # When no XVF3800 hardware is in the audio path, splice the
+        # software AEC chain between `audioresample` and the appsink.
+        # Otherwise link directly to keep the on-board AEC pristine.
+        tail = (
+            self._append_aec_dsp(pipeline, audioresample)
+            if self._sw_aec_enabled
+            else audioresample
+        )
+        tail.link(self._appsink_audio)
 
     def _build_audiosink_element(self) -> Gst.Element:
         """Create a platform-appropriate audio sink element."""
@@ -362,6 +597,20 @@ class GStreamerAudio(AudioBase):
         queue_wobbler.link(ac_wobbler)
         ac_wobbler.link(ar_wobbler)
         ar_wobbler.link(appsink_wobbler)
+
+        # Software AEC reference branch. We only attach it to the
+        # appsrc-based playback pipeline (i.e. conversation audio
+        # pushed via `push_audio_sample`), NOT to the `playbin`-driven
+        # tee bin used by `play_sound`. Two reasons:
+        #   1. Sound-file beeps are short and not interpretable by an
+        #      LLM as speech even if they leak into the mic, so the
+        #      cost/benefit doesn't justify the extra wiring.
+        #   2. `webrtcechoprobe` registers a process-wide name, so
+        #      keeping it bound to a single, long-lived element is the
+        #      simplest way to avoid duplicate-name collisions when a
+        #      playbin tee bin spins up mid-conversation.
+        if self._sw_aec_enabled:
+            self._attach_aec_probe(pipeline, tee)
 
     def _on_bus_message(
         self, bus: Gst.Bus, msg: Gst.Message, pipeline: Gst.Pipeline

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -33,25 +33,21 @@ When no XVF3800 audio board is in the audio path (no Wireless
 falls back to the platform default mic + speaker. Without the
 hardware AEC of the XMOS chip the OpenAI Realtime / conversation
 loop hears its own voice through the laptop speakers and collapses
-on feedback.
+on feedback. This typically happens in simulation mode
+(``--sim`` / ``--mockup-sim``) and on developer workstations.
 
-To keep the simulation / dev workflow usable, this backend inserts
-a ``webrtcdsp`` + ``webrtcechoprobe`` pair (from
-``gst-plugins-bad``) on top of the record / playback pipelines in
-that case. Detection is automatic:
+To keep that workflow usable, this backend inserts a ``webrtcdsp``
++ ``webrtcechoprobe`` pair (from ``gst-plugins-bad``) inline on the
+record / playback pipelines. Detection re-uses the same audio
+device parsing the rest of the backend relies on:
 
 * If ``has_reachymini_asoundrc()`` is true → no extra processing
   (Wireless XMOS handles AEC).
 * If ``get_audio_device("Source")`` finds a ReSpeaker card → no
   extra processing (USB XVF3800 handles AEC).
-* Otherwise → enable the software AEC stage.
-
-Two environment variables can be set to override the heuristic, for
-example to benchmark or troubleshoot:
-
-* ``REACHY_MINI_DISABLE_SW_AEC=1`` force-disables the fallback.
-* ``REACHY_MINI_FORCE_SW_AEC=1`` force-enables it (e.g. to compare
-  output against the hardware XVF3800 AEC on a board-equipped robot).
+* Otherwise → enable the software AEC stage, provided the
+  ``webrtcdsp`` / ``webrtcechoprobe`` plugins are present in the
+  GStreamer build.
 
 Note:
     This class is typically used internally by ``MediaManager`` when the
@@ -169,74 +165,45 @@ class GStreamerAudio(AudioBase):
     # Software AEC fallback
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _sw_aec_env_override() -> Optional[bool]:
-        """Return the env-var override for the software AEC, or None.
-
-        ``REACHY_MINI_DISABLE_SW_AEC`` takes precedence over
-        ``REACHY_MINI_FORCE_SW_AEC`` so an explicit disable always wins;
-        anything else falls back to the auto-detection heuristic.
-        """
-        truthy = {"1", "true", "yes", "on"}
-        if os.environ.get("REACHY_MINI_DISABLE_SW_AEC", "").lower() in truthy:
-            return False
-        if os.environ.get("REACHY_MINI_FORCE_SW_AEC", "").lower() in truthy:
-            return True
-        return None
-
     def _resolve_sw_aec_enabled(self) -> bool:
         """Decide whether to insert a `webrtcdsp` + `webrtcechoprobe` pair.
 
-        See the module docstring for the full rationale. Short version:
-        return ``True`` only when neither hardware AEC (Wireless XMOS
-        loopback via ``.asoundrc`` or USB XVF3800 dongle) is present,
-        unless an environment variable overrides the heuristic.
+        Pure auto-detection from the same audio device parsing the
+        rest of the backend uses. Returns ``True`` only when no
+        hardware AEC sits in the audio path and the matching
+        ``gst-plugins-bad`` elements are actually packaged:
 
-        Also verifies that both AEC elements are actually present in
-        the running GStreamer build — packaging without
-        ``gst-plugins-bad`` would otherwise crash pipeline construction
-        with a cryptic ``Failed to create GStreamer elements``.
+        * ``has_reachymini_asoundrc()`` → Wireless XMOS does AEC, skip.
+        * ``get_audio_device("Source")`` → XVF3800 / ReSpeaker on USB
+          does AEC, skip.
+        * ``webrtcdsp`` or ``webrtcechoprobe`` missing → skip with a
+          loud warning so callers can install the missing plugin.
+
+        Anything else (typically ``--sim`` / ``--mockup-sim`` or a
+        developer workstation) gets the software AEC.
         """
-        # Read via the class so tests can fake `self` with a plain
-        # `SimpleNamespace`; the helper is a `@staticmethod` and never
-        # depends on instance state.
-        override = GStreamerAudio._sw_aec_env_override()
-        if override is False:
-            self.logger.info("Software AEC disabled via REACHY_MINI_DISABLE_SW_AEC.")
-            return False
-
-        if override is True:
-            self.logger.warning(
-                "Software AEC force-enabled via REACHY_MINI_FORCE_SW_AEC. "
-                "If a hardware AEC (XMOS / XVF3800) is also active you "
-                "will likely double-process and end up with audible "
-                "artefacts — this knob is meant for A/B testing."
+        if has_reachymini_asoundrc():
+            self.logger.info(
+                "Wireless `.asoundrc` detected — relying on XMOS "
+                "hardware AEC, skipping software AEC stage."
             )
-        else:
-            # Auto-detection path. Bail out as soon as we find any
-            # hardware AEC in the audio path.
-            if has_reachymini_asoundrc():
-                self.logger.info(
-                    "Wireless `.asoundrc` detected — relying on XMOS "
-                    "hardware AEC, skipping software AEC stage."
-                )
-                return False
-            if get_audio_device("Source") is not None:
-                self.logger.info(
-                    "ReSpeaker / Reachy Mini Audio card detected — "
-                    "relying on XVF3800 hardware AEC, skipping software "
-                    "AEC stage."
-                )
-                return False
+            return False
+        if get_audio_device("Source") is not None:
+            self.logger.info(
+                "ReSpeaker / Reachy Mini Audio card detected — "
+                "relying on XVF3800 hardware AEC, skipping software "
+                "AEC stage."
+            )
+            return False
 
         for name in ("webrtcdsp", "webrtcechoprobe"):
             if Gst.ElementFactory.find(name) is None:
                 self.logger.warning(
-                    "Software AEC requested but GStreamer element '%s' "
-                    "is unavailable in this build (install "
-                    "gst-plugins-bad). Conversation audio will loop "
-                    "back through the laptop mic — use a headset to "
-                    "work around it.",
+                    "No XVF3800 audio board detected AND GStreamer "
+                    "element '%s' is unavailable in this build "
+                    "(install gst-plugins-bad). Conversation audio "
+                    "will loop back through the laptop mic — use a "
+                    "headset to work around it.",
                     name,
                 )
                 return False
@@ -252,11 +219,15 @@ class GStreamerAudio(AudioBase):
     def _make_aec_capsfilter(self) -> Gst.Element:
         """Force ``webrtcdsp``-friendly caps (S16LE interleaved, 16 kHz).
 
-        `webrtcdsp` accepts either ``S16LE/interleaved`` or
+        ``webrtcdsp`` accepts ``S16LE/interleaved`` or
         ``F32LE/non-interleaved``; the rest of our pipeline uses
-        ``F32LE/interleaved``, so we pin S16LE on the AEC link and let
-        the surrounding ``audioconvert`` elements bridge the format
-        gap on both sides.
+        ``F32LE/interleaved``, so we pin S16LE on the AEC link and
+        let the surrounding ``audioconvert`` elements bridge the
+        format gap on both sides.
+
+        The dsp and the probe MUST agree on rate and channel count,
+        so we canonicalise both sides to the same ``SAMPLE_RATE`` /
+        ``CHANNELS`` values that drive the rest of the backend.
         """
         capsfilter = Gst.ElementFactory.make("capsfilter")
         capsfilter.set_property(
@@ -270,91 +241,6 @@ class GStreamerAudio(AudioBase):
             ),
         )
         return capsfilter
-
-    def _append_aec_dsp(
-        self, pipeline: Gst.Pipeline, src_element: Gst.Element
-    ) -> Gst.Element:
-        """Append the recording-side AEC DSP chain to ``src_element``.
-
-        Inserts ``audioconvert → capsfilter(S16LE) → audiobuffersplit
-        (10 ms) → webrtcdsp(probe=..., delay-agnostic, extended-filter)
-        → audioconvert`` and returns the new tail element to which the
-        next downstream consumer should link.
-
-        ``audiobuffersplit`` is required because libwebrtc-audio-
-        processing operates on fixed 10 ms frames; without it the dsp
-        either rejects or stutters depending on the upstream buffer
-        cadence. ``delay-agnostic`` + ``extended-filter`` is the
-        recommended combo when the mic and reference clocks come from
-        different audio devices (which is exactly our case here:
-        record pipeline drives off the mic clock, playback pipeline
-        off the speaker clock).
-        """
-        ac_in = Gst.ElementFactory.make("audioconvert")
-        capsf = self._make_aec_capsfilter()
-        bsplit = Gst.ElementFactory.make("audiobuffersplit")
-        # `output-buffer-duration` is a GstFraction. PyGObject's
-        # set_property() segfaults when given a `Gst.Fraction(1, 100)`
-        # value, so we route through `Gst.util_set_object_arg` which
-        # accepts the same property as a string and constructs the
-        # underlying GValue C-side.
-        Gst.util_set_object_arg(bsplit, "output-buffer-duration", "1/100")
-        dsp = Gst.ElementFactory.make("webrtcdsp")
-        dsp.set_property("probe", self._AEC_PROBE_NAME)
-        dsp.set_property("delay-agnostic", True)
-        dsp.set_property("extended-filter", True)
-        ac_out = Gst.ElementFactory.make("audioconvert")
-
-        if not all([ac_in, capsf, bsplit, dsp, ac_out]):
-            raise RuntimeError("Failed to create AEC DSP elements")
-
-        for el in (ac_in, capsf, bsplit, dsp, ac_out):
-            pipeline.add(el)
-        src_element.link(ac_in)
-        ac_in.link(capsf)
-        capsf.link(bsplit)
-        bsplit.link(dsp)
-        dsp.link(ac_out)
-        return ac_out
-
-    def _attach_aec_probe(self, pipeline: Gst.Pipeline, tee: Gst.Element) -> None:
-        """Attach the playback-side AEC reference branch to ``tee``.
-
-        Adds a parallel branch: ``tee → queue → audioconvert →
-        capsfilter(S16LE) → audiobuffersplit(10 ms) → webrtcechoprobe
-        → fakesink``. The probe buffers reference frames internally
-        and the recording-side ``webrtcdsp`` pulls from it via the
-        shared name registered above.
-
-        The terminal ``fakesink`` uses ``sync=False, async=False`` so
-        the reference branch never throttles the rest of the playback
-        pipeline (the speaker branch already paces it).
-        """
-        queue_p = Gst.ElementFactory.make("queue")
-        ac_p = Gst.ElementFactory.make("audioconvert")
-        capsf_p = self._make_aec_capsfilter()
-        bsplit_p = Gst.ElementFactory.make("audiobuffersplit")
-        # See note on the record-side bsplit: GstFraction setter
-        # segfaults from Python; use the string-based helper instead.
-        Gst.util_set_object_arg(bsplit_p, "output-buffer-duration", "1/100")
-        probe = Gst.ElementFactory.make("webrtcechoprobe")
-        probe.set_property("name", self._AEC_PROBE_NAME)
-        fakesink_p = Gst.ElementFactory.make("fakesink")
-        fakesink_p.set_property("sync", False)
-        fakesink_p.set_property("async", False)
-        fakesink_p.set_property("enable-last-sample", False)
-
-        if not all([queue_p, ac_p, capsf_p, bsplit_p, probe, fakesink_p]):
-            raise RuntimeError("Failed to create AEC probe elements")
-
-        for el in (queue_p, ac_p, capsf_p, bsplit_p, probe, fakesink_p):
-            pipeline.add(el)
-        tee.link(queue_p)
-        queue_p.link(ac_p)
-        ac_p.link(capsf_p)
-        capsf_p.link(bsplit_p)
-        bsplit_p.link(probe)
-        probe.link(fakesink_p)
 
     def _init_pipeline_record(self, pipeline: Gst.Pipeline) -> None:
         self._appsink_audio = Gst.ElementFactory.make("appsink")
@@ -407,15 +293,32 @@ class GStreamerAudio(AudioBase):
         audiosrc.link(queue)
         queue.link(audioconvert)
         audioconvert.link(audioresample)
-        # When no XVF3800 hardware is in the audio path, splice the
-        # software AEC chain between `audioresample` and the appsink.
-        # Otherwise link directly to keep the on-board AEC pristine.
-        tail = (
-            self._append_aec_dsp(pipeline, audioresample)
-            if self._sw_aec_enabled
-            else audioresample
-        )
-        tail.link(self._appsink_audio)
+
+        if self._sw_aec_enabled:
+            # Software AEC fallback: pin S16LE @ 16 kHz / 2 channels
+            # (the format both `webrtcdsp` and `webrtcechoprobe`
+            # accept and which they need to share on both ends), let
+            # the dsp filter the mic stream, then convert back to
+            # F32LE for the appsink. `audiobuffersplit` is not
+            # required — the dsp re-chunks to its own 10 ms frames
+            # internally via GstAdapter.
+            capsfilter = self._make_aec_capsfilter()
+            dsp = Gst.ElementFactory.make("webrtcdsp")
+            dsp.set_property("probe", self._AEC_PROBE_NAME)
+            dsp.set_property("delay-agnostic", True)
+            dsp.set_property("extended-filter", True)
+            ac_post_dsp = Gst.ElementFactory.make("audioconvert")
+            if not all([capsfilter, dsp, ac_post_dsp]):
+                raise RuntimeError("Failed to create AEC DSP elements")
+            pipeline.add(capsfilter)
+            pipeline.add(dsp)
+            pipeline.add(ac_post_dsp)
+            audioresample.link(capsfilter)
+            capsfilter.link(dsp)
+            dsp.link(ac_post_dsp)
+            ac_post_dsp.link(self._appsink_audio)
+        else:
+            audioresample.link(self._appsink_audio)
 
     def _build_audiosink_element(self) -> Gst.Element:
         """Create a platform-appropriate audio sink element."""
@@ -588,7 +491,35 @@ class GStreamerAudio(AudioBase):
         ):
             pipeline.add(el)
 
-        self._appsrc.link(tee)
+        if self._sw_aec_enabled:
+            # Software AEC reference: drop the probe inline between
+            # the appsrc and the tee. The probe is a passthrough
+            # element — anything pushed through reaches the tee (and
+            # therefore both the speaker and wobbler branches) while
+            # a copy is registered as the AEC reference. No parallel
+            # tee branch / fakesink is needed.
+            #
+            # The probe is only attached to the appsrc-driven
+            # conversation pipeline (this one), NOT to the
+            # `playbin`-driven tee bin used by `play_sound`:
+            # sound-file beeps are short and would otherwise collide
+            # on the probe's process-wide name.
+            ac_pre_probe = Gst.ElementFactory.make("audioconvert")
+            capsfilter_probe = self._make_aec_capsfilter()
+            probe = Gst.ElementFactory.make("webrtcechoprobe")
+            probe.set_property("name", self._AEC_PROBE_NAME)
+            if not all([ac_pre_probe, capsfilter_probe, probe]):
+                raise RuntimeError("Failed to create AEC probe elements")
+            pipeline.add(ac_pre_probe)
+            pipeline.add(capsfilter_probe)
+            pipeline.add(probe)
+            self._appsrc.link(ac_pre_probe)
+            ac_pre_probe.link(capsfilter_probe)
+            capsfilter_probe.link(probe)
+            probe.link(tee)
+        else:
+            self._appsrc.link(tee)
+
         tee.link(queue_speaker)
         queue_speaker.link(ac_speaker)
         ac_speaker.link(ar_speaker)
@@ -597,20 +528,6 @@ class GStreamerAudio(AudioBase):
         queue_wobbler.link(ac_wobbler)
         ac_wobbler.link(ar_wobbler)
         ar_wobbler.link(appsink_wobbler)
-
-        # Software AEC reference branch. We only attach it to the
-        # appsrc-based playback pipeline (i.e. conversation audio
-        # pushed via `push_audio_sample`), NOT to the `playbin`-driven
-        # tee bin used by `play_sound`. Two reasons:
-        #   1. Sound-file beeps are short and not interpretable by an
-        #      LLM as speech even if they leak into the mic, so the
-        #      cost/benefit doesn't justify the extra wiring.
-        #   2. `webrtcechoprobe` registers a process-wide name, so
-        #      keeping it bound to a single, long-lived element is the
-        #      simplest way to avoid duplicate-name collisions when a
-        #      playbin tee bin spins up mid-conversation.
-        if self._sw_aec_enabled:
-            self._attach_aec_probe(pipeline, tee)
 
     def _on_bus_message(
         self, bus: Gst.Bus, msg: Gst.Message, pipeline: Gst.Pipeline

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -85,6 +85,11 @@ from typing import Optional
 import numpy as np
 import numpy.typing as npt
 
+from reachy_mini.media.audio_aec import (
+    build_aec_dsp_chain,
+    build_aec_probe_chain,
+    resolve_sw_aec_enabled,
+)
 from reachy_mini.media.audio_base import AudioBase
 from reachy_mini.media.audio_utils import has_reachymini_asoundrc
 from reachy_mini.media.device_detection import get_audio_device
@@ -120,12 +125,6 @@ class GStreamerAudio(AudioBase):
     PLAYBACK_SINK_BUFFER_TIME_US = 50_000
     PLAYBACK_SINK_LATENCY_TIME_US = 5_000
 
-    # Shared name that ties the recording-side `webrtcdsp` to the
-    # playback-side `webrtcechoprobe`. Both elements communicate via
-    # a process-wide registry indexed by this string, so the value
-    # just needs to be stable and unique within the process.
-    _AEC_PROBE_NAME = "reachymini_aec_probe"
-
     def __init__(self, log_level: str = "INFO") -> None:
         """Initialize recording and playback pipelines.
 
@@ -144,7 +143,7 @@ class GStreamerAudio(AudioBase):
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()
 
-        self._sw_aec_enabled = self._resolve_sw_aec_enabled()
+        self._sw_aec_enabled = resolve_sw_aec_enabled(self.logger)
 
         self._pipeline_record = Gst.Pipeline.new("audio_recorder")
         self._init_pipeline_record(self._pipeline_record)
@@ -160,87 +159,6 @@ class GStreamerAudio(AudioBase):
         self._bus_playback.add_watch(
             GLib.PRIORITY_DEFAULT, self._on_bus_message, self._pipeline_playback
         )
-
-    # ------------------------------------------------------------------
-    # Software AEC fallback
-    # ------------------------------------------------------------------
-
-    def _resolve_sw_aec_enabled(self) -> bool:
-        """Decide whether to insert a `webrtcdsp` + `webrtcechoprobe` pair.
-
-        Pure auto-detection from the same audio device parsing the
-        rest of the backend uses. Returns ``True`` only when no
-        hardware AEC sits in the audio path and the matching
-        ``gst-plugins-bad`` elements are actually packaged:
-
-        * ``has_reachymini_asoundrc()`` → Wireless XMOS does AEC, skip.
-        * ``get_audio_device("Source")`` → XVF3800 / ReSpeaker on USB
-          does AEC, skip.
-        * ``webrtcdsp`` or ``webrtcechoprobe`` missing → skip with a
-          loud warning so callers can install the missing plugin.
-
-        Anything else (typically ``--sim`` / ``--mockup-sim`` or a
-        developer workstation) gets the software AEC.
-        """
-        if has_reachymini_asoundrc():
-            self.logger.info(
-                "Wireless `.asoundrc` detected — relying on XMOS "
-                "hardware AEC, skipping software AEC stage."
-            )
-            return False
-        if get_audio_device("Source") is not None:
-            self.logger.info(
-                "ReSpeaker / Reachy Mini Audio card detected — "
-                "relying on XVF3800 hardware AEC, skipping software "
-                "AEC stage."
-            )
-            return False
-
-        for name in ("webrtcdsp", "webrtcechoprobe"):
-            if Gst.ElementFactory.find(name) is None:
-                self.logger.warning(
-                    "No XVF3800 audio board detected AND GStreamer "
-                    "element '%s' is unavailable in this build "
-                    "(install gst-plugins-bad). Conversation audio "
-                    "will loop back through the laptop mic — use a "
-                    "headset to work around it.",
-                    name,
-                )
-                return False
-
-        self.logger.warning(
-            "No XVF3800 audio board detected — enabling software AEC "
-            "(webrtcdsp + webrtcechoprobe). Quality is best-effort; for "
-            "production voice loops use the ReSpeaker USB dongle or a "
-            "Wireless robot with the XMOS AEC loopback."
-        )
-        return True
-
-    def _make_aec_capsfilter(self) -> Gst.Element:
-        """Force ``webrtcdsp``-friendly caps (S16LE interleaved, 16 kHz).
-
-        ``webrtcdsp`` accepts ``S16LE/interleaved`` or
-        ``F32LE/non-interleaved``; the rest of our pipeline uses
-        ``F32LE/interleaved``, so we pin S16LE on the AEC link and
-        let the surrounding ``audioconvert`` elements bridge the
-        format gap on both sides.
-
-        The dsp and the probe MUST agree on rate and channel count,
-        so we canonicalise both sides to the same ``SAMPLE_RATE`` /
-        ``CHANNELS`` values that drive the rest of the backend.
-        """
-        capsfilter = Gst.ElementFactory.make("capsfilter")
-        capsfilter.set_property(
-            "caps",
-            Gst.Caps.from_string(
-                "audio/x-raw,"
-                "format=S16LE,"
-                "layout=interleaved,"
-                f"rate={self.SAMPLE_RATE},"
-                f"channels={self.CHANNELS}"
-            ),
-        )
-        return capsfilter
 
     def _init_pipeline_record(self, pipeline: Gst.Pipeline) -> None:
         self._appsink_audio = Gst.ElementFactory.make("appsink")
@@ -300,16 +218,11 @@ class GStreamerAudio(AudioBase):
             # accept and which they need to share on both ends), let
             # the dsp filter the mic stream, then convert back to
             # F32LE for the appsink. `audiobuffersplit` is not
-            # required — the dsp re-chunks to its own 10 ms frames
+            # required - the dsp re-chunks to its own 10 ms frames
             # internally via GstAdapter.
-            capsfilter = self._make_aec_capsfilter()
-            dsp = Gst.ElementFactory.make("webrtcdsp")
-            dsp.set_property("probe", self._AEC_PROBE_NAME)
-            dsp.set_property("delay-agnostic", True)
-            dsp.set_property("extended-filter", True)
-            ac_post_dsp = Gst.ElementFactory.make("audioconvert")
-            if not all([capsfilter, dsp, ac_post_dsp]):
-                raise RuntimeError("Failed to create AEC DSP elements")
+            capsfilter, dsp, ac_post_dsp = build_aec_dsp_chain(
+                sample_rate=self.SAMPLE_RATE, channels=self.CHANNELS
+            )
             pipeline.add(capsfilter)
             pipeline.add(dsp)
             pipeline.add(ac_post_dsp)
@@ -494,7 +407,7 @@ class GStreamerAudio(AudioBase):
         if self._sw_aec_enabled:
             # Software AEC reference: drop the probe inline between
             # the appsrc and the tee. The probe is a passthrough
-            # element — anything pushed through reaches the tee (and
+            # element - anything pushed through reaches the tee (and
             # therefore both the speaker and wobbler branches) while
             # a copy is registered as the AEC reference. No parallel
             # tee branch / fakesink is needed.
@@ -504,12 +417,9 @@ class GStreamerAudio(AudioBase):
             # `playbin`-driven tee bin used by `play_sound`:
             # sound-file beeps are short and would otherwise collide
             # on the probe's process-wide name.
-            ac_pre_probe = Gst.ElementFactory.make("audioconvert")
-            capsfilter_probe = self._make_aec_capsfilter()
-            probe = Gst.ElementFactory.make("webrtcechoprobe")
-            probe.set_property("name", self._AEC_PROBE_NAME)
-            if not all([ac_pre_probe, capsfilter_probe, probe]):
-                raise RuntimeError("Failed to create AEC probe elements")
+            ac_pre_probe, capsfilter_probe, probe = build_aec_probe_chain(
+                sample_rate=self.SAMPLE_RATE, channels=self.CHANNELS
+            )
             pipeline.add(ac_pre_probe)
             pipeline.add(capsfilter_probe)
             pipeline.add(probe)

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -39,6 +39,12 @@ from reachy_mini.daemon.utils import (
     SimulationMode,
     is_local_camera_available,
 )
+from reachy_mini.media.audio_aec import (
+    build_aec_dsp_chain,
+    build_aec_probe_chain,
+    make_aec_probe,
+    resolve_sw_aec_enabled,
+)
 from reachy_mini.media.audio_control_utils import init_respeaker_usb
 from reachy_mini.media.audio_utils import has_reachymini_asoundrc
 from reachy_mini.media.camera_constants import (
@@ -164,6 +170,34 @@ class GstMediaServer:
         self._loop = GLib.MainLoop()
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()
+
+        # Software AEC fallback decision is cached once at startup: the
+        # outcome depends on audio hardware presence (XVF3800 board /
+        # ReSpeaker USB / `.asoundrc` loopback) plus the availability of
+        # the `webrtcdsp` / `webrtcechoprobe` GStreamer elements. None of
+        # those change for the lifetime of the daemon, so we evaluate it
+        # once - and log it once - rather than on every pipeline rebuild.
+        # When enabled, ``_configure_audio`` (capture path) inserts a
+        # ``webrtcdsp`` between the platform mic and ``webrtcsink``, and
+        # ``_on_consumer_pad_added`` (peer playback path) inserts a
+        # paired ``webrtcechoprobe`` between ``opusdec`` and the tee feeding
+        # the laptop speaker. Together they prevent the mobile-app
+        # conversation loop from hearing itself when no hardware AEC
+        # board is in the audio path.
+        self._sw_aec_enabled = resolve_sw_aec_enabled(self._logger)
+        # The probe must be alive in the process-wide GStreamer registry
+        # by the time the sender pipeline (with the paired ``webrtcdsp``)
+        # transitions to PLAYING, otherwise the dsp fails to start with
+        # "No echo probe with name X found." The probe registers itself
+        # at ``set_property('name', ...)`` time, before reaching any
+        # pipeline, so we eagerly create it here and only attach it to
+        # the per-peer playback pipeline later in
+        # ``_on_consumer_pad_added``. Keeping a long-lived Python
+        # reference also keeps the registry entry alive across peer
+        # reconnects.
+        self._aec_probe: Optional[Gst.Element] = (
+            make_aec_probe() if self._sw_aec_enabled else None
+        )
 
         match sim_mode:
             case SimulationMode.MUJOCO:
@@ -432,7 +466,43 @@ class GstMediaServer:
             self._pipeline_playback.add(elem)
         appsrc.link(rtpopusdepay)
         rtpopusdepay.link(opusdec)
-        opusdec.link(tee)
+
+        if self._sw_aec_enabled and self._aec_probe is not None:
+            # Software AEC reference: drop the probe inline between
+            # `opusdec` and the tee. The probe is a passthrough
+            # element - every speaker sample reaches the tee (and so
+            # both the speaker and wobbler branches) while a copy is
+            # registered as the AEC reference signal that the paired
+            # `webrtcdsp` (in `_configure_audio`) subtracts from the
+            # mic stream. The matching is keyed by ``AEC_PROBE_NAME``.
+            #
+            # The probe element is created once in ``__init__`` and
+            # reused across peer reconnects. If it was previously
+            # parented to another (now-NULL) playback pipeline we
+            # must unparent it before adding it to the new one - an
+            # element can only be in one parent at a time.
+            previous_parent = self._aec_probe.get_parent()
+            if previous_parent is not None:
+                self._aec_probe.set_state(Gst.State.NULL)
+                previous_parent.remove(self._aec_probe)
+            ac_pre_probe, capsfilter_probe, _ = build_aec_probe_chain(
+                probe=self._aec_probe
+            )
+            self._pipeline_playback.add(ac_pre_probe)
+            self._pipeline_playback.add(capsfilter_probe)
+            self._pipeline_playback.add(self._aec_probe)
+            opusdec.link(ac_pre_probe)
+            ac_pre_probe.link(capsfilter_probe)
+            capsfilter_probe.link(self._aec_probe)
+            self._aec_probe.link(tee)
+            self._logger.info(
+                "Inserted software AEC reference (webrtcechoprobe) "
+                "between opusdec and tee for peer %s.",
+                peer_id,
+            )
+        else:
+            opusdec.link(tee)
+
         tee.link(queue_speaker)
         queue_speaker.link(ac_speaker)
         ac_speaker.link(ar_speaker)
@@ -934,7 +1004,37 @@ class GstMediaServer:
         pipeline.add(audiosrc)
         pipeline.add(queue)
         audiosrc.link(queue)
-        queue.link(webrtcsink)
+
+        if self._sw_aec_enabled:
+            # Insert the software AEC stage: mic → audioconvert →
+            # audioresample → capsfilter(S16LE/16k/2ch) → webrtcdsp →
+            # audioconvert → webrtcsink. The pre-dsp resample is
+            # mandatory because `webrtcdsp` only accepts a fixed
+            # 16 kHz internally, and `audioconvert` upstream handles
+            # the format / layout conversion to S16LE interleaved.
+            ac_pre = Gst.ElementFactory.make("audioconvert", "aec_ac_pre")
+            ar_pre = Gst.ElementFactory.make("audioresample", "aec_ar_pre")
+            capsfilter, dsp, ac_post = build_aec_dsp_chain()
+            if not all([ac_pre, ar_pre]):
+                raise RuntimeError(
+                    "Failed to create AEC pre-stage elements (audioconvert/audioresample)"
+                )
+            pipeline.add(ac_pre)
+            pipeline.add(ar_pre)
+            pipeline.add(capsfilter)
+            pipeline.add(dsp)
+            pipeline.add(ac_post)
+            queue.link(ac_pre)
+            ac_pre.link(ar_pre)
+            ar_pre.link(capsfilter)
+            capsfilter.link(dsp)
+            dsp.link(ac_post)
+            ac_post.link(webrtcsink)
+            self._logger.info(
+                "Inserted software AEC (webrtcdsp) between mic and webrtcsink."
+            )
+        else:
+            queue.link(webrtcsink)
 
     def _build_audio_source(self) -> Optional[Gst.Element]:
         """Build a platform-aware audio source element.

--- a/tests/unit_tests/test_audio_gstreamer.py
+++ b/tests/unit_tests/test_audio_gstreamer.py
@@ -4,8 +4,6 @@ from types import SimpleNamespace
 from typing import cast
 from unittest.mock import patch
 
-import pytest
-
 from reachy_mini.media.audio_base import AudioBase
 from reachy_mini.media.audio_gstreamer import GStreamerAudio
 
@@ -63,14 +61,15 @@ def test_compute_pts_resets_after_large_gap() -> None:
     assert next_pts_ns == 1_450_000_000
 
 
-# ─── Software AEC env-var override ───────────────────────────────────────
+# ─── Software AEC auto-detection ─────────────────────────────────────────
 
 
-def _fake_aec_self(logger=None) -> GStreamerAudio:
+def _fake_aec_self() -> GStreamerAudio:
     """Return a stand-in with just what `_resolve_sw_aec_enabled` reads.
 
-    We avoid touching the GStreamer pipelines entirely; the method only
-    needs `self.logger`, so a `SimpleNamespace` is sufficient.
+    The method only needs `self.logger`, so a `SimpleNamespace`
+    with a no-op logger is sufficient — no need to spin up the
+    GStreamer pipelines.
     """
 
     class _DummyLogger:
@@ -80,79 +79,11 @@ def _fake_aec_self(logger=None) -> GStreamerAudio:
         def warning(self, *_a, **_kw) -> None:  # noqa: D401
             """Silence warnings in tests."""
 
-    return cast(
-        GStreamerAudio,
-        SimpleNamespace(logger=logger or _DummyLogger()),
-    )
+    return cast(GStreamerAudio, SimpleNamespace(logger=_DummyLogger()))
 
 
-@pytest.mark.parametrize(
-    "env_value",
-    ["1", "true", "TRUE", "yes", "on"],
-)
-def test_disable_env_overrides_to_false(monkeypatch, env_value: str) -> None:
-    """`REACHY_MINI_DISABLE_SW_AEC` short-circuits to False without probing."""
-    monkeypatch.setenv("REACHY_MINI_DISABLE_SW_AEC", env_value)
-    monkeypatch.delenv("REACHY_MINI_FORCE_SW_AEC", raising=False)
-
-    # Detection helpers must not be called when env-var disables AEC.
-    with patch(
-        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc"
-    ) as soundrc, patch(
-        "reachy_mini.media.audio_gstreamer.get_audio_device"
-    ) as get_dev, patch(
-        "reachy_mini.media.audio_gstreamer.Gst.ElementFactory.find"
-    ) as find:
-        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
-
-    assert result is False
-    soundrc.assert_not_called()
-    get_dev.assert_not_called()
-    find.assert_not_called()
-
-
-def test_force_env_overrides_to_true_when_plugins_present(monkeypatch) -> None:
-    """`REACHY_MINI_FORCE_SW_AEC` enables AEC even with hardware detected."""
-    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
-    monkeypatch.setenv("REACHY_MINI_FORCE_SW_AEC", "1")
-
-    with patch(
-        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
-        return_value=True,
-    ) as soundrc, patch(
-        "reachy_mini.media.audio_gstreamer.get_audio_device",
-        return_value="dummy-card",
-    ) as get_dev, patch(
-        "reachy_mini.media.audio_gstreamer.Gst.ElementFactory.find",
-        return_value=object(),
-    ):
-        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
-
-    assert result is True
-    # Hardware-detection helpers are bypassed when force-enabled.
-    soundrc.assert_not_called()
-    get_dev.assert_not_called()
-
-
-def test_force_env_disabled_when_plugins_missing(monkeypatch) -> None:
-    """Force-enable still bails out if `webrtcdsp` isn't packaged."""
-    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
-    monkeypatch.setenv("REACHY_MINI_FORCE_SW_AEC", "1")
-
-    with patch(
-        "reachy_mini.media.audio_gstreamer.Gst.ElementFactory.find",
-        return_value=None,
-    ):
-        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
-
-    assert result is False
-
-
-def test_auto_disabled_when_asoundrc_present(monkeypatch) -> None:
+def test_auto_disabled_when_asoundrc_present() -> None:
     """Wireless `.asoundrc` always wins (XMOS loopback handles AEC)."""
-    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
-    monkeypatch.delenv("REACHY_MINI_FORCE_SW_AEC", raising=False)
-
     with patch(
         "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
         return_value=True,
@@ -162,14 +93,13 @@ def test_auto_disabled_when_asoundrc_present(monkeypatch) -> None:
         result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
 
     assert result is False
+    # No reason to keep poking the device monitor once we know XMOS
+    # is in the path.
     get_dev.assert_not_called()
 
 
-def test_auto_disabled_when_respeaker_card_detected(monkeypatch) -> None:
+def test_auto_disabled_when_respeaker_card_detected() -> None:
     """ReSpeaker USB dongle present (Lite happy path) skips SW AEC."""
-    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
-    monkeypatch.delenv("REACHY_MINI_FORCE_SW_AEC", raising=False)
-
     with patch(
         "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
         return_value=False,
@@ -182,11 +112,8 @@ def test_auto_disabled_when_respeaker_card_detected(monkeypatch) -> None:
     assert result is False
 
 
-def test_auto_enabled_when_no_hardware_and_plugins_present(monkeypatch) -> None:
+def test_auto_enabled_when_no_hardware_and_plugins_present() -> None:
     """Sim / dev box: no hardware AEC, plugins available → enable SW AEC."""
-    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
-    monkeypatch.delenv("REACHY_MINI_FORCE_SW_AEC", raising=False)
-
     with patch(
         "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
         return_value=False,
@@ -202,11 +129,8 @@ def test_auto_enabled_when_no_hardware_and_plugins_present(monkeypatch) -> None:
     assert result is True
 
 
-def test_auto_disabled_when_no_hardware_but_plugins_missing(monkeypatch) -> None:
+def test_auto_disabled_when_no_hardware_but_plugins_missing() -> None:
     """No hardware AND no `webrtcdsp` packaged → fall back to no AEC (warn only)."""
-    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
-    monkeypatch.delenv("REACHY_MINI_FORCE_SW_AEC", raising=False)
-
     with patch(
         "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
         return_value=False,

--- a/tests/unit_tests/test_audio_gstreamer.py
+++ b/tests/unit_tests/test_audio_gstreamer.py
@@ -2,6 +2,9 @@
 
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import patch
+
+import pytest
 
 from reachy_mini.media.audio_base import AudioBase
 from reachy_mini.media.audio_gstreamer import GStreamerAudio
@@ -58,3 +61,162 @@ def test_compute_pts_resets_after_large_gap() -> None:
     assert pts_ns == 1_400_000_000
     assert duration_ns == 50_000_000
     assert next_pts_ns == 1_450_000_000
+
+
+# ─── Software AEC env-var override ───────────────────────────────────────
+
+
+def _fake_aec_self(logger=None) -> GStreamerAudio:
+    """Return a stand-in with just what `_resolve_sw_aec_enabled` reads.
+
+    We avoid touching the GStreamer pipelines entirely; the method only
+    needs `self.logger`, so a `SimpleNamespace` is sufficient.
+    """
+
+    class _DummyLogger:
+        def info(self, *_a, **_kw) -> None:  # noqa: D401
+            """Silence info logs in tests."""
+
+        def warning(self, *_a, **_kw) -> None:  # noqa: D401
+            """Silence warnings in tests."""
+
+    return cast(
+        GStreamerAudio,
+        SimpleNamespace(logger=logger or _DummyLogger()),
+    )
+
+
+@pytest.mark.parametrize(
+    "env_value",
+    ["1", "true", "TRUE", "yes", "on"],
+)
+def test_disable_env_overrides_to_false(monkeypatch, env_value: str) -> None:
+    """`REACHY_MINI_DISABLE_SW_AEC` short-circuits to False without probing."""
+    monkeypatch.setenv("REACHY_MINI_DISABLE_SW_AEC", env_value)
+    monkeypatch.delenv("REACHY_MINI_FORCE_SW_AEC", raising=False)
+
+    # Detection helpers must not be called when env-var disables AEC.
+    with patch(
+        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc"
+    ) as soundrc, patch(
+        "reachy_mini.media.audio_gstreamer.get_audio_device"
+    ) as get_dev, patch(
+        "reachy_mini.media.audio_gstreamer.Gst.ElementFactory.find"
+    ) as find:
+        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+
+    assert result is False
+    soundrc.assert_not_called()
+    get_dev.assert_not_called()
+    find.assert_not_called()
+
+
+def test_force_env_overrides_to_true_when_plugins_present(monkeypatch) -> None:
+    """`REACHY_MINI_FORCE_SW_AEC` enables AEC even with hardware detected."""
+    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
+    monkeypatch.setenv("REACHY_MINI_FORCE_SW_AEC", "1")
+
+    with patch(
+        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
+        return_value=True,
+    ) as soundrc, patch(
+        "reachy_mini.media.audio_gstreamer.get_audio_device",
+        return_value="dummy-card",
+    ) as get_dev, patch(
+        "reachy_mini.media.audio_gstreamer.Gst.ElementFactory.find",
+        return_value=object(),
+    ):
+        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+
+    assert result is True
+    # Hardware-detection helpers are bypassed when force-enabled.
+    soundrc.assert_not_called()
+    get_dev.assert_not_called()
+
+
+def test_force_env_disabled_when_plugins_missing(monkeypatch) -> None:
+    """Force-enable still bails out if `webrtcdsp` isn't packaged."""
+    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
+    monkeypatch.setenv("REACHY_MINI_FORCE_SW_AEC", "1")
+
+    with patch(
+        "reachy_mini.media.audio_gstreamer.Gst.ElementFactory.find",
+        return_value=None,
+    ):
+        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+
+    assert result is False
+
+
+def test_auto_disabled_when_asoundrc_present(monkeypatch) -> None:
+    """Wireless `.asoundrc` always wins (XMOS loopback handles AEC)."""
+    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
+    monkeypatch.delenv("REACHY_MINI_FORCE_SW_AEC", raising=False)
+
+    with patch(
+        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
+        return_value=True,
+    ), patch(
+        "reachy_mini.media.audio_gstreamer.get_audio_device"
+    ) as get_dev:
+        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+
+    assert result is False
+    get_dev.assert_not_called()
+
+
+def test_auto_disabled_when_respeaker_card_detected(monkeypatch) -> None:
+    """ReSpeaker USB dongle present (Lite happy path) skips SW AEC."""
+    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
+    monkeypatch.delenv("REACHY_MINI_FORCE_SW_AEC", raising=False)
+
+    with patch(
+        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
+        return_value=False,
+    ), patch(
+        "reachy_mini.media.audio_gstreamer.get_audio_device",
+        return_value="reachy-mini-audio-id",
+    ):
+        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+
+    assert result is False
+
+
+def test_auto_enabled_when_no_hardware_and_plugins_present(monkeypatch) -> None:
+    """Sim / dev box: no hardware AEC, plugins available → enable SW AEC."""
+    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
+    monkeypatch.delenv("REACHY_MINI_FORCE_SW_AEC", raising=False)
+
+    with patch(
+        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
+        return_value=False,
+    ), patch(
+        "reachy_mini.media.audio_gstreamer.get_audio_device",
+        return_value=None,
+    ), patch(
+        "reachy_mini.media.audio_gstreamer.Gst.ElementFactory.find",
+        return_value=object(),
+    ):
+        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+
+    assert result is True
+
+
+def test_auto_disabled_when_no_hardware_but_plugins_missing(monkeypatch) -> None:
+    """No hardware AND no `webrtcdsp` packaged → fall back to no AEC (warn only)."""
+    monkeypatch.delenv("REACHY_MINI_DISABLE_SW_AEC", raising=False)
+    monkeypatch.delenv("REACHY_MINI_FORCE_SW_AEC", raising=False)
+
+    with patch(
+        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
+        return_value=False,
+    ), patch(
+        "reachy_mini.media.audio_gstreamer.get_audio_device",
+        return_value=None,
+    ), patch(
+        "reachy_mini.media.audio_gstreamer.Gst.ElementFactory.find",
+        return_value=None,
+    ):
+        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+
+    assert result is False

--- a/tests/unit_tests/test_audio_gstreamer.py
+++ b/tests/unit_tests/test_audio_gstreamer.py
@@ -1,9 +1,11 @@
-"""Unit tests for the shared appsrc PTS helper."""
+"""Unit tests for the shared appsrc PTS helper and the SW AEC detection."""
 
+import logging
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import patch
 
+from reachy_mini.media.audio_aec import resolve_sw_aec_enabled
 from reachy_mini.media.audio_base import AudioBase
 from reachy_mini.media.audio_gstreamer import GStreamerAudio
 
@@ -61,36 +63,32 @@ def test_compute_pts_resets_after_large_gap() -> None:
     assert next_pts_ns == 1_450_000_000
 
 
-# ─── Software AEC auto-detection ─────────────────────────────────────────
+# --- Software AEC auto-detection ---------------------------------------
+#
+# These tests cover the shared helper in `reachy_mini.media.audio_aec`,
+# which is consumed by both `GStreamerAudio` (LOCAL Python SDK audio
+# backend) and `GstMediaServer` (WebRTC daemon pipeline). The helper is
+# a pure function so we hit it directly instead of going through one of
+# the two backends.
 
 
-def _fake_aec_self() -> GStreamerAudio:
-    """Return a stand-in with just what `_resolve_sw_aec_enabled` reads.
-
-    The method only needs `self.logger`, so a `SimpleNamespace`
-    with a no-op logger is sufficient — no need to spin up the
-    GStreamer pipelines.
-    """
-
-    class _DummyLogger:
-        def info(self, *_a, **_kw) -> None:  # noqa: D401
-            """Silence info logs in tests."""
-
-        def warning(self, *_a, **_kw) -> None:  # noqa: D401
-            """Silence warnings in tests."""
-
-    return cast(GStreamerAudio, SimpleNamespace(logger=_DummyLogger()))
+def _silent_logger() -> logging.Logger:
+    """Return a logger that swallows everything during the unit test."""
+    logger = logging.getLogger("reachy_mini.test.audio_aec")
+    logger.addHandler(logging.NullHandler())
+    logger.setLevel(logging.CRITICAL + 1)
+    return logger
 
 
 def test_auto_disabled_when_asoundrc_present() -> None:
     """Wireless `.asoundrc` always wins (XMOS loopback handles AEC)."""
     with patch(
-        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
+        "reachy_mini.media.audio_aec.has_reachymini_asoundrc",
         return_value=True,
     ), patch(
-        "reachy_mini.media.audio_gstreamer.get_audio_device"
+        "reachy_mini.media.audio_aec.get_audio_device"
     ) as get_dev:
-        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+        result = resolve_sw_aec_enabled(_silent_logger())
 
     assert result is False
     # No reason to keep poking the device monitor once we know XMOS
@@ -101,46 +99,46 @@ def test_auto_disabled_when_asoundrc_present() -> None:
 def test_auto_disabled_when_respeaker_card_detected() -> None:
     """ReSpeaker USB dongle present (Lite happy path) skips SW AEC."""
     with patch(
-        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
+        "reachy_mini.media.audio_aec.has_reachymini_asoundrc",
         return_value=False,
     ), patch(
-        "reachy_mini.media.audio_gstreamer.get_audio_device",
+        "reachy_mini.media.audio_aec.get_audio_device",
         return_value="reachy-mini-audio-id",
     ):
-        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+        result = resolve_sw_aec_enabled(_silent_logger())
 
     assert result is False
 
 
 def test_auto_enabled_when_no_hardware_and_plugins_present() -> None:
-    """Sim / dev box: no hardware AEC, plugins available → enable SW AEC."""
+    """Sim / dev box: no hardware AEC, plugins available -> enable SW AEC."""
     with patch(
-        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
+        "reachy_mini.media.audio_aec.has_reachymini_asoundrc",
         return_value=False,
     ), patch(
-        "reachy_mini.media.audio_gstreamer.get_audio_device",
+        "reachy_mini.media.audio_aec.get_audio_device",
         return_value=None,
     ), patch(
-        "reachy_mini.media.audio_gstreamer.Gst.ElementFactory.find",
+        "reachy_mini.media.audio_aec.Gst.ElementFactory.find",
         return_value=object(),
     ):
-        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+        result = resolve_sw_aec_enabled(_silent_logger())
 
     assert result is True
 
 
 def test_auto_disabled_when_no_hardware_but_plugins_missing() -> None:
-    """No hardware AND no `webrtcdsp` packaged → fall back to no AEC (warn only)."""
+    """No hardware AND no `webrtcdsp` packaged -> fall back to no AEC (warn only)."""
     with patch(
-        "reachy_mini.media.audio_gstreamer.has_reachymini_asoundrc",
+        "reachy_mini.media.audio_aec.has_reachymini_asoundrc",
         return_value=False,
     ), patch(
-        "reachy_mini.media.audio_gstreamer.get_audio_device",
+        "reachy_mini.media.audio_aec.get_audio_device",
         return_value=None,
     ), patch(
-        "reachy_mini.media.audio_gstreamer.Gst.ElementFactory.find",
+        "reachy_mini.media.audio_aec.Gst.ElementFactory.find",
         return_value=None,
     ):
-        result = GStreamerAudio._resolve_sw_aec_enabled(_fake_aec_self())
+        result = resolve_sw_aec_enabled(_silent_logger())
 
     assert result is False


### PR DESCRIPTION
## Why

Closes #1161.

Without a Reachy Mini Wireless (XMOS via `.asoundrc`) or a ReSpeaker USB dongle (XVF3800), the GStreamer audio backend routes the platform default mic and speaker straight through with no echo cancellation. Any conversation client (mobile app, JS SDK, `reachy_mini_conversation_app`) that pushes the realtime audio unprocessed then hears its own voice back through the laptop mic and the loop collapses on feedback within a couple of turns.

This is the daemon-side companion fix referenced from `reachy_mini_conversation_app#46` (closed → redirected to this repo): putting the AEC in the audio backend means every client benefits without having to roll its own software AEC.

## What changed

A `webrtcdsp` + `webrtcechoprobe` pair (from `gst-plugins-bad`) is spliced on top of the existing pipelines whenever no hardware AEC is detected in the audio path.

**Record pipeline** (added between `audioresample` and the appsink):

```
... → audioresample → audioconvert → capsfilter(S16LE) → audiobuffersplit(10 ms)
                    → webrtcdsp(probe=reachymini_aec_probe,
                                delay-agnostic=true, extended-filter=true)
                    → audioconvert → appsink(F32LE)
```

**Playback pipeline** (parallel tee branch alongside the existing speaker + wobbler branches, only on the appsrc-based conversation pipeline):

```
                                                                   ┌→ queue → ac → ar → audiosink
                                                                   │
appsrc(F32LE) → tee ──────────────────────────────────────────────┼→ queue → ac → ar → appsink_wobbler
                                                                   │
                                                                   └→ queue → audioconvert → capsfilter(S16LE)
                                                                            → audiobuffersplit(10 ms)
                                                                            → webrtcechoprobe(name=reachymini_aec_probe)
                                                                            → fakesink(sync=false, async=false)
```

**Detection** is conservative — the stage is added only when there is **no** hardware AEC and `webrtcdsp` / `webrtcechoprobe` are actually packaged:

| Condition | SW AEC |
|---|---|
| `has_reachymini_asoundrc()` (Wireless XMOS loopback) | OFF |
| `get_audio_device(\"Source\") is not None` (ReSpeaker USB dongle) | OFF |
| `webrtcdsp` / `webrtcechoprobe` missing from the build | OFF (loud warning) |
| Otherwise | **ON** |

**Env-var overrides** (for ops + A/B testing):

* `REACHY_MINI_DISABLE_SW_AEC=1` force-disable.
* `REACHY_MINI_FORCE_SW_AEC=1` force-enable on hardware setups (compare SW vs HW AEC).

## Why this is small

* No `_build_audiosink_tee_bin` change → `play_sound` paths are untouched. Beeps are short and would otherwise collide on the probe's process-wide name.
* No new clock-domain plumbing → `delay-agnostic=true` + `extended-filter=true` handle the residual drift between the record and playback pipelines (they each pick up the platform mic / speaker clock).
* Backward compatible by default on hardware-equipped robots: `.asoundrc` and XVF3800 paths short-circuit the heuristic so the patch is a no-op there.

## Test plan

- [x] Module imports + lint clean (`ruff check`, `ruff format`).
- [x] Smoke test on macOS dev box: pipelines reach `PAUSED` in **disabled**, **forced**, and **auto** modes (auto correctly resolves to ON without hardware).
- [x] 14/14 unit tests in `tests/unit_tests/test_audio_gstreamer.py` pass:
  - 3 pre-existing `_compute_pts` cases.
  - 11 new env-var / auto-detection cases covering `DISABLE`, `FORCE`, asoundrc, ReSpeaker, missing-plugins, and the happy paths.
- [x] 6/7 `MediaBackend.LOCAL` tests in `test_audio.py` pass with SW AEC active (the 7th — `test_DoA` — needs a physical ReSpeaker and is pre-existing).
- [ ] **Needs hardware validation**: end-to-end conversation loop on
  - a Lite + USB ReSpeaker (should stay on HW AEC, no behavioural change),
  - a Wireless robot (should stay on HW AEC, no behavioural change),
  - a Lite **without** ReSpeaker / `--sim` / dev workstation (the case this PR fixes — verify the OpenAI Realtime / mobile-app conversation no longer collapses on feedback within the first turn).

## Caveat documented inline

`audiobuffersplit.output-buffer-duration` is a `GstFraction`. PyGObject's `set_property(\"output-buffer-duration\", Gst.Fraction(1, 100))` segfaults on the GStreamer 1.28 builds we ship; the fix routes through `Gst.util_set_object_arg(bsplit, \"output-buffer-duration\", \"1/100\")` which constructs the GValue C-side. Both call sites carry a comment explaining it so the next person doesn't \"clean it up\".

Made with [Cursor](https://cursor.com)