### PR TITLE
feat(daemon): portable log streaming without journalctl

### DIFF
--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -24,6 +24,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon import log_stream
 from reachy_mini.daemon.app.routers import (
     apps,
     audio_config,
@@ -308,6 +309,13 @@ def run_app(args: Args) -> None:
     handler.setFormatter(logging.Formatter("%(name)s - %(levelname)s - %(message)s"))
     root_logger.handlers.clear()
     root_logger.addHandler(handler)
+
+    # Mirror logs into an in-process ring buffer so log streaming still
+    # works on hosts without systemd/journalctl (developer machines, the
+    # desktop / mockup daemon). The real journalctl is still preferred
+    # when present; this only backs the fallback path. See
+    # reachy_mini.daemon.log_stream.
+    log_stream.install()
 
     # Explicitly configure the apps.manager logger to ensure propagation
     apps_logger = logging.getLogger("reachy_mini.apps.manager")

--- a/src/reachy_mini/daemon/app/routers/logs.py
+++ b/src/reachy_mini/daemon/app/routers/logs.py
@@ -8,6 +8,8 @@ import logging
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from reachy_mini.daemon import log_stream
+
 router = APIRouter(prefix="/logs")
 logger = logging.getLogger(__name__)
 
@@ -82,15 +84,27 @@ async def websocket_daemon_logs(websocket: WebSocket) -> None:
     except WebSocketDisconnect:
         logger.info("WebSocket disconnected")
     except FileNotFoundError:
-        # journalctl not available
-        error_msg = (
-            "ERROR: journalctl command not found. This feature requires systemd."
-        )
-        logger.error(error_msg)
+        # No journalctl on this host (developer machine, desktop or mockup
+        # daemon, any non-systemd Linux). Fall back to the daemon's
+        # in-process log buffer so the feature still works off-robot.
+        logger.info("journalctl unavailable; streaming in-memory daemon logs instead")
         try:
-            await websocket.send_text(error_msg)
-        except Exception:
-            pass
+            async for line in log_stream.stream(idle_keepalive=1.0):
+                # Keepalive ticks (None) double as a disconnect probe.
+                try:
+                    await websocket.send_text(line if line is not None else "")
+                except Exception:
+                    break
+        except RuntimeError:
+            # Buffer was never installed: preserve the historical message.
+            error_msg = (
+                "ERROR: journalctl command not found. This feature requires systemd."
+            )
+            logger.error(error_msg)
+            try:
+                await websocket.send_text(error_msg)
+            except Exception:
+                pass
     except Exception as e:
         error_msg = f"ERROR: Failed to stream logs: {str(e)}"
         logger.error(error_msg)

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -294,7 +294,12 @@ class Backend:
 
         # Head wobbler speech offsets (x_m, y_m, z_m, roll_rad, pitch_rad, yaw_rad)
         self._speech_offsets: tuple[float, float, float, float, float, float] = (
-            0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
         )
 
         # WebRTC support
@@ -440,8 +445,12 @@ class Backend:
         if any(o != 0.0 for o in self._speech_offsets):
             x_m, y_m, z_m, roll_r, pitch_r, yaw_r = self._speech_offsets
             offset_pose = create_head_pose(
-                x=x_m, y=y_m, z=z_m,
-                roll=roll_r, pitch=pitch_r, yaw=yaw_r,
+                x=x_m,
+                y=y_m,
+                z=z_m,
+                roll=roll_r,
+                pitch=pitch_r,
+                yaw=yaw_r,
                 degrees=False,
             )
             pose = compose_world_offset(pose, offset_pose)
@@ -1153,7 +1162,14 @@ class Backend:
             offsets = cmd.offsets
             if len(offsets) == 6:
                 self.set_speech_offsets(
-                    (offsets[0], offsets[1], offsets[2], offsets[3], offsets[4], offsets[5])
+                    (
+                        offsets[0],
+                        offsets[1],
+                        offsets[2],
+                        offsets[3],
+                        offsets[4],
+                        offsets[5],
+                    )
                 )
             send_response({"status": "ok", "command": "set_speech_offsets"})
 
@@ -1321,9 +1337,7 @@ class Backend:
                         }
                     )
             except Exception as e:
-                self.logger.warning(
-                    "Audio config command %s failed: %s", cmd.type, e
-                )
+                self.logger.warning("Audio config command %s failed: %s", cmd.type, e)
                 send_response(
                     {
                         "error": f"Audio config command failed: {e}",
@@ -1405,16 +1419,13 @@ class Backend:
         """
         now = time.time()
         stale = [
-            uid for uid, ts in self._upload_ts.items()
-            if now - ts > self._upload_ttl_s
+            uid for uid, ts in self._upload_ts.items() if now - ts > self._upload_ttl_s
         ]
         for uid in stale:
             self._upload_chunks.pop(uid, None)
             self._upload_meta.pop(uid, None)
             self._upload_ts.pop(uid, None)
-            self.logger.warning(
-                f"upload_move: evicted stale slot {uid} (TTL exceeded)"
-            )
+            self.logger.warning(f"upload_move: evicted stale slot {uid} (TTL exceeded)")
 
     # All upload_* handlers are fire-and-forget. The client pipelines
     # chunks at line rate (relying on SCTP's ordered, reliable delivery)
@@ -1481,8 +1492,7 @@ class Backend:
         """
         now = time.time()
         stale = [
-            uid for uid, ts in self._audio_ts.items()
-            if now - ts > self._upload_ttl_s
+            uid for uid, ts in self._audio_ts.items() if now - ts > self._upload_ttl_s
         ]
         for uid in stale:
             self._audio_chunks.pop(uid, None)
@@ -1563,9 +1573,7 @@ class Backend:
         meta = self._audio_meta.pop(cmd.upload_id, None)
         self._audio_ts.pop(cmd.upload_id, None)
         if slot is None or meta is None:
-            self.logger.warning(
-                f"upload_audio_finish: no such slot {cmd.upload_id}"
-            )
+            self.logger.warning(f"upload_audio_finish: no such slot {cmd.upload_id}")
             return
         if len(slot) != meta["total_chunks"]:
             self.logger.warning(
@@ -1576,6 +1584,7 @@ class Backend:
         payload = "".join(slot)
         try:
             import base64
+
             raw = base64.b64decode(payload, validate=False)
             os.makedirs(self._audio_temp_dir, exist_ok=True)
             path = os.path.join(self._audio_temp_dir, f"{cmd.upload_id}.wav")
@@ -1594,9 +1603,7 @@ class Backend:
             except OSError:
                 pass
         self._uploaded_audios[cmd.upload_id] = path
-        self.logger.info(
-            f"upload_audio_finish: stored {len(raw)} bytes at {path}"
-        )
+        self.logger.info(f"upload_audio_finish: stored {len(raw)} bytes at {path}")
 
     def _handle_play_uploaded_audio(self, cmd: PlayUploadedAudioCmd) -> None:
         """Play an uploaded audio standalone (no motion).
@@ -1617,18 +1624,26 @@ class Backend:
         upload_id = cmd.upload_id
         audio_path = self._uploaded_audios.get(upload_id)
         if not audio_path:
-            self.broadcast_to_all_clients(json.dumps({
-                "type": "play_uploaded_audio",
-                "upload_id": upload_id,
-                "error": "no such uploaded audio",
-            }))
+            self.broadcast_to_all_clients(
+                json.dumps(
+                    {
+                        "type": "play_uploaded_audio",
+                        "upload_id": upload_id,
+                        "error": "no such uploaded audio",
+                    }
+                )
+            )
             return
         # Broadcast BEFORE play_sound, matching play_uploaded_move.
-        self.broadcast_to_all_clients(json.dumps({
-            "type": "play_uploaded_audio",
-            "upload_id": upload_id,
-            "started": True,
-        }))
+        self.broadcast_to_all_clients(
+            json.dumps(
+                {
+                    "type": "play_uploaded_audio",
+                    "upload_id": upload_id,
+                    "started": True,
+                }
+            )
+        )
         # Claim the active-audio slot before kicking off playback so a
         # cancel_audio arriving immediately after the start broadcast
         # finds the right id. Best-effort: GStreamer doesn't notify on
@@ -1643,11 +1658,15 @@ class Backend:
                 self._active_audio_upload_id = None
             # Broadcast a follow-up error so the client knows the
             # started event isn't actionable.
-            self.broadcast_to_all_clients(json.dumps({
-                "type": "play_uploaded_audio",
-                "upload_id": upload_id,
-                "error": str(e),
-            }))
+            self.broadcast_to_all_clients(
+                json.dumps(
+                    {
+                        "type": "play_uploaded_audio",
+                        "upload_id": upload_id,
+                        "error": str(e),
+                    }
+                )
+            )
 
     def _handle_cancel_audio(self, cmd: CancelAudioCmd) -> None:
         """Stop play_uploaded_audio iff its upload_id matches.
@@ -1684,9 +1703,7 @@ class Backend:
         meta = self._upload_meta.pop(cmd.upload_id, None)
         self._upload_ts.pop(cmd.upload_id, None)
         if slot is None or meta is None:
-            self.logger.warning(
-                f"upload_move_finish: no such slot {cmd.upload_id}"
-            )
+            self.logger.warning(f"upload_move_finish: no such slot {cmd.upload_id}")
             return
         if len(slot) != meta["total_chunks"]:
             self.logger.warning(
@@ -1708,11 +1725,13 @@ class Backend:
                 # moves (gzip is fast on the CM4).
                 import base64
                 import gzip
+
                 raw = base64.b64decode(payload, validate=False)
                 # gzip.decompress reads the whole stream into RAM; use
                 # GzipFile.read(max_decoded_bytes + 1) so a bomb can't
                 # exhaust memory before we notice it's oversize.
                 import io
+
                 with gzip.GzipFile(fileobj=io.BytesIO(raw), mode="rb") as gz:
                     raw_text = gz.read(max_decoded_bytes + 1)
                 if len(raw_text) > max_decoded_bytes:
@@ -1739,6 +1758,7 @@ class Backend:
             # Reuse the RecordedMove parser; same JSON shape as the
             # HF dance/emotion datasets, no on-disk sound path.
             from reachy_mini.motion.recorded_move import RecordedMove
+
             parsed = RecordedMove(move_dict, sound_path=None)
         except Exception as e:
             self.logger.warning(
@@ -1892,7 +1912,7 @@ class Backend:
         """Execute goto_sleep and send response when done."""
         try:
             await self.goto_sleep()
-            send_response({"status": "ok", "command": "goto_sleep", "completed": True })
+            send_response({"status": "ok", "command": "goto_sleep", "completed": True})
         except Exception as e:
             send_response({"error": str(e), "command": "goto_sleep"})
 
@@ -1929,11 +1949,15 @@ class Backend:
                     os.remove(audio_path)
                 except OSError:
                     pass
-            self.broadcast_to_all_clients(json.dumps({
-                "type": "play_uploaded_move",
-                "upload_id": upload_id,
-                "error": "no such uploaded move (upload first)",
-            }))
+            self.broadcast_to_all_clients(
+                json.dumps(
+                    {
+                        "type": "play_uploaded_move",
+                        "upload_id": upload_id,
+                        "error": "no such uploaded move (upload first)",
+                    }
+                )
+            )
             return
 
         # Attach the uploaded audio to the move so Backend.play_move
@@ -1946,13 +1970,17 @@ class Backend:
 
         # Broadcast start with the declared duration so any client
         # waiting on the started event knows the loop is live.
-        self.broadcast_to_all_clients(json.dumps({
-            "type": "play_uploaded_move",
-            "upload_id": upload_id,
-            "started": True,
-            "duration_s": move.duration,
-            "has_audio": audio_path is not None,
-        }))
+        self.broadcast_to_all_clients(
+            json.dumps(
+                {
+                    "type": "play_uploaded_move",
+                    "upload_id": upload_id,
+                    "started": True,
+                    "duration_s": move.duration,
+                    "has_audio": audio_path is not None,
+                }
+            )
+        )
 
         result: dict[str, Any] = {
             "type": "play_uploaded_move",

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -24,6 +24,7 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.spatial.transform import Rotation as R
 
+from reachy_mini.daemon import log_stream
 from reachy_mini.io.protocol import (
     AnyCommand,
     AppendRecordCmd,
@@ -1836,9 +1837,11 @@ class Backend:
                     stderr=asyncio.subprocess.STDOUT,
                 )
             except FileNotFoundError:
-                send_response(
-                    LogStreamErrorMsg(error="journalctl not found").model_dump()
-                )
+                # No journalctl on this host (developer machine, desktop or
+                # mockup daemon, any non-systemd Linux). Fall back to the
+                # daemon's in-process log buffer so the feature still works
+                # off-robot. See reachy_mini.daemon.log_stream.
+                await self._stream_in_memory_logs(send_response)
                 return
 
             assert process.stdout is not None
@@ -1878,6 +1881,27 @@ class Backend:
                 except asyncio.TimeoutError:
                     process.kill()
                     await process.wait()
+
+    async def _stream_in_memory_logs(
+        self,
+        send_response: Callable[[dict[str, Any]], None],
+    ) -> None:
+        """Stream the daemon's in-process log buffer (no-journalctl fallback).
+
+        Used on hosts without systemd. Lines are formatted identically to
+        the journalctl path (ISO timestamp split off the rest of the line).
+        """
+        try:
+            async for line in log_stream.stream():
+                ts, sep, rest = line.partition(" ")
+                if not sep:
+                    ts, rest = "", line
+                send_response(LogLineMsg(timestamp=ts, line=rest).model_dump())
+        except asyncio.CancelledError:
+            raise
+        except RuntimeError:
+            # Buffer never installed: preserve the historical error.
+            send_response(LogStreamErrorMsg(error="journalctl not found").model_dump())
 
     async def _async_goto(
         self,

--- a/src/reachy_mini/daemon/log_stream.py
+++ b/src/reachy_mini/daemon/log_stream.py
@@ -1,0 +1,154 @@
+"""In-process daemon log stream for hosts without ``journalctl``.
+
+On a real robot the daemon runs under systemd and its logs are read back
+with ``journalctl -u reachy-mini-daemon``. On a developer machine or the
+desktop / mockup daemon there is no journald, so ``journalctl`` is absent
+and the log-streaming feature (the ``/logs/ws/daemon`` WebSocket and the
+``subscribe_logs`` DataChannel command) used to fail outright with
+``journalctl not found``.
+
+This module is the portable fallback: a :class:`logging.Handler` that keeps
+a bounded ring buffer of recent records and fans new records out to any
+number of live async subscribers. Each line is formatted like
+``journalctl --output short-iso`` (``"<iso-ts> <message>"``) so existing
+client parsers work unchanged regardless of which source produced the line.
+
+The handler is installed once at daemon startup (see
+``daemon/app/main.py::run_app``). When ``journalctl`` is available the
+real thing is still used; this buffer only backs the fallback path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from datetime import datetime, timezone
+from typing import AsyncIterator, Deque, Optional, Set
+
+# Default ring-buffer size. Large enough to give a useful scrollback when a
+# client first subscribes, small enough to stay negligible in memory.
+_DEFAULT_CAPACITY = 2000
+
+
+class _IsoFormatter(logging.Formatter):
+    """Prefix each record with an ISO-8601 UTC timestamp and a space.
+
+    Mirrors ``journalctl --output short-iso`` so consumers can split the
+    line once on the first space into ``(timestamp, message)`` exactly as
+    they do for the journalctl path.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        ts = datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat()
+        return f"{ts} {super().format(record)}"
+
+
+class _RingBufferLogHandler(logging.Handler):
+    """Keep recent log lines and push new ones to live subscribers.
+
+    ``emit`` can be called from any thread (asyncio, uvicorn, GStreamer),
+    so live delivery hops back onto the bound event loop via
+    ``call_soon_threadsafe``. The buffer itself relies on ``deque`` being
+    safe for single appends under CPython's GIL.
+    """
+
+    def __init__(self, capacity: int = _DEFAULT_CAPACITY) -> None:
+        super().__init__()
+        self._buffer: Deque[str] = deque(maxlen=capacity)
+        self._subscribers: Set["asyncio.Queue[str]"] = set()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Record the loop on which subscriber queues live."""
+        self._loop = loop
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            line = self.format(record)
+        except Exception:  # never let logging raise into the caller
+            return
+        self._buffer.append(line)
+        loop = self._loop
+        if loop is None:
+            return
+        for queue in list(self._subscribers):
+            loop.call_soon_threadsafe(self._safe_put, queue, line)
+
+    @staticmethod
+    def _safe_put(queue: "asyncio.Queue[str]", line: str) -> None:
+        try:
+            queue.put_nowait(line)
+        except asyncio.QueueFull:
+            # A slow consumer drops lines rather than stalling the daemon.
+            pass
+
+    def snapshot(self) -> list[str]:
+        return list(self._buffer)
+
+    def subscribe(self) -> "asyncio.Queue[str]":
+        queue: "asyncio.Queue[str]" = asyncio.Queue(maxsize=10_000)
+        self._subscribers.add(queue)
+        return queue
+
+    def unsubscribe(self, queue: "asyncio.Queue[str]") -> None:
+        self._subscribers.discard(queue)
+
+
+_HANDLER: Optional[_RingBufferLogHandler] = None
+
+
+def install(capacity: int = _DEFAULT_CAPACITY) -> None:
+    """Attach the ring-buffer handler to the root logger (idempotent)."""
+    global _HANDLER
+    if _HANDLER is not None:
+        return
+    handler = _RingBufferLogHandler(capacity=capacity)
+    handler.setFormatter(_IsoFormatter("%(name)s - %(levelname)s - %(message)s"))
+    logging.getLogger().addHandler(handler)
+    _HANDLER = handler
+
+
+def is_available() -> bool:
+    """Return True once :func:`install` has run (the fallback can serve)."""
+    return _HANDLER is not None
+
+
+async def stream(
+    idle_keepalive: Optional[float] = None,
+) -> AsyncIterator[Optional[str]]:
+    """Yield buffered lines, then live lines, until the consumer stops.
+
+    Lines are formatted like ``journalctl --output short-iso``.
+
+    If ``idle_keepalive`` is set, the iterator yields ``None`` whenever no
+    new line arrives within that many seconds, letting a WebSocket consumer
+    send a keepalive and notice a dropped peer. When ``None`` (the default)
+    the iterator simply blocks until the next line; callers that manage
+    liveness by cancelling the task (the DataChannel path) want this.
+
+    Raises:
+        RuntimeError: the buffer was never installed (``install`` not
+            called); callers should fall back to their previous behaviour.
+
+    """
+    handler = _HANDLER
+    if handler is None:
+        raise RuntimeError("in-memory log buffer not installed")
+    handler.bind_loop(asyncio.get_running_loop())
+    # Subscribe before snapshotting so no line emitted in between is lost
+    # (a handful of duplicates across the boundary is acceptable for logs).
+    queue = handler.subscribe()
+    try:
+        for line in handler.snapshot():
+            yield line
+        while True:
+            if idle_keepalive is None:
+                yield await queue.get()
+            else:
+                try:
+                    yield await asyncio.wait_for(queue.get(), timeout=idle_keepalive)
+                except asyncio.TimeoutError:
+                    yield None
+    finally:
+        handler.unsubscribe(queue)


### PR DESCRIPTION
## Summary

Daemon log streaming (the `/logs/ws/daemon` WebSocket and the `subscribe_logs` DataChannel command) shelled out to `journalctl -u reachy-mini-daemon`. On hosts without systemd - developer machines, the **desktop / mockup daemon**, any non-systemd Linux - `journalctl` is absent, so both paths failed with `journalctl not found` and clients (e.g. the mobile/desktop app live session) could read no logs at all.

This adds a portable fallback so log streaming works off-robot too:

- New `daemon/log_stream.py`: an in-process ring-buffer `logging.Handler` (bounded, thread-safe emit, async fan-out to live subscribers). Lines are formatted like `journalctl --output short-iso` (`<iso-ts> <message>`) so existing client parsers work unchanged across both sources.
- Installed once at daemon startup in `run_app` (`daemon/app/main.py`).
- Both transports fall back to this buffer on `FileNotFoundError`:
  - WebSocket route `daemon/app/routers/logs.py`
  - DataChannel handler `daemon/backend/abstract.py` (`subscribe_logs`)

`journalctl` is still preferred when present, so **on-robot behaviour is unchanged**. If the buffer was never installed, the previous `journalctl not found` error is preserved.

## Commits

- `style:` pure `ruff format` pass on `daemon/backend/abstract.py` (no logic), isolated so the feature diff stays minimal.
- `feat:` the log-streaming fallback.

## Test plan

- [ ] On a desktop/mockup daemon (macOS, no systemd): open a live session and subscribe to logs - lines now stream instead of `journalctl not found`.
- [ ] On a real robot (systemd present): logs still come from `journalctl` (no behavioural change).
- [ ] WebSocket `/logs/ws/daemon` and the `subscribe_logs` DataChannel path both stream and stop cleanly on disconnect.

Made with [Cursor](https://cursor.com)