### PR TITLE
feat(host): post-OAuth splash + standalone dev harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,6 +266,9 @@ src/reachy_mini/tools/camera_calibration/*.yaml
 ts/node_modules/
 ts/dist/
 ts/host/dist/
+# Static build of the host dev harness (vite.harness.config.ts output),
+# deployed to a Space - a build artefact, never committed.
+ts/host/dist-harness/
 ts/.vite/
 # The unanchored `lib/` rule above (Python template, intended for
 # root-level build artefacts) also matches `ts/host/src/lib/` and

--- a/ts/host/.env.example
+++ b/ts/host/.env.example
@@ -1,0 +1,18 @@
+# Dev harness auth shortcuts (copy to `host/.env.local`).
+#
+# The host dev harness (`npm run dev` from `ts/`) reads these via
+# Vite's `import.meta.env`. All optional.
+
+# --- Option A: skip OAuth (fastest) ----------------------------------
+# Seed a personal HF access token + username so `authenticate()`
+# resolves with no redirect and the host lands straight on the picker.
+# Get a token at https://huggingface.co/settings/tokens (read scope).
+# NOTE: with this path the post-OAuth splash never shows (no redirect).
+# VITE_HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# VITE_HF_USERNAME=your-hf-username
+
+# --- Option B: real OAuth (needed to see the post-OAuth splash) -------
+# Client ID of a personal HF OAuth app
+# (https://huggingface.co/settings/applications/new). Exercises the
+# genuine login() redirect → return → splash → welcome flow.
+# VITE_HF_OAUTH_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxx

--- a/ts/host/dev/main.ts
+++ b/ts/host/dev/main.ts
@@ -1,0 +1,124 @@
+/**
+ * Standalone dev harness entry for the host shell.
+ *
+ * The host package is self-contained - it bundles its own React +
+ * MUI - so the shell can be exercised in complete isolation, with
+ * no consuming app. This file is the dev-only counterpart of an
+ * app's `dispatch.ts`: it routes the same origin between
+ *
+ *   - the **host shell** (a normal visit), via `mountHost()`, and
+ *   - a deliberately minimal **vanilla embed** (the host's iframe,
+ *     `/?embedded=1`), via `connectToHost()` - which is all the
+ *     host needs on the other side of the postMessage bridge.
+ *
+ * Run it from `ts/`:
+ *
+ *   npm install        # once - pulls React/MUI/vite into ts/node_modules
+ *   npm run dev        # script: `cd host && vite`  →  http://localhost:5173
+ *
+ * Auth in dev (optional, via `host/.env.local`, see `.env.example`):
+ *   - VITE_HF_TOKEN + VITE_HF_USERNAME  seed a token and skip OAuth
+ *     entirely (fastest; lands straight on the picker).
+ *   - VITE_HF_OAUTH_CLIENT_ID           exercise the REAL OAuth
+ *     redirect - required to see the post-OAuth splash, which only
+ *     arms on a genuine redirect return.
+ *
+ * A live robot reachable through central is only needed once you
+ * pick one (to exercise connect → wake → End-session → sleep). The
+ * sign-in, picker, welcome and post-OAuth splash beats all work
+ * with no robot at all.
+ */
+import { ReachyMini } from '@pollen-robotics/reachy-mini-sdk';
+
+// Same bootstrap an app's dispatcher does: expose the SDK
+// constructor on the global both the host shell and the embed
+// client wait for.
+(window as unknown as { ReachyMini: typeof ReachyMini }).ReachyMini = ReachyMini;
+window.dispatchEvent(new Event('reachymini:ready'));
+
+// Vite injects `import.meta.env`; read it defensively so this file
+// stays valid TS even without `vite/client` types in scope.
+const env = (import.meta as unknown as { env?: Record<string, string | undefined> })
+  .env ?? {};
+
+const isEmbed = new URLSearchParams(window.location.search).get('embedded') === '1';
+
+if (isEmbed) {
+  void bootEmbed();
+} else {
+  void bootHost();
+}
+
+async function bootHost(): Promise<void> {
+  const { mountHost } = await import('@/mountHost');
+  const token = env.VITE_HF_TOKEN;
+  // The username is only needed for the dev-token shortcut. If it
+  // wasn't supplied, resolve it from the token via HF `whoami` so a
+  // bare `VITE_HF_TOKEN=...` is enough to skip OAuth.
+  const userName = token
+    ? env.VITE_HF_USERNAME ?? (await resolveUserName(token))
+    : undefined;
+
+  mountHost({
+    appName: 'Host Dev Harness',
+    appEmoji: '🧪',
+    enableMicrophone: false,
+    clientId: env.VITE_HF_OAUTH_CLIENT_ID,
+    devToken: token && userName ? { token, userName } : undefined,
+  });
+}
+
+/** Best-effort `whoami` so the harness only needs `VITE_HF_TOKEN`. */
+async function resolveUserName(token: string): Promise<string | undefined> {
+  try {
+    const res = await fetch('https://huggingface.co/api/whoami-v2', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return undefined;
+    const who = (await res.json()) as { name?: string };
+    return who.name;
+  } catch {
+    return undefined;
+  }
+}
+
+async function bootEmbed(): Promise<void> {
+  const { connectToHost } = await import('@/embed');
+
+  const root = document.getElementById('root') ?? document.body;
+  root.innerHTML = `
+    <main style="font-family:system-ui,sans-serif;display:flex;flex-direction:column;
+                 align-items:center;justify-content:center;height:100%;gap:16px;padding:24px;
+                 text-align:center;color:#111">
+      <h1 style="margin:0;font-size:1.25rem">Minimal embed</h1>
+      <p id="status" style="margin:0;opacity:.7">Connecting…</p>
+      <button id="leave" type="button" hidden
+              style="padding:8px 16px;border-radius:8px;border:1px solid #999;cursor:pointer">
+        Request leave (in-app)
+      </button>
+    </main>`;
+
+  const setStatus = (msg: string): void => {
+    const el = document.getElementById('status');
+    if (el) el.textContent = msg;
+  };
+
+  try {
+    const handle = await connectToHost();
+    setStatus('Live — robot awake. End the session (top bar) to test the leave contract.');
+
+    const leaveBtn = document.getElementById('leave') as HTMLButtonElement | null;
+    if (leaveBtn) {
+      leaveBtn.hidden = false;
+      leaveBtn.addEventListener('click', () => handle.requestLeave());
+    }
+
+    handle.onLeave(() => {
+      // App's OWN cleanup only - per the leave contract the runtime
+      // sleeps the robot and releases the torque for us.
+      setStatus('onLeave fired — app cleaning up; runtime is sleeping the robot.');
+    });
+  } catch (err) {
+    setStatus(`connectToHost failed: ${(err as Error)?.message ?? String(err)}`);
+  }
+}

--- a/ts/host/harness/README.md
+++ b/ts/host/harness/README.md
@@ -1,0 +1,51 @@
+---
+title: Reachy Mini Host Harness
+emoji: 🧪
+colorFrom: indigo
+colorTo: purple
+sdk: static
+pinned: false
+hf_oauth: true
+short_description: Dev harness for the Reachy Mini host shell
+---
+
+# Reachy Mini Host Harness
+
+A standalone deployment of the **Reachy Mini host shell**, used to exercise
+the host in real conditions - in particular the **Hugging Face OAuth flow**
+(real redirect + real Space-injected `OAUTH_CLIENT_ID`), the robot picker,
+the welcome / post-OAuth splash, and the leave / sign-out contract.
+
+This is **not** an end-user app. It is the same shell that apps load via
+`@pollen-robotics/reachy-mini-sdk/host/auto`, built straight from source
+(no CDN, no published npm version in the loop) and served as static files
+so it owns the top-level origin and can complete the OAuth round-trip.
+
+## What it validates
+
+- OAuth sign-in redirect and return leg (no button flicker on return).
+- "Welcome back" overlay + post-OAuth splash timing.
+- Robot picker, connect → wake.
+- Leave / End-session contract: app `onLeave` → sleep → torque release →
+  `stopSession`, including a graceful sign-out from inside a live session.
+
+## Caveats (different from a real app Space)
+
+- This Space gets its **own** auto-provisioned OAuth app: distinct
+  `client_id`, redirect URI and consent screen (owned by this Space).
+  The OAuth *logic and UX* are faithful, but the client/redirect identity
+  is not 1:1 with any production app Space.
+- The robot path uses the default central signaling server, so it matches
+  production.
+- Final go/no-go for a given app should still be validated inside that
+  app's own Space.
+
+## Rebuild & redeploy
+
+From `reachy_mini/ts/host/`:
+
+```bash
+vite build --config vite.harness.config.ts   # → dist-harness/
+```
+
+Then push `dist-harness/` + this README to the Space.

--- a/ts/host/index.html
+++ b/ts/host/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Reachy Mini Host · dev harness</title>
+    <style>
+      html, body, #root { height: 100%; }
+      body { margin: 0; }
+    </style>
+  </head>
+  <body>
+    <!--
+      Standalone dev harness for the host shell. This file exists
+      ONLY for `npm run dev` (vite dev server); it is never shipped
+      - the published package is the library build (`vite build`,
+      see vite.config.ts) which ignores this `index.html`.
+
+      `dev/main.ts` plays the role an app's `dispatch.ts` plays in
+      production: route the same origin between the host shell and a
+      minimal vanilla embed (the iframe). The host is self-contained
+      (bundles its own React + MUI), so no consuming app is needed.
+    -->
+    <div id="root"></div>
+    <script type="module" src="/dev/main.ts"></script>
+  </body>
+</html>

--- a/ts/host/src/components/PostOAuthSplash.tsx
+++ b/ts/host/src/components/PostOAuthSplash.tsx
@@ -1,0 +1,106 @@
+/**
+ * Covering splash shown on the OAuth return leg, while the SDK
+ * resolves the cached token via `authenticate()`.
+ *
+ * Without it the host would render `SignInView` (the "Continue
+ * with Hugging Face" button) for the ~30-500 ms the in-flight
+ * `authenticate()` takes, so the user briefly bounces back to the
+ * sign-in button after already authorising on huggingface.co.
+ *
+ * This splash deliberately mirrors `WelcomeBackOverlay`'s frame
+ * (same `background.default` fill, same centred HF logo) so the
+ * transition reads as one continuous beat:
+ *
+ *   PostOAuthSplash (logo + spinner, no name)
+ *     → WelcomeBackOverlay ("Hello, <name>")
+ *       → PickerView
+ *
+ * It carries NO username on purpose: the name only appears in the
+ * `WelcomeBackOverlay`, which keeps the "Welcome back" → "Hello,
+ * X" text from ever flickering (cf. the welcome-back latch in
+ * `ReachyHostShell`).
+ */
+import type { JSX } from 'react';
+import { Box, CircularProgress, Stack, Typography, keyframes } from '@mui/material';
+
+import { hfLogoSvg } from '../assets';
+import { FONT_WEIGHT, TYPO } from '../lib/tokens';
+
+/** Reserved height of the content block BELOW the logo (heading +
+ *  spinner here, "Hello, X" + subtitle in `WelcomeBackOverlay`).
+ *  Both overlays pin the SAME value and centre their content within
+ *  it, so the logo above sits at the exact same Y in both. Without
+ *  this the splash (heading + spinner) and the welcome (two text
+ *  lines) have different natural heights, and the vertically-centred
+ *  column makes the logo visibly jump at the splash → welcome cut.
+ *  KEEP IN LOCKSTEP with `WelcomeBackOverlay`'s constant. */
+const CONTENT_MIN_HEIGHT = 72;
+
+/** Gentle breathing pulse on the logo so the wait reads as "working"
+ *  rather than "stalled", without the harshness of a spinner alone. */
+const pulseKeyframes = keyframes`
+  0%, 100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(0.94);
+    opacity: 0.75;
+  }
+`;
+
+export function PostOAuthSplash(): JSX.Element {
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        inset: 0,
+        // One below WelcomeBackOverlay (1300) so that, once the
+        // username resolves, the welcome beat fades in cleanly on
+        // top of this splash with no underlying screen bleed.
+        zIndex: 1290,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        bgcolor: 'background.default',
+        color: 'text.primary',
+        touchAction: 'none',
+      }}
+    >
+      <Box
+        component="img"
+        src={hfLogoSvg}
+        alt=""
+        aria-hidden
+        sx={{
+          width: 72,
+          height: 72,
+          mb: 3,
+          display: 'block',
+          animation: `${pulseKeyframes} 1.6s ease-in-out infinite`,
+        }}
+      />
+      <Stack
+        alignItems="center"
+        justifyContent="center"
+        spacing={1}
+        sx={{ minHeight: CONTENT_MIN_HEIGHT }}
+      >
+        <Typography
+          component="h1"
+          sx={{
+            fontSize: TYPO.hero,
+            fontWeight: FONT_WEIGHT.bold,
+            letterSpacing: '-0.3px',
+            textAlign: 'center',
+            m: 0,
+          }}
+        >
+          Signing you in…
+        </Typography>
+        <CircularProgress size={22} thickness={5} color="primary" />
+      </Stack>
+    </Box>
+  );
+}

--- a/ts/host/src/components/ReachyHostShell.tsx
+++ b/ts/host/src/components/ReachyHostShell.tsx
@@ -46,6 +46,7 @@ import { EmbedFrame } from './EmbedFrame';
 import { ErrorView } from './ErrorView';
 import { LeavingView } from './LeavingView';
 import { PickerView } from './PickerView';
+import { PostOAuthSplash } from './PostOAuthSplash';
 import { SignInView } from './SignInView';
 import { TopBar, type HostPhase } from './TopBar';
 import { WelcomeBackOverlay } from './WelcomeBackOverlay';
@@ -519,7 +520,7 @@ function ReachyHostShellNormal({
             />
           )}
 
-          {hostPhase === 'signing-in' && (
+          {hostPhase === 'signing-in' && !isPostOauthReturn && (
             <SignInView
               appName={appName}
               isLocalDevMissingConfig={isLocalDevMissingConfig}
@@ -559,6 +560,15 @@ function ReachyHostShellNormal({
             )}
         </Box>
       </Stack>
+
+      {/* OAuth return leg: cover the screen the moment we know we
+       *  came back from a redirect, so the "Continue with Hugging
+       *  Face" button never flashes while `authenticate()` resolves
+       *  the cached token. Hands off to WelcomeBackOverlay (zIndex
+       *  1300) once the username lands. */}
+      {hostPhase === 'signing-in' && isPostOauthReturn && !welcomeBackShown && (
+        <PostOAuthSplash />
+      )}
 
       {welcomeBackShown && (
         <WelcomeBackOverlay

--- a/ts/host/src/components/WelcomeBackOverlay.tsx
+++ b/ts/host/src/components/WelcomeBackOverlay.tsx
@@ -31,6 +31,14 @@ import { DURATION, FONT_WEIGHT, TYPO } from '../lib/tokens';
  *  celebratory beat land before the picker takes over. */
 const VISIBLE_MS = 3400;
 
+/** Reserved height of the content block BELOW the logo ("Hello, X" +
+ *  subtitle here, heading + spinner in `PostOAuthSplash`). Both
+ *  overlays pin the SAME value and centre their content within it, so
+ *  the logo above sits at the exact same Y in both and does NOT jump
+ *  at the splash → welcome cut. KEEP IN LOCKSTEP with
+ *  `PostOAuthSplash`'s constant. */
+const CONTENT_MIN_HEIGHT = 72;
+
 /** Pop-in keyframes used to stagger the entrance of the logo and
  *  headline. Slight overshoot via the cubic-bezier gives the
  *  motion an "earned" feel rather than a dry fade. */
@@ -103,10 +111,20 @@ export function WelcomeBackOverlay({
             height: 72,
             mb: 3,
             display: 'block',
-            animation: `${popInKeyframes} 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) both`,
+            // Intentionally NOT animated. This overlay takes over from
+            // `PostOAuthSplash`, which already shows the SAME logo at the
+            // SAME size and position. Replaying an entrance animation here
+            // makes the logo visibly "re-pop" at the hand-off; keeping it
+            // static reads as one continuous logo while only the text
+            // (below) swaps in. The entrance motion lives on the text.
           }}
         />
-        <Stack alignItems="center" spacing={0.5}>
+        <Stack
+          alignItems="center"
+          justifyContent="center"
+          spacing={0.5}
+          sx={{ minHeight: CONTENT_MIN_HEIGHT }}
+        >
           <Typography
             component="h1"
             sx={{

--- a/ts/host/vite.harness.config.ts
+++ b/ts/host/vite.harness.config.ts
@@ -1,0 +1,48 @@
+/**
+ * SPA build of the host **dev harness**, for deployment as a static
+ * Hugging Face Space.
+ *
+ * The default `vite.config.ts` is a *library* build (emits the
+ * `dist/*.js` CDN bundles and ignores `index.html`). This config does
+ * the opposite: a plain single-page-app build with `index.html` as the
+ * entry, so the harness can be served as static files on a Space and
+ * the host's OAuth flow exercised in real conditions (real redirect,
+ * real `window.huggingface.variables.OAUTH_CLIENT_ID` injected by the
+ * Space).
+ *
+ * It deliberately reuses the SAME source the local `npm run dev`
+ * harness uses (`index.html` + `dev/main.ts`), so what we test on the
+ * Space is byte-for-byte the host shell we ship - no CDN, no published
+ * npm version in the loop.
+ *
+ * Build:   vite build --config vite.harness.config.ts   (from `host/`)
+ * Output:  host/dist-harness/   →  push as the Space root.
+ */
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [react()],
+  // Relative asset URLs so the bundle works regardless of the path the
+  // Space serves it from (root in practice, but this keeps us safe).
+  base: './',
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      // Same in-tree SDK source the library build and dev server use,
+      // so the harness Space runs our working-copy host, not a
+      // published package.
+      '@pollen-robotics/reachy-mini-sdk': resolve(__dirname, '../reachy-mini-sdk.ts'),
+    },
+  },
+  build: {
+    target: 'es2022',
+    outDir: 'dist-harness',
+    emptyOutDir: true,
+    sourcemap: false,
+  },
+});


### PR DESCRIPTION
## Summary

Host-shell UX polish around the OAuth flow, plus a standalone dev harness to exercise the host in isolation.

- **Post-OAuth splash**: cover the redirect return leg so the "Continue with Hugging Face" button no longer flashes while `authenticate()` resolves the cached token. Hands off to the existing welcome-back overlay once the username lands.
- **Stable HF logo across the splash → welcome cut**:
  - the welcome-back logo is now **static** (the entrance motion lives on the text only), so it no longer "re-pops" when taking over from the splash;
  - both overlays reserve the **same content height** below the logo, so the vertically-centred column places the logo at the exact same Y in both states (no vertical jump between the spinner and the two lines).
- **Standalone dev harness** (`vite.harness.config.ts` + `index.html` + `dev/main.ts` + `.env.example`): builds the host shell from source as a static SPA, so the host (OAuth, picker, overlays) can be tested without a consuming app and deployed to a Space for real-condition OAuth testing. `dist-harness/` is gitignored.

## Notes

- No SDK / embed / protocol changes here. The leave/shutdown-contract work and its diagnostics are intentionally **out of scope** and will land in a separate PR.
- `tsc --noEmit` (host) passes.

## Test plan

- [ ] `cd ts && npm run dev` → host harness boots at localhost.
- [ ] Real OAuth round-trip: no sign-in button flash on return; splash → welcome-back reads as one continuous beat.
- [ ] HF logo does not move or re-animate between the spinner splash and the "Hello, X" welcome.
- [ ] `cd ts/host && vite build --config vite.harness.config.ts` produces a static `dist-harness/` that serves standalone.

Made with [Cursor](https://cursor.com)