### PR TITLE
fix(ble): throttle wrong-PIN guessing on the WiFi provisioning session

### DIFF
--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -671,6 +671,18 @@ class BluetoothCommandService:
     # forever (the PIN is a short proximity secret printed on the device).
     SESSION_TTL_S = 300
 
+    # Wrong-PIN throttle. The PIN is only a few characters, so unmetered
+    # guessing over BLE would brute-force it quickly. The first
+    # PIN_FREE_ATTEMPTS misses are free (fat-finger tolerance); every miss
+    # after that locks the PIN_ command for an exponentially growing window
+    # (PIN_LOCKOUT_BASE_S, doubling each time, capped at PIN_LOCKOUT_MAX_S).
+    # The counter is robot-global and deliberately SURVIVES BLE disconnects
+    # (see _on_central_disconnected) so an attacker cannot reset it by
+    # reconnecting; a correct PIN clears it.
+    PIN_FREE_ATTEMPTS = 3
+    PIN_LOCKOUT_BASE_S = 5
+    PIN_LOCKOUT_MAX_S = 300
+
     def __init__(self, device_name="ReachyMini", pin_code="00000"):
         """Initialize the Bluetooth Command Service."""
         self.device_name = device_name
@@ -678,6 +690,11 @@ class BluetoothCommandService:
         self.connected = False
         # monotonic deadline for the TTL-bounded WiFi session (see _is_authed).
         self._authed_until = 0.0
+        # Wrong-PIN throttle state (see PIN_* constants and _handle_command).
+        # Both deliberately persist across disconnects so reconnecting does
+        # not reset an in-progress lockout.
+        self._pin_failures = 0
+        self._pin_locked_until = 0.0
         self.bus = None
         self.app = None
         self.adv = None
@@ -774,6 +791,39 @@ class BluetoothCommandService:
         """Return whether the TTL-bounded authenticated session is still valid."""
         return self._authed_until > time.monotonic()
 
+    def _pin_lockout_remaining(self) -> float:
+        """Seconds left on the wrong-PIN lockout (0.0 if not locked).
+
+        Touched only from the GLib mainloop thread (WriteValue and the
+        disconnect handler both run there), so no lock is needed.
+        """
+        return max(0.0, self._pin_locked_until - time.monotonic())
+
+    def _register_pin_failure(self) -> None:
+        """Record a wrong PIN and arm the next lockout window.
+
+        Misses beyond PIN_FREE_ATTEMPTS lock the PIN_ command for
+        PIN_LOCKOUT_BASE_S, doubling per consecutive miss, capped at
+        PIN_LOCKOUT_MAX_S.
+        """
+        self._pin_failures += 1
+        over = self._pin_failures - self.PIN_FREE_ATTEMPTS
+        if over > 0:
+            delay = min(
+                self.PIN_LOCKOUT_MAX_S,
+                self.PIN_LOCKOUT_BASE_S * (2 ** (over - 1)),
+            )
+            self._pin_locked_until = time.monotonic() + delay
+            logger.warning(
+                f"Wrong PIN ({self._pin_failures} consecutive). "
+                f"PIN locked for {delay}s."
+            )
+
+    def _reset_pin_throttle(self) -> None:
+        """Clear the wrong-PIN counter and lockout after a successful auth."""
+        self._pin_failures = 0
+        self._pin_locked_until = 0.0
+
     def _emit_response(self, text: str) -> bool:
         """Push a result over the RESPONSE characteristic. Runs on the mainloop."""
         try:
@@ -827,14 +877,24 @@ class BluetoothCommandService:
             self._stop_journal()
             return "OK: Journal streaming stopped"
         elif command_str.startswith("PIN_"):
+            remaining = self._pin_lockout_remaining()
+            if remaining > 0:
+                # Locked out: reject WITHOUT comparing the PIN, so a correct
+                # guess landed mid-spree doesn't win and the lockout window is
+                # the real bottleneck. int()+1 rounds up so we never show "0s".
+                return (
+                    f"ERROR: Too many attempts. Try again in {int(remaining) + 1}s."
+                )
             pin = command_str[4:].strip()
             if pin == self.pin_code:
+                self._reset_pin_throttle()
                 self.connected = True
                 # Open a TTL-bounded session for the WiFi commands so the
                 # client can chain scan → connect → status without re-auth.
                 self._authed_until = time.monotonic() + self.SESSION_TTL_S
                 return "OK: Connected"
             else:
+                self._register_pin_failure()
                 return "ERROR: Incorrect PIN"
 
         # WiFi provisioning over BLE. All of these proxy to the daemon and may
@@ -990,6 +1050,10 @@ class BluetoothCommandService:
         stops any journal stream the dropped client left running, and
         re-asserts advertising so the robot is immediately reconnectable
         rather than relying on BlueZ to auto-resume.
+
+        The wrong-PIN throttle (_pin_failures / _pin_locked_until) is
+        deliberately NOT reset here: otherwise an attacker could wipe an
+        in-progress lockout just by dropping and re-opening the link.
         """
         self.connected = False
         self._authed_until = 0.0

--- a/tests/unit_tests/test_ble_pin_throttle.py
+++ b/tests/unit_tests/test_ble_pin_throttle.py
@@ -1,0 +1,174 @@
+"""Unit tests for the wrong-PIN throttle on the BLE WiFi-provisioning session.
+
+These exercise pure throttle logic in ``BluetoothCommandService`` (time math +
+PIN compare); no real BLE stack is involved.
+
+The service only runs on Linux, so the suite is skipped elsewhere. Even on
+Linux, ``dbus`` (dbus-python) is not a project dependency — the service runs
+under the robot's system Python — so we stub it before importing the module.
+``gi``/PyGObject *is* a Linux dependency and is left real.
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux", reason="BLE provisioning service is Linux-only"
+)
+
+# The service ships as a standalone script run under the robot's system Python
+# (see install_service_bluetooth.sh); it is never imported via the package
+# path and pulls in no reachy_mini modules. Load it directly by file path so we
+# don't drag in the whole daemon app package.
+_SERVICE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py"
+)
+
+
+def _import_bluetooth_service():
+    """Load bluetooth_service with a stubbed ``dbus`` (absent from the venv).
+
+    The GATT classes subclass ``dbus.service.Object`` and use
+    ``@dbus.service.method`` at import time, so the stub must provide a real
+    base class and a no-op decorator factory — not bare MagicMocks. The
+    throttle paths under test never touch dbus at runtime.
+    """
+    service = types.ModuleType("dbus.service")
+
+    class _Object:
+        def __init__(self, *a, **k):
+            pass
+
+    def _decorator_factory(*a, **k):
+        return lambda fn: fn
+
+    service.Object = _Object
+    service.method = _decorator_factory
+    service.signal = _decorator_factory
+
+    exceptions = types.ModuleType("dbus.exceptions")
+
+    class DBusException(Exception):
+        pass
+
+    exceptions.DBusException = DBusException
+
+    mainloop = types.ModuleType("dbus.mainloop")
+    mainloop_glib = types.ModuleType("dbus.mainloop.glib")
+    mainloop_glib.DBusGMainLoop = MagicMock()
+    mainloop.glib = mainloop_glib
+
+    dbus = types.ModuleType("dbus")
+    dbus.service = service
+    dbus.exceptions = exceptions
+    dbus.mainloop = mainloop
+    dbus.__getattr__ = lambda name: MagicMock()  # any other dbus.X at import
+
+    stubs = {
+        "dbus": dbus,
+        "dbus.service": service,
+        "dbus.exceptions": exceptions,
+        "dbus.mainloop": mainloop,
+        "dbus.mainloop.glib": mainloop_glib,
+    }
+    saved = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_ble_bluetooth_service_under_test", _SERVICE_PATH
+        )
+        bt = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(bt)
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+    return bt
+
+
+# Imported once at module scope; only runs on Linux thanks to the guard.
+if sys.platform == "linux":
+    bt = _import_bluetooth_service()
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Controllable monotonic clock for the bluetooth_service module."""
+    state = {"now": 1000.0}
+    monkeypatch.setattr(bt.time, "monotonic", lambda: state["now"])
+    return state
+
+
+@pytest.fixture
+def svc():
+    return bt.BluetoothCommandService(pin_code="12345")
+
+
+def _pin(svc, value):
+    return svc._handle_command(f"PIN_{value}".encode())
+
+
+def _trip_first_lockout(svc):
+    """Send enough wrong PINs to arm the first lockout window."""
+    for _ in range(svc.PIN_FREE_ATTEMPTS + 1):
+        _pin(svc, "00000")
+
+
+def test_correct_pin_connects(svc, clock):
+    assert _pin(svc, "12345").startswith("OK")
+    assert svc.connected is True
+    assert svc._authed_until == clock["now"] + svc.SESSION_TTL_S
+
+
+def test_correct_pin_rejected_during_lockout(svc, clock):
+    """The core invariant: a correct PIN landing mid-lockout must not win."""
+    _trip_first_lockout(svc)
+    assert svc._pin_lockout_remaining() > 0
+    resp = _pin(svc, "12345")  # correct PIN, but locked out
+    assert "Too many attempts" in resp
+    assert svc.connected is False
+
+
+def test_spam_during_lockout_does_not_extend(svc, clock):
+    """Hammering while locked must not escalate the window (no clock advance)."""
+    _trip_first_lockout(svc)
+    locked_until = svc._pin_locked_until
+    for _ in range(20):
+        _pin(svc, "00000")
+    assert svc._pin_locked_until == locked_until
+
+
+def test_lockout_expires(svc, clock):
+    _trip_first_lockout(svc)
+    clock["now"] += svc.PIN_LOCKOUT_BASE_S + 1
+    assert svc._pin_lockout_remaining() == 0.0
+    # Comparison happens again once the window passes.
+    assert "Incorrect PIN" in _pin(svc, "00000")
+
+
+def test_success_resets_throttle(svc, clock):
+    # Several misses, each after the prior lockout expires, then a correct PIN.
+    for _ in range(svc.PIN_FREE_ATTEMPTS + 2):
+        clock["now"] += 10_000
+        _pin(svc, "00000")
+    clock["now"] += 10_000
+    assert _pin(svc, "12345").startswith("OK")
+    assert svc._pin_failures == 0
+    assert svc._pin_locked_until == 0.0
+
+
+def test_disconnect_preserves_throttle(svc, clock, monkeypatch):
+    """Reconnecting must not wipe an in-progress lockout."""
+    monkeypatch.setattr(svc, "_reassert_advertising", lambda: None)
+    _trip_first_lockout(svc)
+    failures, locked = svc._pin_failures, svc._pin_locked_until
+    svc._on_central_disconnected()
+    assert svc._pin_failures == failures
+    assert svc._pin_locked_until == locked


### PR DESCRIPTION
The BLE WiFi-provisioning session is opened by a `PIN_<pin>` command matched against the short serial-derived PIN. The handler compared the PIN and returned "Incorrect PIN" on a miss with no counter, delay, or lockout, so an attacker in BLE range could brute-force the few-character PIN by spamming writes and, on a hit, get a full privileged session (scan / connect / forget). The provisioning docs already claimed a "PIN-attempt gate" existed; it did not.

Add an online-guessing throttle on the PIN_ command:

- First PIN_FREE_ATTEMPTS (3) misses are free (fat-finger tolerance).
- Each miss after that locks the PIN_ command for an exponentially growing window (5s, doubling, capped at 300s), making exhaustive guessing infeasible (5-digit space => ~year+ at the cap).
- While locked, PIN_ is rejected WITHOUT comparing the PIN, so a correct value landed mid-spree cannot win — the lockout is the real bottleneck.
- A correct PIN clears the counter and lockout.
- The counter is robot-global and survives BLE disconnects, so an attacker cannot reset an in-progress lockout by reconnecting.

State is touched only on the GLib mainloop thread, so no extra locking is needed.

This addresses online PIN guessing only. Offline guessing by an active man-in-the-middle (who substitutes the provisioning key, learns the shared secret, then brute-forces the PIN off-device) is NOT closed by this change and needs a PAKE or robot-key authentication — tracked separately.

Assisted-by: Claude:claude-opus-4-8