### PR TITLE
fix(wifi): rescan + retry before joining an AP from hotspot mode

### DIFF
--- a/src/reachy_mini/daemon/app/routers/wifi_config.py
+++ b/src/reachy_mini/daemon/app/routers/wifi_config.py
@@ -17,6 +17,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from fastapi import APIRouter, HTTPException
+from nmcli._exception import NotExistException
 from pydantic import BaseModel
 
 from reachy_mini.utils.hardware_id import get_pin
@@ -137,7 +138,7 @@ def connect_to_wifi_network(
                 setup_wifi_connection(name=ssid, ssid=ssid, password=password)
             except Exception as e:
                 error = e
-                logger.error(f"Failed to connect to WiFi network '{ssid}': {e}")
+                logger.exception(f"Failed to connect to WiFi network '{ssid}'")
                 logger.info("Reverting to hotspot...")
                 remove_connection(name=ssid)
                 setup_wifi_connection(
@@ -411,6 +412,54 @@ def check_if_connection_active(name: str) -> bool:
     return any(c.name == name and c.device != "--" for c in get_wifi_connections())
 
 
+# A user-triggered connect arrives while the robot is serving its own
+# AP/hotspot, so NetworkManager's scan cache is stale or empty for nearby APs.
+# nmcli's wifi_connect needs the target SSID in the current scan list; when it
+# isn't there yet nmcli exits 10 -> NotExistException ("No network with SSID
+# found"). That race is the one a fresh rescan fixes, so it's the ONLY failure
+# we retry. Terminal failures are NOT retried: a wrong password surfaces as
+# ConnectionActivateFailedException (nmcli exit 4), which nmcli reports without
+# the underlying secrets detail and which no amount of rescanning can fix —
+# retrying it would just hold busy_lock and delay the hotspot fallback by
+# ~MAX_RETRIES x (scan settle + connect + delay) seconds on a hopeless connect.
+WIFI_CONNECT_MAX_RETRIES = 3
+WIFI_CONNECT_RETRY_DELAY = 3  # seconds between attempts
+WIFI_CONNECT_SCAN_SETTLE = 2  # seconds to let the rescan populate before connecting
+
+
+def _connect_station_with_rescan(ssid: str, password: str) -> None:
+    """Join an AP as a station, rescanning before each attempt.
+
+    Only the transient SSID-not-found race (see the WIFI_CONNECT_* constants
+    above) is retried; every other error propagates immediately so the caller
+    falls back to hotspot without delay. Re-raises the last NotExistException
+    if the SSID is still missing after every rescan.
+    """
+    last_err: NotExistException | None = None
+    for attempt in range(1, WIFI_CONNECT_MAX_RETRIES + 1):
+        # Refresh the scan list after AP mode; best-effort (a rescan can
+        # fail if one is already in flight, which is harmless here).
+        try:
+            nmcli.device.wifi_rescan()
+            time.sleep(WIFI_CONNECT_SCAN_SETTLE)
+        except Exception as e:
+            logger.debug(f"wifi_rescan before connect failed (continuing): {e}")
+        try:
+            nmcli.device.wifi_connect(ssid=ssid, password=password)
+            return
+        except NotExistException as e:
+            # SSID not in the scan list yet — the race a rescan fixes. Retry.
+            last_err = e
+            logger.warning(
+                f"wifi_connect attempt {attempt}/{WIFI_CONNECT_MAX_RETRIES} "
+                f"for '{ssid}': SSID not found yet ({e})."
+            )
+            if attempt < WIFI_CONNECT_MAX_RETRIES:
+                time.sleep(WIFI_CONNECT_RETRY_DELAY)
+    assert last_err is not None  # loop body ran at least once
+    raise last_err
+
+
 def setup_wifi_connection(
     name: str, ssid: str, password: str, is_hotspot: bool = False
 ) -> None:
@@ -422,7 +471,7 @@ def setup_wifi_connection(
         if is_hotspot:
             nmcli.device.wifi_hotspot(ssid=ssid, password=password)
         else:
-            nmcli.device.wifi_connect(ssid=ssid, password=password)
+            _connect_station_with_rescan(ssid=ssid, password=password)
         return
 
     logger.info("WiFi configuration already exists.")
@@ -453,8 +502,6 @@ def ensure_wifi_on_startup() -> None:
     On final failure the daemon keeps running so the robot stays
     reachable via Bluetooth for recovery.
     """
-    import time
-
     for attempt in range(1, WIFI_INIT_MAX_RETRIES + 1):
         try:
             # Make sure wlan0 is up and running

--- a/tests/unit_tests/test_wifi_connect_retry.py
+++ b/tests/unit_tests/test_wifi_connect_retry.py
@@ -1,0 +1,129 @@
+"""Unit tests for the WiFi station-connect rescan/retry logic.
+
+``_connect_station_with_rescan`` retries ONLY the transient SSID-not-found race
+(``nmcli.NotExistException``) that a rescan fixes; every other failure — notably
+a wrong password (``ConnectionActivateFailedException``) — must propagate
+immediately so the caller falls back to hotspot without burning seconds.
+
+The module imports ``nmcli`` (a Linux-only dependency that runs under the
+daemon venv on the robot), so the suite is skipped off-Linux. Importing the
+module also kicks off ``ensure_wifi_on_startup()`` on a real thread that shells
+out to ``sudo nmcli``; we neutralise ``threading.Thread`` during import so the
+test never touches WiFi hardware.
+"""
+import importlib.util
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux", reason="nmcli is a Linux-only dependency"
+)
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src/reachy_mini/daemon/app/routers/wifi_config.py"
+)
+
+
+class _NoopThread:
+    """Stand-in so importing the module doesn't fire ensure_wifi_on_startup()
+    (which shells out to ``sudo nmcli``) as a real background thread."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def start(self):
+        pass
+
+    def join(self, timeout=None):
+        pass
+
+    def is_alive(self):
+        return False
+
+
+def _import_wifi_config():
+    real_thread = threading.Thread
+    threading.Thread = _NoopThread
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_wifi_config_under_test", _MODULE_PATH
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    finally:
+        threading.Thread = real_thread
+    return mod
+
+
+# Imported once at module scope; only runs on Linux thanks to the guard.
+if sys.platform == "linux":
+    wifi = _import_wifi_config()
+
+
+@pytest.fixture
+def sleeps(monkeypatch):
+    """Make retry/settle delays instant and record their durations."""
+    recorded = []
+    monkeypatch.setattr(wifi.time, "sleep", lambda s: recorded.append(s))
+    return recorded
+
+
+@pytest.fixture
+def device(monkeypatch):
+    """Patchable stand-ins for the two nmcli device calls under test."""
+    connect = MagicMock(name="wifi_connect")
+    rescan = MagicMock(name="wifi_rescan")
+    monkeypatch.setattr(wifi.nmcli.device, "wifi_connect", connect)
+    monkeypatch.setattr(wifi.nmcli.device, "wifi_rescan", rescan)
+    return connect, rescan
+
+
+def test_transient_ssid_not_found_then_success(device, sleeps):
+    """A few NotExistException misses are retried with a rescan each time."""
+    connect, rescan = device
+    attempts = {"n": 0}
+
+    def flaky(ssid, password):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise wifi.nmcli.NotExistException("No network with SSID 'X' found")
+
+    connect.side_effect = flaky
+    wifi._connect_station_with_rescan(ssid="X", password="pw")  # returns on 3rd
+    assert connect.call_count == 3
+    assert rescan.call_count == 3
+
+
+def test_transient_exhausted_reraises(device, sleeps):
+    """A persistently-missing SSID re-raises NotExistException after the cap."""
+    connect, _ = device
+    connect.side_effect = wifi.nmcli.NotExistException("still missing")
+    with pytest.raises(wifi.nmcli.NotExistException):
+        wifi._connect_station_with_rescan(ssid="X", password="pw")
+    assert connect.call_count == wifi.WIFI_CONNECT_MAX_RETRIES
+
+
+def test_wrong_password_fails_fast(device, sleeps):
+    """A terminal auth failure is NOT retried — propagates on the first try."""
+    connect, _ = device
+    connect.side_effect = wifi.nmcli.ConnectionActivateFailedException(
+        "Connection activation failed"
+    )
+    with pytest.raises(wifi.nmcli.ConnectionActivateFailedException):
+        wifi._connect_station_with_rescan(ssid="X", password="wrong")
+    assert connect.call_count == 1
+    # No inter-attempt retry delay should have fired.
+    assert wifi.WIFI_CONNECT_RETRY_DELAY not in sleeps
+
+
+def test_rescan_failure_is_non_fatal(device, sleeps):
+    """A failed rescan (e.g. one already in flight) doesn't abort the connect."""
+    connect, rescan = device
+    rescan.side_effect = Exception("Scanning not allowed")
+    wifi._connect_station_with_rescan(ssid="X", password="pw")  # still succeeds
+    assert connect.call_count == 1


### PR DESCRIPTION
## Problem

Connecting the robot to a WiFi network from the setup flow succeeds only **~3 out of 4 times** — sometimes it silently stays on its own hotspot.

Root cause: a user-triggered connect arrives while the robot is serving its own AP/hotspot, so NetworkManager's scan cache is stale or empty for nearby APs. `nmcli`'s `wifi_connect` needs the target SSID to be in the current scan list; when it isn't (a timing race after AP mode), the connect throws `No network with SSID '…' found`, the connect thread hits its `except`, and **reverts to hotspot**.

The asymmetry that made this a bug: the **startup** path (`ensure_wifi_on_startup`) already guards against exactly this with a rescan + retry loop, but the **user-facing connect** path (`setup_wifi_connection`) did a single one-shot `wifi_connect` with no rescan and no retry.

## Fix

- Factor the station-connect into `_connect_station_with_rescan()`: a best-effort `wifi_rescan()`, a short settle, then `wifi_connect` retried up to 3× with a delay. This lives in `setup_wifi_connection`, so **every caller benefits** — `/connect` today and the sealed BLE connect path when it merges.
- Upgrade the connect-failure log from `logger.error(... {e})` to `logger.exception(...)`, so the real `nmcli` reason (SSID-not-found vs. auth/secrets vs. DHCP timeout) is captured in the journal instead of a one-liner.
- Hoist the now-shared `import time` to module scope (was a local import in `ensure_wifi_on_startup`).

Tunables (module constants): `WIFI_CONNECT_MAX_RETRIES=3`, `WIFI_CONNECT_RETRY_DELAY=3s`, `WIFI_CONNECT_SCAN_SETTLE=2s`.

## Notes / testing

- `ruff check` + `ruff format --check` clean; `py_compile` OK.
- Can't be exercised in CI (needs real `nmcli` + WiFi hardware). Validate on a robot: connect to a new SSID several times from hotspot mode and confirm it lands reliably; on a forced failure, confirm the journal now shows the `wifi_connect attempt N/3 failed: …` warnings and the full `logger.exception` traceback.
- The rescan/retry adds latency on a flaky first attempt (up to ~`(SCAN_SETTLE + connect + RETRY_DELAY) × 3`); the connect already runs off the request thread, so it doesn't block the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)