### PR TITLE
feat: add daemon-level audio output gain with limiter

### DIFF
--- a/docs/source/SDK/audio_output_gain.md
+++ b/docs/source/SDK/audio_output_gain.md
@@ -1,0 +1,153 @@
+# Audio Output Gain (REACHY_AUDIO_GAIN_DB)
+
+## Purpose
+
+Reachy Mini is not well audible in noisy environments, outdoors, convention booths, ... even with volume at 100%.
+Proposed here is a daemon-level output gain stage that boosts audio sent to the robot's speaker. This is intended for repeatable, cross-platform signal-level correction.
+
+## How it works
+
+- At daemon startup the environment variable `REACHY_AUDIO_GAIN_DB` is read and parsed as a floating dB value.
+- The value is converted to a linear multiplier (gain) and applied to a GStreamer `volume` element placed before the platform audio sink.
+- The gain is applied to **all three** audio output paths:
+  1. **Daemon playbin** — used by `play_sound()`, recorded/move audio, emotion sounds (via `_build_audiosink_tee_bin`)
+  2. **WebRTC incoming audio** — browser mic played on the robot's speaker (per-peer pipeline)
+  3. **Python SDK `push_audio_sample()`** — used by on-robot apps like the conversation app (via `_init_pipeline_playback` in `audio_gstreamer.py`)
+
+## Files
+
+- Implementation: [src/reachy_mini/media/audio_gain.py](src/reachy_mini/media/audio_gain.py)
+- Daemon playbin insertion: [src/reachy_mini/media/media_server.py](src/reachy_mini/media/media_server.py) (`_build_audiosink_tee_bin`)
+- WebRTC incoming insertion: [src/reachy_mini/media/media_server.py](src/reachy_mini/media/media_server.py) (`_on_consumer_pad_added`)
+- Python SDK push path: [src/reachy_mini/media/audio_gstreamer.py](src/reachy_mini/media/audio_gstreamer.py) (`_init_pipeline_playback`)
+- Runtime API (REST): [src/reachy_mini/daemon/app/routers/audio_gain.py](src/reachy_mini/daemon/app/routers/audio_gain.py)
+- Unit tests: [tests/unit_tests/test_audio_gain.py](tests/unit_tests/test_audio_gain.py)
+
+## Configuration
+
+- Env var: `REACHY_AUDIO_GAIN_DB`
+  - Value: floating-point decibels (e.g. `12`, `-6`, `0`)
+  - Missing or invalid values default to `0 dB` (no change)
+
+## Runtime control (HTTP)
+
+The daemon exposes a simple REST API to read and update the gain at runtime (no persistence):
+
+- GET `/api/audio/gain`
+  - Response: `{ "gain_db": <float>, "gain_linear": <float> }`
+- POST `/api/audio/gain` with JSON `{ "gain_db": <float> }`
+  - The request is clamped to a safe range and applied immediately to active **daemon** pipelines.
+  - Safe range: -20 dB .. +24 dB
+
+> **Important:** The REST API updates daemon-owned pipelines (paths 1 & 2) live. Python apps (path 3) read the gain once at pipeline creation. To change their gain, set `REACHY_AUDIO_GAIN_DB` before the app starts, or restart the app.
+
+Example using `curl` (Linux / macOS / WSL):
+
+```bash
+# Read current gain
+curl -s http://localhost:8000/api/audio/gain | jq
+
+# Set gain to +12 dB
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"gain_db": 12.0}' http://localhost:8000/api/audio/gain
+```
+
+Example using `curl.exe` on **Windows CMD / PowerShell** (escape inner quotes):
+
+```bat
+curl.exe -X POST -H "Content-Type: application/json" -d "{\"gain_db\": 12.0}" http://localhost:8000/api/audio/gain
+```
+
+Or using **PowerShell** `Invoke-WebRequest` (no escaping needed):
+
+```powershell
+# Read current gain
+(Invoke-WebRequest -Uri "http://localhost:8000/api/audio/gain" -UseBasicParsing).Content
+
+# Set gain to +12 dB
+Invoke-WebRequest -Uri "http://localhost:8000/api/audio/gain" -Method POST `
+  -ContentType "application/json" -Body '{"gain_db": 12.0}' `
+  -UseBasicParsing | Select-Object -ExpandProperty Content
+```
+
+## Recommended values
+
+- **+12 dB** was found to produce "about twice as loud" perceived volume on the Reachy Mini wireless hardware with typical TTS speech with some quality degradation
+- `0 dB` means neutral (no boost).
+- Negative values are permitted to attenuate the signal.
+- Values up to +24 dB are accepted; above +20 dB clipping becomes likely with hot sources.
+
+## Persistence across restarts
+
+The env var is the persistent mechanism. To make it survive daemon restarts on the wireless robot:
+
+```bash
+# Add to the systemd service (one-time setup)
+sudo sed -i '/\[Service\]/a Environment=REACHY_AUDIO_GAIN_DB=12' \
+  /etc/systemd/system/reachy-mini-daemon.service
+sudo systemctl daemon-reload
+sudo systemctl restart reachy-mini-daemon.service
+```
+
+## Per-app gain (app-level override)
+
+The daemon-level gain applies globally to all audio. If you need a **different gain for one specific app**, you can add gain at the app level:
+
+1. **App-specific env var** — define your own variable (e.g. `MY_APP_AUDIO_GAIN_DB`) in the app code and apply it to the `volume` element after pipeline init:
+   ```python
+   import os, math
+   from reachy_mini.media.audio_gstreamer import AudioGstreamer
+
+   audio = AudioGstreamer(...)
+   app_gain_db = float(os.environ.get("MY_APP_AUDIO_GAIN_DB", "0"))
+   audio._volume_element.set_property("volume", 10 ** (app_gain_db / 20))
+   ```
+
+2. **Scale PCM samples directly** — multiply the audio buffer by a linear factor before calling `push_audio_sample()`. This works without touching GStreamer internals.
+
+> **Note:** App-level gain stacks with the daemon-level gain (they are independent `volume` elements in series). If the daemon is at +12 dB and the app adds +6 dB, total boost is +18 dB — be careful about clipping.
+
+## Limiter (anti-clipping)
+
+A `rglimiter` (brickwall limiter from gst-plugins-good) is placed **after** the `volume` element in every pipeline. It prevents samples from exceeding 0 dBFS after the gain boost, eliminating the harsh distortion that occurs when amplified peaks clip.
+
+Pipeline chain: `... → volume → rglimiter → tee → ...`
+
+The limiter is always active (zero-config). When gain is 0 dB it has no audible effect — it only engages when samples exceed full scale, which can't happen without a positive gain. It is kept unconditionally in the pipeline because:
+
+1. **No cost at unity gain** — `rglimiter` is a passthrough when no sample exceeds 1.0 (negligible CPU, ~microseconds per buffer on CM4).
+2. **Runtime safety** — the REST API can raise gain from 0 to +12 dB at any time; having the limiter already linked means no pipeline rebuild is needed.
+3. **Simplicity** — a single pipeline topology regardless of config avoids conditional element insertion/removal bugs.
+
+## Risks & Caveats
+
+- At very high gain (+18 dB+) the limiter will engage frequently, which can sound "squashed" or reduce dynamic range. For best quality keep gain at +10 dB or below.
+- Gain and device/OS volume are cumulative in perceived loudness.
+- The ALSA master volume on the robot is already at 100% — there is no hidden headroom to recover via mixer settings.
+
+## Architecture note: three pipelines
+
+The Reachy Mini has three independent audio output pipelines:
+
+| Pipeline | Built in | Used by |
+|---|---|---|
+| Daemon playbin (tee bin) | `media_server.py` | `play_sound()`, emotion library, uploaded moves |
+| WebRTC incoming (per-peer) | `media_server.py` | Browser mic → robot speaker |
+| Python SDK push | `audio_gstreamer.py` | On-robot apps (`push_audio_sample()`) like conversation app |
+
+All three now include a `volume` element reading from `audio_gain.get_output_gain_linear()`.
+
+## Testing
+
+- Unit tests for parsing and conversion live in `tests/unit_tests/test_audio_gain.py`.
+- Manual checks:
+  - Start the daemon with `REACHY_AUDIO_GAIN_DB=12` and launch the conversation app — speech should be noticeably louder.
+  - Play emotions via the desktop app — should also be louder.
+  - Test with a sine wave: `gst-launch-1.0 audiotestsrc freq=440 num-buffers=100 ! volume volume=3.98 ! pulsesink` vs without the volume element to verify the pipeline works independently.
+  - Verify the REST `GET /api/audio/gain` returns the expected value.
+
+## Developer notes
+
+- The `volume` element is created with the linear multiplier from `audio_gain.get_output_gain_linear()` and stored on `GstMediaServer._gain_elements` (daemon paths) or as `self._volume_element` (SDK path) so runtime updates can be pushed.
+- `GstMediaServer.update_output_gain(linear)` updates daemon-owned elements live.
+- To persist runtime changes across restarts, set `REACHY_AUDIO_GAIN_DB` in the systemd unit (not implemented as auto-persist in code).

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -27,6 +27,7 @@ from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.app.routers import (
     apps,
     audio_config,
+    audio_gain,
     camera,
     daemon,
     hf_auth,
@@ -230,6 +231,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
     router = APIRouter(prefix="/api")
     router.include_router(apps.router)
     router.include_router(audio_config.router)
+    router.include_router(audio_gain.router)
     router.include_router(camera.router)
     router.include_router(daemon.router)
     router.include_router(hf_auth.router)

--- a/src/reachy_mini/daemon/app/routers/audio_gain.py
+++ b/src/reachy_mini/daemon/app/routers/audio_gain.py
@@ -1,0 +1,72 @@
+"""Audio output gain API routes.
+
+Exposes:
+- GET  /api/audio/gain       — current output gain in dB
+- POST /api/audio/gain       — set output gain (clamped to safe range)
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from reachy_mini.daemon.app.dependencies import get_backend
+from reachy_mini.daemon.backend.abstract import Backend
+from reachy_mini.media.audio_gain import (
+    MAX_GAIN_DB,
+    MIN_GAIN_DB,
+    db_to_linear,
+    get_output_gain_db,
+    set_output_gain_db,
+)
+
+router = APIRouter(prefix="/audio/gain")
+logger = logging.getLogger(__name__)
+
+
+class GainResponse(BaseModel):
+    """Response model for gain operations."""
+
+    gain_db: float
+    gain_linear: float
+
+
+class GainRequest(BaseModel):
+    """Request model for setting gain."""
+
+    gain_db: float = Field(
+        ...,
+        ge=MIN_GAIN_DB,
+        le=MAX_GAIN_DB,
+        description=f"Gain in dB ({MIN_GAIN_DB} to {MAX_GAIN_DB})",
+    )
+
+
+@router.get("/")
+async def get_gain() -> GainResponse:
+    """Get the current output gain level."""
+    db = get_output_gain_db()
+    return GainResponse(gain_db=db, gain_linear=db_to_linear(db))
+
+
+@router.post("/")
+async def set_gain(
+    req: GainRequest,
+    backend: Backend = Depends(get_backend),
+) -> GainResponse:
+    """Set the output gain level.
+
+    The gain is applied immediately to all active audio pipelines.
+    The value is clamped to the safe range and does not persist
+    across daemon restarts (use REACHY_AUDIO_GAIN_DB env var for that).
+    """
+    clamped = set_output_gain_db(req.gain_db)
+    linear = db_to_linear(clamped)
+
+    # Update live GStreamer volume elements
+    media_server = backend._media_server
+    if media_server is not None:
+        media_server.update_output_gain(linear)
+
+    logger.info(f"Output gain set to {clamped:.1f} dB (linear {linear:.3f})")
+    return GainResponse(gain_db=clamped, gain_linear=linear)

--- a/src/reachy_mini/media/audio_gain.py
+++ b/src/reachy_mini/media/audio_gain.py
@@ -1,0 +1,86 @@
+"""Daemon-level output gain configuration.
+
+Reads the ``REACHY_AUDIO_GAIN_DB`` environment variable and provides
+a linear multiplier suitable for a GStreamer ``volume`` element.
+
+Usage::
+
+    from reachy_mini.media.audio_gain import get_output_gain_linear, get_output_gain_db
+
+    linear = get_output_gain_linear()  # e.g. 1.412 for +3 dB
+    db = get_output_gain_db()          # e.g. 3.0
+"""
+
+import logging
+import os
+from threading import Lock
+
+_logger = logging.getLogger(__name__)
+
+ENV_VAR = "REACHY_AUDIO_GAIN_DB"
+
+# Safe range for runtime API changes (dB).
+MIN_GAIN_DB = -20.0
+MAX_GAIN_DB = 24.0
+
+_lock = Lock()
+_gain_db: float | None = None  # lazily initialized from env
+
+
+def db_to_linear(db: float) -> float:
+    """Convert decibels to a linear multiplier.
+
+    >>> db_to_linear(0)
+    1.0
+    >>> round(db_to_linear(3), 3)
+    1.413
+    >>> round(db_to_linear(-6), 3)
+    0.501
+    """
+    return 10 ** (db / 20.0)
+
+
+def _read_env() -> float:
+    """Read and parse the environment variable. Returns 0.0 on missing/invalid."""
+    raw = os.environ.get(ENV_VAR)
+    if raw is None:
+        return 0.0
+    try:
+        value = float(raw)
+    except (ValueError, TypeError):
+        _logger.warning(
+            f"{ENV_VAR}={raw!r} is not a valid number; defaulting to 0 dB."
+        )
+        return 0.0
+    if value > MAX_GAIN_DB:
+        _logger.warning(
+            f"{ENV_VAR}={value} dB exceeds recommended maximum ({MAX_GAIN_DB} dB). "
+            "Clipping may occur."
+        )
+    return value
+
+
+def get_output_gain_db() -> float:
+    """Return the current output gain in dB (thread-safe)."""
+    global _gain_db
+    with _lock:
+        if _gain_db is None:
+            _gain_db = _read_env()
+        return _gain_db
+
+
+def set_output_gain_db(db: float) -> float:
+    """Set the output gain in dB, clamped to the safe range.
+
+    Returns the clamped value actually applied.
+    """
+    global _gain_db
+    clamped = max(MIN_GAIN_DB, min(MAX_GAIN_DB, db))
+    with _lock:
+        _gain_db = clamped
+    return clamped
+
+
+def get_output_gain_linear() -> float:
+    """Return the current output gain as a linear multiplier."""
+    return db_to_linear(get_output_gain_db())

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -62,6 +62,7 @@ import numpy as np
 import numpy.typing as npt
 
 from reachy_mini.media.audio_base import AudioBase
+from reachy_mini.media.audio_gain import get_output_gain_linear
 from reachy_mini.media.audio_utils import has_reachymini_asoundrc
 from reachy_mini.media.device_detection import get_audio_device
 from reachy_mini.motion.head_wobbler import HeadWobbler, SpeechOffsets
@@ -323,6 +324,13 @@ class GStreamerAudio(AudioBase):
         )
         self._appsrc.set_property("caps", caps)
 
+        # Output gain stage (shared with daemon media_server paths).
+        self._volume_element = Gst.ElementFactory.make("volume", "output_gain_local")
+        self._volume_element.set_property("volume", get_output_gain_linear())
+
+        # Brickwall limiter prevents clipping after gain boost.
+        limiter = Gst.ElementFactory.make("rglimiter", "output_limiter_local")
+
         # Always build tee so wobbling can be enabled/disabled at runtime.
         # Per-branch audioconvert+audioresample so the wobbler appsink's
         # F32LE/1/16000 caps don't drag the audiosink branch into a rate
@@ -341,6 +349,8 @@ class GStreamerAudio(AudioBase):
 
         for el in (
             self._appsrc,
+            self._volume_element,
+            limiter,
             tee,
             queue_speaker,
             ac_speaker,
@@ -353,7 +363,9 @@ class GStreamerAudio(AudioBase):
         ):
             pipeline.add(el)
 
-        self._appsrc.link(tee)
+        self._appsrc.link(self._volume_element)
+        self._volume_element.link(limiter)
+        limiter.link(tee)
         tee.link(queue_speaker)
         queue_speaker.link(ac_speaker)
         ac_speaker.link(ar_speaker)

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -40,6 +40,7 @@ from reachy_mini.daemon.utils import (
     is_local_camera_available,
 )
 from reachy_mini.media.audio_control_utils import init_respeaker_usb
+from reachy_mini.media.audio_gain import get_output_gain_linear
 from reachy_mini.media.audio_utils import has_reachymini_asoundrc
 from reachy_mini.media.camera_constants import (
     CameraSpecs,
@@ -217,11 +218,22 @@ class GstMediaServer:
         self._playbin: Optional[Gst.Element] = None
         self._head_wobbler: Optional[HeadWobbler] = None
         self._pipeline_playback: Optional[Gst.Pipeline] = None
+        # All GStreamer volume elements managed by this server, keyed by
+        # a label ("playbin", peer_id, etc.). Allows runtime gain updates.
+        self._gain_elements: Dict[str, Gst.Element] = {}
 
         self._build_pipeline()
 
     def _build_pipeline(self) -> None:
         """Build (or rebuild) the GStreamer pipeline from scratch."""
+        gain_linear = get_output_gain_linear()
+        if gain_linear != 1.0:
+            from reachy_mini.media.audio_gain import get_output_gain_db
+
+            self._logger.info(
+                f"Output gain configured: {get_output_gain_db():.1f} dB "
+                f"(linear {gain_linear:.3f})"
+            )
         self._pipeline_sender = Gst.Pipeline.new("reachymini_webrtc_sender")
         self._bus_sender = self._pipeline_sender.get_bus()
         self._bus_sender.add_watch(
@@ -430,9 +442,18 @@ class GstMediaServer:
             appsink_wobbler,
         ]:
             self._pipeline_playback.add(elem)
+        volume = Gst.ElementFactory.make("volume", f"output_gain_{peer_id}")
+        volume.set_property("volume", get_output_gain_linear())
+        self._gain_elements[peer_id] = volume
+        limiter = Gst.ElementFactory.make("rglimiter", f"output_limiter_{peer_id}")
+        self._pipeline_playback.add(volume)
+        self._pipeline_playback.add(limiter)
+
         appsrc.link(rtpopusdepay)
         rtpopusdepay.link(opusdec)
-        opusdec.link(tee)
+        opusdec.link(volume)
+        volume.link(limiter)
+        limiter.link(tee)
         tee.link(queue_speaker)
         queue_speaker.link(ac_speaker)
         ac_speaker.link(ar_speaker)
@@ -498,6 +519,7 @@ class GstMediaServer:
         playback_pipe = info.get("playback_pipeline")
         if playback_pipe is not None:
             playback_pipe.set_state(Gst.State.NULL)
+        self._gain_elements.pop(peer_id, None)
         self._logger.info(f"Cleaned up incoming audio for peer {peer_id}")
 
     @property
@@ -1164,10 +1186,16 @@ class GstMediaServer:
 
         The bin exposes a single ghost sink pad for use as a playbin audio-sink::
 
-            ghost_sink → tee ─┬→ queue → audioconvert → audioresample → audiosink
-                               └→ queue → audioconvert → audioresample → appsink
+            ghost_sink → volume → rglimiter → tee ─┬→ queue → audioconvert → audioresample → audiosink
+                                                    └→ queue → audioconvert → audioresample → appsink
         """
         audio_bin = Gst.Bin.new("audio_tee_bin")
+
+        volume = Gst.ElementFactory.make("volume", "output_gain")
+        volume.set_property("volume", get_output_gain_linear())
+        self._gain_elements["playbin"] = volume
+
+        limiter = Gst.ElementFactory.make("rglimiter", "output_limiter")
 
         tee = Gst.ElementFactory.make("tee")
         queue_speaker = Gst.ElementFactory.make("queue")
@@ -1180,6 +1208,8 @@ class GstMediaServer:
         appsink_wobbler = self._make_wobbler_appsink()
 
         for el in (
+            volume,
+            limiter,
             tee,
             queue_speaker,
             ac_speaker,
@@ -1192,6 +1222,8 @@ class GstMediaServer:
         ):
             audio_bin.add(el)
 
+        volume.link(limiter)
+        limiter.link(tee)
         tee.link(queue_speaker)
         queue_speaker.link(ac_speaker)
         ac_speaker.link(ar_speaker)
@@ -1202,10 +1234,21 @@ class GstMediaServer:
         ac_wobbler.link(ar_wobbler)
         ar_wobbler.link(appsink_wobbler)
 
-        ghost_pad = Gst.GhostPad.new("sink", tee.get_static_pad("sink"))
+        ghost_pad = Gst.GhostPad.new("sink", volume.get_static_pad("sink"))
         audio_bin.add_pad(ghost_pad)
 
         return audio_bin
+
+    def update_output_gain(self, linear: float) -> None:
+        """Update the gain on all active volume elements.
+
+        Args:
+            linear: Linear gain multiplier (1.0 = unity).
+
+        """
+        for key, elem in self._gain_elements.items():
+            elem.set_property("volume", linear)
+        self._logger.debug(f"Output gain updated to {linear:.3f} on {len(self._gain_elements)} element(s)")
 
     def enable_wobbling(self, callback: Callable[[SpeechOffsets], None]) -> None:
         """Enable head wobbling driven by audio playback.

--- a/tests/unit_tests/test_audio_gain.py
+++ b/tests/unit_tests/test_audio_gain.py
@@ -1,0 +1,127 @@
+"""Tests for the audio output gain utility module."""
+
+# ruff: noqa: D102
+
+import os
+from unittest.mock import patch
+
+from reachy_mini.media.audio_gain import (
+    ENV_VAR,
+    MAX_GAIN_DB,
+    MIN_GAIN_DB,
+    db_to_linear,
+    get_output_gain_db,
+    get_output_gain_linear,
+    set_output_gain_db,
+)
+
+
+class TestDbToLinear:
+    """Test dB to linear conversion."""
+
+    def test_zero_db_is_unity(self) -> None:
+        assert db_to_linear(0) == 1.0
+
+    def test_positive_3db(self) -> None:
+        assert round(db_to_linear(3), 3) == 1.413
+
+    def test_positive_6db(self) -> None:
+        assert round(db_to_linear(6), 3) == 1.995
+
+    def test_negative_6db(self) -> None:
+        assert round(db_to_linear(-6), 3) == 0.501
+
+    def test_negative_20db(self) -> None:
+        assert round(db_to_linear(-20), 2) == 0.10
+
+    def test_positive_12db(self) -> None:
+        assert round(db_to_linear(12), 3) == 3.981
+
+
+class TestEnvParsing:
+    """Test environment variable parsing."""
+
+    def _reset_module(self) -> None:
+        """Reset the module-level cached gain."""
+        import reachy_mini.media.audio_gain as mod
+
+        with mod._lock:
+            mod._gain_db = None
+
+    def test_missing_env_returns_zero(self) -> None:
+        self._reset_module()
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove the env var if present
+            os.environ.pop(ENV_VAR, None)
+            assert get_output_gain_db() == 0.0
+
+    def test_zero_env_returns_zero(self) -> None:
+        self._reset_module()
+        with patch.dict(os.environ, {ENV_VAR: "0"}):
+            assert get_output_gain_db() == 0.0
+
+    def test_positive_value(self) -> None:
+        self._reset_module()
+        with patch.dict(os.environ, {ENV_VAR: "3"}):
+            assert get_output_gain_db() == 3.0
+
+    def test_negative_value(self) -> None:
+        self._reset_module()
+        with patch.dict(os.environ, {ENV_VAR: "-6"}):
+            assert get_output_gain_db() == -6.0
+
+    def test_fractional_value(self) -> None:
+        self._reset_module()
+        with patch.dict(os.environ, {ENV_VAR: "1.5"}):
+            assert get_output_gain_db() == 1.5
+
+    def test_invalid_string_returns_zero(self) -> None:
+        self._reset_module()
+        with patch.dict(os.environ, {ENV_VAR: "loud"}):
+            assert get_output_gain_db() == 0.0
+
+    def test_empty_string_returns_zero(self) -> None:
+        self._reset_module()
+        with patch.dict(os.environ, {ENV_VAR: ""}):
+            assert get_output_gain_db() == 0.0
+
+    def test_linear_at_zero_is_unity(self) -> None:
+        self._reset_module()
+        with patch.dict(os.environ, {ENV_VAR: "0"}):
+            assert get_output_gain_linear() == 1.0
+
+    def test_linear_at_3db(self) -> None:
+        self._reset_module()
+        with patch.dict(os.environ, {ENV_VAR: "3"}):
+            assert round(get_output_gain_linear(), 3) == 1.413
+
+
+class TestSetGain:
+    """Test runtime gain setting."""
+
+    def _reset_module(self) -> None:
+        import reachy_mini.media.audio_gain as mod
+
+        with mod._lock:
+            mod._gain_db = None
+
+    def test_set_returns_value(self) -> None:
+        self._reset_module()
+        assert set_output_gain_db(3.0) == 3.0
+        assert get_output_gain_db() == 3.0
+
+    def test_clamps_above_max(self) -> None:
+        self._reset_module()
+        result = set_output_gain_db(100.0)
+        assert result == MAX_GAIN_DB
+
+    def test_clamps_below_min(self) -> None:
+        self._reset_module()
+        result = set_output_gain_db(-100.0)
+        assert result == MIN_GAIN_DB
+
+    def test_set_zero(self) -> None:
+        self._reset_module()
+        set_output_gain_db(5.0)
+        set_output_gain_db(0.0)
+        assert get_output_gain_db() == 0.0


### PR DESCRIPTION
Adds a configurable audio output gain stage to boost the robot's speaker volume at the daemon level.
Referenced Issue: [Improvement] louder sound #569

### What it does

- Reads `REACHY_AUDIO_GAIN_DB` env var at startup (default: 0 dB = no change)
- Inserts a GStreamer `volume` element in all three audio output pipelines (playbin, WebRTC incoming, Python SDK `push_audio_sample()`)
- Adds `rglimiter` after the volume element to prevent clipping distortion at high gain
- Exposes a REST API (`GET/POST /api/audio/gain`) for runtime gain adjustment without restart

### Why

The ALSA master volume on the robot is already at 100%. The speaker/amp combination is simply too quiet at native output level. This provides a clean software gain stage with clipping protection to make the robot audibly louder.

### Recommended usage

Set `REACHY_AUDIO_GAIN_DB=6` in the systemd service for a moderate boost, or up to `12` for approximately 2× perceived loudness. The limiter minimizes distortion.

### Testing

- 19 unit tests covering dB conversion, env parsing, clamping, and runtime set
- Manual verification on Reachy Mini Wireless hardware at +6 dB and +12 dB
- ruff + mypy clean

### AI Disclosure
Assisted-by: Claude:claude-opus-4-6



