### PR TITLE
feat: add sim transport flag for JS clients

### DIFF
--- a/docs/source/SDK/javascript-sdk.md
+++ b/docs/source/SDK/javascript-sdk.md
@@ -84,7 +84,7 @@ new ReachyMini({
 | Property | Type | Description |
 | :--- | :--- | :--- |
 | `state` | `string` | `"disconnected"`, `"connected"`, or `"streaming"` |
-| `robots` | `Array` | Available robots: `[{ id, meta: { name } }]` |
+| `robots` | `Array` | Available robots: `[{ id, meta: { name }, transport }]`. `transport` is `"wifi"`, `"usb"`, or `"sim"` (simulation mode) |
 | `robotState` | `Object` | Latest `state` event detail — `{ head: number[16], antennas: [rRad, lRad], body_yaw, motor_mode, is_move_running }` (wire shape) |
 | `username` | `string\|null` | HF username after `authenticate()` |
 | `isAuthenticated` | `boolean` | True if a valid HF token is available |

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -184,7 +184,12 @@ class Daemon:
             # Lite variant is plugged into the user's desktop and the
             # daemon runs there, reached over USB. Keyed off
             # ``wireless_version`` so the badging follows the robot SKU.
-            transport = "wifi" if self.wireless_version else "usb"
+            if self._status.simulation_enabled:
+                transport = "sim"
+            elif self.wireless_version:
+                transport = "wifi"
+            else:
+                transport = "usb"
 
             self.logger.info("Starting central signaling relay...")
             relay = await start_central_relay(


### PR DESCRIPTION

  ## What

  - #1191 
  - sets `transport="sim"` in addition to `usb` and `wifi` in the signaling meta when daemon runs with simulation mode
  - documents the `transport` field in the JS SDK docs

  ## For JS apps, it can be used as:
  ```js
  const isSim = r.meta?.transport === 'sim';
  ```