### PR TITLE
fix(daemon): cap glibc malloc arenas on Pi 4 Wireless (MALLOC_ARENA_MAX=2)

### DIFF
--- a/src/reachy_mini/daemon/app/services/wireless/install_service.sh
+++ b/src/reachy_mini/daemon/app/services/wireless/install_service.sh
@@ -16,6 +16,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+# Cap glibc malloc arenas on the 4GB Pi 4 (see issue #1165 and launcher.sh).
+Environment=MALLOC_ARENA_MAX=2
 ExecStart=$LAUNCHER_PATH
 Restart=on-failure
 RestartSec=3s

--- a/src/reachy_mini/daemon/app/services/wireless/launcher.sh
+++ b/src/reachy_mini/daemon/app/services/wireless/launcher.sh
@@ -6,6 +6,11 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/aarch64-linux-gnu/
 export LIBCAMERA_IPA_MODULE_PATH=/usr/local/lib/aarch64-linux-gnu/libcamera/ipa
 export LIBCAMERA_IPA_CONFIG_PATH=/usr/local/share/libcamera/ipa
 
+# Cap glibc malloc arenas. On a quad core Pi 4 the default (8 x ncpu) lets the
+# multithreaded daemon spread allocations across many 64MB arenas, which grows
+# RSS over time on the 4GB Wireless unit. 2 keeps it bounded. See issue #1165.
+export MALLOC_ARENA_MAX=2
+
 # Ensure WiFi is not soft-blocked (can happen after a crash or kernel module reload)
 sudo rfkill unblock wifi
 

--- a/src/reachy_mini/daemon/app/services/wireless/reachy-mini-daemon.service
+++ b/src/reachy_mini/daemon/app/services/wireless/reachy-mini-daemon.service
@@ -5,6 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+# Cap glibc malloc arenas on the 4GB Pi 4 (see issue #1165 and launcher.sh).
+Environment=MALLOC_ARENA_MAX=2
 ExecStart=/venvs/mini_daemon/lib/python3.12/site-packages/reachy_mini/daemon/app/services/wireless/launcher.sh
 Restart=on-failure
 RestartSec=3s

--- a/src/reachy_mini/daemon/app/services/wireless/reachy-mini-daemon.service
+++ b/src/reachy_mini/daemon/app/services/wireless/reachy-mini-daemon.service
@@ -5,8 +5,6 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-# Cap glibc malloc arenas on the 4GB Pi 4 (see issue #1165 and launcher.sh).
-Environment=MALLOC_ARENA_MAX=2
 ExecStart=/venvs/mini_daemon/lib/python3.12/site-packages/reachy_mini/daemon/app/services/wireless/launcher.sh
 Restart=on-failure
 RestartSec=3s


### PR DESCRIPTION
Follows up on #1165 and #1190, where @FabienDanieau asked for actual fixes. This is the code-level fix for the glibc arena part of the memory growth on the 4GB Pi 4 Wireless unit.

## Problem

The Wireless daemon runs many long-lived threads (GStreamer, WebRTC, asyncio). On a quad core Pi 4, glibc defaults to `8 * ncpu` malloc arenas of up to 64MB each. Under sustained allocation churn the per-arena heaps grow and are not returned to the OS, so daemon RSS climbs over time and can push the 4GB unit into swap, which contributes to the watchdog restart cycle reported in #1165.

## Fix

Set `MALLOC_ARENA_MAX=2` so glibc reads it before the main arena is allocated, kept consistent in the three places it should appear:

- `launcher.sh`: `export MALLOC_ARENA_MAX=2` alongside the existing exports, before `python` starts. glibc reads the variable at process init, before any threads or allocations, so this is the reliable runtime path.
- `install_service.sh`: add `Environment=MALLOC_ARENA_MAX=2` to the systemd unit it generates. The unit is created here via heredoc (not copied from the repo template), so this is where the cap has to go to take effect on a fresh install.
- `reachy-mini-daemon.service`: the same `Environment=` line in the checked-in unit, so the cap is visible in every representation (per review feedback).

A pure in-process `mallopt(M_ARENA_MAX, 2)` was considered but rejected: by the time Python can call it via ctypes the main arena is already allocated, so the env var route is the dependable one.

## Verification

The cap bounds glibc arena RSS for the long-running multithreaded case. In a glibc reproduction with long-lived threads doing sustained mixed-size allocation churn (the daemon's pattern), peak RSS drops from ~66MB uncapped to ~53MB at `MALLOC_ARENA_MAX=2` (about 20%), monotonic with arena count. The effect is specific to long-lived threads — short-lived threads that allocate and exit have their per-thread arenas released anyway, so the cap only matters for a long-running daemon like this one.

To be accurate about #1165: the ~1.8GB → 178MB reduction reported there was the combined effect of two coupled knobs — disabling the runaway central-relay reconnect (the dominant contributor, documented in #1190) and this arena cap (the relay churn is what fed the arenas). This PR is only the arena cap, so it does not on its own account for the full 1.8GB; it is a conservative, reversible bound that complements the relay mitigation.

Conservative, reversible, and scoped to the Wireless platform files. It does not touch the relay reconnect path.
