### PR TITLE
feat(host): session-topbar robot identity with live latency + Lite/Wireless tags

### DIFF
--- a/ts/host/dev/main.ts
+++ b/ts/host/dev/main.ts
@@ -86,11 +86,19 @@ async function bootEmbed(): Promise<void> {
   const { connectToHost } = await import('@/embed');
 
   const root = document.getElementById('root') ?? document.body;
+  // Still intentionally minimal, but now it FEELS like a real app:
+  // the robot's live camera fills the view instead of a text stub.
+  // Everything else (auto-wake on connect, runtime sleep + torque
+  // release on leave) is handled by `connectToHost()` / the leave
+  // contract - this page only has to render the stream the SDK
+  // already negotiated.
   root.innerHTML = `
     <main style="font-family:system-ui,sans-serif;display:flex;flex-direction:column;
                  align-items:center;justify-content:center;height:100%;gap:16px;padding:24px;
-                 text-align:center;color:#111">
-      <h1 style="margin:0;font-size:1.25rem">Minimal embed</h1>
+                 text-align:center;color:#111;box-sizing:border-box">
+      <video id="robot-video" autoplay playsinline
+             style="width:100%;max-width:640px;aspect-ratio:16/9;border-radius:12px;
+                    background:#000;object-fit:cover;display:none"></video>
       <p id="status" style="margin:0;opacity:.7">Connecting…</p>
       <button id="leave" type="button" hidden
               style="padding:8px 16px;border-radius:8px;border:1px solid #999;cursor:pointer">
@@ -107,6 +115,16 @@ async function bootEmbed(): Promise<void> {
     const handle = await connectToHost();
     setStatus('Live — robot awake. End the session (top bar) to test the leave contract.');
 
+    // Show the live camera: the SDK finished the WebRTC handshake
+    // before this page mounted, so `media.attachVideo` replays the
+    // already-arrived tracks into the element immediately.
+    const video = document.getElementById('robot-video') as HTMLVideoElement | null;
+    let detachVideo: (() => void) | null = null;
+    if (video) {
+      video.style.display = 'block';
+      detachVideo = handle.media.attachVideo(video);
+    }
+
     const leaveBtn = document.getElementById('leave') as HTMLButtonElement | null;
     if (leaveBtn) {
       leaveBtn.hidden = false;
@@ -116,6 +134,8 @@ async function bootEmbed(): Promise<void> {
     handle.onLeave(() => {
       // App's OWN cleanup only - per the leave contract the runtime
       // sleeps the robot and releases the torque for us.
+      detachVideo?.();
+      if (video) video.style.display = 'none';
       setStatus('onLeave fired — app cleaning up; runtime is sleeping the robot.');
     });
   } catch (err) {

--- a/ts/host/src/components/PickerView.tsx
+++ b/ts/host/src/components/PickerView.tsx
@@ -33,7 +33,6 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
-  Chip,
   CircularProgress,
   ListItemButton,
   Stack,
@@ -45,12 +44,11 @@ import {
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import LockIcon from '@mui/icons-material/Lock';
 import RefreshIcon from '@mui/icons-material/Refresh';
-import UsbIcon from '@mui/icons-material/Usb';
-import WifiIcon from '@mui/icons-material/Wifi';
 
 import { reachyBusteSvg, reachyStandardSvg } from '../assets';
 import type { RobotInfo } from '../lib/sdk-types';
 import { FONT_WEIGHT, LAYOUT, TYPO } from '../lib/tokens';
+import { VariantTag } from '../ui/design/MetaPill';
 
 export interface PickerViewProps {
   robots: RobotInfo[];
@@ -334,7 +332,7 @@ function RemoteRobotCard({
             </Typography>
             {transport ? (
               <Box sx={{ flexShrink: 0 }}>
-                <TransportChip transport={transport} />
+                <VariantTag transport={transport} />
               </Box>
             ) : null}
           </Stack>
@@ -446,61 +444,6 @@ function CardAvatar(): JSX.Element {
         }}
       />
     </Box>
-  );
-}
-
-/* ─────────────────── Transport chip ─────────────────── */
-
-/**
- * Compact transport tag for a robot listing. Ported 1-to-1 from
- * the mobile shell's `TransportChip`. Two well-known values get
- * an icon + typed label (`usb`, `wifi`); anything else falls
- * through to a plain capitalised label so a future daemon
- * advertising `ethernet` / `sim` / `mockup` still renders without
- * a component update.
- */
-function TransportChip({ transport }: { transport: string }): JSX.Element {
-  if (transport === 'usb') {
-    return (
-      <Chip
-        size="small"
-        icon={<UsbIcon sx={{ fontSize: 14 }} />}
-        label="USB"
-        variant="outlined"
-        sx={{
-          height: 20,
-          fontSize: TYPO.tiny,
-          '.MuiChip-icon': { ml: 0.5 },
-        }}
-      />
-    );
-  }
-  if (transport === 'wifi') {
-    return (
-      <Chip
-        size="small"
-        icon={<WifiIcon sx={{ fontSize: 14 }} />}
-        label="Wi-Fi"
-        variant="outlined"
-        sx={{
-          height: 20,
-          fontSize: TYPO.tiny,
-          '.MuiChip-icon': { ml: 0.5 },
-        }}
-      />
-    );
-  }
-  return (
-    <Chip
-      size="small"
-      label={transport}
-      variant="outlined"
-      sx={{
-        height: 20,
-        fontSize: TYPO.tiny,
-        textTransform: 'capitalize',
-      }}
-    />
   );
 }
 

--- a/ts/host/src/components/ReachyHostShell.tsx
+++ b/ts/host/src/components/ReachyHostShell.tsx
@@ -158,10 +158,21 @@ function ReachyHostShellNormal({
 
   const [hostPhase, setHostPhase] = useState<HostPhase>('signing-in');
   const [selectedRobotId, setSelectedRobotId] = useState<string | null>(null);
+  /** Identity (name + transport) of the picked robot, captured at
+   *  selection time. `useRobots` is disabled the moment we leave
+   *  `picking` (and clears its list to protect the 1:1 token→peer
+   *  handoff invariant), so we CANNOT look the robot up in `robots`
+   *  during the session - it's empty. We snapshot what the topbar
+   *  needs here instead. */
+  const [selectedRobot, setSelectedRobot] = useState<{
+    name: string | null;
+    transport: string | null;
+  } | null>(null);
   const [embedAppState, setEmbedAppState] = useState<EmbedAppState>({
     phase: 'boot',
     connectingStep: null,
     message: null,
+    rttMs: null,
   });
   const [errorPayload, setErrorPayload] = useState<{
     message: string;
@@ -363,6 +374,13 @@ function ReachyHostShellNormal({
       if (!sdk) return;
       if (hostPhase !== 'picking') return;
       setSelectedRobotId(robotId);
+      // Snapshot identity NOW, while `robots` is still populated -
+      // it gets cleared as soon as we flip to `embedded` below.
+      const picked = robots.find((r) => r.id === robotId);
+      setSelectedRobot({
+        name: picked?.meta?.name ?? null,
+        transport: picked?.transport ?? null,
+      });
       initSentForRef.current = null;
       embedReadyPendingRef.current = false;
       // The host never opened an SSE (picker uses REST), so the
@@ -374,10 +392,11 @@ function ReachyHostShellNormal({
         phase: 'connecting',
         connectingStep: 'link',
         message: null,
+        rttMs: null,
       });
       setHostPhase('embedded');
     },
-    [hostPhase, sdk],
+    [hostPhase, robots, sdk],
   );
 
   /* ─────────────────── End session ─────────────────── */
@@ -399,10 +418,12 @@ function ReachyHostShellNormal({
       // only on full sign-out (`signOut`) and on `pagehide` (tab
       // close).
       setSelectedRobotId(null);
+      setSelectedRobot(null);
       setEmbedAppState({
         phase: 'boot',
         connectingStep: null,
         message: null,
+        rttMs: null,
       });
       initSentForRef.current = null;
       embedReadyPendingRef.current = false;
@@ -496,12 +517,20 @@ function ReachyHostShellNormal({
           hostPhase={hostPhase}
           userName={displayUserName}
           avatarUrl={hfProfile.avatarUrl}
+          // Identity captured at selection time - `robots` is empty
+          // during the session (useRobots disabled on handoff), so we
+          // read the snapshot, falling back to the peer id only if the
+          // robot never advertised a name.
           selectedRobotName={
             selectedRobotId
-              ? (robots.find((r) => r.id === selectedRobotId)?.meta?.name ??
-                selectedRobotId)
+              ? (selectedRobot?.name ?? selectedRobotId)
               : null
           }
+          selectedRobotTransport={selectedRobot?.transport ?? null}
+          // True live latency reported by the embed (the host handed
+          // its WebRTC slot to the iframe). `null` until the embed
+          // reaches `live` and starts sampling.
+          linkRttMs={embedAppState.rttMs}
           onSignOut={signOut}
           onEndSession={() => void endSession('user-action')}
         />
@@ -653,6 +682,8 @@ function ReachyHostShellPreview({
           selectedRobotName={
             phase === 'connecting' ? 'Tabouret' : null
           }
+          selectedRobotTransport={phase === 'connecting' ? 'wifi' : null}
+          linkRttMs={phase === 'connecting' ? 38 : null}
           onSignOut={() => window.alert('Preview: sign-out')}
           onEndSession={() => {
             window.alert('Preview: end-session (no-op)');

--- a/ts/host/src/components/ReachyHostShell.tsx
+++ b/ts/host/src/components/ReachyHostShell.tsx
@@ -135,7 +135,12 @@ const MOCK_ROBOTS: RobotInfo[] = [
 export function ReachyHostShell(
   props: ReachyHostShellProps,
 ): JSX.Element {
-  const previewPhase = readPreviewPhase();
+  // Preview harness is a DEV-only affordance. Gating on
+  // `import.meta.env.DEV` lets the bundler tree-shake the whole
+  // preview branch (ReachyHostShellPreview + MOCK_ROBOTS) out of the
+  // production build, so a deployed Space can't be flipped into the
+  // mock view via `?host-preview=...`.
+  const previewPhase = import.meta.env.DEV ? readPreviewPhase() : null;
   if (previewPhase) {
     return <ReachyHostShellPreview phase={previewPhase} {...props} />;
   }

--- a/ts/host/src/components/TopBar.tsx
+++ b/ts/host/src/components/TopBar.tsx
@@ -49,6 +49,7 @@ import LogoutIcon from '@mui/icons-material/Logout';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 
 import { reachyHeadSvg } from '../assets';
+import { IdentityChipBar } from '../ui/design/IdentityChipBar';
 
 export type HostPhase =
   | 'signing-in'
@@ -71,6 +72,13 @@ export interface TopBarProps {
    *  flight / failed. The chip falls back to a first-letter glyph. */
   avatarUrl?: string | null;
   selectedRobotName?: string | null;
+  /** Physical transport of the selected robot (`wifi` / `usb` / …),
+   *  surfaced as the Lite/Wireless tag on the in-session identity
+   *  sub-line. `null` when no robot is selected. */
+  selectedRobotTransport?: string | null;
+  /** Rolling-min RTT (ms) the embed reports once live, or `null` while
+   *  not yet measured. Drives the latency pill on the sub-line. */
+  linkRttMs?: number | null;
   onSignOut(): void;
   onEndSession(): void;
 }
@@ -82,7 +90,9 @@ export function TopBar({
   hostPhase,
   userName,
   avatarUrl = null,
-  selectedRobotName: _selectedRobotName,
+  selectedRobotName = null,
+  selectedRobotTransport = null,
+  linkRttMs = null,
   onSignOut,
   onEndSession,
 }: TopBarProps): JSX.Element {
@@ -154,6 +164,24 @@ export function TopBar({
           >
             {appName}
           </Typography>
+          {/* In-session identity sub-line: the running app is the
+              headline (above); the robot it's driving + its link
+              facts (Lite/Wireless, live latency) read as the smaller
+              context line, mirroring the mobile app overlay. Only the
+              embed measures the live RTT (the host handed off its
+              WebRTC slot), so the latency pill is gated on a reported
+              value to avoid a misleading `0 ms`. */}
+          {sessionOpen && selectedRobotName && (
+            <Box sx={{ mt: 0.25 }}>
+              <IdentityChipBar
+                robotName={selectedRobotName}
+                transport={selectedRobotTransport}
+                linkRttMs={linkRttMs}
+                showLatency={linkRttMs !== null}
+                variant="secondary"
+              />
+            </Box>
+          )}
         </Box>
 
         {showEndSession && (

--- a/ts/host/src/components/TopBar.tsx
+++ b/ts/host/src/components/TopBar.tsx
@@ -222,10 +222,6 @@ export function TopBar({
               fontWeight: 600,
               py: 0.5,
               px: 1.25,
-              // Lock the horizontal footprint to the widest label
-              // ("End session") so swapping in the shorter "Ending…"
-              // copy doesn't visibly shrink the chip mid-teardown.
-              minWidth: 116,
               borderRadius: 999,
               textTransform: 'none',
               lineHeight: 1.1,
@@ -235,7 +231,12 @@ export function TopBar({
           </Button>
         )}
 
-        {isSignedIn && (
+        {/* Account menu (avatar + sign-out) is a PICKER-only affordance:
+            sign-out lives in the robot list, not mid-session. Once a
+            session is open we swap it for the "End session" button
+            above, so the right cluster shows exactly one primary action
+            for the current phase. */}
+        {isSignedIn && !showEndSession && (
           <AccountMenu
             username={userName}
             avatarUrl={avatarUrl}

--- a/ts/host/src/embed/index.ts
+++ b/ts/host/src/embed/index.ts
@@ -342,6 +342,11 @@ async function bootOnce(
   bridge.attachPageHide(sdk);
   pushAppState('live', null);
 
+  // 9. Start sampling our own WebRTC RTT and reporting it upstream so
+  //    a host shell that handed its session off to us (mobile app)
+  //    can show a true live latency instead of a frozen value.
+  startLiveLinkMonitor(sdk);
+
   return bridge.buildHandle<unknown>(sdk, live);
 }
 
@@ -652,6 +657,7 @@ function pushAppState(
   phase: AppPhase,
   connectingStep: AppConnectingStep | null,
   message: string | null = null,
+  rttMs: number | null = null,
 ): void {
   postToHost({
     source: PROTOCOL_SOURCE,
@@ -660,7 +666,99 @@ function pushAppState(
     phase,
     connectingStep,
     message,
+    rttMs,
   });
+}
+
+/* ─────────────────── Live link latency monitor ─────────────────── */
+
+/** Poll cadence for the live RTT sampler. Matches the host-side
+ *  `TransportMonitor` so the number updates at the same rhythm the
+ *  user is used to on the session screen. */
+const LINK_MONITOR_INTERVAL_MS = 1500;
+/** Rolling-min window: ~6 ticks ≈ 9 s of history, so a single Wi-Fi
+ *  jitter spike doesn't bounce the displayed latency. Mirrors the
+ *  host's `RTT_WINDOW_SIZE`. */
+const RTT_WINDOW_SIZE = 6;
+
+/**
+ * Sample the selected ICE candidate pair's `currentRoundTripTime`
+ * from a peer connection and return it in milliseconds, or `null`
+ * when no nominated pair exposes it yet (or the platform omits it,
+ * e.g. iOS WKWebView). Pure read of `getStats()` - same field the
+ * host's `TransportMonitor` reads.
+ */
+async function sampleRttMs(pc: RTCPeerConnection): Promise<number | null> {
+  try {
+    const stats = await pc.getStats();
+    let rtt: number | null = null;
+    stats.forEach((report) => {
+      const r = report as {
+        type: string;
+        selected?: boolean;
+        nominated?: boolean;
+        state?: string;
+        currentRoundTripTime?: number;
+      };
+      if (r.type !== 'candidate-pair') return;
+      const isSelected =
+        r.selected === true || (r.nominated === true && r.state === 'succeeded');
+      if (!isSelected) return;
+      if (typeof r.currentRoundTripTime === 'number') {
+        rtt = r.currentRoundTripTime * 1000;
+      }
+    });
+    return rtt;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Once the app is live, periodically sample the embed's OWN WebRTC
+ * RTT and re-emit `embed:app-state` (still `phase: 'live'`) carrying
+ * the rolling-min latency. This is what lets a host shell that has
+ * released its session to us (the mobile app) display a TRUE,
+ * up-to-date link latency: the host no longer holds a connection, so
+ * the iframe is the only place the candidate pair still exists.
+ *
+ * Self-stops on `sessionStopped` and `pagehide`. No-op (never emits)
+ * when the platform doesn't expose RTT, so the host keeps hiding the
+ * latency pill rather than showing a frozen value.
+ */
+function startLiveLinkMonitor(sdk: ReachyMiniInstance): void {
+  if (typeof window === 'undefined') return;
+  const pc = (sdk as unknown as { _pc?: RTCPeerConnection | null })._pc;
+  if (!pc) return;
+
+  const windowMs: number[] = [];
+  let stopped = false;
+
+  const tick = async (): Promise<void> => {
+    if (stopped) return;
+    const sample = await sampleRttMs(pc);
+    if (sample === null) return;
+    windowMs.push(sample);
+    if (windowMs.length > RTT_WINDOW_SIZE) windowMs.shift();
+    pushAppState('live', null, null, Math.min(...windowMs));
+  };
+
+  const interval = window.setInterval(() => void tick(), LINK_MONITOR_INTERVAL_MS);
+  // Kick a first sample shortly after going live (the pair is already
+  // nominated by the time `connectToHost()` resolves).
+  window.setTimeout(() => void tick(), 600);
+
+  const stop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    window.clearInterval(interval);
+  };
+  try {
+    sdk.addEventListener('sessionStopped', stop);
+  } catch {
+    /* ignore - sampler will keep running until pagehide */
+  }
+  window.addEventListener('pagehide', stop, { once: true });
 }
 
 /**

--- a/ts/host/src/hooks/useHostBridge.ts
+++ b/ts/host/src/hooks/useHostBridge.ts
@@ -33,6 +33,12 @@ export interface EmbedAppState {
   phase: AppPhase;
   connectingStep: AppConnectingStep | null;
   message: string | null;
+  /** Rolling-min round-trip time (ms) the embed measures on its own
+   *  WebRTC pair and reports over `embed:app-state` once `live`. The
+   *  host released its session slot to the iframe, so this is the only
+   *  TRUE link-latency signal available; `null` when not yet measured
+   *  or unavailable (e.g. iOS WKWebView). */
+  rttMs: number | null;
 }
 
 export interface UseHostBridgeOptions {
@@ -94,6 +100,7 @@ export function useHostBridge(opts: UseHostBridgeOptions): HostBridge {
             phase: data.phase,
             connectingStep: data.connectingStep ?? null,
             message: data.message ?? null,
+            rttMs: data.rttMs ?? null,
           });
           return;
         case 'embed:request-leave':

--- a/ts/host/src/lib/protocol.ts
+++ b/ts/host/src/lib/protocol.ts
@@ -187,6 +187,20 @@ export interface EmbedAppStateMsg {
   connectingStep?: AppConnectingStep | null;
   /** Optional human-readable hint shown in the overlay caption. */
   message?: string | null;
+  /**
+   * Rolling-min round-trip time (ms) on the embed's own WebRTC
+   * candidate pair, sampled from `sdk._pc.getStats()`. Additive
+   * field (no version bump): emitted periodically once `phase ===
+   * 'live'` so a host shell that has handed its session off to this
+   * iframe (mobile app) can still surface a TRUE link latency -
+   * the host itself no longer holds a connection to measure.
+   *
+   * `null` (or omitted) when the platform doesn't expose RTT (iOS
+   * WKWebView) or no pair is nominated yet. Hosts that don't care
+   * (the standalone web shell, which measures its own link) simply
+   * ignore it.
+   */
+  rttMs?: number | null;
 }
 
 /** App requests to leave (user clicked an in-app exit, error,

--- a/ts/host/src/ui/design/IdentityChipBar.tsx
+++ b/ts/host/src/ui/design/IdentityChipBar.tsx
@@ -1,0 +1,106 @@
+/**
+ * Robot identity block: robot name + transport tag (+ optional live
+ * latency pill). Ported from the mobile shell's `IdentityChipBar`
+ * (`reachy_mini_mobile_app/src/ui/screens/session/IdentityChipBar.tsx`),
+ * trimmed for the host:
+ *
+ *   - No session-phase spinner: the host renders this only while the
+ *     embedded app is live, so the transient Connecting/Reconnecting
+ *     cue from the mobile session FSM has no equivalent here.
+ *   - Latency comes from the embed-reported `rttMs` (the embed owns
+ *     the live WebRTC pair; the host released its slot to the iframe),
+ *     so the bars are driven purely by RTT.
+ *
+ * Layout:
+ *
+ *   Reachy_mini  [⌁ Lite]  [▮▮▮ 38 ms]
+ *
+ * The `secondary` variant renders the name as a muted sub-line (used
+ * under the bigger app title in the host topbar).
+ */
+import type { JSX } from 'react';
+import { Stack, Typography } from '@mui/material';
+
+import { LinkQualityBars, linkQualityLevel } from './LinkQualityBars';
+import { MetaPill, TagLabel, VariantTag } from './MetaPill';
+import { FONT_WEIGHT, TYPO } from '../../lib/tokens';
+
+/**
+ * Format the rolling-min RTT as a compact integer `… ms` tag. An
+ * unknown / not-yet-measured RTT reads as `0 ms`.
+ */
+function formatLatencyTag(rttMs: number | null): string {
+  const ms = rttMs !== null && Number.isFinite(rttMs) && rttMs > 0 ? Math.round(rttMs) : 0;
+  return `${ms} ms`;
+}
+
+export interface IdentityChipBarProps {
+  robotName: string;
+  /** Physical transport string from central (`wifi` / `usb` / …),
+   *  rendered via `<VariantTag>` as the stable Lite/Wireless tag.
+   *  `null` when central didn't advertise `meta.transport` for this
+   *  robot - the tag is then omitted, but the robot name (and the
+   *  latency pill, if any) still render. */
+  transport: string | null;
+  /** Rolling-min RTT (ms) reported by the embed, or `null` when not
+   *  yet measured / unavailable. Drives the latency pill value + bars. */
+  linkRttMs: number | null;
+  /** Whether to show the live latency pill. Defaults to `true`; pass
+   *  `false` (or rely on it being gated upstream) when no RTT is
+   *  available so we don't paint a misleading `0 ms`. */
+  showLatency?: boolean;
+  /**
+   * Visual weight of the robot name.
+   *  - `'primary'` (default): bold, `text.primary`, `TYPO.md`.
+   *  - `'secondary'`: medium, `text.secondary`, `TYPO.sm` - a sub-line
+   *    under a bigger headline (the host topbar's app title).
+   */
+  variant?: 'primary' | 'secondary';
+}
+
+export function IdentityChipBar({
+  robotName,
+  transport,
+  linkRttMs,
+  showLatency = true,
+  variant = 'primary',
+}: IdentityChipBarProps): JSX.Element {
+  const secondary = variant === 'secondary';
+  const latencyText = formatLatencyTag(linkRttMs);
+
+  return (
+    <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0, flex: 1 }}>
+      <Typography
+        sx={{
+          minWidth: 0,
+          fontSize: secondary ? TYPO.sm : TYPO.md,
+          fontWeight: secondary ? FONT_WEIGHT.medium : FONT_WEIGHT.bold,
+          color: secondary ? 'text.secondary' : 'text.primary',
+          letterSpacing: '-0.1px',
+          lineHeight: 1.2,
+          flexShrink: 1,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          '&::first-letter': { textTransform: 'uppercase' },
+        }}
+        noWrap
+      >
+        {robotName}
+      </Typography>
+
+      <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', flexShrink: 0 }}>
+        {transport && <VariantTag transport={transport} />}
+        {showLatency && (
+          <MetaPill>
+            <LinkQualityBars
+              level={linkQualityLevel(linkRttMs)}
+              title={`Link quality (${latencyText})`}
+            />
+            <TagLabel>{latencyText}</TagLabel>
+          </MetaPill>
+        )}
+      </Stack>
+    </Stack>
+  );
+}

--- a/ts/host/src/ui/design/LinkQualityBars.tsx
+++ b/ts/host/src/ui/design/LinkQualityBars.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tiny "signal bars" glyph that reads the live link QUALITY at a
+ * glance, driven by latency (RTT).
+ *
+ * Ported from the mobile shell
+ * (`reachy_mini_mobile_app/src/ui/design/LinkQualityBars.tsx` +
+ * the `linkQualityLevel` mapping from its `transport-monitor`). The
+ * host has no `TransportMonitor` of its own - it consumes the RTT the
+ * embedded app reports over `embed:app-state` - so the level mapping
+ * lives here, self-contained.
+ *
+ *   < 40 ms   ▮▮▮  excellent
+ *   < 150 ms  ▮▮▯  good
+ *   ≥ 150 ms  ▮▯▯  poor
+ */
+import type { JSX } from 'react';
+import { Box, Stack } from '@mui/material';
+
+import { STATUS } from '../../lib/tokens';
+
+/** Discrete signal level, 0 (measuring / empty) to 3 (excellent). */
+export type LinkQuality = 0 | 1 | 2 | 3;
+
+/** RTT (ms) cut-offs for the 3 → 2 and 2 → 1 bar transitions. */
+const RTT_GOOD_MS = 40; // < 40 ms  : excellent → 3 bars
+const RTT_OK_MS = 150; // < 150 ms : usable     → 2 bars
+//                        ≥ 150 ms : laggy      → 1 bar
+
+/**
+ * Map a rolling-min RTT (ms) to a 0-3 quality level. `null` (RTT not
+ * yet measured / unavailable) reads as `0` (muted/empty bars).
+ */
+export function linkQualityLevel(rttMs: number | null): LinkQuality {
+  if (rttMs === null) return 0;
+  if (rttMs < RTT_GOOD_MS) return 3;
+  if (rttMs < RTT_OK_MS) return 2;
+  return 1;
+}
+
+/** Lit-bar colour + human label per quality level. */
+const LEVEL_META: Record<LinkQuality, { color: string | null; label: string }> = {
+  0: { color: null, label: 'measuring…' },
+  1: { color: STATUS.warning, label: 'poor' },
+  2: { color: 'text.secondary', label: 'good' },
+  3: { color: STATUS.success, label: 'excellent' },
+};
+
+/** Bar heights from shortest to tallest, in px. */
+const BAR_HEIGHTS_PX = [5, 8, 11] as const;
+const BAR_WIDTH_PX = 3;
+
+interface LinkQualityBarsProps {
+  /** Pre-computed signal level (0-3), via `linkQualityLevel`. */
+  level: LinkQuality;
+  /** Accessible label / tooltip; defaults to the level's word. */
+  title?: string;
+}
+
+export function LinkQualityBars({ level, title }: LinkQualityBarsProps): JSX.Element {
+  const meta = LEVEL_META[level];
+  const label = title ?? `Link quality: ${meta.label}`;
+
+  return (
+    <Stack
+      role="img"
+      aria-label={label}
+      title={label}
+      direction="row"
+      spacing="2px"
+      sx={{
+        alignItems: 'flex-end',
+        height: BAR_HEIGHTS_PX[BAR_HEIGHTS_PX.length - 1],
+      }}
+    >
+      {BAR_HEIGHTS_PX.map((h, i) => {
+        const lit = i < level;
+        return (
+          <Box
+            key={i}
+            sx={{
+              width: BAR_WIDTH_PX,
+              height: h,
+              borderRadius: '1px',
+              bgcolor: lit
+                ? (meta.color ?? 'text.disabled')
+                : (theme) =>
+                    theme.palette.mode === 'dark'
+                      ? 'rgba(255,255,255,0.18)'
+                      : 'rgba(0,0,0,0.16)',
+            }}
+          />
+        );
+      })}
+    </Stack>
+  );
+}

--- a/ts/host/src/ui/design/MetaPill.tsx
+++ b/ts/host/src/ui/design/MetaPill.tsx
@@ -1,0 +1,94 @@
+/**
+ * Shared meta-pill primitives for the robot identity row.
+ *
+ * Ported from `reachy_mini_mobile_app/src/ui/design/MetaPill.tsx`.
+ * A meta pill is a small, light-bordered tag (icon/glyph + text) used
+ * both in the picker list and in the in-session topbar so a robot
+ * keeps the same visual taxonomy before and after the user picks it.
+ *
+ *   [⌁ Lite]   [▮▮▮ 38 ms]
+ *
+ * `VariantTag` is the always-on first pill: the USB / Wi-Fi icon plus
+ * the product SKU it maps onto (`Lite` / `Wireless`).
+ */
+import type { JSX, ReactNode } from 'react';
+import { Box, Typography } from '@mui/material';
+
+import { TransportChip, transportLabelOf } from './TransportChip';
+import { FONT_WEIGHT, RADIUS, TYPO } from '../../lib/tokens';
+
+/** Uniform pill height so the meta row lines up cleanly. */
+export const META_PILL_HEIGHT_PX = 24;
+
+/**
+ * Self-contained, light-bordered pill holding one meta module
+ * (icon/glyph + text). An optional `tone` tints the border + content;
+ * omitted = neutral.
+ */
+export function MetaPill({
+  children,
+  tone,
+  pl = 0.875,
+}: {
+  children: ReactNode;
+  tone?: string;
+  /** Left padding override - the icon-led variant pill tightens this
+   *  so the glyph's own whitespace doesn't read as extra padding. */
+  pl?: number;
+}): JSX.Element {
+  return (
+    <Box
+      sx={(theme) => ({
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.5,
+        height: META_PILL_HEIGHT_PX,
+        pl,
+        pr: 0.875,
+        flexShrink: 0,
+        borderRadius: `${RADIUS.sm}px`,
+        border: `1px solid ${tone ?? theme.palette.divider}`,
+        bgcolor:
+          theme.palette.mode === 'dark'
+            ? 'rgba(255,255,255,0.03)'
+            : 'rgba(0,0,0,0.02)',
+        color: tone ?? 'text.secondary',
+      })}
+    >
+      {children}
+    </Box>
+  );
+}
+
+/** Text inside a meta pill, inheriting the pill's (possibly toned) colour. */
+export function TagLabel({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <Typography
+      component="span"
+      sx={{
+        fontSize: TYPO.micro,
+        fontWeight: FONT_WEIGHT.medium,
+        letterSpacing: '0.2px',
+        color: 'inherit',
+        whiteSpace: 'nowrap',
+        lineHeight: 1,
+      }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+/**
+ * Product-variant pill: USB / Wi-Fi icon + the SKU it maps onto
+ * (`Lite` / `Wireless`). Always-on, neutral - it's stable identity,
+ * not a health signal.
+ */
+export function VariantTag({ transport }: { transport: string }): JSX.Element {
+  return (
+    <MetaPill pl={0.5}>
+      <TransportChip transport={transport} iconOnly />
+      <TagLabel>{transportLabelOf(transport)}</TagLabel>
+    </MetaPill>
+  );
+}

--- a/ts/host/src/ui/design/TransportChip.tsx
+++ b/ts/host/src/ui/design/TransportChip.tsx
@@ -1,0 +1,109 @@
+/**
+ * Compact transport tag for a robot listing.
+ *
+ * Ported from `reachy_mini_mobile_app/src/ui/design/TransportChip.tsx`
+ * so the host shell and the mobile shell read the same `Lite` /
+ * `Wireless` taxonomy. The host is a separate package (no cross-import
+ * with the mobile app), so this is an assumed duplication - same
+ * stance as the shared `lib/tokens.ts`.
+ *
+ * Two well-known values get an icon + typed label (`usb`, `wifi`);
+ * anything else falls through to a plain label so a future daemon
+ * advertising `ethernet` / `sim` / `mockup` still renders without a
+ * component update.
+ */
+import type { JSX } from 'react';
+import { Box, Chip } from '@mui/material';
+import UsbIcon from '@mui/icons-material/Usb';
+import WifiIcon from '@mui/icons-material/Wifi';
+
+import { TYPO } from '../../lib/tokens';
+
+/**
+ * Map a transport string onto the product variant it implies. The
+ * link type IS the SKU: `usb` -> Reachy Mini Lite (wired, needs a host
+ * computer), `wifi` -> Reachy Mini Wireless (onboard compute +
+ * battery). Anything else falls through to the raw string.
+ */
+export function transportLabelOf(transport: string): string {
+  if (transport === 'usb') return 'Lite';
+  if (transport === 'wifi') return 'Wireless';
+  return transport;
+}
+
+export interface TransportChipProps {
+  transport: string;
+  /** Pixel height of the labelled chip. Defaults to 20px. */
+  height?: number;
+  /** Font size override. Defaults to `TYPO.tiny`. */
+  fontSize?: string | number;
+  /**
+   * Icon-only variant for the well-known transports (`usb` /
+   * `wifi`): drops the chip border + text label and renders just
+   * the glyph in a muted colour. Used inside `<VariantTag>` so the
+   * pill carries the label itself. Unknown transports still fall
+   * through to the labelled chip.
+   */
+  iconOnly?: boolean;
+}
+
+export function TransportChip({
+  transport,
+  height = 20,
+  fontSize = TYPO.tiny,
+  iconOnly = false,
+}: TransportChipProps): JSX.Element {
+  const knownIcon =
+    transport === 'usb' ? UsbIcon : transport === 'wifi' ? WifiIcon : null;
+
+  // Icon-only variant: glyph alone, muted, no chrome.
+  if (iconOnly && knownIcon) {
+    const Icon = knownIcon;
+    return (
+      <Box
+        aria-label={transport === 'usb' ? 'USB' : 'Wi-Fi'}
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          color: (theme) =>
+            theme.palette.mode === 'dark'
+              ? 'rgba(255,255,255,0.45)'
+              : 'rgba(0,0,0,0.40)',
+        }}
+      >
+        <Icon sx={{ fontSize: 16 }} />
+      </Box>
+    );
+  }
+
+  if (transport === 'usb') {
+    return (
+      <Chip
+        size="small"
+        icon={<UsbIcon sx={{ fontSize: 14 }} />}
+        label="USB"
+        variant="outlined"
+        sx={{ height, fontSize, '.MuiChip-icon': { ml: 0.5 } }}
+      />
+    );
+  }
+  if (transport === 'wifi') {
+    return (
+      <Chip
+        size="small"
+        icon={<WifiIcon sx={{ fontSize: 14 }} />}
+        label="Wi-Fi"
+        variant="outlined"
+        sx={{ height, fontSize, '.MuiChip-icon': { ml: 0.5 } }}
+      />
+    );
+  }
+  return (
+    <Chip
+      size="small"
+      label={transport}
+      variant="outlined"
+      sx={{ height, fontSize, textTransform: 'capitalize' }}
+    />
+  );
+}

--- a/ts/host/src/vite-env.d.ts
+++ b/ts/host/src/vite-env.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Minimal ambient typing for the Vite `import.meta.env` flags the host
+ * shell relies on (currently just `DEV`, used to gate the preview
+ * harness out of production builds).
+ *
+ * We deliberately do NOT `/// <reference types="vite/client" />` here:
+ * vite/client also declares `*.svg` (and friends), which would clash
+ * with the package's own `src/assets/svg.d.ts`. Declaring only the
+ * `ImportMeta.env` shape keeps the literal `import.meta.env.DEV` form
+ * (so esbuild's define still statically replaces it and tree-shakes
+ * the dev-only branch) without pulling in the asset module ambients.
+ */
+interface ImportMetaEnv {
+  readonly DEV: boolean;
+  readonly PROD: boolean;
+  readonly MODE: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

Brings the host shell's in-session chrome in line with the mobile app, and makes the dev harness usable against a real stream. Three focused commits:

1. **Shared identity pill primitives + picker tag** - port the mobile shell's identity-row primitives into `ts/host/src/ui/design` (`TransportChip`, `MetaPill`/`TagLabel`/`VariantTag`, `LinkQualityBars` + a self-contained `linkQualityLevel`, and a trimmed `IdentityChipBar`). `PickerView` now shows the product `VariantTag` (`Lite`/`Wireless`) instead of the raw USB/Wi-Fi chip. (Assumed duplication, same stance as `lib/tokens.ts`, since the host is a separate package.)
2. **Topbar robot identity + live latency** - in session the topbar reads like the mobile overlay: running app as the headline, with a secondary sub-line carrying the robot name, its `Lite`/`Wireless` tag and a live latency pill.
   - Robot identity (name + transport) is **snapshotted at selection time**, because `useRobots` is disabled the moment we leave the picker (to protect the 1:1 `token -> peer` handoff invariant) and clears its list - so it can't be looked up during the session (this was surfacing the peer-id hash instead of the name).
   - Latency is a **true live value**: the embed measures RTT on its own WebRTC candidate pair (the host released its slot on handoff) and reports it via an additive `rttMs` field on `embed:app-state`. `embed/index.ts` samples a rolling-min RTT once live, `useHostBridge` forwards it, and the topbar shows the pill only when a value is present (never a frozen number).
3. **Dev harness live camera** - the minimal, dependency-free harness embed now renders the robot's live camera (via `media.attachVideo`) instead of a text-only status, so the topbar work can be exercised against a real stream. Auto-wake on connect and runtime sleep + torque release on leave are unchanged.

## Notes

- Additive protocol change only (`rttMs?` on `embed:app-state`), no version bump; hosts that don't care (the standalone web shell, which measures its own link) simply ignore it.
- No persona avatars on the host: personality profiles are not stored on the robot, so the host can't know them.

## Test plan

- [ ] `npm run typecheck:host` passes (verified locally).
- [ ] Preview chrome: `?host-preview=connecting` shows app headline + robot sub-line (name, Wireless tag, latency pill).
- [ ] Real session: robot **name** (not the peer-id hash) shows in the topbar; `Lite`/`Wireless` tag appears when central advertises `meta.transport`; latency pill appears a few seconds after going live.
- [ ] Dev harness embed shows the live camera; End-session tears down cleanly.

Made with [Cursor](https://cursor.com)