### PR TITLE
Back off central relay reconnect loop on 401 from stale HF token

### DIFF
--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -687,8 +687,7 @@ class CentralSignalingRelay:
                         )
 
                 if self._running and not had_exception and self._state == RelayState.ERROR:
-                    # Connect returned cleanly but left us in ERROR (e.g. a 401
-                    # from a stale token) - back off like a connection failure.
+                    # Clean return but ERROR (e.g. 401) - back off like a failure.
                     had_exception = True
                     self._connection_attempts += 1
 

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -686,6 +686,12 @@ class CentralSignalingRelay:
                             f"Connection failed after {self._connection_attempts} attempts: {e}",
                         )
 
+                if self._running and not had_exception and self._state == RelayState.ERROR:
+                    # Connect returned cleanly but left us in ERROR (e.g. a 401
+                    # from a stale token) - back off like a connection failure.
+                    had_exception = True
+                    self._connection_attempts += 1
+
                 if self._running and had_exception:
                     # Only wait after connection failures, not after normal returns
                     # (e.g., when token update triggered reconnection)

--- a/tests/unit_tests/test_central_signaling_relay.py
+++ b/tests/unit_tests/test_central_signaling_relay.py
@@ -492,15 +492,7 @@ def test_public_notify_schedules_work_on_relay_loop() -> None:
 def test_run_loop_backs_off_when_connect_returns_in_error_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A 401-style failure (ERROR state, no exception) still gets a backoff.
-
-    ``_handle_central_sse`` returns normally - without raising - when
-    central rejects the token (401) or returns a non-200 status, leaving
-    the relay in ``RelayState.ERROR``. Without the fix, ``_run_loop``
-    would treat that as a normal return and immediately retry, spinning a
-    tight reconnect loop against the local GStreamer signaling server on a
-    stale/invalid token.
-    """
+    """A 401-style failure (ERROR state, no exception) still gets a backoff."""
     monkeypatch.setattr(
         "reachy_mini.media.central_signaling_relay.RECONNECT_INTERVAL", 0.05
     )

--- a/tests/unit_tests/test_central_signaling_relay.py
+++ b/tests/unit_tests/test_central_signaling_relay.py
@@ -23,6 +23,7 @@ from reachy_mini.media.central_signaling_relay import (
     HEARTBEAT_MAX_INTERVAL,
     HEARTBEAT_MIN_INTERVAL,
     CentralSignalingRelay,
+    RelayState,
     _clamp_heartbeat_interval,
 )
 
@@ -486,3 +487,51 @@ def test_public_notify_schedules_work_on_relay_loop() -> None:
     assert len(journal.sent) == 1
     assert journal.sent[0]["sessionId"] == "central-1"
     assert journal.sent[0]["reason"] == "ice_negotiation_timeout"
+
+
+# ---------------------------------------------------------------------------
+# _run_loop backoff
+# ---------------------------------------------------------------------------
+
+
+def test_run_loop_backs_off_when_connect_returns_in_error_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 401-style failure (ERROR state, no exception) still gets a backoff.
+
+    ``_handle_central_sse`` returns normally - without raising - when
+    central rejects the token (401) or returns a non-200 status, leaving
+    the relay in ``RelayState.ERROR``. Without the fix, ``_run_loop``
+    would treat that as a normal return and immediately retry, spinning a
+    tight reconnect loop against the local GStreamer signaling server on a
+    stale/invalid token.
+    """
+    monkeypatch.setattr(
+        "reachy_mini.media.central_signaling_relay.RECONNECT_INTERVAL", 0.05
+    )
+
+    relay = _make_relay()
+    relay._running = True
+
+    call_count = 0
+
+    async def fake_connect_and_relay() -> None:
+        nonlocal call_count
+        call_count += 1
+        relay._set_state(
+            RelayState.ERROR, "Authentication failed - token may be invalid"
+        )
+        if call_count >= 3:
+            # Stop before the post-call backoff bookkeeping for this
+            # iteration runs, mirroring `stop()` racing the next attempt.
+            relay._running = False
+
+    relay._connect_and_relay = fake_connect_and_relay  # type: ignore[method-assign]
+
+    start = time.monotonic()
+    asyncio.run(relay._run_loop())
+    elapsed = time.monotonic() - start
+
+    assert call_count == 3
+    assert relay._connection_attempts == 2
+    assert elapsed >= 0.1

--- a/tests/unit_tests/test_central_signaling_relay.py
+++ b/tests/unit_tests/test_central_signaling_relay.py
@@ -489,11 +489,6 @@ def test_public_notify_schedules_work_on_relay_loop() -> None:
     assert journal.sent[0]["reason"] == "ice_negotiation_timeout"
 
 
-# ---------------------------------------------------------------------------
-# _run_loop backoff
-# ---------------------------------------------------------------------------
-
-
 def test_run_loop_backs_off_when_connect_returns_in_error_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Addresses the stale-token reconnect loop suspected in https://github.com/pollen-robotics/reachy_mini/issues/1198

When central rejects a stored HF token with 401, for example, stale/invalid token, the relay now applies the same backoff used for connection failures instead of retrying immediately, preventing log spam and connection churn against the local GStreamer signaling server during long-running sessions.