### PR TITLE
test(media): jitter buffer & Opus FEC resilience measurement harnesses

### DIFF
--- a/tests/integration_tests/media_resilience/README.md
+++ b/tests/integration_tests/media_resilience/README.md
@@ -1,0 +1,119 @@
+# Media resilience measurements (jitter buffer & Opus FEC)
+
+Experimental harnesses used to characterise the Wi-Fi resilience tuning added
+to the WebRTC media server in PR #1195
+(`feat(media): harden conversation audio against Wi-Fi packet loss & jitter`).
+
+That PR added, in `src/reachy_mini/media/media_server.py`:
+
+| Knob | Leg | What |
+|------|-----|------|
+| `RX_JITTER_LATENCY_MS = 300` | phone → robot | consumer `webrtcbin` jitter buffer depth |
+| `opusdec use-inband-fec=True, plc=True` | phone → robot | decoder loss recovery |
+| `opusenc inband-fec=True, packet-loss-percentage=20` | robot mic → phone | encoder loss resilience |
+
+These scripts answer the review question *"did you compare jitter buffer vs
+FEC?"* They are standalone, do **not** touch the running daemon, and rebuild a
+representative receive path with the same GStreamer elements `webrtcsink` /
+`webrtcbin` wrap internally.
+
+> **TL;DR**
+> - **Jitter buffer latency is a fixed cost, paid even on a clean link** —
+>   measured, see below. This is the main thing the review asked about.
+> - **Jitter buffer and FEC are complementary, not alternatives** (delay vs
+>   loss). Keeping both is the correct call.
+> - **FEC recovery quality could not be quantified objectively offline** — the
+>   reason is documented below; it needs a perceptual metric (PESQ/ViSQOL) or
+>   decoder instrumentation.
+
+## Environment
+
+Measured on a wireless Reachy Mini (daemon `1.8.0`), GStreamer `1.26.2`,
+Python `3.13`.
+
+```bash
+# Latency harness needs nothing beyond system GStreamer python bindings.
+python3 measure_jitter_fec.py --sweep --duration 7
+
+# The quality/spectral harnesses additionally need numpy:
+python3 -m venv --system-site-packages /tmp/venv
+/tmp/venv/bin/pip install numpy
+/tmp/venv/bin/python measure_fec_spectral.py
+```
+
+## 1. `measure_jitter_fec.py` — latency (CONCLUSIVE)
+
+Builds `audiotestsrc → opusenc → rtpopuspay → [loss] → rtpjitterbuffer →
+rtpopusdepay → opusdec → fakesink(sync=true)` and measures, per config:
+
+- the pipeline `LATENCY` query,
+- the **start delay** (first packet in → first packet out), via pad probes on
+  the jitter buffer sink/src,
+- per-packet hold time inside the jitter buffer,
+- `rtpjitterbuffer` stats (`num-pushed/num-lost/num-late/avg-jitter`).
+
+### Result (clean local link, `avg-jitter = 0`)
+
+| latency config | measured start delay |
+|---:|---:|
+| 0 ms | 1.5 ms |
+| 40 ms | 36.8 ms |
+| 200 ms (GStreamer default) | 197.4 ms |
+| 300 ms (this PR) | 296.3 ms |
+
+The start delay tracks the configured `latency` almost exactly, on a link with
+zero measured jitter. **The GStreamer `rtpjitterbuffer` is static** (not
+adaptive like a browser's): on a good Wi-Fi link it does *not* shrink towards
+zero — it sits at the configured depth. Raising 200 → 300 ms therefore adds
+~100 ms of permanent latency on the phone → robot leg, in exchange for
+surviving jitter spikes.
+
+This matches the GStreamer docs and maintainer statements (the `latency`
+property is "the maximum latency of the jitterbuffer", and by default the
+buffer "starts after the latency has elapsed").
+
+## 2. `measure_fec_quality.py` — waveform SNR (EXPLORATORY, confounded)
+
+Compares the lossy decode against its own clean decode (same codec config, loss
+0) using waveform SNR. **Does not discriminate FEC from PLC.**
+
+Reason: packet concealment (PLC *and* FEC) never reproduces the exact sample
+phase of the original. On any time-sensitive signal the per-sample error is
+large regardless of whether the audio sounds fine, so both FEC on and off score
+the same low SNR. Kept to document why waveform SNR is the wrong tool here.
+
+## 3. `measure_fec_spectral.py` — per-frame dominant frequency (EXPLORATORY, confounded)
+
+Attempts a phase-insensitive metric: per-20 ms-frame dominant frequency of a
+chirp, lossy vs clean. Also inconclusive, because `opusdec use-inband-fec`
+delays output by one frame **only when it actually uses FEC**, introducing a
+variable timeline shift between the lossy run and its loss-free reference. On a
+chirp (frequency changes every frame) any time shift looks like a frequency
+error, so the numbers are dominated by drift, not recovery quality.
+
+## Why FEC efficacy is not numerically reported
+
+Two independent objective approaches (waveform SNR, spectral) are both
+confounded by the same root cause: concealment does not preserve exact
+phase/timeline, and the deterministic test signals are time-sensitive. A
+trustworthy FEC-vs-PLC number requires one of:
+
+1. **PESQ / ViSQOL** on a real speech sample — perceptual metrics designed to be
+   robust to concealment timing. This is the standard approach.
+2. **Instrumenting `opusdec`** to count actual `decode_fec` reconstructions —
+   a direct "how many frames did FEC save" count, not exposed by GStreamer.
+
+Enabling Opus in-band FEC follows the WebRTC recommendation
+([RFC 8854](https://www.rfc-editor.org/info/rfc8854/): *"use of the built-in
+Opus FEC mechanism is RECOMMENDED"*); its receive-side cost is ~1 frame of
+look-ahead and is only engaged on loss. The phone → robot leg was validated
+subjectively in PR #1195 (assistant voice no longer stutters on a jittery
+link). A formal perceptual A/B remains future work.
+
+## Files
+
+| File | Status | Needs numpy |
+|------|--------|:-----------:|
+| `measure_jitter_fec.py` | conclusive (latency) | no |
+| `measure_fec_quality.py` | exploratory (confounded) | no |
+| `measure_fec_spectral.py` | exploratory (confounded) | yes |

--- a/tests/integration_tests/media_resilience/measure_fec_quality.py
+++ b/tests/integration_tests/media_resilience/measure_fec_quality.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Measure Opus in-band FEC *audio recovery* quality under packet loss.
+
+Companion to measure_jitter_fec.py (which measured latency). This one answers
+the reviewer's real question: does FEC actually recover audio better than PLC
+alone, on the phone->robot leg, and by how much?
+
+Method (fully offline, deterministic, reproducible):
+  1. Generate a fixed reference signal (frequency chirp 200->3400 Hz, the voice
+     band) as S16LE 48k mono. PLC predicts a steady tone too well, so a sweep +
+     light noise makes concealment errors visible.
+  2. Push it through a representative receive chain:
+       filesrc -> opusenc(inband-fec,packet-loss-percentage)
+               -> rtpopuspay -> [seeded RTP loss injector]
+               -> rtpjitterbuffer(do-lost=true)   (emits GstRTPPacketLost)
+               -> rtpopusdepay -> opusdec(use-inband-fec, plc)
+               -> S16LE 48k mono -> appsink (captured)
+  3. Reference run = loss 0. Test runs = same SEEDED loss pattern, FEC off vs on
+     (identical dropped seqnums => fair A/B).
+  4. Align (constant codec delay) and compute SNR of the recovered audio vs the
+     clean decode. Higher SNR = better recovery.
+
+No numpy required (pure Python).
+
+Usage:
+  python3 measure_fec_quality.py                 # default A/B at 5% and 15%
+  python3 measure_fec_quality.py --loss 10 --seconds 6
+"""
+
+import argparse
+import array
+import math
+import os
+import random
+import sys
+
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst, GLib  # noqa: E402
+
+RATE = 48000
+CH = 1
+REF_PATH = "/tmp/_fec_ref.s16"
+
+
+def gen_reference(seconds):
+    """Chirp 200->3400 Hz + light deterministic noise, S16LE mono."""
+    n = int(RATE * seconds)
+    f0, f1 = 200.0, 3400.0
+    a = array.array("h")
+    amp = 0.6 * 32767
+    noise_amp = 0.05 * 32767
+    rng = random.Random(1234)  # deterministic
+    for i in range(n):
+        t = i / RATE
+        # linear chirp
+        k = (f1 - f0) / seconds
+        phase = 2 * math.pi * (f0 * t + 0.5 * k * t * t)
+        s = amp * math.sin(phase) + noise_amp * (rng.random() * 2 - 1)
+        if s > 32767:
+            s = 32767
+        elif s < -32768:
+            s = -32768
+        a.append(int(s))
+    with open(REF_PATH, "wb") as f:
+        f.write(a.tobytes())
+    return n
+
+
+class Decode:
+    def __init__(self, fec, loss_perc, seed):
+        self.fec = fec
+        self.loss_perc = loss_perc
+        self.seed = seed
+        self.rng = random.Random(seed)
+        self.out = bytearray()
+        self.injected = 0
+        self.pipeline = None
+        self.loop = None
+
+    def _loss_probe(self, pad, info, _):
+        if self.loss_perc <= 0:
+            return Gst.PadProbeReturn.OK
+        if self.rng.random() * 100.0 < self.loss_perc:
+            self.injected += 1
+            return Gst.PadProbeReturn.DROP
+        return Gst.PadProbeReturn.OK
+
+    def _on_sample(self, sink):
+        sample = sink.emit("pull-sample")
+        if sample is None:
+            return Gst.FlowReturn.OK
+        buf = sample.get_buffer()
+        ok, mi = buf.map(Gst.MapFlags.READ)
+        if ok:
+            try:
+                self.out.extend(mi.data)
+            finally:
+                buf.unmap(mi)
+        return Gst.FlowReturn.OK
+
+    def build(self):
+        fec_bool = "true" if self.fec else "false"
+        ploss = int(self.loss_perc) if self.fec else 0
+        desc = (
+            f"filesrc location={REF_PATH} ! "
+            "rawaudioparse format=pcm pcm-format=s16le "
+            f"sample-rate={RATE} num-channels={CH} ! "
+            "audioconvert ! audioresample ! "
+            f"opusenc inband-fec={fec_bool} packet-loss-percentage={ploss} "
+            "frame-size=20 ! rtpopuspay ! "
+            "application/x-rtp,media=audio,encoding-name=OPUS,clock-rate=48000,payload=96 ! "
+            "identity name=lossy silent=true ! "
+            "rtpjitterbuffer name=jb latency=200 do-lost=true ! "
+            "rtpopusdepay ! "
+            f"opusdec name=dec use-inband-fec={fec_bool} plc=true ! "
+            "audioconvert ! audioresample ! "
+            f"audio/x-raw,format=S16LE,rate={RATE},channels={CH},layout=interleaved ! "
+            "appsink name=out emit-signals=true sync=false max-buffers=0 drop=false"
+        )
+        self.pipeline = Gst.parse_launch(desc)
+        self.pipeline.get_by_name("lossy").get_static_pad("src").add_probe(
+            Gst.PadProbeType.BUFFER, self._loss_probe, None
+        )
+        sink = self.pipeline.get_by_name("out")
+        sink.connect("new-sample", self._on_sample)
+
+    def run(self):
+        self.build()
+        self.loop = GLib.MainLoop()
+        bus = self.pipeline.get_bus()
+        bus.add_signal_watch()
+
+        def on_msg(_b, msg):
+            if msg.type == Gst.MessageType.ERROR:
+                err, dbg = msg.parse_error()
+                print(f"  ERROR: {err.message} | {dbg}", file=sys.stderr)
+                self.loop.quit()
+            elif msg.type == Gst.MessageType.EOS:
+                self.loop.quit()
+
+        bus.connect("message", on_msg)
+        self.pipeline.set_state(Gst.State.PLAYING)
+        GLib.timeout_add(20000, lambda: self.loop.quit())  # safety
+        try:
+            self.loop.run()
+        finally:
+            self.pipeline.set_state(Gst.State.NULL)
+        return array.array("h", bytes(self.out))
+
+
+def best_offset_snr(ref, test):
+    """Compute SNR(dB) of test vs ref, searching a small alignment offset."""
+    n = min(len(ref), len(test))
+    if n == 0:
+        return None, 0
+    best = None
+    best_off = 0
+    for off in (-160, -80, -40, 0, 40, 80, 160):
+        # ref[i] vs test[i+off]
+        lo = max(0, -off)
+        hi = min(n, n - off)
+        if hi - lo < RATE:  # need >=1s overlap
+            continue
+        num = 0.0
+        den = 0.0
+        # step to keep it fast in pure python (~ every sample is fine for 6s)
+        for i in range(lo, hi):
+            r = ref[i]
+            t = test[i + off]
+            num += r * r
+            d = r - t
+            den += d * d
+        if den <= 0:
+            snr = float("inf")
+        else:
+            snr = 10.0 * math.log10(num / den) if num > 0 else None
+        if snr is not None and (best is None or snr > best):
+            best = snr
+            best_off = off
+    return best, best_off
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--loss", type=float, default=None,
+                    help="single loss %% to test (default: sweep 5 and 15)")
+    ap.add_argument("--seconds", type=float, default=6.0)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+
+    Gst.init(None)
+
+    print(f"[gen] reference chirp {args.seconds}s ...", flush=True)
+    gen_reference(args.seconds)
+
+    # Per-config clean decode: compare each codec config to ITS OWN loss-free
+    # output so the only difference measured is loss recovery (not the
+    # baseline codec/delay difference between FEC on and off).
+    print("[ref] clean decode  FEC off (loss 0) ...", flush=True)
+    ref_off = Decode(fec=False, loss_perc=0.0, seed=args.seed).run()
+    print("[ref] clean decode  FEC on  (loss 0) ...", flush=True)
+    ref_on = Decode(fec=True, loss_perc=0.0, seed=args.seed).run()
+
+    # Sanity: loss-0 test vs its ref should be ~identical (very high SNR).
+    sanity, _ = best_offset_snr(ref_off, ref_off)
+    print(f"[sanity] self-SNR (should be huge): {sanity}", flush=True)
+
+    losses = [args.loss] if args.loss is not None else [5.0, 15.0, 30.0]
+
+    rows = []
+    for loss in losses:
+        # Same seed => identical dropped seqnums for off vs on (fair A/B).
+        seed = args.seed + int(loss)
+        print(f"[test] loss {loss}%  FEC off ...", flush=True)
+        off_run = Decode(fec=False, loss_perc=loss, seed=seed).run()
+        print(f"[test] loss {loss}%  FEC on  ...", flush=True)
+        on_run = Decode(fec=True, loss_perc=loss, seed=seed).run()
+
+        snr_off, _ = best_offset_snr(ref_off, off_run)
+        snr_on, _ = best_offset_snr(ref_on, on_run)
+        rows.append((loss, snr_off, snr_on))
+
+    print()
+    print("=" * 60)
+    print("  FEC AUDIO RECOVERY  (SNR of recovered audio vs clean decode)")
+    print("=" * 60)
+    print(f"{'loss':>6} | {'PLC only (FEC off)':>20} | {'FEC on':>10} | {'gain':>8}")
+    print("-" * 60)
+    for loss, soff, son in rows:
+        def f(x):
+            return f"{x:.1f} dB" if x is not None and x != float('inf') else "  -  "
+        gain = (f"+{son - soff:.1f} dB"
+                if (soff is not None and son is not None
+                    and soff != float('inf') and son != float('inf'))
+                else "  -  ")
+        print(f"{loss:>5.0f}% | {f(soff):>20} | {f(son):>10} | {gain:>8}")
+    print("=" * 60)
+    print("Higher SNR = closer to the clean decode = better recovery.")
+    print("A positive 'gain' means in-band FEC recovered audio that PLC alone could not.")
+    print()
+
+    try:
+        os.remove(REF_PATH)
+    except OSError:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration_tests/media_resilience/measure_fec_spectral.py
+++ b/tests/integration_tests/media_resilience/measure_fec_spectral.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Objectively quantify Opus in-band FEC recovery vs PLC, using a
+phase-insensitive *spectral* metric on the deterministic chirp.
+
+Why this works where waveform SNR failed:
+  The reference is a frequency sweep (chirp). When a packet is lost:
+    * PLC alone repeats the PREVIOUS frame -> wrong (stale) frequency.
+    * In-band FEC reconstructs the frame from the next packet's redundancy
+      -> correct frequency.
+  So the *dominant frequency per 20ms frame* is a clean discriminator that
+  does not care about exact sample phase (which concealment never matches).
+
+Metric: for each config, compare the per-frame dominant frequency of the
+lossy decode against its OWN clean decode, and report the mean absolute
+frequency error (Hz). Lower = better recovery. FEC should beat PLC.
+
+Reuses the loss-injection pipeline from measure_fec_quality.py.
+
+Run with the venv that has gi + numpy:
+  /tmp/venv/bin/python /tmp/measure_fec_spectral.py
+"""
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst  # noqa: E402
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import measure_fec_quality as q  # noqa: E402
+
+RATE = 48000
+FRAME = 960  # 20 ms
+
+
+def to_np(arr):
+    return np.frombuffer(bytes(arr), dtype=np.int16).astype(np.float64)
+
+
+def dom_freq_track(samples):
+    """Dominant frequency (Hz) per 20ms frame, DC removed, Hann-windowed."""
+    n = (len(samples) // FRAME) * FRAME
+    if n == 0:
+        return np.zeros(0)
+    frames = samples[:n].reshape(-1, FRAME)
+    win = np.hanning(FRAME)
+    spec = np.abs(np.fft.rfft(frames * win, axis=1))
+    spec[:, 0] = 0.0  # kill DC
+    bins = np.argmax(spec, axis=1)
+    return bins * (RATE / FRAME)
+
+
+def compare(ref_track, test_track):
+    m = min(len(ref_track), len(test_track))
+    if m == 0:
+        return None, None, None
+    r = ref_track[:m]
+    t = test_track[:m]
+    err = np.abs(r - t)
+    mean_err = float(np.mean(err))
+    # "affected" frames = where the lossy decode deviates noticeably
+    affected = err > (RATE / FRAME)  # > 1 bin (50 Hz)
+    n_aff = int(np.sum(affected))
+    mean_err_aff = float(np.mean(err[affected])) if n_aff else 0.0
+    return mean_err, n_aff, mean_err_aff
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seconds", type=float, default=5.0)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--losses", type=float, nargs="+", default=[5.0, 15.0, 30.0])
+    args = ap.parse_args()
+
+    Gst.init(None)
+    print(f"[gen] chirp {args.seconds}s", flush=True)
+    q.gen_reference(args.seconds)
+
+    print("[ref] clean FEC off", flush=True)
+    ref_off = dom_freq_track(to_np(q.Decode(False, 0.0, args.seed).run()))
+    print("[ref] clean FEC on", flush=True)
+    ref_on = dom_freq_track(to_np(q.Decode(True, 0.0, args.seed).run()))
+
+    rows = []
+    for loss in args.losses:
+        seed = args.seed + int(loss)
+        print(f"[test] loss {loss}%  FEC off", flush=True)
+        toff = dom_freq_track(to_np(q.Decode(False, loss, seed).run()))
+        print(f"[test] loss {loss}%  FEC on", flush=True)
+        ton = dom_freq_track(to_np(q.Decode(True, loss, seed).run()))
+
+        e_off, naff_off, eaff_off = compare(ref_off, toff)
+        e_on, naff_on, eaff_on = compare(ref_on, ton)
+        rows.append((loss, e_off, eaff_off, naff_off, e_on, eaff_on, naff_on))
+
+    print()
+    print("=" * 84)
+    print("  FEC RECOVERY - per-frame dominant-frequency error vs clean decode (lower=better)")
+    print("=" * 84)
+    print(f"{'loss':>5} | {'PLC mean':>9} {'PLC@lost':>9} {'#lost':>6} | "
+          f"{'FEC mean':>9} {'FEC@lost':>9} {'#lost':>6} | {'@lost gain':>11}")
+    print("-" * 84)
+    for loss, e_off, eaff_off, naff_off, e_on, eaff_on, naff_on in rows:
+        gain = eaff_off - eaff_on
+        print(f"{loss:>4.0f}% | "
+              f"{e_off:>8.0f}Hz {eaff_off:>8.0f}Hz {naff_off:>6} | "
+              f"{e_on:>8.0f}Hz {eaff_on:>8.0f}Hz {naff_on:>6} | "
+              f"{gain:>+9.0f}Hz")
+    print("=" * 84)
+    print("PLC@lost / FEC@lost = mean frequency error on the frames that were actually")
+    print("concealed. A large positive '@lost gain' = FEC reconstructed the correct")
+    print("frequency where PLC repeated a stale one.")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration_tests/media_resilience/measure_jitter_fec.py
+++ b/tests/integration_tests/media_resilience/measure_jitter_fec.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Standalone GStreamer harness to measure the latency contribution of the
+jitter buffer and Opus in-band FEC on the Reachy Mini phone->robot voice leg.
+
+It does NOT touch the running daemon. It rebuilds a representative receive
+path:
+
+    audiotestsrc(is-live)
+      -> opusenc(inband-fec, packet-loss-percentage)
+      -> rtpopuspay
+      -> [optional probabilistic RTP loss injector]
+      -> rtpjitterbuffer(latency, do-lost)   <-- same element webrtcbin wraps
+      -> rtpopusdepay
+      -> opusdec(use-inband-fec, plc)
+      -> fakesink(sync=true)
+
+For each config it reports:
+  * pipeline LATENCY query (min/max) -- what GStreamer advertises as added latency
+  * measured per-packet hold time through the jitter buffer (probe in vs out)
+  * measured start delay (first packet in -> first packet out)
+  * rtpjitterbuffer stats (num-pushed / num-lost / num-late / avg-jitter)
+  * injected loss vs reconstructed (so FEC effect is visible via num-lost)
+
+Usage:
+  python3 measure_jitter_fec.py                 # default sweep
+  python3 measure_jitter_fec.py --latency 300 --fec on --loss 0 --duration 8
+  python3 measure_jitter_fec.py --sweep         # full matrix
+"""
+
+import argparse
+import statistics
+import sys
+import time
+
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst, GLib  # noqa: E402
+
+
+def percentile(values, pct):
+    if not values:
+        return 0.0
+    s = sorted(values)
+    k = (len(s) - 1) * (pct / 100.0)
+    f = int(k)
+    c = min(f + 1, len(s) - 1)
+    if f == c:
+        return s[f]
+    return s[f] + (s[c] - s[f]) * (k - f)
+
+
+class Run:
+    """One measurement run for a single (latency, fec, loss) config."""
+
+    def __init__(self, latency_ms, fec, loss_perc, duration_s):
+        self.latency_ms = latency_ms
+        self.fec = fec
+        self.loss_perc = loss_perc
+        self.duration_s = duration_s
+
+        self.in_times = {}          # seqnum -> running-time (ns) at jb input
+        self.hold_times_ms = []     # out_rt - in_rt per packet (ms)
+        self.first_in_rt = None
+        self.first_out_rt = None
+        self.injected_drops = 0
+        self.packets_in = 0
+        self.packets_out = 0
+
+        self.pipeline = None
+        self.jb = None
+        self.loop = None
+
+    def _now_rt(self):
+        """Pipeline running-time in ns."""
+        clock = self.pipeline.get_clock()
+        if clock is None:
+            return 0
+        return clock.get_time() - self.pipeline.get_base_time()
+
+    @staticmethod
+    def _seqnum(buf):
+        """Extract RTP seqnum from a buffer (bytes 2-3 of the RTP header)."""
+        ok, mapinfo = buf.map(Gst.MapFlags.READ)
+        if not ok:
+            return None
+        try:
+            if mapinfo.size < 4:
+                return None
+            data = mapinfo.data
+            return (data[2] << 8) | data[3]
+        finally:
+            buf.unmap(mapinfo)
+
+    def _loss_probe(self, pad, info, _):
+        buf = info.get_buffer()
+        if buf is None:
+            return Gst.PadProbeReturn.OK
+        if self.loss_perc > 0:
+            # Deterministic-ish drop based on seqnum to avoid RNG import cost.
+            import random
+            if random.random() * 100.0 < self.loss_perc:
+                self.injected_drops += 1
+                return Gst.PadProbeReturn.DROP
+        return Gst.PadProbeReturn.OK
+
+    def _jb_in_probe(self, pad, info, _):
+        buf = info.get_buffer()
+        if buf is None:
+            return Gst.PadProbeReturn.OK
+        seq = self._seqnum(buf)
+        rt = self._now_rt()
+        if seq is not None:
+            self.in_times[seq] = rt
+        if self.first_in_rt is None:
+            self.first_in_rt = rt
+        self.packets_in += 1
+        return Gst.PadProbeReturn.OK
+
+    def _jb_out_probe(self, pad, info, _):
+        buf = info.get_buffer()
+        if buf is None:
+            return Gst.PadProbeReturn.OK
+        seq = self._seqnum(buf)
+        rt = self._now_rt()
+        if self.first_out_rt is None:
+            self.first_out_rt = rt
+        if seq is not None and seq in self.in_times:
+            hold_ms = (rt - self.in_times.pop(seq)) / 1e6
+            if hold_ms >= 0:
+                self.hold_times_ms.append(hold_ms)
+        self.packets_out += 1
+        return Gst.PadProbeReturn.OK
+
+    def build(self):
+        fec_bool = "true" if self.fec else "false"
+        # 20ms ptime (frame-size=20) like WebRTC; voice path.
+        desc = (
+            "audiotestsrc is-live=true wave=ticks samplesperbuffer=960 ! "
+            "audio/x-raw,rate=48000,channels=1 ! audioconvert ! "
+            f"opusenc inband-fec={fec_bool} "
+            f"packet-loss-percentage={int(self.loss_perc) if self.fec else 0} "
+            "frame-size=20 ! rtpopuspay ! "
+            "application/x-rtp,media=audio,encoding-name=OPUS,clock-rate=48000,payload=96 ! "
+            "identity name=lossy silent=true ! "
+            f"rtpjitterbuffer name=jb latency={self.latency_ms} do-lost=true ! "
+            "rtpopusdepay ! "
+            f"opusdec name=dec use-inband-fec={fec_bool} plc=true ! "
+            "audioconvert ! fakesink name=sink sync=true"
+        )
+        self.pipeline = Gst.parse_launch(desc)
+        self.jb = self.pipeline.get_by_name("jb")
+
+        lossy = self.pipeline.get_by_name("lossy")
+        lossy.get_static_pad("src").add_probe(
+            Gst.PadProbeType.BUFFER, self._loss_probe, None
+        )
+        self.jb.get_static_pad("sink").add_probe(
+            Gst.PadProbeType.BUFFER, self._jb_in_probe, None
+        )
+        self.jb.get_static_pad("src").add_probe(
+            Gst.PadProbeType.BUFFER, self._jb_out_probe, None
+        )
+
+    def query_latency(self):
+        q = Gst.Query.new_latency()
+        if self.pipeline.query(q):
+            live, mn, mx = q.parse_latency()
+            mn_ms = mn / 1e6 if mn != Gst.CLOCK_TIME_NONE else None
+            mx_ms = mx / 1e6 if mx != Gst.CLOCK_TIME_NONE else None
+            return live, mn_ms, mx_ms
+        return None, None, None
+
+    def jb_stats(self):
+        s = self.jb.get_property("stats")
+        if s is None:
+            return {}
+        out = {}
+        for key in ("num-pushed", "num-lost", "num-late",
+                    "num-duplicates", "avg-jitter"):
+            ok, val = (s.get_uint64(key) if key != "num-late"
+                       else s.get_uint64(key))
+            if ok:
+                out[key] = val
+        # avg-jitter is in ns
+        return out
+
+    def run(self):
+        self.build()
+        self.loop = GLib.MainLoop()
+        bus = self.pipeline.get_bus()
+        bus.add_signal_watch()
+
+        def on_msg(_bus, msg):
+            t = msg.type
+            if t == Gst.MessageType.ERROR:
+                err, dbg = msg.parse_error()
+                print(f"  ERROR: {err.message} | {dbg}", file=sys.stderr)
+                self.loop.quit()
+            elif t == Gst.MessageType.EOS:
+                self.loop.quit()
+
+        bus.connect("message", on_msg)
+
+        self.pipeline.set_state(Gst.State.PLAYING)
+        # Wait for preroll so the LATENCY query is meaningful.
+        self.pipeline.get_state(Gst.CLOCK_TIME_NONE)
+
+        live, mn_ms, mx_ms = self.query_latency()
+
+        GLib.timeout_add(int(self.duration_s * 1000), lambda: self.loop.quit())
+        try:
+            self.loop.run()
+        finally:
+            self.pipeline.set_state(Gst.State.NULL)
+
+        stats = self.jb_stats()
+        start_delay_ms = None
+        if self.first_in_rt is not None and self.first_out_rt is not None:
+            start_delay_ms = (self.first_out_rt - self.first_in_rt) / 1e6
+
+        return {
+            "latency_ms": self.latency_ms,
+            "fec": self.fec,
+            "loss_perc": self.loss_perc,
+            "query_live": live,
+            "query_min_ms": mn_ms,
+            "query_max_ms": mx_ms,
+            "start_delay_ms": start_delay_ms,
+            "hold_n": len(self.hold_times_ms),
+            "hold_mean_ms": statistics.mean(self.hold_times_ms)
+            if self.hold_times_ms else None,
+            "hold_p50_ms": percentile(self.hold_times_ms, 50),
+            "hold_p95_ms": percentile(self.hold_times_ms, 95),
+            "hold_max_ms": max(self.hold_times_ms) if self.hold_times_ms else None,
+            "packets_in": self.packets_in,
+            "packets_out": self.packets_out,
+            "injected_drops": self.injected_drops,
+            "jb_num_pushed": stats.get("num-pushed"),
+            "jb_num_lost": stats.get("num-lost"),
+            "jb_num_late": stats.get("num-late"),
+            "jb_avg_jitter_ms": (stats.get("avg-jitter") / 1e6)
+            if stats.get("avg-jitter") is not None else None,
+        }
+
+
+def fmt(v, unit=""):
+    if v is None:
+        return "  -  "
+    if isinstance(v, bool):
+        return "yes" if v else "no"
+    if isinstance(v, float):
+        return f"{v:.1f}{unit}"
+    return f"{v}{unit}"
+
+
+def print_report(rows):
+    print()
+    print("=" * 96)
+    print("  RESULTS  (lat=jitterbuffer latency config, fec=Opus in-band FEC, loss=injected RTP loss)")
+    print("=" * 96)
+    header = (
+        f"{'lat':>4} {'fec':>4} {'loss':>5} | "
+        f"{'query_min':>9} {'start':>7} {'hold_p50':>8} {'hold_p95':>8} {'hold_max':>8} | "
+        f"{'drop':>4} {'jb_lost':>7} {'jb_late':>7} {'avg_jit':>7}"
+    )
+    print(header)
+    print("-" * 96)
+    for r in rows:
+        line = (
+            f"{fmt(r['latency_ms']):>4} "
+            f"{fmt(r['fec']):>4} "
+            f"{fmt(r['loss_perc'],'%'):>5} | "
+            f"{fmt(r['query_min_ms'],'ms'):>9} "
+            f"{fmt(r['start_delay_ms'],'ms'):>7} "
+            f"{fmt(r['hold_p50_ms'],'ms'):>8} "
+            f"{fmt(r['hold_p95_ms'],'ms'):>8} "
+            f"{fmt(r['hold_max_ms'],'ms'):>8} | "
+            f"{fmt(r['injected_drops']):>4} "
+            f"{fmt(r['jb_num_lost']):>7} "
+            f"{fmt(r['jb_num_late']):>7} "
+            f"{fmt(r['jb_avg_jitter_ms'],'ms'):>7}"
+        )
+        print(line)
+    print("=" * 96)
+    print("Reading guide:")
+    print("  * query_min  : latency GStreamer advertises for the pipeline (jitter buffer dominates).")
+    print("  * start      : measured delay first-packet-in -> first-packet-out (~ configured latency).")
+    print("  * hold_*     : per-packet time spent inside the jitter buffer on THIS link.")
+    print("  * jb_lost    : packets the jitter buffer gave up on (lower with FEC under loss).")
+    print("  * avg_jit    : jitter the buffer actually measured on this (clean, local) link.")
+    print()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--latency", type=int, default=300)
+    ap.add_argument("--fec", choices=["on", "off"], default="on")
+    ap.add_argument("--loss", type=float, default=0.0,
+                    help="injected RTP loss percent")
+    ap.add_argument("--duration", type=float, default=8.0)
+    ap.add_argument("--sweep", action="store_true",
+                    help="run the full comparison matrix")
+    args = ap.parse_args()
+
+    Gst.init(None)
+
+    rows = []
+    if args.sweep:
+        # Isolate each factor: latency sweep (no loss), then loss A/B at 300ms.
+        configs = [
+            (0, True, 0.0),
+            (40, True, 0.0),
+            (200, True, 0.0),
+            (300, True, 0.0),
+            (300, False, 5.0),
+            (300, True, 5.0),
+            (300, False, 15.0),
+            (300, True, 15.0),
+        ]
+    else:
+        configs = [(args.latency, args.fec == "on", args.loss)]
+
+    for latency_ms, fec, loss in configs:
+        tag = f"lat={latency_ms} fec={'on' if fec else 'off'} loss={loss}%"
+        print(f"[run] {tag} ...", flush=True)
+        r = Run(latency_ms, fec, loss, args.duration).run()
+        rows.append(r)
+        time.sleep(0.3)
+
+    print_report(rows)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context

Follow-up to #1195 (`harden conversation audio against Wi-Fi packet loss & jitter`, already merged). That PR raised the RX jitter buffer to 300 ms and enabled Opus in-band FEC on both audio legs. The review asked: *did you compare jitter buffer vs FEC?*

This PR adds the **standalone measurement harnesses** I used to characterise that tuning, plus a README documenting methodology, results and limitations. They live in `tests/integration_tests/media_resilience/`, rebuild a representative WebRTC receive path with the same GStreamer elements, and **do not touch the running daemon**.

## TL;DR

- **Jitter buffer vs FEC is not an either/or** - they fix different problems (delay-absorption vs loss-recovery). Keeping both is correct.
- **The GStreamer `rtpjitterbuffer` is static, not adaptive.** Measured start delay tracks the configured depth almost exactly even on a zero-jitter link, so 200 -> 300 ms is a ~100 ms permanent latency cost on the phone -> robot leg, not something that shrinks on good Wi-Fi.

  | latency config | measured start delay |
  |---:|---:|
  | 0 ms | 1.5 ms |
  | 40 ms | 36.8 ms |
  | 200 ms (default) | 197.4 ms |
  | 300 ms (PR #1195) | 296.3 ms |

- **FEC recovery quality could not be quantified objectively offline.** Two independent metrics (waveform SNR, per-frame dominant frequency) are both confounded by the same root cause: concealment (PLC and FEC alike) does not preserve exact sample phase/timeline, and `opusdec use-inband-fec` adds a variable 1-frame shift only when it actually uses FEC. A trustworthy number needs a perceptual metric (PESQ/ViSQOL) on speech, or instrumenting `opusdec` to count real `decode_fec` reconstructions. Enabling FEC still follows the WebRTC recommendation (RFC 8854) and was validated subjectively in #1195.

## Files

| File | Status |
|------|--------|
| `measure_jitter_fec.py` | conclusive (latency) |
| `measure_fec_quality.py` | exploratory (confounded), kept to document the dead end |
| `measure_fec_spectral.py` | exploratory (confounded), kept to document the dead end |
| `README.md` | methodology + results + limitations |

cc @FabienDanieau

Made with [Cursor](https://cursor.com)