### PR TITLE
daemon: bind loopback off-wireless; remove dead --localhost-only flag

### DIFF
--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -90,19 +90,27 @@ class Args:
 
     robot_name: str = "reachy_mini"
 
-    fastapi_host: str = "0.0.0.0"
+    # None means "auto": bind 0.0.0.0 on the wireless version (must be reachable
+    # over Wi-Fi) and 127.0.0.1 everywhere else. See _resolve_bind_host().
+    fastapi_host: str | None = None
     fastapi_port: int = 8000
 
-    localhost_only: bool | None = None
+
+def _resolve_bind_host(args: Args) -> str:
+    """Resolve the address the HTTP API binds to.
+
+    An explicit ``--fastapi-host`` always wins. Otherwise the daemon binds all
+    interfaces only on the wireless version (the robot has to be reachable on
+    the LAN); every other configuration (Lite, desktop, simulation) stays on
+    loopback so the unauthenticated API is not exposed to the network.
+    """
+    if args.fastapi_host:
+        return args.fastapi_host
+    return "0.0.0.0" if args.wireless_version else "127.0.0.1"
 
 
 def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
-    localhost_only = (
-        args.localhost_only
-        if args.localhost_only is not None
-        else (False if args.wireless_version else True)
-    )
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
@@ -166,7 +174,6 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                     kinematics_engine=args.kinematics_engine,
                     check_collision=args.check_collision,
                     wake_up_on_start=args.wake_up_on_start,
-                    localhost_only=localhost_only,
                     hardware_config_filepath=args.hardware_config_filepath,
                 )
 
@@ -371,7 +378,7 @@ def run_app(args: Args) -> None:
 
         config = uvicorn.Config(
             app,
-            host=args.fastapi_host,
+            host=_resolve_bind_host(args),
             port=args.fastapi_port,
             log_config=None,  # Don't override Python logging configuration
         )
@@ -565,19 +572,6 @@ def main() -> None:
         dest="dataset_update_interval_hours",
         help="Interval in hours for background dataset update checks (default: 24.0, 0 to disable).",
     )
-    # Server options
-    parser.add_argument(
-        "--localhost-only",
-        action="store_true",
-        default=default_args.localhost_only,
-        help="Restrict the server to localhost only (default: True).",
-    )
-    parser.add_argument(
-        "--no-localhost-only",
-        action="store_false",
-        dest="localhost_only",
-        help="Allow the server to listen on all interfaces (default: False).",
-    )
     # Kinematics options
     parser.add_argument(
         "--check-collision",
@@ -598,6 +592,10 @@ def main() -> None:
         "--fastapi-host",
         type=str,
         default=default_args.fastapi_host,
+        help=(
+            "Address the HTTP API binds to. Default (unset): 0.0.0.0 on the "
+            "wireless version, 127.0.0.1 otherwise."
+        ),
     )
     parser.add_argument(
         "--fastapi-port",

--- a/src/reachy_mini/daemon/app/routers/daemon.py
+++ b/src/reachy_mini/daemon/app/routers/daemon.py
@@ -35,7 +35,6 @@ async def start_daemon(
                 sim=request.app.state.args.sim,
                 serialport=request.app.state.args.serialport,
                 scene=request.app.state.args.scene,
-                localhost_only=request.app.state.args.localhost_only,
                 wake_up_on_start=wake_up,
                 check_collision=request.app.state.args.check_collision,
                 kinematics_engine=request.app.state.args.kinematics_engine,

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -224,7 +224,6 @@ class Daemon:
         mockup_sim: bool = False,
         serialport: str = "auto",
         scene: str = "empty",
-        localhost_only: bool = True,
         wake_up_on_start: bool = True,
         check_collision: bool = False,
         kinematics_engine: str = "AnalyticalKinematics",
@@ -239,7 +238,6 @@ class Daemon:
             mockup_sim (bool): If True, run in lightweight simulation mode (no MuJoCo). Defaults to False.
             serialport (str): Serial port for real motors. Defaults to "auto", which will try to find the port automatically.
             scene (str): Name of the scene to load in simulation mode ("empty" or "minimal"). Defaults to "empty".
-            localhost_only (bool): If True, restrict the server to localhost only clients. Defaults to True.
             wake_up_on_start (bool): If True, wake up Reachy Mini on start. Defaults to True.
             check_collision (bool): If True, enable collision checking. Defaults to False.
             kinematics_engine (str): Kinematics engine to use. Defaults to "AnalyticalKinematics".
@@ -256,7 +254,7 @@ class Daemon:
             return self._status.state
 
         self.logger.info(
-            f"Daemon start parameters: sim={sim}, mockup_sim={mockup_sim}, serialport={serialport}, scene={scene}, localhost_only={localhost_only}, wake_up_on_start={wake_up_on_start}, check_collision={check_collision}, kinematics_engine={kinematics_engine}, headless={headless}, hardware_config_filepath={hardware_config_filepath}"
+            f"Daemon start parameters: sim={sim}, mockup_sim={mockup_sim}, serialport={serialport}, scene={scene}, wake_up_on_start={wake_up_on_start}, check_collision={check_collision}, kinematics_engine={kinematics_engine}, headless={headless}, hardware_config_filepath={hardware_config_filepath}"
         )
 
         # mockup-sim behaves exactly like a real robot for apps (they open webcam directly)
@@ -264,7 +262,9 @@ class Daemon:
         self._status.simulation_enabled = sim
         self._status.mockup_sim_enabled = mockup_sim
 
-        if not localhost_only:
+        # The wireless version binds all interfaces and advertises its LAN
+        # address; loopback-only configurations have no meaningful wlan_ip.
+        if self.wireless_version:
             self._status.wlan_ip = get_ip_address()
 
         # When no_media is set, override use_audio to False
@@ -277,7 +277,6 @@ class Daemon:
             "headless": headless,
             "use_audio": effective_use_audio,
             "scene": scene,
-            "localhost_only": localhost_only,
         }
 
         self.logger.info("Starting Reachy Mini daemon...")
@@ -469,7 +468,6 @@ class Daemon:
         scene: Optional[str] = None,
         headless: Optional[bool] = None,
         use_audio: Optional[bool] = None,
-        localhost_only: Optional[bool] = None,
         wake_up_on_start: Optional[bool] = None,
         goto_sleep_on_stop: Optional[bool] = None,
     ) -> "DaemonState":
@@ -482,7 +480,6 @@ class Daemon:
             scene (str): Name of the scene to load in simulation mode ("empty" or "minimal"). Defaults to None (uses the previous value).
             headless (bool): If True, run Mujoco in headless mode (no GUI). Defaults to None (uses the previous value).
             use_audio (bool): If True, enable audio. Defaults to None (uses the previous value).
-            localhost_only (bool): If True, restrict the server to localhost only clients. Defaults to None (uses the previous value).
             wake_up_on_start (bool): If True, wake up Reachy Mini on start. Defaults to None (don't wake up).
             goto_sleep_on_stop (bool): If True, put Reachy Mini to sleep on stop. Defaults to None (don't go to sleep).
 
@@ -517,9 +514,6 @@ class Daemon:
                 "use_audio": use_audio
                 if use_audio is not None
                 else self._start_params["use_audio"],
-                "localhost_only": localhost_only
-                if localhost_only is not None
-                else self._start_params["localhost_only"],
                 "wake_up_on_start": wake_up_on_start
                 if wake_up_on_start is not None
                 else False,


### PR DESCRIPTION
The --localhost-only flag never affected the socket bind. uvicorn always bound args.fastapi_host (default 0.0.0.0), and the flag only gated whether self._status.wlan_ip was populated, so the Lite/desktop/simulation daemons exposed the unauthenticated HTTP API on all interfaces despite the flag defaulting to "localhost only".

Derive the bind address from wireless_version instead: bind 0.0.0.0 only on the wireless version (which must be reachable over the LAN) and 127.0.0.1 everywhere else. An explicit --fastapi-host still overrides. Remove the misleading, unused --localhost-only/--no-localhost-only flags and the localhost_only parameter threaded through Daemon.start()/restart().
