### PR TITLE
daemon: only allow HuggingFace Spaces to be installed via the API

### DIFF
--- a/src/reachy_mini/daemon/app/routers/apps.py
+++ b/src/reachy_mini/daemon/app/routers/apps.py
@@ -66,6 +66,16 @@ async def install_app(
     app_manager: "AppManager" = Depends(get_app_manager),
 ) -> dict[str, str]:
     """Install a new app by its info (background, returns job_id)."""
+    # HuggingFace Spaces are the only source kind installable via the API.
+    if app_info.source_kind != SourceKind.HF_SPACE:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"source_kind '{app_info.source_kind.value}' is not installable "
+                "via the API"
+            ),
+        )
+
     global _update_cache
     _update_cache = None  # Invalidate cache
 


### PR DESCRIPTION
POST /api/apps/install accepted any source_kind. The LOCAL kind passes extra["path"] straight to pip as the install target, so a caller could hand pip an arbitrary URL/git/local spec whose build code runs as the daemon user.

Reject every source kind except HF_SPACE at the router. The dashboard and desktop app only ever install hf_space apps, and local dev installs go through the reachy-mini-app-assistant CLI (in-process pip), not this endpoint, so nothing legitimate is affected.

Refs: GHSA-p4cp-8gwf-3fgv

Assisted-by: Claude:claude-opus-4-8