### PR TITLE
daemon: restrict CORS to localhost instead of wildcard

### DIFF
--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -259,9 +259,11 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
             health_check_event.set()
             return {"status": "ok"}
 
+    # Restrict cross-origin access to local browser tooling; everything else is
+    # same-origin, native, or WebRTC.
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],  # or restrict to your HF domain
+        allow_origin_regex=r"https?://(localhost|127\.0\.0\.1)(:\d+)?",
         allow_methods=["*"],
         allow_headers=["*"],
     )


### PR DESCRIPTION
allow_origins=["*"] let any web page issue cross-origin requests to the unauthenticated daemon API from a visitor's browser. All real clients are same-origin (the dashboard and web app are served by the daemon), native (the desktop/tray/mobile Tauri apps use a local proxy), or reach the robot over WebRTC (Hub apps), so no browser legitimately needs cross-origin access.

Replace the wildcard with allow_origin_regex limited to localhost origins, keeping local browser dev tooling working while blocking internet-hosted pages.

Refs: GHSA-p4cp-8gwf-3fgv

Assisted-by: Claude:claude-opus-4-8