### PR TITLE
feat(daemon): add start_update WebRTC data channel command

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -334,8 +334,11 @@ class Backend:
         # followed by a restart. Wired in by `Daemon`, same fire-and-ack
         # contract as `_restart_daemon_callback`: the update ends with a
         # `systemctl restart` that tears the transport down, so the
-        # callback must return promptly (it spawns its own thread).
-        self._start_update_callback: Optional[Callable[[bool], None]] = None
+        # callback must return promptly (it spawns its own thread). It runs
+        # cheap pre-checks (wireless robot, update available, not already
+        # running) synchronously and returns a refusal reason string when it
+        # declines, or ``None`` once the update job has been accepted.
+        self._start_update_callback: Optional[Callable[[bool], Optional[str]]] = None
 
     # Life cycle methods
     def wrapped_run(self) -> None:
@@ -1394,9 +1397,14 @@ class Backend:
                 self.logger.error(f"restart_daemon callback failed: {e}")
 
         elif isinstance(cmd, StartUpdateCmd):
-            # Same fire-and-ack contract as `restart_daemon`: the update
-            # ends with a `systemctl restart` that tears this transport
-            # down, so ack first and let the consumer reconnect.
+            # Same fire-and-ack contract as `restart_daemon`: a successful
+            # update ends with a `systemctl restart` that tears this
+            # transport down. The callback runs cheap pre-checks (wireless
+            # robot, an update is available, none already running)
+            # synchronously and returns a refusal reason if it declined; we
+            # only ack ok once the update job has actually been accepted, so
+            # the consumer can surface a real error instead of waiting for a
+            # reconnect that never comes.
             if self._start_update_callback is None:
                 send_response(
                     {
@@ -1405,11 +1413,18 @@ class Backend:
                     }
                 )
                 return
-            send_response({"status": "ok", "command": "start_update"})
             try:
-                self._start_update_callback(cmd.pre_release)
+                refusal = self._start_update_callback(cmd.pre_release)
             except Exception as e:
                 self.logger.error(f"start_update callback failed: {e}")
+                send_response(
+                    {"error": f"start_update failed: {e}", "command": "start_update"}
+                )
+                return
+            if refusal is not None:
+                send_response({"error": refusal, "command": "start_update"})
+                return
+            send_response({"status": "ok", "command": "start_update"})
 
         elif isinstance(cmd, UploadMoveStartCmd):
             self._handle_upload_start(cmd)
@@ -2087,14 +2102,18 @@ class Backend:
         """
         self._restart_daemon_callback = callback
 
-    def set_start_update_callback(self, callback: Callable[[bool], None]) -> None:
+    def set_start_update_callback(
+        self, callback: Callable[[bool], Optional[str]]
+    ) -> None:
         """Wire the trigger used by the ``start_update`` DataChannel cmd.
 
         ``Daemon`` injects a callback that runs ``update_reachy_mini`` on
         a fresh background thread (mirroring ``set_restart_daemon_callback``).
         Takes the ``pre_release`` flag and MUST return promptly so the ack
         is flushed before the update's ``systemctl restart`` tears the
-        DataChannel down.
+        DataChannel down. It returns a refusal reason string when it declines
+        the update (non-wireless robot, no update available, or one already
+        running), or ``None`` once the job has been accepted.
         """
         self._start_update_callback = callback
 

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -65,6 +65,7 @@ from reachy_mini.io.protocol import (
     SetVolumeCmd,
     SetWobblingCmd,
     StartRecordingCmd,
+    StartUpdateCmd,
     StopRecordingCmd,
     SubscribeLogsCmd,
     UnsubscribeLogsCmd,
@@ -328,6 +329,13 @@ class Backend:
         # Returns immediately - the actual restart runs on a fresh
         # thread so the data channel can flush its ack first.
         self._restart_daemon_callback: Optional[Callable[[], None]] = None
+
+        # Synchronous callback that triggers a PyPI update of the daemon
+        # followed by a restart. Wired in by `Daemon`, same fire-and-ack
+        # contract as `_restart_daemon_callback`: the update ends with a
+        # `systemctl restart` that tears the transport down, so the
+        # callback must return promptly (it spawns its own thread).
+        self._start_update_callback: Optional[Callable[[bool], None]] = None
 
     # Life cycle methods
     def wrapped_run(self) -> None:
@@ -1385,6 +1393,24 @@ class Backend:
             except Exception as e:
                 self.logger.error(f"restart_daemon callback failed: {e}")
 
+        elif isinstance(cmd, StartUpdateCmd):
+            # Same fire-and-ack contract as `restart_daemon`: the update
+            # ends with a `systemctl restart` that tears this transport
+            # down, so ack first and let the consumer reconnect.
+            if self._start_update_callback is None:
+                send_response(
+                    {
+                        "error": "start_update not supported by this backend host",
+                        "command": "start_update",
+                    }
+                )
+                return
+            send_response({"status": "ok", "command": "start_update"})
+            try:
+                self._start_update_callback(cmd.pre_release)
+            except Exception as e:
+                self.logger.error(f"start_update callback failed: {e}")
+
         elif isinstance(cmd, UploadMoveStartCmd):
             self._handle_upload_start(cmd)
         elif isinstance(cmd, UploadMoveChunkCmd):
@@ -2060,6 +2086,17 @@ class Backend:
         flush its ack on the about-to-be-torn-down DataChannel.
         """
         self._restart_daemon_callback = callback
+
+    def set_start_update_callback(self, callback: Callable[[bool], None]) -> None:
+        """Wire the trigger used by the ``start_update`` DataChannel cmd.
+
+        ``Daemon`` injects a callback that runs ``update_reachy_mini`` on
+        a fresh background thread (mirroring ``set_restart_daemon_callback``).
+        Takes the ``pre_release`` flag and MUST return promptly so the ack
+        is flushed before the update's ``systemctl restart`` tears the
+        DataChannel down.
+        """
+        self._start_update_callback = callback
 
     def setup_media_server(self, media_server: Any) -> None:
         """Connect the backend to the media server.

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -334,6 +334,7 @@ class Daemon:
                 if self.backend is not None:
                     self.backend.setup_media_server(self._media_server)
                     self.backend.set_restart_daemon_callback(self._spawn_webrtc_restart)
+                    self.backend.set_start_update_callback(self._spawn_webrtc_update)
                 self._media_server.start()
 
                 # Start central signaling relay for remote WebRTC access
@@ -558,6 +559,32 @@ class Daemon:
                 self.logger.error(f"WebRTC restart_daemon failed: {e}")
 
         Thread(target=_run, daemon=True, name="webrtc-restart-daemon").start()
+
+    def _spawn_webrtc_update(self, pre_release: bool = False) -> None:
+        """Run a PyPI update of the daemon on a fresh thread.
+
+        Called from the backend's WebRTC ``start_update`` handler. Mirrors
+        ``_spawn_webrtc_restart`` and the REST ``/update/start`` endpoint:
+        ``update_reachy_mini`` upgrades the package and ends with a
+        ``systemctl restart``. We run it on a daemon thread with its own
+        asyncio loop so the caller can flush its DataChannel ack before the
+        WebRTC stack is torn down by the restart.
+        """
+        if self._status.state == DaemonState.STOPPED:
+            self.logger.warning("Ignoring WebRTC start_update: daemon already stopped.")
+            return
+
+        # Local import: keeps the wireless-update dependency chain out of
+        # the daemon module's import-time graph (matches routers/update.py).
+        from reachy_mini.utils.wireless_version.update import update_reachy_mini
+
+        def _run() -> None:
+            try:
+                asyncio.run(update_reachy_mini(self.logger, pre_release=pre_release))
+            except Exception as e:
+                self.logger.error(f"WebRTC start_update failed: {e}")
+
+        Thread(target=_run, daemon=True, name="webrtc-start-update").start()
 
     def status(self) -> "DaemonStatus":
         """Get the current status of the Reachy Mini daemon."""

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -561,7 +561,7 @@ class Daemon:
 
         Thread(target=_run, daemon=True, name="webrtc-restart-daemon").start()
 
-    def _spawn_webrtc_update(self, pre_release: bool = False) -> None:
+    def _spawn_webrtc_update(self, pre_release: bool = False) -> Optional[str]:
         """Run a PyPI update of the daemon on a fresh thread.
 
         Called from the backend's WebRTC ``start_update`` handler. Mirrors
@@ -571,6 +571,20 @@ class Daemon:
         asyncio loop so the caller can flush its DataChannel ack before the
         WebRTC stack is torn down by the restart.
 
+        Returns a refusal reason string when the update is declined so the
+        caller can ack an error instead of ``ok`` (and never spawns the
+        thread in that case); returns ``None`` once the job is accepted.
+        The same guards as the REST endpoint are enforced:
+
+        * wireless-only -- the self-update path lives in
+          ``utils.wireless_version`` and has no meaning on a Lite, which is
+          updated through its host machine;
+        * an update must actually be available, otherwise we would force a
+          needless reinstall + restart of the running version;
+        * the shared ``busy_lock`` from ``routers/update.py`` is acquired so
+          a WebRTC update and a concurrent REST update can never run at the
+          same time and corrupt the venv.
+
         Progress is fanned out to every connected client as
         ``update_progress`` broadcasts (one per log line), mirroring the
         REST ``WS /update/ws/logs`` stream. A successful update restarts
@@ -579,11 +593,38 @@ class Daemon:
         """
         if self._status.state == DaemonState.STOPPED:
             self.logger.warning("Ignoring WebRTC start_update: daemon already stopped.")
-            return
+            return "Daemon is stopped"
+
+        # The PyPI self-update only exists on the wireless robot; a Lite is
+        # updated via its host machine, so reject it here rather than failing
+        # deep inside `update_reachy_mini`.
+        if not self.wireless_version:
+            return "start_update is only supported on Reachy Mini Wireless"
 
         # Local import: keeps the wireless-update dependency chain out of
         # the daemon module's import-time graph (matches routers/update.py).
+        from reachy_mini.daemon.app.routers.update import busy_lock
         from reachy_mini.utils.wireless_version.update import update_reachy_mini
+        from reachy_mini.utils.wireless_version.update_available import (
+            is_update_available,
+        )
+
+        # Share the REST router's lock so a WebRTC-triggered update and an
+        # HTTP-triggered one are mutually exclusive (a concurrent pip install
+        # into the same venv would corrupt it). Acquire non-blocking up front
+        # so we can reject immediately; on the accepted path the worker thread
+        # owns the lock and releases it, on every rejection we release here.
+        if not busy_lock.acquire(blocking=False):
+            return "Update already in progress"
+
+        try:
+            if not is_update_available("reachy_mini", pre_release):
+                busy_lock.release()
+                return "No update available"
+        except Exception as e:
+            busy_lock.release()
+            self.logger.error(f"WebRTC start_update availability check failed: {e}")
+            return f"Update availability check failed: {e}"
 
         backend = self.backend
 
@@ -618,8 +659,15 @@ class Daemon:
             except Exception as e:
                 self.logger.error(f"WebRTC start_update failed: {e}")
                 _broadcast("failed", error=str(e))
+            finally:
+                # On success `update_reachy_mini` triggers a `systemctl
+                # restart` that kills this process before we get here; the
+                # release only matters when the update failed without
+                # restarting, freeing the lock for a retry.
+                busy_lock.release()
 
         Thread(target=_run, daemon=True, name="webrtc-start-update").start()
+        return None
 
     def status(self) -> "DaemonStatus":
         """Get the current status of the Reachy Mini daemon."""

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -6,6 +6,7 @@ It also provides a command-line interface for easy interaction.
 """
 
 import asyncio
+import json
 import logging
 import time
 from importlib.metadata import PackageNotFoundError, version
@@ -569,6 +570,12 @@ class Daemon:
         ``systemctl restart``. We run it on a daemon thread with its own
         asyncio loop so the caller can flush its DataChannel ack before the
         WebRTC stack is torn down by the restart.
+
+        Progress is fanned out to every connected client as
+        ``update_progress`` broadcasts (one per log line), mirroring the
+        REST ``WS /update/ws/logs`` stream. A successful update restarts
+        the daemon before a ``done`` event can be sent, so consumers infer
+        success from the transport teardown + reconnect.
         """
         if self._status.state == DaemonState.STOPPED:
             self.logger.warning("Ignoring WebRTC start_update: daemon already stopped.")
@@ -578,11 +585,39 @@ class Daemon:
         # the daemon module's import-time graph (matches routers/update.py).
         from reachy_mini.utils.wireless_version.update import update_reachy_mini
 
+        backend = self.backend
+
+        def _broadcast(status: str, *, line: str | None = None, error: str | None = None) -> None:
+            if backend is None:
+                return
+            payload: dict[str, Any] = {"type": "update_progress", "status": status}
+            if line is not None:
+                payload["line"] = line
+            if error is not None:
+                payload["error"] = error
+            try:
+                backend.broadcast_to_all_clients(json.dumps(payload))
+            except Exception as e:
+                self.logger.warning(f"update_progress broadcast failed: {e}")
+
+        class _ProgressHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                _broadcast("in_progress", line=self.format(record))
+
+        # Dedicated logger: streams update output to clients while still
+        # propagating to the daemon's journalctl logs (propagate=True).
+        update_logger = logging.getLogger("reachy_mini.webrtc_update")
+        update_logger.setLevel(logging.INFO)
+        update_logger.handlers.clear()
+        update_logger.addHandler(_ProgressHandler())
+
         def _run() -> None:
             try:
-                asyncio.run(update_reachy_mini(self.logger, pre_release=pre_release))
+                asyncio.run(update_reachy_mini(update_logger, pre_release=pre_release))
+                _broadcast("done")
             except Exception as e:
                 self.logger.error(f"WebRTC start_update failed: {e}")
+                _broadcast("failed", error=str(e))
 
         Thread(target=_run, daemon=True, name="webrtc-start-update").start()
 

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -17,7 +17,8 @@ Client->Server command types:
 
 Server->Client message types:
     joint_positions, head_pose, imu_data, recorded_data,
-    daemon_status, task_progress
+    daemon_status, task_progress, log_line, log_stream_error,
+    update_progress
 """
 
 from datetime import datetime
@@ -801,6 +802,30 @@ class LogStreamErrorMsg(BaseModel):
 
 
 # ------------------------------------------------------------------
+# Update progress broadcast over the DataChannel.
+#
+# Unsolicited fan-out emitted while a `start_update` job runs, mirroring
+# the REST `WS /update/ws/logs` stream. One message per log line of the
+# underlying `update_reachy_mini` job (`status="in_progress"`), plus a
+# terminal `status="failed"` if the install raises before the restart.
+#
+# Note: a *successful* update ends with a `systemctl restart` that tears
+# the transport down, so `status="done"` is best-effort and usually
+# never arrives - consumers infer success from the channel teardown +
+# reconnect, exactly like the desktop app does with the REST WS close.
+# ------------------------------------------------------------------
+
+
+class UpdateProgressMsg(BaseModel):
+    """A progress event for an in-flight ``start_update`` job."""
+
+    type: Literal["update_progress"] = "update_progress"
+    status: Literal["in_progress", "done", "failed"]
+    line: str | None = None
+    error: str | None = None
+
+
+# ------------------------------------------------------------------
 # Task protocol
 # ------------------------------------------------------------------
 
@@ -855,7 +880,8 @@ AnyServerMsg = Annotated[
     | DaemonStatus
     | TaskProgress
     | LogLineMsg
-    | LogStreamErrorMsg,
+    | LogStreamErrorMsg
+    | UpdateProgressMsg,
     Field(discriminator="type"),
 ]
 server_msg_adapter: TypeAdapter[AnyServerMsg] = TypeAdapter(AnyServerMsg)

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -8,7 +8,7 @@ Client->Server command types:
     set_motor_mode, set_torque, get_motor_mode,
     set_gravity_compensation, set_automatic_body_yaw,
     get_state, get_version, start_recording, stop_recording, append_record,
-    subscribe_logs, unsubscribe_logs, restart_daemon,
+    subscribe_logs, unsubscribe_logs, restart_daemon, start_update,
     upload_move_start, upload_move_chunk, upload_move_finish,
     upload_audio_start, upload_audio_chunk, upload_audio_finish,
     play_uploaded_move, cancel_move,
@@ -379,6 +379,35 @@ class RestartDaemonCmd(BaseModel):
 
 
 # ------------------------------------------------------------------
+# Remote daemon update over the DataChannel.
+#
+# Remote counterpart of ``POST /update/start`` (``routers/update.py``):
+# upgrades the ``reachy_mini`` package in the daemon venv from PyPI.
+# Exposed over the typed transport so Central-routed peers can trigger
+# an update without an LAN HTTP path.
+#
+# Like ``restart_daemon``, this is fire-and-ack: the update ends with a
+# ``systemctl restart`` that tears the transport down, so the daemon
+# sends a single ack (``{"status": "ok", "command": "start_update"}``)
+# immediately and the consumer is expected to reconnect once the daemon
+# is back up. No completion / log message is streamed over this channel;
+# consumers that need progress can pair this with ``subscribe_logs``.
+# ------------------------------------------------------------------
+
+
+class StartUpdateCmd(BaseModel):
+    """Start a PyPI update of the daemon, then restart it.
+
+    ``pre_release`` mirrors the REST endpoint: when true the daemon
+    installs the latest pre-release. See :class:`RestartDaemonCmd` for
+    the fire-and-ack semantics (the transport dies with the restart).
+    """
+
+    type: Literal["start_update"] = "start_update"
+    pre_release: bool = False
+
+
+# ------------------------------------------------------------------
 # Inline-move upload + daemon-side playback.
 #
 # Streaming control over the data channel (one set_target per tick)
@@ -685,6 +714,7 @@ AnyCommand = Annotated[
     | SubscribeLogsCmd
     | UnsubscribeLogsCmd
     | RestartDaemonCmd
+    | StartUpdateCmd
     | UploadMoveStartCmd
     | UploadMoveChunkCmd
     | UploadMoveFinishCmd

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -387,12 +387,15 @@ class RestartDaemonCmd(BaseModel):
 # Exposed over the typed transport so Central-routed peers can trigger
 # an update without an LAN HTTP path.
 #
-# Like ``restart_daemon``, this is fire-and-ack: the update ends with a
-# ``systemctl restart`` that tears the transport down, so the daemon
-# sends a single ack (``{"status": "ok", "command": "start_update"}``)
-# immediately and the consumer is expected to reconnect once the daemon
-# is back up. No completion / log message is streamed over this channel;
-# consumers that need progress can pair this with ``subscribe_logs``.
+# Like ``restart_daemon``, this is fire-and-ack: the daemon validates the
+# request (wireless robot, an update is actually available, no update
+# already running) and either rejects it with an ``error`` ack or accepts
+# it with ``{"status": "ok", "command": "start_update"}``. Once accepted,
+# the job's log lines are fanned out to every client as ``update_progress``
+# broadcasts (see :class:`UpdateProgressMsg`). A successful update ends
+# with a ``systemctl restart`` that tears the transport down before a
+# ``done`` event is delivered, so consumers infer success from the
+# teardown + reconnect.
 # ------------------------------------------------------------------
 
 

--- a/src/reachy_mini/utils/wireless_version/update_available.py
+++ b/src/reachy_mini/utils/wireless_version/update_available.py
@@ -47,7 +47,7 @@ def is_update_available(package_name: str, pre_release: bool) -> bool:
 def get_pypi_version(package_name: str, pre_release: bool) -> semver.Version:
     """Get the latest version of a package from PyPI."""
     url = f"https://pypi.org/pypi/{package_name}/json"
-    response = requests.get(url)
+    response = requests.get(url, timeout=5)
     response.raise_for_status()
     data = response.json()
 

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -1952,6 +1952,20 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
             }
             return;
         }
+        if (data.command === 'start_update') {
+            // Refusal ack (non-wireless robot, no update available, or one
+            // already running): the daemon never spawned the job, so surface
+            // it to `onProgress` as a terminal `failed` event - there will be
+            // no transport teardown to infer success from.
+            if (typeof data.error === 'string') {
+                const event: UpdateProgressEvent = { status: 'failed', error: data.error };
+                for (const cb of this._updateProgressSubscribers) {
+                    try { cb(event); }
+                    catch (e) { console.error('startDaemonUpdate onProgress threw:', e); }
+                }
+            }
+            return;
+        }
         if (data.type === 'update_progress') {
             const event: UpdateProgressEvent = {
                 status: data.status as UpdateProgressEvent['status'],

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -1132,6 +1132,17 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
         return this._sendCommand({ type: 'clear_incoming_audio' });
     }
 
+    /**
+     * Trigger a PyPI update of the daemon over the data channel. Remote
+     * counterpart of `POST /update/start`. Fire-and-forget: the daemon
+     * acks then restarts itself once the install finishes, which tears
+     * this session down - the caller is expected to reconnect afterwards.
+     * No progress is streamed here; pair with `subscribeLogs()` if needed.
+     */
+    startDaemonUpdate({ preRelease = false }: { preRelease?: boolean } = {}): boolean {
+        return this._sendCommand({ type: 'start_update', pre_release: preRelease });
+    }
+
     setMotorMode(mode: 'enabled' | 'disabled' | 'gravity_compensation'): boolean {
         return this._sendCommand({ type: 'set_motor_mode', mode });
     }

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -63,6 +63,17 @@ interface LogSubscriber {
     onError?: (error: string) => void;
 }
 
+/** One progress event from an in-flight `startDaemonUpdate()`. */
+export interface UpdateProgressEvent {
+    status: 'in_progress' | 'done' | 'failed';
+    /** A log line of the underlying update job (when `in_progress`). */
+    line?: string;
+    /** Set when `status === 'failed'`. */
+    error?: string;
+}
+
+type UpdateProgressCallback = (event: UpdateProgressEvent) => void;
+
 interface SignalingMessage {
     type?: string;
     sessionId?: string;
@@ -177,6 +188,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
 
     // ─── Log subscribers ─────────────────────────────────────────────────
     private readonly _logSubscribers: Set<LogSubscriber> = new Set();
+    private readonly _updateProgressSubscribers: Set<UpdateProgressCallback> = new Set();
 
     // ─── Broadcast waiters (playMove / playUploadedAudio) ────────────────
     private _broadcastWaiters: BroadcastWaiter[] = [];
@@ -717,6 +729,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
         if (this._applyAudioConfigResolve) { this._applyAudioConfigResolve(false); this._applyAudioConfigResolve = null; }
         if (this._readAudioParameterResolve) { this._readAudioParameterResolve(null); this._readAudioParameterResolve = null; }
         this._logSubscribers.clear();
+        this._updateProgressSubscribers.clear();
         this._rejectPendingMotionCompletions(new Error('Session stopped'));
         // Tear down resilience plumbing BEFORE closing `_pc` so a
         // queued grace callback can't dereference a dead handle.
@@ -763,6 +776,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
         if (this._applyAudioConfigResolve) { this._applyAudioConfigResolve(false); this._applyAudioConfigResolve = null; }
         if (this._readAudioParameterResolve) { this._readAudioParameterResolve(null); this._readAudioParameterResolve = null; }
         this._logSubscribers.clear();
+        this._updateProgressSubscribers.clear();
         this._rejectPendingMotionCompletions(new Error('Disconnected'));
         // Mirrors the resilience teardown in `stopSession()`.
         this._clearIceGrace();
@@ -1134,12 +1148,22 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
 
     /**
      * Trigger a PyPI update of the daemon over the data channel. Remote
-     * counterpart of `POST /update/start`. Fire-and-forget: the daemon
-     * acks then restarts itself once the install finishes, which tears
-     * this session down - the caller is expected to reconnect afterwards.
-     * No progress is streamed here; pair with `subscribeLogs()` if needed.
+     * counterpart of `POST /update/start`. The daemon acks then restarts
+     * itself once the install finishes, which tears this session down -
+     * the caller is expected to reconnect afterwards.
+     *
+     * Pass `onProgress` to receive `update_progress` events (one per log
+     * line of the update job). A *successful* update restarts the daemon
+     * before a `done` event can arrive, so treat the session teardown +
+     * a successful reconnect as the success signal; `onProgress` will fire
+     * with `status: 'failed'` if the install errors before the restart.
+     *
+     * Returns `false` if the data channel isn't open.
      */
-    startDaemonUpdate({ preRelease = false }: { preRelease?: boolean } = {}): boolean {
+    startDaemonUpdate(
+        { preRelease = false, onProgress }: { preRelease?: boolean; onProgress?: UpdateProgressCallback } = {},
+    ): boolean {
+        if (onProgress) this._updateProgressSubscribers.add(onProgress);
         return this._sendCommand({ type: 'start_update', pre_release: preRelease });
     }
 
@@ -1925,6 +1949,18 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
                     try { sub.onError(data.error as string); }
                     catch (e) { console.error('subscribeLogs onError threw:', e); }
                 }
+            }
+            return;
+        }
+        if (data.type === 'update_progress') {
+            const event: UpdateProgressEvent = {
+                status: data.status as UpdateProgressEvent['status'],
+                line: typeof data.line === 'string' ? data.line : undefined,
+                error: typeof data.error === 'string' ? data.error : undefined,
+            };
+            for (const cb of this._updateProgressSubscribers) {
+                try { cb(event); }
+                catch (e) { console.error('startDaemonUpdate onProgress threw:', e); }
             }
             return;
         }


### PR DESCRIPTION
## Summary

Adds a `start_update` command to the typed WebRTC data channel so Central-routed (remote) peers can trigger a daemon PyPI update without an LAN HTTP path. Today the update is only reachable via the REST `POST /update/start` endpoint on the robot's port 8000 (LAN-only); the data channel exposed `restart_daemon` but no update.

This mirrors the existing `restart_daemon` plumbing end to end.

## Changes

- **`io/protocol.py`**: new `StartUpdateCmd` (`type: "start_update"`, optional `pre_release`), added to the `AnyCommand` union.
- **`daemon/backend/abstract.py`**: `_start_update_callback` slot, `set_start_update_callback()`, and a handler in `_handle_command` that acks then fires the callback (errors if no host wired it).
- **`daemon/daemon.py`**: `_spawn_webrtc_update()` wired via `set_start_update_callback`; runs `update_reachy_mini` on a background thread (same pattern as `_spawn_webrtc_restart` / REST `/update/start`).
- **`ts/lib/reachy-mini.ts`**: `startDaemonUpdate({ preRelease })` SDK method.

## Semantics

Fire-and-ack, identical to `restart_daemon`: the update ends with a `systemctl restart` that tears the transport down, so the daemon sends a single ack immediately and the consumer reconnects afterwards. No progress is streamed on this channel; consumers that want logs can pair it with `subscribe_logs`.

## Test plan

- [ ] Send `{ "type": "start_update" }` over the data channel and confirm the `{"status":"ok","command":"start_update"}` ack, then the daemon updates + restarts.
- [ ] Confirm `pre_release: true` installs a pre-release.
- [ ] Confirm a backend host without the callback wired returns the `start_update not supported` error.
- [ ] Confirm reconnection after the post-update restart.

Made with [Cursor](https://cursor.com)