### PR TITLE
Fix media sounds upload validation

### DIFF
--- a/docs/source/API/openapi.json
+++ b/docs/source/API/openapi.json
@@ -1403,7 +1403,7 @@
     "/api/media/sounds/upload": {
       "post": {
         "summary": "Upload Sound",
-        "description": "Upload a sound file to the daemon's temporary sound directory.\n\nThe file is saved to ``/tmp/reachy_mini_sounds/<original_filename>``.\nIf a file with the same name already exists it is overwritten.\n\nReturns:\n    JSON with the absolute *path* of the saved file on the daemon.",
+        "description": "Upload a sound file to the daemon's temporary sound directory.\n\nThe file is saved to ``/tmp/reachy_mini_sounds/<original_filename>``.\nIf a file with the same name already exists it is overwritten.\n\nThe upload is restricted to known audio extensions, capped at\n``MAX_SOUND_UPLOAD_BYTES``, and validated by content before being stored,\nso non-audio payloads cannot be written to disk.\n\nReturns:\n    JSON with the absolute *path* of the saved file on the daemon.",
         "operationId": "upload_sound_api_media_sounds_upload_post",
         "requestBody": {
           "content": {

--- a/docs/source/SDK/apps.md
+++ b/docs/source/SDK/apps.md
@@ -378,7 +378,7 @@ Audio recording, playback, and direction-of-arrival detection work the same way 
 Refer to the official examples for working code:
 
 - **[Sound Recording](../examples/sound_record)**: Record from the mic array and save to WAV.
-- **[Sound Playback](../examples/sound_play)**: Play a WAV file or push real-time audio (e.g., from a TTS engine).
+- **[Sound Playback](../examples/sound_play)**: Play a sound file or push real-time audio (e.g., from a TTS engine).
 - **[Sound Direction of Arrival](../examples/sound_doa)**: Detect who is speaking and make the robot look at them.
 
 For details on how audio streams differ between Wireless and Lite, see [Media Architecture](media-architecture.md).

--- a/docs/source/examples/sound_play.md
+++ b/docs/source/examples/sound_play.md
@@ -1,20 +1,20 @@
 # Sound Playback
 
 This example demonstrates two ways to play audio through Reachy Mini's speaker:
-- **`--wav`**: Play a WAV file using the `play_sound()` API.
+- **`--file`**: Play a sound file (WAV, OGG, MP3, FLAC, ...) using the `play_sound()` API.
 - **`--live`**: Push a continuous sine tone using the low-level `push_audio_sample()` API, useful for real-time audio sources such as text-to-speech engines or microphone input.
 
 **Usage:**
 ```bash
-# Play a wav file
-python sound_play.py --wav /path/to/file.wav --backend webrtc
+# Play a sound file
+python sound_play.py --file /path/to/file.ogg --backend webrtc
 
 # Push a continuous sine tone (Ctrl+C to stop)
 python sound_play.py --live --backend webrtc --tone-hz 440
 ```
 
 **Options:**
-- `--wav <path>`: Path to a WAV file to play.
+- `--file <path>`: Path to a sound file to play (WAV, OGG, MP3, FLAC, ...).
 - `--live`: Push a continuous sine tone.
 - `--tone-hz <freq>`: Sine wave frequency in Hz (`--live` mode only, default: 440).
 - `--backend`: Media backend to use (`default`, `local`, or `webrtc`).

--- a/examples/sound_play.py
+++ b/examples/sound_play.py
@@ -1,8 +1,8 @@
 """Reachy Mini sound playback example.
 
 Two modes:
-  --wav <path>  Play a wav file using the media play_sound API.
-  --live        Push a continuous sine tone using push_audio_sample.
+  --file <path>  Play a sound file (WAV, OGG, MP3, FLAC, ...) via play_sound.
+  --live         Push a continuous sine tone using push_audio_sample.
 """
 
 # START doc_example
@@ -10,22 +10,20 @@ Two modes:
 import argparse
 import os
 import time
-import wave
 
 import numpy as np
 
 from reachy_mini import ReachyMini
+from reachy_mini.media.gstreamer_utils import audio_duration_seconds
 
 
-def play_wav(mini: "ReachyMini", wav_path: str) -> None:
-    """Play a wav file using the media play_sound API."""
-    wav_path = os.path.abspath(wav_path)
-    print(f"Playing {wav_path}...")
-    mini.media.play_sound(wav_path)
+def play_file(mini: "ReachyMini", file_path: str) -> None:
+    """Play a sound file using the media play_sound API."""
+    file_path = os.path.abspath(file_path)
+    print(f"Playing {file_path}...")
+    mini.media.play_sound(file_path)
 
-    with wave.open(wav_path, "rb") as wf:
-        wav_duration = wf.getnframes() / mini.media.get_output_audio_samplerate()
-    time.sleep(wav_duration)
+    time.sleep(audio_duration_seconds(file_path))
     print("Playback finished.")
 
 
@@ -52,14 +50,14 @@ def play_live_tone(mini: "ReachyMini", tone_hz: float) -> None:
 
 
 def main(
-    backend: str, wav_path: str | None, tone_hz: float, wobbling: bool = False
+    backend: str, file_path: str | None, tone_hz: float, wobbling: bool = False
 ) -> None:
     """Run the sound playback example."""
     with ReachyMini(log_level="DEBUG", media_backend=backend) as mini:
         if wobbling:
             mini.enable_wobbling()
-        if wav_path:
-            play_wav(mini, wav_path)
+        if file_path:
+            play_file(mini, file_path)
         else:
             play_live_tone(mini, tone_hz)
 
@@ -78,9 +76,9 @@ if __name__ == "__main__":
 
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument(
-        "--wav",
+        "--file",
         type=str,
-        help="Path to a wav file to play.",
+        help="Path to a sound file to play (WAV, OGG, MP3, FLAC, ...).",
     )
     mode.add_argument(
         "--live",
@@ -103,7 +101,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     main(
         backend=args.backend,
-        wav_path=args.wav,
+        file_path=args.file,
         tone_hz=args.tone_hz,
         wobbling=args.wobbling,
     )

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -24,6 +24,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon.app.middleware import MaxBodySizeMiddleware
 from reachy_mini.daemon.app.routers import (
     apps,
     audio_config,
@@ -265,6 +266,16 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
             """Health check endpoint to reset the health check timer."""
             health_check_event.set()
             return {"status": "ok"}
+
+    # Cap the size of sound uploads before the body is read, so a large file
+    # cannot be streamed to disk (see GHSA-m2pc-3q4q-w6jr). Added before CORS
+    # so CORS remains the outermost middleware and even a 413 carries its
+    # headers.
+    app.add_middleware(
+        MaxBodySizeMiddleware,
+        max_body_size=media.MAX_SOUND_UPLOAD_BYTES,
+        paths={"/api/media/sounds/upload"},
+    )
 
     # Restrict cross-origin access to local browser tooling; everything else is
     # same-origin, native, or WebRTC.

--- a/src/reachy_mini/daemon/app/middleware.py
+++ b/src/reachy_mini/daemon/app/middleware.py
@@ -1,0 +1,103 @@
+"""Custom ASGI middleware for the daemon HTTP app."""
+
+import json
+import logging
+from collections.abc import Iterable
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+
+class _BodyTooLarge(Exception):
+    """Raised internally once a request body exceeds the configured limit."""
+
+
+class MaxBodySizeMiddleware:
+    """Reject requests to *paths* whose body exceeds *max_body_size* bytes.
+
+    The limit is enforced *before* the body is parsed, so a large upload is
+    never read in full:
+
+    - an explicit ``Content-Length`` over the limit is rejected outright,
+      before a single byte of the body is read;
+    - a body that crosses the limit while streaming (chunked transfer, or an
+      understated/absent ``Content-Length``) is aborted as soon as the
+      threshold is passed.
+
+    Other paths and non-HTTP scopes are passed through untouched.
+    """
+
+    def __init__(
+        self, app: ASGIApp, *, max_body_size: int, paths: Iterable[str]
+    ) -> None:
+        """Wrap *app*, capping bodies on *paths* at *max_body_size* bytes."""
+        self.app = app
+        self.max_body_size = max_body_size
+        self.paths = frozenset(paths)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Enforce the body-size limit on matching requests."""
+        if scope["type"] != "http" or scope.get("path") not in self.paths:
+            await self.app(scope, receive, send)
+            return
+
+        # Fast path: an honest, oversized Content-Length is rejected before the
+        # body is read at all (covers curl, browsers, requests, ...).
+        for name, value in scope.get("headers", []):
+            if name == b"content-length":
+                try:
+                    declared = int(value)
+                except ValueError:
+                    break
+                if declared > self.max_body_size:
+                    await self._send_too_large(send)
+                    return
+                break
+
+        received = 0
+        response_started = False
+
+        async def limited_receive() -> Message:
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_body_size:
+                    raise _BodyTooLarge
+            return message
+
+        async def tracking_send(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await self.app(scope, limited_receive, tracking_send)
+        except _BodyTooLarge:
+            # The body parser raises before producing a response, so the
+            # response stream is still ours to write.
+            if not response_started:
+                await self._send_too_large(send)
+            else:
+                logger.warning(
+                    "Request body exceeded %d bytes after the response started",
+                    self.max_body_size,
+                )
+
+    async def _send_too_large(self, send: Send) -> None:
+        body = json.dumps(
+            {"detail": f"Request body too large; maximum is {self.max_body_size} bytes"}
+        ).encode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 413,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode()),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})

--- a/src/reachy_mini/daemon/app/routers/media.py
+++ b/src/reachy_mini/daemon/app/routers/media.py
@@ -8,6 +8,7 @@ so that WebRTC clients can upload, play, list and delete sound files on
 the daemon.
 """
 
+import asyncio
 import os
 import tempfile
 from pathlib import Path
@@ -203,7 +204,8 @@ async def upload_sound(
             while chunk := await file.read(1 << 20):
                 f.write(chunk)
 
-        if not is_valid_audio_file(tmp_path):
+        # Offload the blocking GStreamer probe (up to 5 s) off the event loop.
+        if not await asyncio.to_thread(is_valid_audio_file, tmp_path):
             raise HTTPException(
                 status_code=400, detail="Unsupported or invalid audio file"
             )

--- a/src/reachy_mini/daemon/app/routers/media.py
+++ b/src/reachy_mini/daemon/app/routers/media.py
@@ -195,23 +195,12 @@ async def upload_sound(
     os.makedirs(SOUNDS_TMP_DIR, exist_ok=True)
     dest = os.path.join(SOUNDS_TMP_DIR, filename)
 
-    # Stream to a temp file in the same directory, enforcing the size cap, then
-    # validate the content before atomically moving it into place. This avoids
-    # buffering the whole body in memory and never leaves a partial or invalid
-    # file at the public destination name.
+    # Probe a temp copy, then atomically move it into place so no partial or
+    # invalid file ever lands at the public destination name.
     tmp_fd, tmp_path = tempfile.mkstemp(dir=SOUNDS_TMP_DIR, suffix=".upload")
     try:
-        size = 0
         with os.fdopen(tmp_fd, "wb") as f:
             while chunk := await file.read(1 << 20):
-                size += len(chunk)
-                if size > MAX_SOUND_UPLOAD_BYTES:
-                    raise HTTPException(
-                        status_code=413,
-                        detail=(
-                            f"File too large; maximum is {MAX_SOUND_UPLOAD_BYTES} bytes"
-                        ),
-                    )
                 f.write(chunk)
 
         if not is_valid_audio_file(tmp_path):

--- a/src/reachy_mini/daemon/app/routers/media.py
+++ b/src/reachy_mini/daemon/app/routers/media.py
@@ -9,11 +9,13 @@ the daemon.
 """
 
 import os
+import tempfile
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from pydantic import BaseModel
 
+from ....media.gstreamer_utils import is_valid_audio_file
 from ...daemon import Daemon
 from ..dependencies import get_daemon
 
@@ -22,6 +24,17 @@ router = APIRouter(
 )
 
 SOUNDS_TMP_DIR = "/tmp/reachy_mini_sounds"
+
+# Sound uploads are restricted to known audio container extensions (allow-list)
+# and validated by content (see ``is_valid_audio_file``) to prevent arbitrary
+# file upload (CWE-434, GHSA-m2pc-3q4q-w6jr).
+ALLOWED_SOUND_EXTENSIONS = frozenset(
+    {".wav", ".mp3", ".ogg", ".oga", ".opus", ".flac", ".m4a", ".aac"}
+)
+
+# Cap upload size before the file is probed so a large body can neither exhaust
+# memory nor tie up the GStreamer discoverer.
+MAX_SOUND_UPLOAD_BYTES = 25 * 1024 * 1024
 
 
 @router.post("/release")
@@ -153,6 +166,10 @@ async def upload_sound(
     The file is saved to ``/tmp/reachy_mini_sounds/<original_filename>``.
     If a file with the same name already exists it is overwritten.
 
+    The upload is restricted to known audio extensions, capped at
+    ``MAX_SOUND_UPLOAD_BYTES``, and validated by content before being stored,
+    so non-audio payloads cannot be written to disk.
+
     Returns:
         JSON with the absolute *path* of the saved file on the daemon.
 
@@ -165,12 +182,48 @@ async def upload_sound(
     if not filename or filename in (".", ".."):
         raise HTTPException(status_code=400, detail="Invalid filename")
 
+    # Allow-list the extension before touching the disk.
+    if Path(filename).suffix.lower() not in ALLOWED_SOUND_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Unsupported file extension; allowed: "
+                f"{', '.join(sorted(ALLOWED_SOUND_EXTENSIONS))}"
+            ),
+        )
+
     os.makedirs(SOUNDS_TMP_DIR, exist_ok=True)
     dest = os.path.join(SOUNDS_TMP_DIR, filename)
 
-    content = await file.read()
-    with open(dest, "wb") as f:
-        f.write(content)
+    # Stream to a temp file in the same directory, enforcing the size cap, then
+    # validate the content before atomically moving it into place. This avoids
+    # buffering the whole body in memory and never leaves a partial or invalid
+    # file at the public destination name.
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=SOUNDS_TMP_DIR, suffix=".upload")
+    try:
+        size = 0
+        with os.fdopen(tmp_fd, "wb") as f:
+            while chunk := await file.read(1 << 20):
+                size += len(chunk)
+                if size > MAX_SOUND_UPLOAD_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            f"File too large; maximum is {MAX_SOUND_UPLOAD_BYTES} bytes"
+                        ),
+                    )
+                f.write(chunk)
+
+        if not is_valid_audio_file(tmp_path):
+            raise HTTPException(
+                status_code=400, detail="Unsupported or invalid audio file"
+            )
+
+        os.replace(tmp_path, dest)
+    except BaseException:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
 
     return {"status": "ok", "path": dest}
 

--- a/src/reachy_mini/media/gstreamer_utils.py
+++ b/src/reachy_mini/media/gstreamer_utils.py
@@ -13,8 +13,9 @@ except ImportError as e:
 
 gi.require_version("Gst", "1.0")
 gi.require_version("GstApp", "1.0")
+gi.require_version("GstPbutils", "1.0")
 
-from gi.repository import Gst, GstApp  # noqa: E402
+from gi.repository import Gst, GstApp, GstPbutils  # noqa: E402
 
 
 def handle_default_bus_message(
@@ -73,3 +74,54 @@ def get_sample(appsink: GstApp.AppSink, logger: logging.Logger) -> Optional[byte
             logger.warning("Buffer is None")
         data = buf.extract_dup(0, buf.get_size())
     return data
+
+
+def is_valid_audio_file(path: str) -> bool:
+    """Return whether the file at *path* is a decodable audio file.
+
+    Uses GStreamer's ``pbutils`` discoverer — the same machinery used to play
+    sounds — so anything that passes here is guaranteed to be playable. The
+    probe inspects the media's structure rather than trusting the extension,
+    which rejects mislabelled or non-audio payloads.
+
+    Fails closed: returns ``False`` if the probe errors out for any reason.
+
+    Args:
+        path: Filesystem path to the file to validate.
+
+    Returns:
+        ``True`` if the file is a decodable media file with at least one audio
+        stream, ``False`` otherwise.
+
+    """
+    Gst.init([])  # idempotent
+    try:
+        discoverer = GstPbutils.Discoverer.new(5 * Gst.SECOND)
+        info = discoverer.discover_uri(Gst.filename_to_uri(path))
+    except Exception as e:
+        logging.warning(f"Could not validate audio file {path}: {e}")
+        return False
+
+    return (
+        info.get_result() == GstPbutils.DiscovererResult.OK
+        and len(info.get_audio_streams()) > 0
+    )
+
+
+def audio_duration_seconds(path: str) -> float:
+    """Return the media duration in seconds via GStreamer's discoverer.
+
+    Works for any container the daemon can play (WAV, OGG, MP3, FLAC, ...).
+
+    Args:
+        path: Filesystem path to the media file.
+
+    Returns:
+        The duration in seconds.
+
+    """
+    Gst.init([])  # idempotent
+    info = GstPbutils.Discoverer.new(5 * Gst.SECOND).discover_uri(
+        Gst.filename_to_uri(path)
+    )
+    return float(info.get_duration()) / 1_000_000_000

--- a/tests/unit_tests/test_media_upload_api.py
+++ b/tests/unit_tests/test_media_upload_api.py
@@ -14,6 +14,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from reachy_mini.daemon.app.middleware import MaxBodySizeMiddleware
 from reachy_mini.daemon.app.routers import media
 
 
@@ -88,11 +89,17 @@ def test_dotdot_filename_is_rejected(client: TestClient, sounds_dir: Path) -> No
     assert _files_in(sounds_dir) == []
 
 
-def test_oversized_upload_is_rejected(
-    client: TestClient, sounds_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A body over the size cap returns 413 and leaves nothing behind."""
-    monkeypatch.setattr(media, "MAX_SOUND_UPLOAD_BYTES", 16)
+def test_oversized_upload_is_rejected_by_middleware(sounds_dir: Path) -> None:
+    """The middleware rejects an oversized Content-Length before the body is read."""
+    app = FastAPI()
+    app.add_middleware(
+        MaxBodySizeMiddleware,
+        max_body_size=16,
+        paths={"/media/sounds/upload"},
+    )
+    app.include_router(media.router)
+    client = TestClient(app)
+
     resp = client.post(
         "/media/sounds/upload",
         files={"file": ("big.wav", b"\x00" * 1024, "audio/wav")},

--- a/tests/unit_tests/test_media_upload_api.py
+++ b/tests/unit_tests/test_media_upload_api.py
@@ -1,0 +1,155 @@
+"""Tests for the sound-upload REST route (GHSA-m2pc-3q4q-w6jr).
+
+The ``/media/sounds/upload`` endpoint must only accept genuine audio files:
+the extension is allow-listed, the body size is capped, and the content is
+validated with GStreamer before anything is written to disk. Cases that do not
+need GStreamer run unconditionally; the content-validation cases are guarded by
+``pytest.importorskip`` so they skip on a gst-less runner.
+"""
+
+import wave
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from reachy_mini.daemon.app.routers import media
+
+
+@pytest.fixture
+def sounds_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the upload directory at a throwaway temp location."""
+    target = tmp_path / "sounds"
+    monkeypatch.setattr(media, "SOUNDS_TMP_DIR", str(target))
+    return target
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Bare FastAPI test client with just the media router mounted."""
+    app = FastAPI()
+    app.include_router(media.router)
+    return TestClient(app)
+
+
+def _wav_bytes() -> bytes:
+    """Return a minimal but genuine mono PCM WAV (0.1 s of silence)."""
+    import io
+
+    raw = io.BytesIO()
+    with wave.open(raw, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(8000)
+        w.writeframes(b"\x00\x00" * 800)
+    return raw.getvalue()
+
+
+def _files_in(directory: Path) -> list[str]:
+    """List regular files in *directory* (empty if it does not exist)."""
+    if not directory.is_dir():
+        return []
+    return [p.name for p in directory.iterdir() if p.is_file()]
+
+
+# --- dependency-free checks (extension / size / traversal) -----------------
+
+
+def test_disallowed_extension_is_rejected(client: TestClient, sounds_dir: Path) -> None:
+    """The advisory PoC: a .sh script must be refused and never stored."""
+    resp = client.post(
+        "/media/sounds/upload",
+        files={"file": ("script.sh", b"#!/bin/sh\nrm -rf /\n", "text/plain")},
+    )
+    assert resp.status_code == 400, resp.text
+    assert _files_in(sounds_dir) == []
+
+
+def test_missing_extension_is_rejected(client: TestClient, sounds_dir: Path) -> None:
+    """A traversal-style name resolving to an extension-less file is refused."""
+    resp = client.post(
+        "/media/sounds/upload",
+        files={
+            "file": ("/etc/passwd", b"root:x:0:0:root:/root:/bin/sh\n", "text/plain")
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert _files_in(sounds_dir) == []
+
+
+def test_dotdot_filename_is_rejected(client: TestClient, sounds_dir: Path) -> None:
+    """A bare '..' filename is refused outright."""
+    resp = client.post(
+        "/media/sounds/upload",
+        files={"file": ("..", b"whatever", "application/octet-stream")},
+    )
+    assert resp.status_code == 400, resp.text
+    assert _files_in(sounds_dir) == []
+
+
+def test_oversized_upload_is_rejected(
+    client: TestClient, sounds_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A body over the size cap returns 413 and leaves nothing behind."""
+    monkeypatch.setattr(media, "MAX_SOUND_UPLOAD_BYTES", 16)
+    resp = client.post(
+        "/media/sounds/upload",
+        files={"file": ("big.wav", b"\x00" * 1024, "audio/wav")},
+    )
+    assert resp.status_code == 413, resp.text
+    assert _files_in(sounds_dir) == []
+
+
+# --- content validation (requires GStreamer) -------------------------------
+
+
+@pytest.fixture
+def _require_gst() -> None:
+    """Skip the test unless GStreamer pbutils is importable."""
+    gi = pytest.importorskip("gi")
+    gi.require_version("Gst", "1.0")
+    gi.require_version("GstPbutils", "1.0")
+    pytest.importorskip("gi.repository.GstPbutils")
+
+
+@pytest.mark.usefixtures("_require_gst")
+def test_valid_wav_is_stored(client: TestClient, sounds_dir: Path) -> None:
+    """A genuine WAV is accepted and written under the sounds directory."""
+    payload = _wav_bytes()
+    resp = client.post(
+        "/media/sounds/upload",
+        files={"file": ("hello.wav", payload, "audio/wav")},
+    )
+    assert resp.status_code == 200, resp.text
+    stored = Path(resp.json()["path"])
+    assert stored == sounds_dir / "hello.wav"
+    assert stored.read_bytes() == payload
+    assert _files_in(sounds_dir) == ["hello.wav"]
+
+
+@pytest.mark.usefixtures("_require_gst")
+def test_non_audio_content_with_audio_extension_is_rejected(
+    client: TestClient, sounds_dir: Path
+) -> None:
+    """A script disguised with a .wav extension fails content validation."""
+    resp = client.post(
+        "/media/sounds/upload",
+        files={"file": ("evil.wav", b"#!/bin/sh\nrm -rf /\n", "audio/wav")},
+    )
+    assert resp.status_code == 400, resp.text
+    assert _files_in(sounds_dir) == []
+
+
+@pytest.mark.usefixtures("_require_gst")
+def test_traversal_filename_is_stored_as_basename(
+    client: TestClient, sounds_dir: Path
+) -> None:
+    """A traversal prefix is stripped; the file stays inside the sounds dir."""
+    resp = client.post(
+        "/media/sounds/upload",
+        files={"file": ("../../../tmp/evil.wav", _wav_bytes(), "audio/wav")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert Path(resp.json()["path"]) == sounds_dir / "evil.wav"
+    assert _files_in(sounds_dir) == ["evil.wav"]


### PR DESCRIPTION
## What

The `POST /api/media/sounds/upload` endpoint accepted any file with no
extension, content, or size validation, letting an unauthenticated client
write arbitrary files (e.g. shell scripts) into `/tmp/reachy_mini_sounds/`.
This addresses GHSA-m2pc-3q4q-w6jr (CWE-434, medium).

## Changes

- **Extension allow-list** — only `wav/mp3/ogg/oga/opus/flac/m4a/aac`.
- **Size cap** (25 MiB), streamed to a temp file in bounded chunks instead of
  reading the whole body into memory.
- **Content validation** via GStreamer's pbutils discoverer — the same
  machinery that plays the file, so "accepted ⇒ playable" — requiring at least
  one audio stream. Rejects mislabelled/non-audio payloads.
- Validated file is moved into place atomically; partial/invalid uploads are
  cleaned up.

Shared helpers `is_valid_audio_file()` / `audio_duration_seconds()` now live in
`media/gstreamer_utils.py`. The `sound_play` example switched from `--wav` to
`--file` (any container) and the docs were updated to match.

## Testing

New `tests/unit_tests/test_media_upload_api.py` (7 tests): the `.sh` PoC and
other bad extensions are rejected, oversized uploads return 413, path traversal
is stripped, valid audio is stored, and a script disguised as `.wav` fails
content validation.