### PR TITLE
chore(host): migrate MUI v7 to v9

### DIFF
--- a/ts/host/src/components/ConnectingView.tsx
+++ b/ts/host/src/components/ConnectingView.tsx
@@ -78,11 +78,15 @@ export function ConnectingView({
       aria-live="polite"
     >
       <Stack
-        alignItems="center"
-        justifyContent="center"
         spacing={3.5}
-        sx={{ flex: 1, minHeight: 0, width: '100%', px: 3 }}
-      >
+        sx={{
+          alignItems: 'center',
+          justifyContent: 'center',
+          flex: 1,
+          minHeight: 0,
+          width: '100%',
+          px: 3
+        }}>
         {/* Hero illustration: the "Reachy connecting" hand-drawn SVG
             from the design system. Sits above the stepper to anchor
             the screen visually before the eye drops to the
@@ -124,7 +128,9 @@ export function ConnectingView({
           />
         </Stack>
 
-        <Stack alignItems="center" spacing={0.75}>
+        <Stack spacing={0.75} sx={{
+          alignItems: 'center'
+        }}>
           <Typography
             sx={{
               fontSize: TYPO.lg,

--- a/ts/host/src/components/ErrorView.tsx
+++ b/ts/host/src/components/ErrorView.tsx
@@ -57,7 +57,9 @@ export function ErrorView({
         </Box>
         <Stack spacing={1} sx={{ alignItems: 'center' }}>
           <Typography variant="h5">{title}</Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" sx={{
+            color: 'text.secondary'
+          }}>
             {message}
           </Typography>
         </Stack>

--- a/ts/host/src/components/LeavingView.tsx
+++ b/ts/host/src/components/LeavingView.tsx
@@ -46,11 +46,15 @@ export function LeavingView(): JSX.Element {
       aria-live="polite"
     >
       <Stack
-        alignItems="center"
-        justifyContent="center"
         spacing={2}
-        sx={{ flex: 1, minHeight: 0, width: '100%', px: 3 }}
-      >
+        sx={{
+          alignItems: 'center',
+          justifyContent: 'center',
+          flex: 1,
+          minHeight: 0,
+          width: '100%',
+          px: 3
+        }}>
         {/* Discreet, thin-stroked spinner. Size + thickness tuned
             to read as "a small ambient activity indicator" rather
             than "the focal point of the screen". `text.secondary`

--- a/ts/host/src/components/PickerView.tsx
+++ b/ts/host/src/components/PickerView.tsx
@@ -111,7 +111,9 @@ export function PickerView({
             py: 4,
           }}
         >
-          <Stack alignItems="center" spacing={2}>
+          <Stack spacing={2} sx={{
+            alignItems: 'center'
+          }}>
             <HeroBuste />
             <RobotsHeader
               isRefreshing={isRefreshing}
@@ -149,7 +151,6 @@ export function PickerView({
           )}
         </Stack>
       </Stack>
-
       <StickyRefreshBar
         onRefresh={onRefresh}
         isRefreshing={isRefreshing}
@@ -210,7 +211,12 @@ function RobotsHeader({
   }, [hasRobots, hasError, isRefreshing, count]);
 
   return (
-    <Stack alignItems="center" spacing={0.5} sx={{ width: '100%' }}>
+    <Stack
+      spacing={0.5}
+      sx={{
+        alignItems: 'center',
+        width: '100%'
+      }}>
       <Typography
         component="h1"
         sx={{
@@ -297,10 +303,11 @@ function RemoteRobotCard({
     >
       <Stack
         direction="row"
-        alignItems="center"
         spacing={2}
-        sx={{ width: '100%' }}
-      >
+        sx={{
+          alignItems: 'center',
+          width: '100%'
+        }}>
         <CardAvatar />
         {/* Two-row identity grid: name + transport chip, then id.
             Mirrors the mobile `RemoteRobotCard` so users moving
@@ -309,10 +316,11 @@ function RemoteRobotCard({
         <Stack sx={{ flex: 1, minWidth: 0 }} spacing={0.25}>
           <Stack
             direction="row"
-            alignItems="center"
             spacing={1}
-            sx={{ minWidth: 0 }}
-          >
+            sx={{
+              alignItems: 'center',
+              minWidth: 0
+            }}>
             <Typography
               sx={{
                 minWidth: 0,
@@ -483,17 +491,16 @@ function StickyRefreshBar({
 
   return (
     <Stack
-      alignItems="center"
       sx={{
+        alignItems: 'center',
         width: '100%',
         flexShrink: 0,
         pt: 1.5,
         pb: 2,
         px: 2,
         bgcolor: 'background.default',
-        borderTop: (theme) => `1px solid ${theme.palette.divider}`,
-      }}
-    >
+        borderTop: (theme) => `1px solid ${theme.palette.divider}`
+      }}>
       <Button
         variant="text"
         color="primary"
@@ -590,10 +597,11 @@ function LoadingState(): JSX.Element {
   return (
     <StateCard>
       <Stack
-        alignItems="center"
         spacing={1.5}
-        sx={{ color: 'text.secondary' }}
-      >
+        sx={{
+          alignItems: 'center',
+          color: 'text.secondary'
+        }}>
         <CircularProgress size={24} sx={{ color: 'text.secondary' }} />
         <Typography sx={{ fontSize: TYPO.sm, fontWeight: FONT_WEIGHT.medium }}>
           Asking Hugging Face for your robots…
@@ -613,10 +621,12 @@ function CenteredMessageState({
   return (
     <StateCard>
       <Stack
-        alignItems="center"
         spacing={0.75}
-        sx={{ textAlign: 'center', maxWidth: 280 }}
-      >
+        sx={{
+          alignItems: 'center',
+          textAlign: 'center',
+          maxWidth: 280
+        }}>
         <Typography
           sx={{
             fontSize: TYPO.lg,

--- a/ts/host/src/components/PostOAuthSplash.tsx
+++ b/ts/host/src/components/PostOAuthSplash.tsx
@@ -82,11 +82,12 @@ export function PostOAuthSplash(): JSX.Element {
         }}
       />
       <Stack
-        alignItems="center"
-        justifyContent="center"
         spacing={1}
-        sx={{ minHeight: CONTENT_MIN_HEIGHT }}
-      >
+        sx={{
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: CONTENT_MIN_HEIGHT
+        }}>
         <Typography
           component="h1"
           sx={{

--- a/ts/host/src/components/TopBar.tsx
+++ b/ts/host/src/components/TopBar.tsx
@@ -144,17 +144,16 @@ export function TopBar({
     >
       <Stack
         direction="row"
-        alignItems="center"
         spacing={1.25}
         sx={{
+          alignItems: 'center',
           py: 1,
           px: 2,
           // Same fixed height as the rest of the host shell expects
           // (the iframe layout reserves `--reachy-host-topbar-h`
           // px above it).
-          minHeight: 'var(--reachy-host-topbar-h)',
-        }}
-      >
+          minHeight: 'var(--reachy-host-topbar-h)'
+        }}>
         <AppLogo iconUrl={appIconUrl} emoji={appEmoji} />
         <Box sx={{ minWidth: 0, flex: 1 }}>
           <Typography
@@ -355,7 +354,6 @@ function AccountMenu({
           }}
         />
       </ButtonBase>
-
       <Menu
         anchorEl={anchorEl}
         open={open}
@@ -418,7 +416,9 @@ function AccountMenu({
           </ListItemIcon>
           <ListItemText
             primary="Sign out"
-            primaryTypographyProps={{ fontSize: 14, fontWeight: 500 }}
+            slotProps={{
+              primary: { sx: { fontSize: 14, fontWeight: 500 } }
+            }}
           />
         </MenuItem>
       </Menu>

--- a/ts/host/src/components/WelcomeBackOverlay.tsx
+++ b/ts/host/src/components/WelcomeBackOverlay.tsx
@@ -120,11 +120,12 @@ export function WelcomeBackOverlay({
           }}
         />
         <Stack
-          alignItems="center"
-          justifyContent="center"
           spacing={0.5}
-          sx={{ minHeight: CONTENT_MIN_HEIGHT }}
-        >
+          sx={{
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: CONTENT_MIN_HEIGHT
+          }}>
           <Typography
             component="h1"
             sx={{

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -12,8 +12,8 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@huggingface/hub": "^0.15.2",
-        "@mui/icons-material": "^7.3.5",
-        "@mui/material": "^7.3.5"
+        "@mui/icons-material": "^9.0.0",
+        "@mui/material": "^9.0.0"
       },
       "devDependencies": {
         "@types/node": "^25.7.0",
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.11.tgz",
-      "integrity": "sha512-a7I/b/nBTdXYz2cOSlEmkQ9WWE1x8FHpqMhFPp+Y1VPFxcOw91G5ELOHARQAGSPy5V+UCgJua6K/1x70bAtQPw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.1.1.tgz",
+      "integrity": "sha512-AupmMICbdJHqAh6FfOMaaiiIr7dfEgZJn5DFfiPuGNrbs+ZZy9cD1APwO0TSVBz5j08MJEEY6n7iC76/2wjMEA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -831,12 +831,12 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.11.tgz",
-      "integrity": "sha512-+hz5ilwHZ3djd5es3sCErLioqe/NhZcYTsV/TNXZAMdJdb23F4xzJjqnnZdnurc3S1+ietcssRNqieOhPQLZ7Q==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.1.1.tgz",
+      "integrity": "sha512-OXhm9DajemStb58AumM06DuPhHTa3XD36TFD4yf6WtJyNRO5DfEZbbnHlBg/US2Y2oOXwM/XurMTBOD6L/YYZw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -846,7 +846,7 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^7.3.11",
+        "@mui/material": "^9.1.1",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -857,23 +857,23 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.11.tgz",
-      "integrity": "sha512-yq8bPc3LxOwKRWpcjRgDkYFmpM6aKlARfESTmOQcvLYFeJwtHte2tw6hJDrb8sk8wcvpDprHEHVaoUU0MslIkw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.1.1.tgz",
+      "integrity": "sha512-Wv+gInjrpf99l1Q0oHe0eOWGTnlbkzs5nowClX65KCT/2fyPMwcbFEEkUsOHdpcHhB5UAbz/d7jlwt5ajWVvlA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/core-downloads-tracker": "^7.3.11",
-        "@mui/system": "^7.3.11",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.11",
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.1.1",
+        "@mui/system": "^9.1.1",
+        "@mui/types": "^9.1.1",
+        "@mui/utils": "^9.1.1",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.3",
+        "react-is": "^19.2.6",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -886,7 +886,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.11",
+        "@mui/material-pigment-css": "^9.1.1",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -907,13 +907,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.11.tgz",
-      "integrity": "sha512-9B+YKms0fRHbNrqp9tOT/DNbNnU5gyvJ1o3qAGXfq8GmZcbJnE3At9x07Zr/o0pkhzg4aDdwXVqe4+AcgtOCPA==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.1.1.tgz",
+      "integrity": "sha512-oH6c+d6sJ1CZT0Vg2/fHdUQ5zvo9Pn+f+WWk0tlQliHqqIRdN32DZ7UxjalW3LUj4OkHbdWR31biWuLxK9i7Cg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/utils": "^7.3.11",
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.1.1",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -934,12 +934,12 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
-      "integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.1.1.tgz",
+      "integrity": "sha512-neaYKdJfvEG54q8efHLJR7swpHG/gfSv9xGqW5iTSMsubD7yPCPFrhVBt284j1DOF3uZaaDJSHQL7gz6jGF21Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
+        "@babel/runtime": "^7.29.2",
         "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -968,16 +968,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.11.tgz",
-      "integrity": "sha512-7izwGWdNawAKpBKcRlx7f2gFnAAjmASBWvMcyX4YYEeLOFsbfGRbUYGInvnAcUeql3rPxI7F9Ft4oY2OLRz44g==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.1.1.tgz",
+      "integrity": "sha512-q+aqNa58QZUwmmyUvJKKrStrej+4BcWFw4M0Ug+zRylPIQgR64cqvBnE3QTfLZm4OXulydp8Hl3zwKxMayrdsA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/private-theming": "^7.3.11",
-        "@mui/styled-engine": "^7.3.10",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.11",
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.1.1",
+        "@mui/styled-engine": "^9.1.1",
+        "@mui/types": "^9.1.1",
+        "@mui/utils": "^9.1.1",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
@@ -1008,12 +1008,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.12",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
-      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.1.1.tgz",
+      "integrity": "sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1025,17 +1025,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.11.tgz",
-      "integrity": "sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.1.1.tgz",
+      "integrity": "sha512-qSNfnkzZMptaaWFFklpDf4NPJztgwsMDVfM/sSDt+wq4ssYSBhLYwwjuB6eS/+p2IUYbeRzHluzXbw0Zn7aI4A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/types": "^7.4.12",
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.1.1",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.3"
+        "react-is": "^19.2.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2251,9 +2251,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/react-transition-group": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -59,8 +59,8 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@huggingface/hub": "^0.15.2",
-    "@mui/icons-material": "^7.3.5",
-    "@mui/material": "^7.3.5"
+    "@mui/icons-material": "^9.0.0",
+    "@mui/material": "^9.0.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
## Summary

Bumps the host UI from MUI v7 to v9 (`@mui/material` and `@mui/icons-material` `^7.3.5` -> `^9.0.0`, resolved to `9.1.1`) and applies the MUI codemod across the host components.

## Changes

- **`ts/package.json` / `ts/package-lock.json`**: `@mui/material` and `@mui/icons-material` bumped to `^9.0.0` (resolved `9.1.1`).
- **Host components** (`PickerView`, `TopBar`, `ConnectingView`, `ErrorView`, `LeavingView`, `PostOAuthSplash`, `WelcomeBackOverlay`): move deprecated `Stack` shorthand layout props (`alignItems`, etc.) into the `sx` prop, per the MUI migration codemod.

## Test plan

- [x] `npm run build` (SDK + host via Vite + tsc) passes on v9
- [ ] Manual smoke test of the host UI (picker, top bar, connecting/error/leaving views, OAuth splash)

Made with [Cursor](https://cursor.com)