### PR TITLE
daemon: allow native app webview origins through CORS

### DIFF
--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -58,6 +58,11 @@ from reachy_mini.utils.wireless_version.startup_check import (
 
 logger = logging.getLogger(__name__)
 
+# Origins allowed to call the unauthenticated API cross-origin: localhost tooling
+# plus the native app webview schemes (Tauri/Capacitor), which a browser cannot
+# forge, so the drive-by protection of GHSA-p4cp-8gwf-3fgv holds.
+CORS_ORIGIN_REGEX = r"(https?://(localhost|127\.0\.0\.1)(:\d+)?|tauri://localhost|https?://tauri\.localhost|capacitor://localhost)"
+
 
 @dataclass
 class Args:
@@ -277,11 +282,11 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         paths={"/api/media/sounds/upload"},
     )
 
-    # Restrict cross-origin access to local browser tooling; everything else is
-    # same-origin, native, or WebRTC.
+    # Restrict cross-origin access to local browser tooling and the native app
+    # webviews (see CORS_ORIGIN_REGEX); everything else is same-origin or WebRTC.
     app.add_middleware(
         CORSMiddleware,
-        allow_origin_regex=r"https?://(localhost|127\.0\.0\.1)(:\d+)?",
+        allow_origin_regex=CORS_ORIGIN_REGEX,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/tests/unit_tests/test_daemon.py
+++ b/tests/unit_tests/test_daemon.py
@@ -1,11 +1,12 @@
 import asyncio
+import re
 import threading
 
 import numpy as np
 import pytest
 import uvicorn
 
-from reachy_mini.daemon.app.main import Args, create_app
+from reachy_mini.daemon.app.main import CORS_ORIGIN_REGEX, Args, create_app
 from reachy_mini.daemon.daemon import Daemon
 from reachy_mini.reachy_mini import ReachyMini
 
@@ -194,3 +195,27 @@ async def test_multi_robot_isolation() -> None:
         await daemon2.stop(goto_sleep_on_stop=False)
         await _stop_app_server(server1, thread1)
         await _stop_app_server(server2, thread2)
+
+
+def test_cors_origin_regex():
+    """Starlette fullmatches Origin against CORS_ORIGIN_REGEX (GHSA-p4cp-8gwf-3fgv)."""
+    pat = re.compile(CORS_ORIGIN_REGEX)
+    allowed = [
+        "http://localhost:3000",
+        "https://localhost",
+        "http://127.0.0.1:8000",
+        "tauri://localhost",
+        "https://tauri.localhost",
+        "capacitor://localhost",
+    ]
+    blocked = [
+        "http://evil.com",
+        "http://localhost.evil.com",
+        "https://reachy.tauri.localhost.evil.com",
+        "tauri://evil",
+        "capacitor://evil",
+    ]
+    for origin in allowed:
+        assert pat.fullmatch(origin), origin
+    for origin in blocked:
+        assert not pat.fullmatch(origin), origin


### PR DESCRIPTION
The v1.8.2 CORS lockdown (GHSA-p4cp-8gwf-3fgv) restricted cross-origin access to localhost/127.0.0.1. The desktop app's WiFi pre-flight probe (probeWifiHost.ts) does a direct, cross-origin browser fetch to the robot, bypassing the local proxy on purpose, so it carries the Tauri webview Origin (tauri://localhost, or tauri.localhost on Windows). That failed CORS, the browser dropped the response, and the app reported "Cannot reach <ip>" despite the daemon being bound and reachable.

Extend the allowlist to the native app webview schemes (Tauri/Capacitor) in addition to localhost. A browser cannot forge these origins, so the drive-by protection of the advisory still holds. Lift the pattern to a CORS_ORIGIN_REGEX constant so the new test asserts against the same source.

Assisted-by: Claude:claude-opus-4-8[1m]