### PR TITLE
feat(audio): let moves carry non-wav sound files

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -1633,7 +1633,9 @@ class Backend:
             import base64
             raw = base64.b64decode(payload, validate=False)
             os.makedirs(self._audio_temp_dir, exist_ok=True)
-            path = os.path.join(self._audio_temp_dir, f"{cmd.upload_id}.wav")
+            # encoding "<container>-base64" → file extension; wav for legacy clients.
+            ext = str(meta.get("encoding", "wav-base64")).split("-")[0] or "wav"
+            path = os.path.join(self._audio_temp_dir, f"{cmd.upload_id}.{ext}")
             with open(path, "wb") as f:
                 f.write(raw)
         except Exception as e:

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -526,11 +526,10 @@ class UploadAudioStartCmd(BaseModel):
     matching move is held until either a matching move arrives or
     the TTL expires.
 
-    ``encoding`` is currently always ``"wav-base64"``: raw PCM WAV
-    bytes (any container the GStreamer playbin can decode) sliced
-    into chunks and base64-encoded.  Defined as an enum so a future
-    encoding (raw binary frames, opus, ...) can be added without
-    breaking older clients.
+    ``encoding`` is ``"<container>-base64"``: transport is always
+    base64, the prefix just sets the written file's extension (playbin
+    sniffs content, so playback works regardless).  Defaults to
+    ``"wav-base64"`` for older clients.
     """
 
     type: Literal["upload_audio_start"] = "upload_audio_start"
@@ -541,7 +540,16 @@ class UploadAudioStartCmd(BaseModel):
     # exposing the CM4 to multi-GB allocations on a misbehaving
     # client.
     total_chunks: int = Field(..., ge=1, le=16384)
-    encoding: Literal["wav-base64"] = "wav-base64"
+    encoding: Literal[
+        "wav-base64",
+        "mp3-base64",
+        "ogg-base64",
+        "oga-base64",
+        "opus-base64",
+        "flac-base64",
+        "m4a-base64",
+        "aac-base64",
+    ] = "wav-base64"
     description: str = ""
 
 

--- a/src/reachy_mini/motion/recorded_move.py
+++ b/src/reachy_mini/motion/recorded_move.py
@@ -16,6 +16,9 @@ from reachy_mini.utils.interpolation import linear_pose_interpolation
 
 logger = logging.getLogger(__name__)
 
+# Sidecar audio containers; mirrors media.py ALLOWED_SOUND_EXTENSIONS. .wav wins ties.
+SOUND_EXTENSIONS = (".wav", ".mp3", ".ogg", ".oga", ".opus", ".flac", ".m4a", ".aac")
+
 # Default datasets to preload at daemon startup
 DEFAULT_DATASETS = [
     "pollen-robotics/reachy-mini-emotions-library",
@@ -200,11 +203,14 @@ class RecordedMoves:
             move = json.load(open(move_path, "r"))
             self.moves[move_name] = move
 
-            sound_path = move_path.with_suffix(".wav")
-            self.sounds[move_name] = None
-
-            if os.path.exists(sound_path):
-                self.sounds[move_name] = sound_path
+            self.sounds[move_name] = next(
+                (
+                    p
+                    for ext in SOUND_EXTENSIONS
+                    if (p := move_path.with_suffix(ext)).exists()
+                ),
+                None,
+            )
 
     def get(self, move_name: str) -> RecordedMove:
         """Get a recorded move by name."""


### PR DESCRIPTION
GStreamer playbin already sniffs content, so non-wav audio plays fine; the only wav assumptions were in naming/lookup, not playback.

- recorded_move: dataset sidecar lookup tries all containers the daemon can play (wav/mp3/ogg/oga/opus/flac/m4a/aac), wav winning ties, instead of only .wav. This is what actually unblocks bundled non-wav moves.
- protocol: generalize UploadAudioStartCmd.encoding from wav-base64 to any "<container>-base64"; wav-base64 stays the default so older clients are unaffected.
- daemon: _handle_audio_finish derives the written extension from the declared encoding instead of hard-coding .wav.

The TS SDK still sends encoding='wav-base64', so live uploads stay wav until it's updated; this only widens what the daemon accepts.

Assisted-by: Claude:claude-opus-4-8