### PR TITLE
Use capped exponential backoff for central relay reconnect

### DIFF
--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import logging
 import os
+import random
 import threading
 from enum import Enum
 from typing import Any, Callable, Optional
@@ -49,6 +50,8 @@ LOCAL_GSTREAMER_SIGNALING = "ws://127.0.0.1:8443"
 
 # Reconnection settings
 RECONNECT_INTERVAL = 5.0  # seconds
+MAX_RECONNECT_INTERVAL = 60.0  # seconds - cap for the reconnect backoff
+RECONNECT_BACKOFF_JITTER = 0.1  # fractional jitter (+0-10%) per backoff
 TOKEN_CHECK_INTERVAL = 30.0  # seconds - how often to check for token when not connected
 LOCAL_WS_CONNECT_TIMEOUT = 5.0  # seconds - timeout for local websocket connection
 LOCAL_WS_WELCOME_TIMEOUT = (
@@ -623,6 +626,22 @@ class CentralSignalingRelay:
         finally:
             self._closing = False
 
+    def _reconnect_delay(self) -> float:
+        """Return the next reconnect wait using capped exponential backoff.
+
+        The delay grows as ``RECONNECT_INTERVAL * 2 ** (attempts - 1)`` per
+        consecutive failed attempt, capped at ``MAX_RECONNECT_INTERVAL``, with
+        a small additive jitter to de-synchronize reconnects across a fleet.
+        ``_connection_attempts`` resets to 0 on a successful connection, so the
+        backoff restarts from ``RECONNECT_INTERVAL`` after recovery. The
+        ``_token_updated`` event still short-circuits the wait, so a login or
+        token refresh reconnects immediately regardless of the backoff.
+        """
+        exponent = min(max(self._connection_attempts - 1, 0), 20)
+        base: float = min(RECONNECT_INTERVAL * (2**exponent), MAX_RECONNECT_INTERVAL)
+        jitter: float = random.uniform(0.0, base * RECONNECT_BACKOFF_JITTER)
+        return base + jitter
+
     async def _run_loop(self) -> None:
         """Maintain connections and relay messages."""
         logger.info("[Central Relay] _run_loop started")
@@ -697,7 +716,8 @@ class CentralSignalingRelay:
                     self._token_updated.clear()
                     try:
                         await asyncio.wait_for(
-                            self._token_updated.wait(), timeout=RECONNECT_INTERVAL
+                            self._token_updated.wait(),
+                            timeout=self._reconnect_delay(),
                         )
                     except asyncio.TimeoutError:
                         pass

--- a/tests/unit_tests/test_central_signaling_relay.py
+++ b/tests/unit_tests/test_central_signaling_relay.py
@@ -22,6 +22,9 @@ from reachy_mini.media.central_signaling_relay import (
     HEARTBEAT_DEFAULT_INTERVAL,
     HEARTBEAT_MAX_INTERVAL,
     HEARTBEAT_MIN_INTERVAL,
+    MAX_RECONNECT_INTERVAL,
+    RECONNECT_BACKOFF_JITTER,
+    RECONNECT_INTERVAL,
     CentralSignalingRelay,
     RelayState,
     _clamp_heartbeat_interval,
@@ -522,3 +525,27 @@ def test_run_loop_backs_off_when_connect_returns_in_error_state(
     assert call_count == 3
     assert relay._connection_attempts == 2
     assert elapsed >= 0.1
+
+
+def test_reconnect_delay_grows_and_is_capped() -> None:
+    """``_reconnect_delay`` backs off exponentially and stays under the cap."""
+    relay = _make_relay()
+
+    relay._connection_attempts = 1
+    d1 = relay._reconnect_delay()
+    relay._connection_attempts = 2
+    d2 = relay._reconnect_delay()
+    relay._connection_attempts = 3
+    d3 = relay._reconnect_delay()
+
+    # Strictly increasing: the base doubles each step, and the additive
+    # jitter (<=10%) cannot make a later attempt shorter than an earlier one.
+    assert RECONNECT_INTERVAL <= d1 < d2 < d3
+
+    # Capped on long outages, even with the maximum jitter applied.
+    relay._connection_attempts = 1000
+    assert (
+        relay._reconnect_delay()
+        <= MAX_RECONNECT_INTERVAL * (1 + RECONNECT_BACKOFF_JITTER) + 1e-9
+    )
+


### PR DESCRIPTION
Follow-up to #1201, addressing #1165.

#1201 routes the 401/ERROR reconnect through the existing fixed `RECONNECT_INTERVAL` (5 s). That stops the storm, but a persistently unreachable central server is still retried every 5 s. This swaps the fixed wait for a capped exponential backoff (5 s → … → `MAX_RECONNECT_INTERVAL`, 60 s) with a small additive jitter to de-synchronize reconnects across a fleet.

`_connection_attempts` already resets to 0 on a successful connection (and via `update_token` / `force_reconnect`), so the backoff restarts from 5 s after recovery, and the `_token_updated` event still short-circuits the wait — a login / token refresh reconnects immediately.

On the auth-failure circuit breaker also floated in #1165: I left it out on purpose. The loop already re-fetches the token on every attempt and resets the counter on success, so a token that becomes valid self-heals on the next retry even without `update_token` firing. A hard "stop retrying until token update" breaker would regress that and could get stuck on a transient 401; the capped backoff stops the hammering while keeping recovery automatic. Happy to add the breaker if you'd prefer it.

Added a unit test covering the backoff growth and cap; the existing relay tests still pass. `MAX_RECONNECT_INTERVAL` and the jitter fraction are easy to tune.
