### PR TITLE
feat(sdk): forward audio container type on upload instead of forcing wav

### DIFF
--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -24,6 +24,7 @@ import {
     bytesToBase64,
     gzipBase64,
     clampVolume,
+    audioUploadEncoding,
 } from './upload-helpers.js';
 import type {
     ApplyAudioConfigOptions,
@@ -1508,7 +1509,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
                 type: 'upload_audio_start',
                 upload_id: uploadId,
                 total_chunks: audioTotal,
-                encoding: 'wav-base64',
+                encoding: audioUploadEncoding(audioBlob),
                 description,
             });
             for (let i = 0; i < audioTotal; i++) {
@@ -1607,7 +1608,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
             type: 'upload_audio_start',
             upload_id: uploadId,
             total_chunks: total,
-            encoding: 'wav-base64',
+            encoding: audioUploadEncoding(audioBlob),
             description,
         });
         for (let i = 0; i < total; i++) {

--- a/ts/lib/upload-helpers.ts
+++ b/ts/lib/upload-helpers.ts
@@ -53,3 +53,42 @@ export function clampVolume(v: number): number {
     const n = Math.round(Number(v) || 0);
     return Math.max(0, Math.min(100, n));
 }
+
+/**
+ * Map an audio Blob to the daemon's `"<container>-base64"` upload encoding.
+ *
+ * Transport is always base64; the prefix only tells the daemon which file
+ * extension to write so GStreamer playbin picks the right demuxer (playbin
+ * also sniffs content, so this is a hint, not a hard requirement). We forward
+ * the Blob's own MIME type rather than forcing WAV — the daemon already decodes
+ * any container it supports. Unknown or empty types fall back to `wav-base64`,
+ * so legacy WAV recordings and untyped Blobs are unchanged.
+ *
+ * Container set mirrors the daemon's `UploadAudioStartCmd.encoding` enum and
+ * `media.py` `ALLOWED_SOUND_EXTENSIONS`.
+ */
+export function audioUploadEncoding(blob: Blob): string {
+    const mime = (blob.type || '').toLowerCase().split(';')[0]?.trim() ?? '';
+    switch (mime) {
+        case 'audio/ogg':
+        case 'application/ogg':
+            return 'ogg-base64';
+        case 'audio/opus':
+            return 'opus-base64';
+        case 'audio/mpeg':
+        case 'audio/mp3':
+            return 'mp3-base64';
+        case 'audio/flac':
+        case 'audio/x-flac':
+            return 'flac-base64';
+        case 'audio/mp4':
+        case 'audio/m4a':
+        case 'audio/x-m4a':
+            return 'm4a-base64';
+        case 'audio/aac':
+            return 'aac-base64';
+        default:
+            // audio/wav, audio/x-wav, audio/wave, unknown, or empty.
+            return 'wav-base64';
+    }
+}


### PR DESCRIPTION
The daemon (UploadAudioStartCmd.encoding) already accepts any <container>-base64 and GStreamer playbin decodes whatever it's given, so the TS SDK shouldn't narrow valid audio to WAV. Derive the upload encoding from the audioBlob's MIME type, defaulting to wav-base64 for untyped/legacy blobs. Unblocks bundling Opus/Ogg move audio from the Marionette apps.

Closes #1232 