### PR TITLE
Stop /state/ws/full streaming loop when backend is no longer ready

### DIFF
--- a/src/reachy_mini/daemon/app/routers/state.py
+++ b/src/reachy_mini/daemon/app/routers/state.py
@@ -149,7 +149,7 @@ async def ws_full_state(
     period = 1.0 / frequency
 
     try:
-        while True:
+        while backend.ready.is_set():
             full_state = await get_full_state(
                 with_head_pose=with_head_pose,
                 with_target_head_pose=with_target_head_pose,


### PR DESCRIPTION
Gate the `/state/ws/full` streaming loop on `backend.ready` so it exits cleanly when the daemon stops, instead of reading from the closed backend and throwing the AssertionError from the linked issue.
Closes https://github.com/pollen-robotics/reachy_mini/issues/1236