### PR TITLE
Feat/auto start app

### DIFF
--- a/src/reachy_mini/apps/sources/hf_space.py
+++ b/src/reachy_mini/apps/sources/hf_space.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+from datetime import date, datetime
 
 import aiohttp
 from huggingface_hub import HfApi
@@ -19,6 +20,23 @@ HF_SPACES_LIMIT = 500
 REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30)
 logger = logging.getLogger("reachy_mini.apps.sources.hf_space")
 SpaceData = dict[str, object]
+
+
+def _to_plain_json(value: object) -> object:
+    """Deep-convert HfApi objects to the plain-JSON types the HTTP API returns.
+
+    The HTTP spaces API hands back plain JSON, but the HfApi path yields
+    SpaceInfo objects whose nested fields (RepoSibling, datetimes, card data)
+    are not JSON-serializable. Round-tripping through json normalizes the
+    HfApi path to the same shape, so AppInfo.extra is always plain data.
+    """
+
+    def default(o: object) -> object:
+        if isinstance(o, (datetime, date)):
+            return o.isoformat()
+        return getattr(o, "__dict__", str(o))
+
+    return json.loads(json.dumps(value, default=default))
 
 
 def _coerce_space_data(value: object) -> SpaceData | None:
@@ -105,7 +123,7 @@ def _list_all_spaces_with_hf_api(token: str | None) -> list[SpaceData]:
     )
     payloads: list[SpaceData] = []
     for space in spaces:
-        space_data = _coerce_space_data(space.__dict__)
+        space_data = _coerce_space_data(_to_plain_json(space.__dict__))
         if space_data is None or _get_string(space_data, "id") is None:
             continue
         payloads.append(_normalize_space_data(space_data))

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -11,6 +11,7 @@ import argparse
 import asyncio
 import logging
 import types
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -23,6 +24,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from reachy_mini.apps import SourceKind
 from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.app.middleware import MaxBodySizeMiddleware
 from reachy_mini.daemon.app.routers import (
@@ -91,6 +93,7 @@ class Args:
 
     wake_up_on_start: bool = True
     goto_sleep_on_stop: bool = True
+    startup_app: str | None = None  # app name to auto-start after wake-up
     preload_datasets: bool = False
     dataset_update_interval_hours: float = 24.0  # 0 to disable periodic updates
 
@@ -113,6 +116,63 @@ def _resolve_bind_host(args: Args) -> str:
     if args.fastapi_host:
         return args.fastapi_host
     return "0.0.0.0" if args.wireless_version else "127.0.0.1"
+
+
+async def _ensure_startup_app_installed(app_manager: AppManager, name: str) -> bool:
+    """Install ``name`` from the catalog if it isn't already installed.
+
+    Runs *before* wake-up so a long download/install doesn't leave the robot
+    awake and idle. Installing needs no robot, only the apps venv. Best-effort:
+    returns True if the app is ready to start, False (logged) on any failure.
+    """
+    try:
+        installed = await app_manager.list_available_apps(SourceKind.INSTALLED)
+        if any(a.name == name for a in installed):
+            return True
+
+        catalog = await app_manager.list_available_apps(SourceKind.HF_SPACE)
+        match = next((a for a in catalog if a.name == name), None)
+        if match is None:
+            logger.error(f"Startup app '{name}' not installed and not in catalog")
+            return False
+
+        logger.info(f"Installing startup app: {name}")
+        await app_manager.install_new_app(match, logger)
+        return True
+    except Exception as e:
+        logger.error(f"Failed to install startup app '{name}': {e}")
+        return False
+
+
+async def _start_startup_app(app_manager: AppManager, name: str) -> None:
+    """Start ``name`` after wake-up. Best-effort: failures are logged, not raised."""
+    try:
+        logger.info(f"Auto-starting app: {name}")
+        await app_manager.start_app(name)
+    except Exception as e:
+        logger.error(f"Failed to auto-start app '{name}': {e}")
+
+
+def _make_startup_app_launcher(
+    app_manager: AppManager, name: str
+) -> Callable[[], None]:
+    """Build a one-shot, synchronous callback that launches the startup app.
+
+    Wired into the backend's wake-up hook so the app starts after the robot
+    first wakes (however that wake is triggered). Fires once — later wakes are
+    ignored — and schedules the async start as a task so the wake sequence is
+    not blocked.
+    """
+    launched = False
+
+    def launch() -> None:
+        nonlocal launched
+        if launched:
+            return
+        launched = True
+        asyncio.create_task(_start_startup_app(app_manager, name))
+
+    return launch
 
 
 def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> FastAPI:
@@ -169,6 +229,19 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
             )
 
         try:
+            # Install the startup app (if missing) before waking the robot, so a
+            # long download/install doesn't leave it awake and idle. The wireless
+            # unit boots asleep (--no-wake-up-on-start), so the app is started by
+            # a one-shot hook on the first wake-up rather than here.
+            on_wake_up_callback = None
+            if args.autostart and args.startup_app:
+                if await _ensure_startup_app_installed(
+                    app.state.app_manager, args.startup_app
+                ):
+                    on_wake_up_callback = _make_startup_app_launcher(
+                        app.state.app_manager, args.startup_app
+                    )
+
             if args.autostart:
                 await app.state.daemon.start(
                     serialport=args.serialport,
@@ -181,6 +254,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                     check_collision=args.check_collision,
                     wake_up_on_start=args.wake_up_on_start,
                     hardware_config_filepath=args.hardware_config_filepath,
+                    on_wake_up_callback=on_wake_up_callback,
                 )
 
             # Register mDNS service only after the daemon is ready
@@ -558,6 +632,14 @@ def main() -> None:
         action="store_false",
         dest="wake_up_on_start",
         help="Do not wake up the robot on daemon start (default: False).",
+    )
+    parser.add_argument(
+        "--startup-app",
+        type=str,
+        default=default_args.startup_app,
+        dest="startup_app",
+        help="Name of an app to start automatically after the robot wakes up "
+        "(installed from the catalog first if it isn't already installed).",
     )
     parser.add_argument(
         "--goto-sleep-on-stop",

--- a/src/reachy_mini/daemon/app/routers/state.py
+++ b/src/reachy_mini/daemon/app/routers/state.py
@@ -6,6 +6,7 @@ This exposes:
 """
 
 import asyncio
+import logging
 from datetime import datetime, timezone
 from typing import Any
 
@@ -14,6 +15,8 @@ from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from ....daemon.backend.abstract import Backend
 from ..dependencies import get_backend, ws_get_backend
 from ..models import AnyPose, DoAInfo, FullState, as_any_pose
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/state")
 
@@ -148,8 +151,9 @@ async def ws_full_state(
     await websocket.accept()
     period = 1.0 / frequency
 
-    try:
-        while True:
+    last_err: str | None = None
+    while True:
+        try:
             full_state = await get_full_state(
                 with_head_pose=with_head_pose,
                 with_target_head_pose=with_target_head_pose,
@@ -165,6 +169,14 @@ async def ws_full_state(
                 backend=backend,
             )
             await websocket.send_text(full_state.model_dump_json())
-            await asyncio.sleep(period)
-    except WebSocketDisconnect:
-        pass
+            last_err = None
+        except WebSocketDisconnect:
+            break
+        except Exception as e:
+            # transient backend read (e.g. motor comms): skip frame, keep stream
+            # alive; dedup so a persistent fault doesn't spam at stream frequency
+            msg = str(e)
+            if msg != last_err:
+                logger.warning(f"Skipping full-state frame: {msg}")
+                last_err = msg
+        await asyncio.sleep(period)

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -340,6 +340,11 @@ class Backend:
         # declines, or ``None`` once the update job has been accepted.
         self._start_update_callback: Optional[Callable[[bool], Optional[str]]] = None
 
+        # Synchronous callback fired once every time wake_up() completes. Wired
+        # in by `Daemon` to auto-start a configured startup app after the robot
+        # wakes (however the wake was triggered: on-start, button, or REST).
+        self._on_wake_up_callback: Optional[Callable[[], None]] = None
+
     # Life cycle methods
     def wrapped_run(self) -> None:
         """Run the backend in a try-except block to store errors."""
@@ -973,6 +978,9 @@ class Backend:
 
         # Go back to the initial position
         await self.goto_target(self.INIT_HEAD_POSE, duration=0.2)
+
+        if self._on_wake_up_callback is not None:
+            self._on_wake_up_callback()
 
     async def goto_sleep(self) -> None:
         """Put the robot to sleep by moving the head and antennas to a predefined sleep position.
@@ -2116,6 +2124,16 @@ class Backend:
         running), or ``None`` once the job has been accepted.
         """
         self._start_update_callback = callback
+
+    def set_on_wake_up_callback(self, callback: Callable[[], None]) -> None:
+        """Wire a callback fired once each time ``wake_up()`` completes.
+
+        ``Daemon`` injects this to auto-start a configured startup app after
+        the robot wakes, regardless of how the wake was triggered. The callback
+        runs inside the event loop, so it must return promptly (it schedules
+        any async work as a task).
+        """
+        self._on_wake_up_callback = callback
 
     def setup_media_server(self, media_server: Any) -> None:
         """Connect the backend to the media server.

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import time
+from collections.abc import Callable
 from importlib.metadata import PackageNotFoundError, version
 from threading import Event, Thread
 from typing import Any, Optional
@@ -231,6 +232,7 @@ class Daemon:
         headless: bool = False,
         use_audio: bool = True,  # kept for backward compat, overridden by no_media
         hardware_config_filepath: str | None = None,
+        on_wake_up_callback: Callable[[], None] | None = None,
     ) -> "DaemonState":
         """Start the Reachy Mini daemon.
 
@@ -245,6 +247,7 @@ class Daemon:
             headless (bool): If True, run Mujoco in headless mode (no GUI). Defaults to False.
             use_audio (bool): If True, enable audio. Defaults to True.
             hardware_config_filepath (str | None): Path to the hardware configuration YAML file. Defaults to None.
+            on_wake_up_callback (Callable[[], None] | None): Fired once each time the robot finishes waking up. Defaults to None.
 
         Returns:
             DaemonState: The current state of the daemon after attempting to start it.
@@ -339,6 +342,11 @@ class Daemon:
 
                 # Start central signaling relay for remote WebRTC access
                 await self._start_central_signaling_relay()
+
+            # Wire the wake-up hook before any wake can fire (on-start below, or
+            # later via button/REST on the wireless unit, which boots asleep).
+            if on_wake_up_callback is not None:
+                self.backend.set_on_wake_up_callback(on_wake_up_callback)
 
             if wake_up_on_start:
                 try:

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -1036,27 +1036,6 @@ class GstMediaServer:
             )
             return
 
-        # Prevent PulseAudio/PipeWire audio sources from becoming the
-        # pipeline clock provider.  Their clock causes unixfdsink to stall
-        # because it cannot synchronise video buffers against the audio
-        # clock.  ALSA sources (wireless CM4) don't have this issue and
-        # must keep their default clock behaviour to match the original
-        # daemon.  autoaudiosrc is a GstBin and does not expose the
-        # property at all.
-        factory = audiosrc.get_factory()
-        factory_name = factory.get_name() if factory else ""
-        if (
-            factory_name != "alsasrc"
-            and factory_name != "osxaudiosrc"
-            and audiosrc.find_property("provide-clock") is not None
-        ):
-            audiosrc.set_property("provide-clock", False)
-            self._logger.debug(f"Set provide-clock=False on {factory_name}")
-        else:
-            self._logger.debug(
-                f"{factory_name} — keeping default provide-clock behaviour."
-            )
-
         queue = Gst.ElementFactory.make("queue", "queue_audiosrc")
         pipeline.add(audiosrc)
         pipeline.add(queue)
@@ -1068,6 +1047,8 @@ class GstMediaServer:
         # needed, so disable AEC if either is unavailable.
         self._aec_enabled = False
         webrtcdsp = None
+        factory = audiosrc.get_factory()
+        factory_name = factory.get_name() if factory else ""
         if factory_name == "autoaudiosrc":
             if self._webrtcechoprobe is None:
                 self._webrtcechoprobe = Gst.ElementFactory.make("webrtcechoprobe")

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -249,7 +249,11 @@ class ReachyMini:
 
         """
         def _send_offsets(offsets: tuple[float, float, float, float, float, float]) -> None:
-            self.client.send_command(SetSpeechOffsetsCmd(offsets=list(offsets)))
+            try:
+                self.client.send_command(SetSpeechOffsetsCmd(offsets=list(offsets)))
+            except ConnectionError:
+                # best-effort cosmetic motion; ws may already be closing at teardown
+                pass
 
         # Enable SDK-side wobbling (LOCAL backend only, no-op for WEBRTC)
         self.media_manager.enable_wobbling(_send_offsets)

--- a/tests/unit_tests/test_app_metadata.py
+++ b/tests/unit_tests/test_app_metadata.py
@@ -1,0 +1,27 @@
+import json
+from dataclasses import dataclass
+from datetime import datetime
+
+from reachy_mini.apps.sources.hf_space import _to_plain_json
+
+
+@dataclass
+class _FakeSibling:
+    rfilename: str
+
+
+def test_to_plain_json_normalizes_hf_objects() -> None:
+    # Mirrors a SpaceInfo.__dict__: nested SDK objects + datetimes that the raw
+    # HfApi path would otherwise leave non-serializable in AppInfo.extra.
+    raw = {
+        "id": "owner/app",
+        "siblings": [_FakeSibling("app/__main__.py")],
+        "created_at": datetime(2024, 1, 2, 3, 4, 5),
+    }
+
+    plain = _to_plain_json(raw)
+
+    # Result must be pure JSON (no exception) and match the HTTP API shape.
+    json.dumps(plain)  # must not raise
+    assert plain["siblings"][0]["rfilename"] == "app/__main__.py"
+    assert plain["created_at"] == "2024-01-02T03:04:05"

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -1,0 +1,95 @@
+import asyncio
+
+import pytest
+
+from reachy_mini.apps import AppInfo, SourceKind
+from reachy_mini.daemon.app.main import (
+    _ensure_startup_app_installed,
+    _make_startup_app_launcher,
+    _start_startup_app,
+)
+
+
+class StubAppManager:
+    """Records install/start calls and serves canned app lists per source."""
+
+    def __init__(self, installed: list[str], catalog: list[str]) -> None:
+        self._installed = installed
+        self._catalog = catalog
+        self.installed_calls: list[str] = []
+        self.started: list[str] = []
+
+    async def list_available_apps(self, source: SourceKind) -> list[AppInfo]:
+        names = self._installed if source == SourceKind.INSTALLED else self._catalog
+        return [AppInfo(name=n, source_kind=source) for n in names]
+
+    async def install_new_app(self, app: AppInfo, logger: object) -> None:
+        self.installed_calls.append(app.name)
+        self._installed.append(app.name)
+
+    async def start_app(self, name: str) -> None:
+        self.started.append(name)
+
+
+@pytest.mark.asyncio
+async def test_already_installed_is_ready_without_install() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=["foo", "bar"])
+    assert await _ensure_startup_app_installed(mgr, "foo") is True  # type: ignore[arg-type]
+    assert mgr.installed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_app_installed_from_catalog() -> None:
+    mgr = StubAppManager(installed=[], catalog=["bar"])
+    assert await _ensure_startup_app_installed(mgr, "bar") is True  # type: ignore[arg-type]
+    assert mgr.installed_calls == ["bar"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_app_not_ready_and_not_installed() -> None:
+    mgr = StubAppManager(installed=[], catalog=["bar"])
+    assert await _ensure_startup_app_installed(mgr, "nope") is False  # type: ignore[arg-type]
+    assert mgr.installed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_install_failure_returns_false() -> None:
+    mgr = StubAppManager(installed=[], catalog=["bar"])
+
+    async def boom(app: AppInfo, logger: object) -> None:
+        raise RuntimeError("network down")
+
+    mgr.install_new_app = boom  # type: ignore[assignment]
+    assert await _ensure_startup_app_installed(mgr, "bar") is False  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_start_calls_start_app() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    await _start_startup_app(mgr, "foo")  # type: ignore[arg-type]
+    assert mgr.started == ["foo"]
+
+
+@pytest.mark.asyncio
+async def test_start_failure_is_swallowed() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+
+    async def boom(name: str) -> None:
+        raise RuntimeError("an app is already running")
+
+    mgr.start_app = boom  # type: ignore[assignment]
+    await _start_startup_app(mgr, "foo")  # must not raise  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_launcher_starts_app_once_across_multiple_wakes() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    launch = _make_startup_app_launcher(mgr, "foo")  # type: ignore[arg-type]
+
+    # Simulate several wake-ups; only the first should launch the app.
+    launch()
+    launch()
+    launch()
+    await asyncio.sleep(0)  # let the scheduled task(s) run
+
+    assert mgr.started == ["foo"]


### PR DESCRIPTION
Auto-start an app after wake-up

Adds a `--startup-app` flag so the daemon launches a chosen app once the robot wakes up. It's **opt-in** (off by default) — a first step toward having the conversation app run out of the box.

### How it works
- **Install at boot:** if the app isn't already installed, it's fetched from the Hugging Face catalog and installed when the daemon starts (no robot needed to download into `apps_venv`), so it's ready before the robot wakes.
- **Start on first wake-up:** the app is launched by a one-shot hook fired when `wake_up()` completes — so it works however the wake is triggered (on-start, the desktop app, the button, or the REST endpoint). It fires only on the **first** wake; later wakes are ignored.
- Every step is best-effort: a bad app name or a failed install is logged and never blocks daemon startup.
- Includes a small fix: HfApi space metadata is normalized to JSON-plain so installing from the catalog in-process doesn't choke on non-serializable objects.

### Try it
The wireless unit boots asleep (`--no-wake-up-on-start`), so start the daemon with:

```bash
reachy-mini-daemon --wireless-version --no-wake-up-on-start --startup-app reachy_mini_conversation_app
```

Then wake it manually (motors must be enabled **first**, then play the wake animation):

```
http://reachy-mini.local:8000/docs#/default/set_motor_mode_api_motors_set_mode__mode__post
http://reachy-mini.local:8000/docs#/default/play_wake_up_api_move_play_wake_up_post
```

Or just open the **desktop app** — it enables motors, wakes the robot, and you'll see the conversation app running on the robot.

### Open questions / follow-ups
- **Persist the selected startup app** in a config file, tunable from the desktop/mobile apps (rather than a CLI flag). Likely a follow-up PR.
- **Wake-on-word / touch:** let the robot wake on its own so you don't need to open an app at all — the natural next step.