### PR TITLE
Start default app from antenna touch

### DIFF
--- a/docs/source/SDK/apps.md
+++ b/docs/source/SDK/apps.md
@@ -214,6 +214,31 @@ reachy-mini-daemon --sim    # Simulation
 
 Then open <a href="http://127.0.0.1:8000/">http://127.0.0.1:8000/</a> — your app appears in the installed list.
 
+### 4. Make an app start on wake-up or antenna touch
+
+Use the daemon's existing `--startup-app` option when you want one installed
+app to be the default experience:
+
+```bash
+reachy-mini-daemon --startup-app reachy_mini_conversation_app
+```
+
+If the app is not installed yet but exists in the app catalog, the daemon
+installs it before the robot wakes up. The app starts after wake-up. On an idle
+robot that is already running the daemon while asleep, touching an antenna also
+wakes the robot and starts the same startup app.
+
+For example, the Wireless flow keeps the daemon running without waking the
+robot immediately:
+
+```bash
+reachy-mini-daemon --wireless-version --no-wake-up-on-start --startup-app reachy_mini_conversation_app
+```
+
+No extra antenna-specific flag is needed: setting `--startup-app <app_name>` is
+the opt-in. The app only starts when the managed app slot is free, so it does
+not replace a running local app or an active remote session.
+
 ---
 
 ## Publishing to Hugging Face

--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -100,8 +100,19 @@ class AppManager:
             AppState.STOPPING,
         )
 
-    async def start_app(self, app_name: str, *args: Any, **kwargs: Any) -> AppStatus:
-        """Start the app as a subprocess, raises RuntimeError if an app is already running."""
+    async def start_app(
+        self,
+        app_name: str,
+        *args: Any,
+        evict_remote: bool = True,
+        **kwargs: Any,
+    ) -> AppStatus:
+        """Start the app as a subprocess.
+
+        Raises RuntimeError if an app is already running. When
+        ``evict_remote`` is false, a remote WebRTC session holding the app slot
+        makes the start fail instead of being evicted.
+        """
         if self.is_app_running():
             raise RuntimeError("An app is already running")
 
@@ -112,43 +123,48 @@ class AppManager:
         # the normal case, but the lock is the single source of truth
         # shared with the relay thread).
         if self.daemon is not None:
-            await self.daemon.robot_app_lock.acquire_local_evicting_remote(app_name)
+            if evict_remote:
+                await self.daemon.robot_app_lock.acquire_local_evicting_remote(
+                    app_name
+                )
+            elif not self.daemon.robot_app_lock.try_acquire_local(app_name):
+                raise RuntimeError("The robot app slot is already in use")
 
-        # Get module name and Python path for subprocess execution
-        module_name = local_common_venv.get_app_module(
-            app_name, self.wireless_version, self.desktop_app_daemon
-        )
-        python_path = local_common_venv.get_app_python(
-            app_name, self.wireless_version, self.desktop_app_daemon
-        )
-
-        # Launch app as subprocess with unbuffered output.
-        #
-        # Scrub GStreamer env vars that the daemon's own `.venv/.../gstreamer_bundle.pth`
-        # set pointing at paths inside the daemon's .venv. The app runs in apps_venv and
-        # its own gstreamer_bundle.pth will set fresh values at Python startup. Leaving
-        # the parent's values in place is actively harmful:
-        #   * Single-value vars like GST_REGISTRY_1_0 and GST_PLUGIN_SCANNER_1_0 get
-        #     prepended to (via gstreamer_libs.setup_python_environment) producing a
-        #     malformed `apps_venv_path:.venv_path` string that GStreamer can't parse.
-        #   * The app ends up using .venv's plugin scanner binary and registry cache,
-        #     which can mask issues specific to apps_venv's own gstreamer install.
-        # See pollen-robotics/reachy-mini-desktop-app#185.
-        app_env = os.environ.copy()
-        for key in (
-            "GST_PLUGIN_PATH_1_0",
-            "GST_PLUGIN_SYSTEM_PATH_1_0",
-            "GST_REGISTRY_1_0",
-            "GST_PLUGIN_SCANNER_1_0",
-            "GI_TYPELIB_PATH",
-            "PYGI_DLL_DIRS",
-            "XDG_DATA_DIRS",
-            "XDG_CONFIG_DIRS",
-        ):
-            app_env.pop(key, None)
-
-        self.logger.getChild("runner").info(f"Starting app {app_name}")
         try:
+            # Get module name and Python path for subprocess execution.
+            module_name = local_common_venv.get_app_module(
+                app_name, self.wireless_version, self.desktop_app_daemon
+            )
+            python_path = local_common_venv.get_app_python(
+                app_name, self.wireless_version, self.desktop_app_daemon
+            )
+
+            # Launch app as subprocess with unbuffered output.
+            #
+            # Scrub GStreamer env vars that the daemon's own `.venv/.../gstreamer_bundle.pth`
+            # set pointing at paths inside the daemon's .venv. The app runs in apps_venv and
+            # its own gstreamer_bundle.pth will set fresh values at Python startup. Leaving
+            # the parent's values in place is actively harmful:
+            #   * Single-value vars like GST_REGISTRY_1_0 and GST_PLUGIN_SCANNER_1_0 get
+            #     prepended to (via gstreamer_libs.setup_python_environment) producing a
+            #     malformed `apps_venv_path:.venv_path` string that GStreamer can't parse.
+            #   * The app ends up using .venv's plugin scanner binary and registry cache,
+            #     which can mask issues specific to apps_venv's own gstreamer install.
+            # See pollen-robotics/reachy-mini-desktop-app#185.
+            app_env = os.environ.copy()
+            for key in (
+                "GST_PLUGIN_PATH_1_0",
+                "GST_PLUGIN_SYSTEM_PATH_1_0",
+                "GST_REGISTRY_1_0",
+                "GST_PLUGIN_SCANNER_1_0",
+                "GI_TYPELIB_PATH",
+                "PYGI_DLL_DIRS",
+                "XDG_DATA_DIRS",
+                "XDG_CONFIG_DIRS",
+            ):
+                app_env.pop(key, None)
+
+            self.logger.getChild("runner").info(f"Starting app {app_name}")
             process = await asyncio.create_subprocess_exec(
                 str(python_path),
                 "-u",  # Unbuffered stdout/stderr for real-time logging
@@ -165,7 +181,6 @@ class AppManager:
             if self.daemon is not None:
                 self.daemon.robot_app_lock.release_local(app_name)
             raise
-
 
         # Create status and monitor task
         status = AppStatus(

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -43,6 +43,7 @@ from reachy_mini.daemon.app.routers import (
     volume,
 )
 from reachy_mini.daemon.daemon import Daemon
+from reachy_mini.daemon.robot_app_lock import RobotAppLockState
 from reachy_mini.daemon.utils import SimulationMode
 from reachy_mini.media.audio_utils import (
     check_reachymini_asoundrc,
@@ -64,6 +65,9 @@ logger = logging.getLogger(__name__)
 # plus the native app webview schemes (Tauri/Capacitor), which a browser cannot
 # forge, so the drive-by protection of GHSA-p4cp-8gwf-3fgv holds.
 CORS_ORIGIN_REGEX = r"(https?://(localhost|127\.0\.0\.1)(:\d+)?|tauri://localhost|https?://tauri\.localhost|capacitor://localhost)"
+
+STARTUP_APP_ANTENNA_IDLE_POLL_INTERVAL_S = 0.1
+STARTUP_APP_ANTENNA_BLOCKED_POLL_INTERVAL_S = 0.5
 
 
 @dataclass
@@ -175,6 +179,134 @@ def _make_startup_app_launcher(
     return launch
 
 
+@dataclass
+class _AntennaTouchDetector:
+    """Hysteresis detector for antenna touches relative to commanded target."""
+
+    press_delta_rad: float = 0.25
+    release_delta_rad: float = 0.10
+    _armed: bool = False
+
+    def reset(self) -> None:
+        """Disarm until both antennas are back near their target positions."""
+        self._armed = False
+
+    def update(
+        self,
+        present: tuple[float, float],
+        target: tuple[float, float],
+    ) -> bool:
+        """Return True once when either antenna is pushed away from target."""
+        delta = max(abs(p - t) for p, t in zip(present, target))
+
+        if not self._armed:
+            if delta <= self.release_delta_rad:
+                self._armed = True
+            return False
+
+        if delta >= self.press_delta_rad:
+            self._armed = False
+            return True
+
+        return False
+
+
+def _as_antenna_pair(values: Any) -> tuple[float, float] | None:
+    """Convert a backend antenna vector to a typed pair, or None if missing."""
+    if values is None:
+        return None
+
+    try:
+        return (float(values[0]), float(values[1]))
+    except (IndexError, TypeError, ValueError):
+        return None
+
+
+def _read_current_antenna_pair(backend: Any) -> tuple[float, float] | None:
+    """Read cached antenna positions when available, falling back to backend API."""
+    current = _as_antenna_pair(
+        getattr(backend, "current_antenna_joint_positions", None)
+    )
+    if current is not None:
+        return current
+
+    return _as_antenna_pair(backend.get_present_antenna_joint_positions())
+
+
+def _startup_app_slot_is_free(app_manager: AppManager, daemon: Daemon) -> bool:
+    """Return whether no managed local or remote app currently owns the robot."""
+    return (
+        not app_manager.is_app_running()
+        and daemon.robot_app_lock.status().state == RobotAppLockState.FREE
+    )
+
+
+async def _start_startup_app_if_idle(
+    app_manager: AppManager,
+    daemon: Daemon,
+    name: str,
+) -> bool:
+    """Start the startup app only if the managed app slot is still free."""
+    if not _startup_app_slot_is_free(app_manager, daemon):
+        return False
+
+    try:
+        logger.info(f"Auto-starting app from antenna touch: {name}")
+        await app_manager.start_app(name, evict_remote=False)
+        return True
+    except Exception as e:
+        logger.error(f"Failed to auto-start app '{name}' from antenna touch: {e}")
+        return False
+
+
+async def _watch_antennas_for_startup_app(
+    app_manager: AppManager,
+    daemon: Daemon,
+    name: str,
+    *,
+    detector: _AntennaTouchDetector | None = None,
+    idle_poll_interval_s: float = STARTUP_APP_ANTENNA_IDLE_POLL_INTERVAL_S,
+    blocked_poll_interval_s: float = STARTUP_APP_ANTENNA_BLOCKED_POLL_INTERVAL_S,
+) -> None:
+    """Start the startup app when an idle robot receives an antenna touch."""
+    detector = detector or _AntennaTouchDetector()
+    detector.reset()
+
+    while True:
+        try:
+            backend = daemon.backend
+            if backend is None or not backend.ready.is_set():
+                detector.reset()
+                await asyncio.sleep(blocked_poll_interval_s)
+                continue
+
+            if not _startup_app_slot_is_free(app_manager, daemon):
+                detector.reset()
+                await asyncio.sleep(blocked_poll_interval_s)
+                continue
+
+            present = _read_current_antenna_pair(backend)
+            target = _as_antenna_pair(backend.target_antenna_joint_positions)
+            if present is None or target is None:
+                detector.reset()
+                await asyncio.sleep(idle_poll_interval_s)
+                continue
+
+            if detector.update(present, target):
+                await _start_startup_app_if_idle(app_manager, daemon, name)
+                await asyncio.sleep(blocked_poll_interval_s)
+                continue
+
+            await asyncio.sleep(idle_poll_interval_s)
+        except asyncio.CancelledError:
+            logger.info("Startup app antenna watcher cancelled")
+            raise
+        except Exception as e:
+            logger.warning(f"Startup app antenna watcher error: {e}")
+            detector.reset()
+            await asyncio.sleep(blocked_poll_interval_s)
+
+
 def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
 
@@ -183,6 +315,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         """Lifespan context manager for the FastAPI application."""
         args = app.state.args  # type: Args
         dataset_updater_task: asyncio.Task[None] | None = None
+        startup_app_antenna_watcher_task: asyncio.Task[None] | None = None
 
         mdns = MdnsServiceRegistration(
             args.robot_name,
@@ -234,10 +367,12 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
             # unit boots asleep (--no-wake-up-on-start), so the app is started by
             # a one-shot hook on the first wake-up rather than here.
             on_wake_up_callback = None
+            startup_app_ready = False
             if args.autostart and args.startup_app:
                 if await _ensure_startup_app_installed(
                     app.state.app_manager, args.startup_app
                 ):
+                    startup_app_ready = True
                     on_wake_up_callback = _make_startup_app_launcher(
                         app.state.app_manager, args.startup_app
                     )
@@ -257,6 +392,24 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                     on_wake_up_callback=on_wake_up_callback,
                 )
 
+            if (
+                args.autostart
+                and args.startup_app
+                and startup_app_ready
+                and app.state.daemon.backend is not None
+            ):
+                startup_app_antenna_watcher_task = asyncio.create_task(
+                    _watch_antennas_for_startup_app(
+                        app.state.app_manager,
+                        app.state.daemon,
+                        args.startup_app,
+                    )
+                )
+                logger.info(
+                    "Startup app antenna watcher started for app: "
+                    f"{args.startup_app}"
+                )
+
             # Register mDNS service only after the daemon is ready
             mdns.register()
 
@@ -267,6 +420,17 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                 dataset_updater_task.cancel()
                 try:
                     await dataset_updater_task
+                except asyncio.CancelledError:
+                    pass
+
+            # Cancel startup app antenna watcher before closing the app manager.
+            if (
+                startup_app_antenna_watcher_task
+                and not startup_app_antenna_watcher_task.done()
+            ):
+                startup_app_antenna_watcher_task.cancel()
+                try:
+                    await startup_app_antenna_watcher_task
                 except asyncio.CancelledError:
                     pass
 

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -220,8 +220,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                     )
                 )
                 logger.info(
-                    "Startup app antenna watcher started for app: "
-                    f"{args.startup_app}"
+                    f"Startup app antenna watcher started for app: {args.startup_app}"
                 )
 
             # Register mDNS service only after the daemon is ready
@@ -617,7 +616,8 @@ def main() -> None:
         default=default_args.startup_app,
         dest="startup_app",
         help="Name of an app to start automatically after the robot wakes up "
-        "(installed from the catalog first if it isn't already installed).",
+        "and from an idle antenna touch (installed from the catalog first if "
+        "it isn't already installed).",
     )
     parser.add_argument(
         "--goto-sleep-on-stop",

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -11,7 +11,6 @@ import argparse
 import asyncio
 import logging
 import types
-from collections.abc import Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,7 +23,6 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from reachy_mini.apps import SourceKind
 from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.app.middleware import MaxBodySizeMiddleware
 from reachy_mini.daemon.app.routers import (
@@ -42,8 +40,12 @@ from reachy_mini.daemon.app.routers import (
     state,
     volume,
 )
+from reachy_mini.daemon.app.startup_app import (
+    ensure_startup_app_installed,
+    make_startup_app_launcher,
+    watch_antennas_for_startup_app,
+)
 from reachy_mini.daemon.daemon import Daemon
-from reachy_mini.daemon.robot_app_lock import RobotAppLockState
 from reachy_mini.daemon.utils import SimulationMode
 from reachy_mini.media.audio_utils import (
     check_reachymini_asoundrc,
@@ -65,9 +67,6 @@ logger = logging.getLogger(__name__)
 # plus the native app webview schemes (Tauri/Capacitor), which a browser cannot
 # forge, so the drive-by protection of GHSA-p4cp-8gwf-3fgv holds.
 CORS_ORIGIN_REGEX = r"(https?://(localhost|127\.0\.0\.1)(:\d+)?|tauri://localhost|https?://tauri\.localhost|capacitor://localhost)"
-
-STARTUP_APP_ANTENNA_IDLE_POLL_INTERVAL_S = 0.1
-STARTUP_APP_ANTENNA_BLOCKED_POLL_INTERVAL_S = 0.5
 
 
 @dataclass
@@ -120,191 +119,6 @@ def _resolve_bind_host(args: Args) -> str:
     if args.fastapi_host:
         return args.fastapi_host
     return "0.0.0.0" if args.wireless_version else "127.0.0.1"
-
-
-async def _ensure_startup_app_installed(app_manager: AppManager, name: str) -> bool:
-    """Install ``name`` from the catalog if it isn't already installed.
-
-    Runs *before* wake-up so a long download/install doesn't leave the robot
-    awake and idle. Installing needs no robot, only the apps venv. Best-effort:
-    returns True if the app is ready to start, False (logged) on any failure.
-    """
-    try:
-        installed = await app_manager.list_available_apps(SourceKind.INSTALLED)
-        if any(a.name == name for a in installed):
-            return True
-
-        catalog = await app_manager.list_available_apps(SourceKind.HF_SPACE)
-        match = next((a for a in catalog if a.name == name), None)
-        if match is None:
-            logger.error(f"Startup app '{name}' not installed and not in catalog")
-            return False
-
-        logger.info(f"Installing startup app: {name}")
-        await app_manager.install_new_app(match, logger)
-        return True
-    except Exception as e:
-        logger.error(f"Failed to install startup app '{name}': {e}")
-        return False
-
-
-async def _start_startup_app(app_manager: AppManager, name: str) -> None:
-    """Start ``name`` after wake-up. Best-effort: failures are logged, not raised."""
-    try:
-        logger.info(f"Auto-starting app: {name}")
-        await app_manager.start_app(name)
-    except Exception as e:
-        logger.error(f"Failed to auto-start app '{name}': {e}")
-
-
-def _make_startup_app_launcher(
-    app_manager: AppManager, name: str
-) -> Callable[[], None]:
-    """Build a one-shot, synchronous callback that launches the startup app.
-
-    Wired into the backend's wake-up hook so the app starts after the robot
-    first wakes (however that wake is triggered). Fires once — later wakes are
-    ignored — and schedules the async start as a task so the wake sequence is
-    not blocked.
-    """
-    launched = False
-
-    def launch() -> None:
-        nonlocal launched
-        if launched:
-            return
-        launched = True
-        asyncio.create_task(_start_startup_app(app_manager, name))
-
-    return launch
-
-
-@dataclass
-class _AntennaTouchDetector:
-    """Hysteresis detector for antenna touches relative to commanded target."""
-
-    press_delta_rad: float = 0.25
-    release_delta_rad: float = 0.10
-    _armed: bool = False
-
-    def reset(self) -> None:
-        """Disarm until both antennas are back near their target positions."""
-        self._armed = False
-
-    def update(
-        self,
-        present: tuple[float, float],
-        target: tuple[float, float],
-    ) -> bool:
-        """Return True once when either antenna is pushed away from target."""
-        delta = max(abs(p - t) for p, t in zip(present, target))
-
-        if not self._armed:
-            if delta <= self.release_delta_rad:
-                self._armed = True
-            return False
-
-        if delta >= self.press_delta_rad:
-            self._armed = False
-            return True
-
-        return False
-
-
-def _as_antenna_pair(values: Any) -> tuple[float, float] | None:
-    """Convert a backend antenna vector to a typed pair, or None if missing."""
-    if values is None:
-        return None
-
-    try:
-        return (float(values[0]), float(values[1]))
-    except (IndexError, TypeError, ValueError):
-        return None
-
-
-def _read_current_antenna_pair(backend: Any) -> tuple[float, float] | None:
-    """Read cached antenna positions when available, falling back to backend API."""
-    current = _as_antenna_pair(
-        getattr(backend, "current_antenna_joint_positions", None)
-    )
-    if current is not None:
-        return current
-
-    return _as_antenna_pair(backend.get_present_antenna_joint_positions())
-
-
-def _startup_app_slot_is_free(app_manager: AppManager, daemon: Daemon) -> bool:
-    """Return whether no managed local or remote app currently owns the robot."""
-    return (
-        not app_manager.is_app_running()
-        and daemon.robot_app_lock.status().state == RobotAppLockState.FREE
-    )
-
-
-async def _start_startup_app_if_idle(
-    app_manager: AppManager,
-    daemon: Daemon,
-    name: str,
-) -> bool:
-    """Start the startup app only if the managed app slot is still free."""
-    if not _startup_app_slot_is_free(app_manager, daemon):
-        return False
-
-    try:
-        logger.info(f"Auto-starting app from antenna touch: {name}")
-        await app_manager.start_app(name, evict_remote=False)
-        return True
-    except Exception as e:
-        logger.error(f"Failed to auto-start app '{name}' from antenna touch: {e}")
-        return False
-
-
-async def _watch_antennas_for_startup_app(
-    app_manager: AppManager,
-    daemon: Daemon,
-    name: str,
-    *,
-    detector: _AntennaTouchDetector | None = None,
-    idle_poll_interval_s: float = STARTUP_APP_ANTENNA_IDLE_POLL_INTERVAL_S,
-    blocked_poll_interval_s: float = STARTUP_APP_ANTENNA_BLOCKED_POLL_INTERVAL_S,
-) -> None:
-    """Start the startup app when an idle robot receives an antenna touch."""
-    detector = detector or _AntennaTouchDetector()
-    detector.reset()
-
-    while True:
-        try:
-            backend = daemon.backend
-            if backend is None or not backend.ready.is_set():
-                detector.reset()
-                await asyncio.sleep(blocked_poll_interval_s)
-                continue
-
-            if not _startup_app_slot_is_free(app_manager, daemon):
-                detector.reset()
-                await asyncio.sleep(blocked_poll_interval_s)
-                continue
-
-            present = _read_current_antenna_pair(backend)
-            target = _as_antenna_pair(backend.target_antenna_joint_positions)
-            if present is None or target is None:
-                detector.reset()
-                await asyncio.sleep(idle_poll_interval_s)
-                continue
-
-            if detector.update(present, target):
-                await _start_startup_app_if_idle(app_manager, daemon, name)
-                await asyncio.sleep(blocked_poll_interval_s)
-                continue
-
-            await asyncio.sleep(idle_poll_interval_s)
-        except asyncio.CancelledError:
-            logger.info("Startup app antenna watcher cancelled")
-            raise
-        except Exception as e:
-            logger.warning(f"Startup app antenna watcher error: {e}")
-            detector.reset()
-            await asyncio.sleep(blocked_poll_interval_s)
 
 
 def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> FastAPI:
@@ -369,11 +183,11 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
             on_wake_up_callback = None
             startup_app_ready = False
             if args.autostart and args.startup_app:
-                if await _ensure_startup_app_installed(
+                if await ensure_startup_app_installed(
                     app.state.app_manager, args.startup_app
                 ):
                     startup_app_ready = True
-                    on_wake_up_callback = _make_startup_app_launcher(
+                    on_wake_up_callback = make_startup_app_launcher(
                         app.state.app_manager, args.startup_app
                     )
 
@@ -399,7 +213,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                 and app.state.daemon.backend is not None
             ):
                 startup_app_antenna_watcher_task = asyncio.create_task(
-                    _watch_antennas_for_startup_app(
+                    watch_antennas_for_startup_app(
                         app.state.app_manager,
                         app.state.daemon,
                         args.startup_app,

--- a/src/reachy_mini/daemon/app/startup_app.py
+++ b/src/reachy_mini/daemon/app/startup_app.py
@@ -6,9 +6,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-import numpy as np
-from scipy.spatial.transform import Rotation as R
-
 from reachy_mini.apps import SourceKind
 from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.robot_app_lock import RobotAppLockState
@@ -167,19 +164,8 @@ async def start_startup_app_if_idle(
 
 
 async def play_awake_startup_cue(backend: Any) -> None:
-    """Play the wake sound and head tilt without running the full wake-up pose."""
-    try:
-        start_pose = np.array(backend.get_current_head_pose(), dtype=float).copy()
-    except Exception:
-        start_pose = np.array(backend.INIT_HEAD_POSE, dtype=float).copy()
-
-    tilt_pose = start_pose.copy()
-    roll = R.from_euler("xyz", [20, 0, 0], degrees=True).as_matrix()
-    tilt_pose[:3, :3] = roll @ start_pose[:3, :3]
-
+    """Play the wake sound without running the full wake-up pose."""
     backend.play_sound("wake_up.wav")
-    await backend.goto_target(tilt_pose, duration=0.2)
-    await backend.goto_target(start_pose, duration=0.2)
 
 
 async def wake_or_start_startup_app_if_idle(

--- a/src/reachy_mini/daemon/app/startup_app.py
+++ b/src/reachy_mini/daemon/app/startup_app.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from reachy_mini.apps import SourceKind
 from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.robot_app_lock import RobotAppLockState
+from reachy_mini.io.protocol import MotorControlMode
 
 if TYPE_CHECKING:
     from reachy_mini.daemon.daemon import Daemon
@@ -49,7 +50,7 @@ async def start_startup_app(app_manager: AppManager, name: str) -> None:
     """Start ``name`` after wake-up. Best-effort: failures are logged, not raised."""
     try:
         logger.info(f"Auto-starting app: {name}")
-        await app_manager.start_app(name)
+        await app_manager.start_app(name, evict_remote=False)
     except Exception as e:
         logger.error(f"Failed to auto-start app '{name}': {e}")
 
@@ -81,19 +82,29 @@ class AntennaTouchDetector:
 
     press_delta_rad: float = 0.25
     release_delta_rad: float = 0.10
+    _reference: tuple[float, float] | None = None
     _armed: bool = False
 
     def reset(self) -> None:
         """Disarm until both antennas are back near their target positions."""
+        self._reference = None
         self._armed = False
 
     def update(
         self,
         present: tuple[float, float],
-        target: tuple[float, float],
+        target: tuple[float, float] | None = None,
     ) -> bool:
-        """Return True once when either antenna is pushed away from target."""
-        delta = max(abs(p - t) for p, t in zip(present, target))
+        """Return True once when either antenna is pushed away from reference."""
+        if target is not None:
+            self._reference = target
+        elif self._reference is None:
+            self._reference = present
+            self._armed = True
+            return False
+
+        assert self._reference is not None
+        delta = max(abs(p - r) for p, r in zip(present, self._reference))
 
         if not self._armed:
             if delta <= self.release_delta_rad:
@@ -155,6 +166,31 @@ async def start_startup_app_if_idle(
         return False
 
 
+async def wake_or_start_startup_app_if_idle(
+    app_manager: AppManager,
+    daemon: "Daemon",
+    name: str,
+) -> bool:
+    """Wake a sleeping idle robot, then start the startup app if still idle."""
+    if not _startup_app_slot_is_free(app_manager, daemon):
+        return False
+
+    backend = daemon.backend
+    if backend is None:
+        return False
+
+    try:
+        if backend.get_motor_control_mode() == MotorControlMode.Disabled:
+            logger.info(f"Waking up from antenna touch before starting app: {name}")
+            backend.set_motor_control_mode(MotorControlMode.Enabled)
+            await backend.wake_up()
+
+        return await start_startup_app_if_idle(app_manager, daemon, name)
+    except Exception as e:
+        logger.error(f"Failed to wake/start app '{name}' from antenna touch: {e}")
+        return False
+
+
 async def watch_antennas_for_startup_app(
     app_manager: AppManager,
     daemon: "Daemon",
@@ -183,13 +219,13 @@ async def watch_antennas_for_startup_app(
 
             present = _read_current_antenna_pair(backend)
             target = _as_antenna_pair(backend.target_antenna_joint_positions)
-            if present is None or target is None:
+            if present is None:
                 detector.reset()
                 await asyncio.sleep(idle_poll_interval_s)
                 continue
 
             if detector.update(present, target):
-                await start_startup_app_if_idle(app_manager, daemon, name)
+                await wake_or_start_startup_app_if_idle(app_manager, daemon, name)
                 await asyncio.sleep(blocked_poll_interval_s)
                 continue
 

--- a/src/reachy_mini/daemon/app/startup_app.py
+++ b/src/reachy_mini/daemon/app/startup_app.py
@@ -6,6 +6,9 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
 from reachy_mini.apps import SourceKind
 from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.robot_app_lock import RobotAppLockState
@@ -163,6 +166,22 @@ async def start_startup_app_if_idle(
         return False
 
 
+async def play_awake_startup_cue(backend: Any) -> None:
+    """Play the wake sound and head tilt without running the full wake-up pose."""
+    try:
+        start_pose = np.array(backend.get_current_head_pose(), dtype=float).copy()
+    except Exception:
+        start_pose = np.array(backend.INIT_HEAD_POSE, dtype=float).copy()
+
+    tilt_pose = start_pose.copy()
+    roll = R.from_euler("xyz", [20, 0, 0], degrees=True).as_matrix()
+    tilt_pose[:3, :3] = roll @ start_pose[:3, :3]
+
+    backend.play_sound("wake_up.wav")
+    await backend.goto_target(tilt_pose, duration=0.2)
+    await backend.goto_target(start_pose, duration=0.2)
+
+
 async def wake_or_start_startup_app_if_idle(
     app_manager: AppManager,
     daemon: "Daemon",
@@ -181,6 +200,10 @@ async def wake_or_start_startup_app_if_idle(
             logger.info(f"Waking up from antenna touch before starting app: {name}")
             backend.set_motor_control_mode(MotorControlMode.Enabled)
             await backend.wake_up()
+            if not _startup_app_slot_is_free(app_manager, daemon):
+                return True
+        else:
+            await play_awake_startup_cue(backend)
 
         return await start_startup_app_if_idle(app_manager, daemon, name)
     except Exception as e:

--- a/src/reachy_mini/daemon/app/startup_app.py
+++ b/src/reachy_mini/daemon/app/startup_app.py
@@ -1,0 +1,203 @@
+"""Helpers for daemon startup-app installation and idle antenna launch."""
+
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from reachy_mini.apps import SourceKind
+from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon.robot_app_lock import RobotAppLockState
+
+if TYPE_CHECKING:
+    from reachy_mini.daemon.daemon import Daemon
+
+logger = logging.getLogger(__name__)
+
+STARTUP_APP_ANTENNA_IDLE_POLL_INTERVAL_S = 0.1
+STARTUP_APP_ANTENNA_BLOCKED_POLL_INTERVAL_S = 0.5
+
+
+async def ensure_startup_app_installed(app_manager: AppManager, name: str) -> bool:
+    """Install ``name`` from the catalog if it isn't already installed.
+
+    Runs before wake-up so a long download/install doesn't leave the robot
+    awake and idle. Installing needs no robot, only the apps venv. Best-effort:
+    returns True if the app is ready to start, False (logged) on any failure.
+    """
+    try:
+        installed = await app_manager.list_available_apps(SourceKind.INSTALLED)
+        if any(a.name == name for a in installed):
+            return True
+
+        catalog = await app_manager.list_available_apps(SourceKind.HF_SPACE)
+        match = next((a for a in catalog if a.name == name), None)
+        if match is None:
+            logger.error(f"Startup app '{name}' not installed and not in catalog")
+            return False
+
+        logger.info(f"Installing startup app: {name}")
+        await app_manager.install_new_app(match, logger)
+        return True
+    except Exception as e:
+        logger.error(f"Failed to install startup app '{name}': {e}")
+        return False
+
+
+async def start_startup_app(app_manager: AppManager, name: str) -> None:
+    """Start ``name`` after wake-up. Best-effort: failures are logged, not raised."""
+    try:
+        logger.info(f"Auto-starting app: {name}")
+        await app_manager.start_app(name)
+    except Exception as e:
+        logger.error(f"Failed to auto-start app '{name}': {e}")
+
+
+def make_startup_app_launcher(
+    app_manager: AppManager, name: str
+) -> Callable[[], None]:
+    """Build a one-shot, synchronous callback that launches the startup app.
+
+    Wired into the backend's wake-up hook so the app starts after the robot
+    first wakes, however that wake is triggered. Fires once and schedules the
+    async start as a task so the wake sequence is not blocked.
+    """
+    launched = False
+
+    def launch() -> None:
+        nonlocal launched
+        if launched:
+            return
+        launched = True
+        asyncio.create_task(start_startup_app(app_manager, name))
+
+    return launch
+
+
+@dataclass
+class AntennaTouchDetector:
+    """Hysteresis detector for antenna touches relative to commanded target."""
+
+    press_delta_rad: float = 0.25
+    release_delta_rad: float = 0.10
+    _armed: bool = False
+
+    def reset(self) -> None:
+        """Disarm until both antennas are back near their target positions."""
+        self._armed = False
+
+    def update(
+        self,
+        present: tuple[float, float],
+        target: tuple[float, float],
+    ) -> bool:
+        """Return True once when either antenna is pushed away from target."""
+        delta = max(abs(p - t) for p, t in zip(present, target))
+
+        if not self._armed:
+            if delta <= self.release_delta_rad:
+                self._armed = True
+            return False
+
+        if delta >= self.press_delta_rad:
+            self._armed = False
+            return True
+
+        return False
+
+
+def _as_antenna_pair(values: Any) -> tuple[float, float] | None:
+    """Convert a backend antenna vector to a typed pair, or None if missing."""
+    if values is None:
+        return None
+
+    try:
+        return (float(values[0]), float(values[1]))
+    except (IndexError, TypeError, ValueError):
+        return None
+
+
+def _read_current_antenna_pair(backend: Any) -> tuple[float, float] | None:
+    """Read cached antenna positions when available, falling back to backend API."""
+    current = _as_antenna_pair(
+        getattr(backend, "current_antenna_joint_positions", None)
+    )
+    if current is not None:
+        return current
+
+    return _as_antenna_pair(backend.get_present_antenna_joint_positions())
+
+
+def _startup_app_slot_is_free(app_manager: AppManager, daemon: "Daemon") -> bool:
+    """Return whether no managed local or remote app currently owns the robot."""
+    return (
+        not app_manager.is_app_running()
+        and daemon.robot_app_lock.status().state == RobotAppLockState.FREE
+    )
+
+
+async def start_startup_app_if_idle(
+    app_manager: AppManager,
+    daemon: "Daemon",
+    name: str,
+) -> bool:
+    """Start the startup app only if the managed app slot is still free."""
+    if not _startup_app_slot_is_free(app_manager, daemon):
+        return False
+
+    try:
+        logger.info(f"Auto-starting app from antenna touch: {name}")
+        await app_manager.start_app(name, evict_remote=False)
+        return True
+    except Exception as e:
+        logger.error(f"Failed to auto-start app '{name}' from antenna touch: {e}")
+        return False
+
+
+async def watch_antennas_for_startup_app(
+    app_manager: AppManager,
+    daemon: "Daemon",
+    name: str,
+    *,
+    detector: AntennaTouchDetector | None = None,
+    idle_poll_interval_s: float = STARTUP_APP_ANTENNA_IDLE_POLL_INTERVAL_S,
+    blocked_poll_interval_s: float = STARTUP_APP_ANTENNA_BLOCKED_POLL_INTERVAL_S,
+) -> None:
+    """Start the startup app when an idle robot receives an antenna touch."""
+    detector = detector or AntennaTouchDetector()
+    detector.reset()
+
+    while True:
+        try:
+            backend = daemon.backend
+            if backend is None or not backend.ready.is_set():
+                detector.reset()
+                await asyncio.sleep(blocked_poll_interval_s)
+                continue
+
+            if not _startup_app_slot_is_free(app_manager, daemon):
+                detector.reset()
+                await asyncio.sleep(blocked_poll_interval_s)
+                continue
+
+            present = _read_current_antenna_pair(backend)
+            target = _as_antenna_pair(backend.target_antenna_joint_positions)
+            if present is None or target is None:
+                detector.reset()
+                await asyncio.sleep(idle_poll_interval_s)
+                continue
+
+            if detector.update(present, target):
+                await start_startup_app_if_idle(app_manager, daemon, name)
+                await asyncio.sleep(blocked_poll_interval_s)
+                continue
+
+            await asyncio.sleep(idle_poll_interval_s)
+        except asyncio.CancelledError:
+            logger.info("Startup app antenna watcher cancelled")
+            raise
+        except Exception as e:
+            logger.warning(f"Startup app antenna watcher error: {e}")
+            detector.reset()
+            await asyncio.sleep(blocked_poll_interval_s)

--- a/src/reachy_mini/daemon/app/startup_app.py
+++ b/src/reachy_mini/daemon/app/startup_app.py
@@ -55,9 +55,7 @@ async def start_startup_app(app_manager: AppManager, name: str) -> None:
         logger.error(f"Failed to auto-start app '{name}': {e}")
 
 
-def make_startup_app_launcher(
-    app_manager: AppManager, name: str
-) -> Callable[[], None]:
+def make_startup_app_launcher(app_manager: AppManager, name: str) -> Callable[[], None]:
     """Build a one-shot, synchronous callback that launches the startup app.
 
     Wired into the backend's wake-up hook so the app starts after the robot
@@ -186,6 +184,10 @@ async def wake_or_start_startup_app_if_idle(
             logger.info(f"Waking up from antenna touch before starting app: {name}")
             backend.set_motor_control_mode(MotorControlMode.Enabled)
             await backend.wake_up()
+            # wake_up() may fire the daemon-level startup-app callback, which
+            # schedules the same app start as a task. Yield once so that task
+            # can acquire the app slot before this antenna path checks it.
+            await asyncio.sleep(0)
             if not _startup_app_slot_is_free(app_manager, daemon):
                 return True
         else:
@@ -230,7 +232,11 @@ async def watch_antennas_for_startup_app(
                 continue
 
             if detector.update(present):
-                await wake_or_start_startup_app_if_idle(app_manager, daemon, name)
+                started = await wake_or_start_startup_app_if_idle(
+                    app_manager, daemon, name
+                )
+                if not started:
+                    detector.reset()
                 await asyncio.sleep(blocked_poll_interval_s)
                 continue
 

--- a/src/reachy_mini/daemon/app/startup_app.py
+++ b/src/reachy_mini/daemon/app/startup_app.py
@@ -78,7 +78,7 @@ def make_startup_app_launcher(
 
 @dataclass
 class AntennaTouchDetector:
-    """Hysteresis detector for antenna touches relative to commanded target."""
+    """Hysteresis detector for antenna touches relative to the idle pose."""
 
     press_delta_rad: float = 0.25
     release_delta_rad: float = 0.10
@@ -93,12 +93,9 @@ class AntennaTouchDetector:
     def update(
         self,
         present: tuple[float, float],
-        target: tuple[float, float] | None = None,
     ) -> bool:
         """Return True once when either antenna is pushed away from reference."""
-        if target is not None:
-            self._reference = target
-        elif self._reference is None:
+        if self._reference is None:
             self._reference = present
             self._armed = True
             return False
@@ -218,13 +215,12 @@ async def watch_antennas_for_startup_app(
                 continue
 
             present = _read_current_antenna_pair(backend)
-            target = _as_antenna_pair(backend.target_antenna_joint_positions)
             if present is None:
                 detector.reset()
                 await asyncio.sleep(idle_poll_interval_s)
                 continue
 
-            if detector.update(present, target):
+            if detector.update(present):
                 await wake_or_start_startup_app_if_idle(app_manager, daemon, name)
                 await asyncio.sleep(blocked_poll_interval_s)
                 continue

--- a/src/reachy_mini/daemon/robot_app_lock.py
+++ b/src/reachy_mini/daemon/robot_app_lock.py
@@ -112,6 +112,30 @@ class RobotAppLock:
     # Local acquire / release
     # ------------------------------------------------------------------
 
+    def try_acquire_local(self, app_name: str) -> bool:
+        """Acquire the lock for a local Python app only if the slot is free.
+
+        Returns:
+            True if the lock was acquired. False if another local app or a
+            remote session already holds it. Unlike
+            :meth:`acquire_local_evicting_remote`, this never evicts a remote
+            session.
+
+        """
+        with self._mutex:
+            if self._state != RobotAppLockState.FREE:
+                logger.info(
+                    "RobotAppLock: local acquire refused (state=%s holder=%r requester=%r)",
+                    self._state.value,
+                    self._holder_name,
+                    app_name,
+                )
+                return False
+            self._state = RobotAppLockState.LOCAL_APP
+            self._holder_name = app_name
+            logger.info("RobotAppLock: acquired by local app %r", app_name)
+            return True
+
     async def acquire_local_evicting_remote(self, app_name: str) -> None:
         """Acquire the lock for a local Python app, evicting any remote session.
 

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -11,9 +11,11 @@ from reachy_mini.daemon.app.startup_app import (
     make_startup_app_launcher,
     start_startup_app,
     start_startup_app_if_idle,
+    wake_or_start_startup_app_if_idle,
     watch_antennas_for_startup_app,
 )
 from reachy_mini.daemon.robot_app_lock import RobotAppLock
+from reachy_mini.io.protocol import MotorControlMode
 
 
 class StubAppManager:
@@ -53,10 +55,21 @@ class StubBackend:
         self.ready = Event()
         self.ready.set()
         self.present = [0.0, 0.0]
-        self.target_antenna_joint_positions = [0.0, 0.0]
+        self.target_antenna_joint_positions: list[float] | None = [0.0, 0.0]
+        self.motor_control_mode = MotorControlMode.Enabled
+        self.wake_up_calls = 0
 
     def get_present_antenna_joint_positions(self) -> list[float]:
         return self.present
+
+    def get_motor_control_mode(self) -> MotorControlMode:
+        return self.motor_control_mode
+
+    def set_motor_control_mode(self, mode: MotorControlMode) -> None:
+        self.motor_control_mode = mode
+
+    async def wake_up(self) -> None:
+        self.wake_up_calls += 1
 
 
 class StubDaemon:
@@ -104,6 +117,7 @@ async def test_start_calls_start_app() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
     await start_startup_app(mgr, "foo")  # type: ignore[arg-type]
     assert mgr.started == ["foo"]
+    assert mgr.evict_remote_values == [False]
 
 
 def test_antenna_touch_detector_triggers_once_until_release() -> None:
@@ -115,6 +129,17 @@ def test_antenna_touch_detector_triggers_once_until_release() -> None:
     assert detector.update((0.30, 0.0), (0.0, 0.0)) is False
     assert detector.update((0.05, 0.0), (0.0, 0.0)) is False
     assert detector.update((0.0, -0.26), (0.0, 0.0)) is True
+
+
+def test_antenna_touch_detector_uses_present_baseline_without_target() -> None:
+    detector = AntennaTouchDetector(press_delta_rad=0.25, release_delta_rad=0.1)
+
+    assert detector.update((1.0, -1.0), None) is False
+    assert detector.update((1.2, -1.0), None) is False
+    assert detector.update((1.3, -1.0), None) is True
+    assert detector.update((1.3, -1.0), None) is False
+    assert detector.update((1.05, -1.0), None) is False
+    assert detector.update((1.0, -1.3), None) is True
 
 
 @pytest.mark.asyncio
@@ -140,6 +165,20 @@ async def test_antenna_touch_start_skips_when_remote_session_is_active() -> None
 
 
 @pytest.mark.asyncio
+async def test_antenna_touch_wakes_sleeping_robot_before_starting_app() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+    daemon.backend.motor_control_mode = MotorControlMode.Disabled
+
+    assert await wake_or_start_startup_app_if_idle(mgr, daemon, "foo") is True  # type: ignore[arg-type]
+
+    assert daemon.backend.motor_control_mode == MotorControlMode.Enabled
+    assert daemon.backend.wake_up_calls == 1
+    assert mgr.started == ["foo"]
+    assert mgr.evict_remote_values == [False]
+
+
+@pytest.mark.asyncio
 async def test_antenna_watcher_starts_app_on_touch() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
     daemon = StubDaemon()
@@ -158,6 +197,36 @@ async def test_antenna_watcher_starts_app_on_touch() -> None:
         daemon.backend.present = [0.30, 0.0]
         await asyncio.sleep(0.03)
 
+        assert mgr.started == ["foo"]
+        assert mgr.evict_remote_values == [False]
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_antenna_watcher_wakes_from_baseline_when_target_is_missing() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+    daemon.backend.motor_control_mode = MotorControlMode.Disabled
+    daemon.backend.target_antenna_joint_positions = None
+    task = asyncio.create_task(
+        watch_antennas_for_startup_app(
+            mgr,  # type: ignore[arg-type]
+            daemon,  # type: ignore[arg-type]
+            "foo",
+            idle_poll_interval_s=0.01,
+            blocked_poll_interval_s=0.01,
+        )
+    )
+
+    try:
+        await asyncio.sleep(0.03)
+        daemon.backend.present = [0.30, 0.0]
+        await asyncio.sleep(0.03)
+
+        assert daemon.backend.wake_up_calls == 1
         assert mgr.started == ["foo"]
         assert mgr.evict_remote_values == [False]
     finally:
@@ -195,7 +264,7 @@ async def test_antenna_watcher_does_not_start_while_app_is_running() -> None:
 async def test_start_failure_is_swallowed() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
 
-    async def boom(name: str) -> None:
+    async def boom(name: str, *, evict_remote: bool = True) -> None:
         raise RuntimeError("an app is already running")
 
     mgr.start_app = boom  # type: ignore[assignment]

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -2,7 +2,6 @@ import asyncio
 from contextlib import suppress
 from threading import Event
 
-import numpy as np
 import pytest
 
 from reachy_mini.apps import AppInfo, SourceKind
@@ -61,14 +60,10 @@ class StubBackend:
         self.motor_control_mode = MotorControlMode.Enabled
         self.wake_up_calls = 0
         self.played_sounds: list[str] = []
-        self.goto_targets: list[tuple[list[list[float]], float]] = []
-        self.current_head_pose = np.eye(4)
+        self.goto_target_calls = 0
 
     def get_present_antenna_joint_positions(self) -> list[float]:
         return self.present
-
-    def get_current_head_pose(self) -> np.ndarray:
-        return self.current_head_pose.copy()
 
     def get_motor_control_mode(self) -> MotorControlMode:
         return self.motor_control_mode
@@ -82,14 +77,8 @@ class StubBackend:
     def play_sound(self, sound_file: str) -> None:
         self.played_sounds.append(sound_file)
 
-    async def goto_target(
-        self,
-        head: np.ndarray,
-        *,
-        duration: float,
-    ) -> None:
-        self.goto_targets.append((head.tolist(), duration))
-        self.current_head_pose = head.copy()
+    async def goto_target(self, *args: object, **kwargs: object) -> None:
+        self.goto_target_calls += 1
 
 
 class StubDaemon:
@@ -203,13 +192,13 @@ async def test_antenna_touch_wakes_sleeping_robot_before_starting_app() -> None:
     assert daemon.backend.motor_control_mode == MotorControlMode.Enabled
     assert daemon.backend.wake_up_calls == 1
     assert daemon.backend.played_sounds == []
-    assert daemon.backend.goto_targets == []
+    assert daemon.backend.goto_target_calls == 0
     assert mgr.started == ["foo"]
     assert mgr.evict_remote_values == [False]
 
 
 @pytest.mark.asyncio
-async def test_antenna_touch_plays_awake_cue_before_starting_app() -> None:
+async def test_antenna_touch_plays_awake_sound_before_starting_app() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
     daemon = StubDaemon()
 
@@ -217,21 +206,19 @@ async def test_antenna_touch_plays_awake_cue_before_starting_app() -> None:
 
     assert daemon.backend.wake_up_calls == 0
     assert daemon.backend.played_sounds == ["wake_up.wav"]
-    assert len(daemon.backend.goto_targets) == 2
-    assert [duration for _, duration in daemon.backend.goto_targets] == [0.2, 0.2]
+    assert daemon.backend.goto_target_calls == 0
     assert mgr.started == ["foo"]
     assert mgr.evict_remote_values == [False]
 
 
 @pytest.mark.asyncio
-async def test_awake_startup_cue_returns_to_start_pose() -> None:
+async def test_awake_startup_cue_only_plays_sound() -> None:
     backend = StubBackend()
 
     await play_awake_startup_cue(backend)
 
     assert backend.played_sounds == ["wake_up.wav"]
-    assert len(backend.goto_targets) == 2
-    assert np.allclose(np.array(backend.goto_targets[-1][0]), np.eye(4))
+    assert backend.goto_target_calls == 0
 
 
 @pytest.mark.asyncio
@@ -256,7 +243,7 @@ async def test_antenna_watcher_starts_app_on_touch() -> None:
         assert mgr.started == ["foo"]
         assert mgr.evict_remote_values == [False]
         assert daemon.backend.played_sounds == ["wake_up.wav"]
-        assert len(daemon.backend.goto_targets) == 2
+        assert daemon.backend.goto_target_calls == 0
     finally:
         task.cancel()
         with suppress(asyncio.CancelledError):

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -2,6 +2,7 @@ import asyncio
 from contextlib import suppress
 from threading import Event
 
+import numpy as np
 import pytest
 
 from reachy_mini.apps import AppInfo, SourceKind
@@ -9,6 +10,7 @@ from reachy_mini.daemon.app.startup_app import (
     AntennaTouchDetector,
     ensure_startup_app_installed,
     make_startup_app_launcher,
+    play_awake_startup_cue,
     start_startup_app,
     start_startup_app_if_idle,
     wake_or_start_startup_app_if_idle,
@@ -58,9 +60,15 @@ class StubBackend:
         self.target_antenna_joint_positions: list[float] | None = [0.0, 0.0]
         self.motor_control_mode = MotorControlMode.Enabled
         self.wake_up_calls = 0
+        self.played_sounds: list[str] = []
+        self.goto_targets: list[tuple[list[list[float]], float]] = []
+        self.current_head_pose = np.eye(4)
 
     def get_present_antenna_joint_positions(self) -> list[float]:
         return self.present
+
+    def get_current_head_pose(self) -> np.ndarray:
+        return self.current_head_pose.copy()
 
     def get_motor_control_mode(self) -> MotorControlMode:
         return self.motor_control_mode
@@ -70,6 +78,18 @@ class StubBackend:
 
     async def wake_up(self) -> None:
         self.wake_up_calls += 1
+
+    def play_sound(self, sound_file: str) -> None:
+        self.played_sounds.append(sound_file)
+
+    async def goto_target(
+        self,
+        head: np.ndarray,
+        *,
+        duration: float,
+    ) -> None:
+        self.goto_targets.append((head.tolist(), duration))
+        self.current_head_pose = head.copy()
 
 
 class StubDaemon:
@@ -182,8 +202,36 @@ async def test_antenna_touch_wakes_sleeping_robot_before_starting_app() -> None:
 
     assert daemon.backend.motor_control_mode == MotorControlMode.Enabled
     assert daemon.backend.wake_up_calls == 1
+    assert daemon.backend.played_sounds == []
+    assert daemon.backend.goto_targets == []
     assert mgr.started == ["foo"]
     assert mgr.evict_remote_values == [False]
+
+
+@pytest.mark.asyncio
+async def test_antenna_touch_plays_awake_cue_before_starting_app() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+
+    assert await wake_or_start_startup_app_if_idle(mgr, daemon, "foo") is True  # type: ignore[arg-type]
+
+    assert daemon.backend.wake_up_calls == 0
+    assert daemon.backend.played_sounds == ["wake_up.wav"]
+    assert len(daemon.backend.goto_targets) == 2
+    assert [duration for _, duration in daemon.backend.goto_targets] == [0.2, 0.2]
+    assert mgr.started == ["foo"]
+    assert mgr.evict_remote_values == [False]
+
+
+@pytest.mark.asyncio
+async def test_awake_startup_cue_returns_to_start_pose() -> None:
+    backend = StubBackend()
+
+    await play_awake_startup_cue(backend)
+
+    assert backend.played_sounds == ["wake_up.wav"]
+    assert len(backend.goto_targets) == 2
+    assert np.allclose(np.array(backend.goto_targets[-1][0]), np.eye(4))
 
 
 @pytest.mark.asyncio
@@ -207,6 +255,8 @@ async def test_antenna_watcher_starts_app_on_touch() -> None:
 
         assert mgr.started == ["foo"]
         assert mgr.evict_remote_values == [False]
+        assert daemon.backend.played_sounds == ["wake_up.wav"]
+        assert len(daemon.backend.goto_targets) == 2
     finally:
         task.cancel()
         with suppress(asyncio.CancelledError):

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -5,13 +5,13 @@ from threading import Event
 import pytest
 
 from reachy_mini.apps import AppInfo, SourceKind
-from reachy_mini.daemon.app.main import (
-    _AntennaTouchDetector,
-    _ensure_startup_app_installed,
-    _make_startup_app_launcher,
-    _start_startup_app,
-    _start_startup_app_if_idle,
-    _watch_antennas_for_startup_app,
+from reachy_mini.daemon.app.startup_app import (
+    AntennaTouchDetector,
+    ensure_startup_app_installed,
+    make_startup_app_launcher,
+    start_startup_app,
+    start_startup_app_if_idle,
+    watch_antennas_for_startup_app,
 )
 from reachy_mini.daemon.robot_app_lock import RobotAppLock
 
@@ -70,21 +70,21 @@ class StubDaemon:
 @pytest.mark.asyncio
 async def test_already_installed_is_ready_without_install() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=["foo", "bar"])
-    assert await _ensure_startup_app_installed(mgr, "foo") is True  # type: ignore[arg-type]
+    assert await ensure_startup_app_installed(mgr, "foo") is True  # type: ignore[arg-type]
     assert mgr.installed_calls == []
 
 
 @pytest.mark.asyncio
 async def test_missing_app_installed_from_catalog() -> None:
     mgr = StubAppManager(installed=[], catalog=["bar"])
-    assert await _ensure_startup_app_installed(mgr, "bar") is True  # type: ignore[arg-type]
+    assert await ensure_startup_app_installed(mgr, "bar") is True  # type: ignore[arg-type]
     assert mgr.installed_calls == ["bar"]
 
 
 @pytest.mark.asyncio
 async def test_unknown_app_not_ready_and_not_installed() -> None:
     mgr = StubAppManager(installed=[], catalog=["bar"])
-    assert await _ensure_startup_app_installed(mgr, "nope") is False  # type: ignore[arg-type]
+    assert await ensure_startup_app_installed(mgr, "nope") is False  # type: ignore[arg-type]
     assert mgr.installed_calls == []
 
 
@@ -96,18 +96,18 @@ async def test_install_failure_returns_false() -> None:
         raise RuntimeError("network down")
 
     mgr.install_new_app = boom  # type: ignore[assignment]
-    assert await _ensure_startup_app_installed(mgr, "bar") is False  # type: ignore[arg-type]
+    assert await ensure_startup_app_installed(mgr, "bar") is False  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio
 async def test_start_calls_start_app() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
-    await _start_startup_app(mgr, "foo")  # type: ignore[arg-type]
+    await start_startup_app(mgr, "foo")  # type: ignore[arg-type]
     assert mgr.started == ["foo"]
 
 
 def test_antenna_touch_detector_triggers_once_until_release() -> None:
-    detector = _AntennaTouchDetector(press_delta_rad=0.25, release_delta_rad=0.1)
+    detector = AntennaTouchDetector(press_delta_rad=0.25, release_delta_rad=0.1)
 
     assert detector.update((0.0, 0.0), (0.0, 0.0)) is False
     assert detector.update((0.20, 0.0), (0.0, 0.0)) is False
@@ -122,7 +122,7 @@ async def test_antenna_touch_start_uses_non_evicting_app_start() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
     daemon = StubDaemon()
 
-    assert await _start_startup_app_if_idle(mgr, daemon, "foo") is True  # type: ignore[arg-type]
+    assert await start_startup_app_if_idle(mgr, daemon, "foo") is True  # type: ignore[arg-type]
 
     assert mgr.started == ["foo"]
     assert mgr.evict_remote_values == [False]
@@ -134,7 +134,7 @@ async def test_antenna_touch_start_skips_when_remote_session_is_active() -> None
     daemon = StubDaemon()
     assert daemon.robot_app_lock.try_acquire_remote("remote") is True
 
-    assert await _start_startup_app_if_idle(mgr, daemon, "foo") is False  # type: ignore[arg-type]
+    assert await start_startup_app_if_idle(mgr, daemon, "foo") is False  # type: ignore[arg-type]
 
     assert mgr.started == []
 
@@ -144,7 +144,7 @@ async def test_antenna_watcher_starts_app_on_touch() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
     daemon = StubDaemon()
     task = asyncio.create_task(
-        _watch_antennas_for_startup_app(
+        watch_antennas_for_startup_app(
             mgr,  # type: ignore[arg-type]
             daemon,  # type: ignore[arg-type]
             "foo",
@@ -173,7 +173,7 @@ async def test_antenna_watcher_does_not_start_while_app_is_running() -> None:
     daemon = StubDaemon()
     daemon.backend.present = [0.30, 0.0]
     task = asyncio.create_task(
-        _watch_antennas_for_startup_app(
+        watch_antennas_for_startup_app(
             mgr,  # type: ignore[arg-type]
             daemon,  # type: ignore[arg-type]
             "foo",
@@ -199,13 +199,13 @@ async def test_start_failure_is_swallowed() -> None:
         raise RuntimeError("an app is already running")
 
     mgr.start_app = boom  # type: ignore[assignment]
-    await _start_startup_app(mgr, "foo")  # must not raise  # type: ignore[arg-type]
+    await start_startup_app(mgr, "foo")  # must not raise  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio
 async def test_launcher_starts_app_once_across_multiple_wakes() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
-    launch = _make_startup_app_launcher(mgr, "foo")  # type: ignore[arg-type]
+    launch = make_startup_app_launcher(mgr, "foo")  # type: ignore[arg-type]
 
     # Simulate several wake-ups; only the first should launch the app.
     launch()

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Callable
 from contextlib import suppress
 from threading import Event
 
@@ -26,6 +27,7 @@ class StubAppManager:
         self._installed = installed
         self._catalog = catalog
         self.installed_calls: list[str] = []
+        self.start_attempts: list[str] = []
         self.started: list[str] = []
         self.evict_remote_values: list[bool] = []
         self.running = False
@@ -42,6 +44,7 @@ class StubAppManager:
         return self.running
 
     async def start_app(self, name: str, *, evict_remote: bool = True) -> None:
+        self.start_attempts.append(name)
         if self.running:
             raise RuntimeError("An app is already running")
         self.started.append(name)
@@ -61,6 +64,7 @@ class StubBackend:
         self.wake_up_calls = 0
         self.played_sounds: list[str] = []
         self.goto_target_calls = 0
+        self.on_wake_up_callback: Callable[[], None] | None = None
 
     def get_present_antenna_joint_positions(self) -> list[float]:
         return self.present
@@ -73,6 +77,8 @@ class StubBackend:
 
     async def wake_up(self) -> None:
         self.wake_up_calls += 1
+        if self.on_wake_up_callback is not None:
+            self.on_wake_up_callback()
 
     def play_sound(self, sound_file: str) -> None:
         self.played_sounds.append(sound_file)
@@ -198,6 +204,24 @@ async def test_antenna_touch_wakes_sleeping_robot_before_starting_app() -> None:
 
 
 @pytest.mark.asyncio
+async def test_antenna_touch_wake_does_not_duplicate_startup_callback() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+    daemon.backend.motor_control_mode = MotorControlMode.Disabled
+    daemon.backend.on_wake_up_callback = make_startup_app_launcher(
+        mgr,
+        "foo",  # type: ignore[arg-type]
+    )
+
+    assert await wake_or_start_startup_app_if_idle(mgr, daemon, "foo") is True  # type: ignore[arg-type]
+
+    assert daemon.backend.wake_up_calls == 1
+    assert mgr.start_attempts == ["foo"]
+    assert mgr.started == ["foo"]
+    assert mgr.evict_remote_values == [False]
+
+
+@pytest.mark.asyncio
 async def test_antenna_touch_plays_awake_sound_before_starting_app() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
     daemon = StubDaemon()
@@ -244,6 +268,45 @@ async def test_antenna_watcher_starts_app_on_touch() -> None:
         assert mgr.evict_remote_values == [False]
         assert daemon.backend.played_sounds == ["wake_up.wav"]
         assert daemon.backend.goto_target_calls == 0
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_antenna_watcher_resets_detector_after_start_failure() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+    detector = AntennaTouchDetector()
+
+    async def boom(name: str, *, evict_remote: bool = True) -> None:
+        mgr.start_attempts.append(name)
+        raise RuntimeError("start failed")
+
+    mgr.start_app = boom  # type: ignore[assignment]
+    task = asyncio.create_task(
+        watch_antennas_for_startup_app(
+            mgr,  # type: ignore[arg-type]
+            daemon,  # type: ignore[arg-type]
+            "foo",
+            detector=detector,
+            idle_poll_interval_s=0.01,
+            blocked_poll_interval_s=1.0,
+        )
+    )
+
+    try:
+        await asyncio.sleep(0.03)
+        daemon.backend.present = [0.30, 0.0]
+        for _ in range(20):
+            if mgr.start_attempts:
+                break
+            await asyncio.sleep(0.01)
+
+        assert mgr.start_attempts == ["foo"]
+        assert detector._reference is None
+        assert detector._armed is False
     finally:
         task.cancel()
         with suppress(asyncio.CancelledError):

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -1,13 +1,19 @@
 import asyncio
+from contextlib import suppress
+from threading import Event
 
 import pytest
 
 from reachy_mini.apps import AppInfo, SourceKind
 from reachy_mini.daemon.app.main import (
+    _AntennaTouchDetector,
     _ensure_startup_app_installed,
     _make_startup_app_launcher,
     _start_startup_app,
+    _start_startup_app_if_idle,
+    _watch_antennas_for_startup_app,
 )
+from reachy_mini.daemon.robot_app_lock import RobotAppLock
 
 
 class StubAppManager:
@@ -18,6 +24,8 @@ class StubAppManager:
         self._catalog = catalog
         self.installed_calls: list[str] = []
         self.started: list[str] = []
+        self.evict_remote_values: list[bool] = []
+        self.running = False
 
     async def list_available_apps(self, source: SourceKind) -> list[AppInfo]:
         names = self._installed if source == SourceKind.INSTALLED else self._catalog
@@ -27,8 +35,36 @@ class StubAppManager:
         self.installed_calls.append(app.name)
         self._installed.append(app.name)
 
-    async def start_app(self, name: str) -> None:
+    def is_app_running(self) -> bool:
+        return self.running
+
+    async def start_app(self, name: str, *, evict_remote: bool = True) -> None:
+        if self.running:
+            raise RuntimeError("An app is already running")
         self.started.append(name)
+        self.evict_remote_values.append(evict_remote)
+        self.running = True
+
+
+class StubBackend:
+    """Mutable backend surface used by the antenna watcher tests."""
+
+    def __init__(self) -> None:
+        self.ready = Event()
+        self.ready.set()
+        self.present = [0.0, 0.0]
+        self.target_antenna_joint_positions = [0.0, 0.0]
+
+    def get_present_antenna_joint_positions(self) -> list[float]:
+        return self.present
+
+
+class StubDaemon:
+    """Daemon-like object with just the fields the watcher needs."""
+
+    def __init__(self) -> None:
+        self.backend = StubBackend()
+        self.robot_app_lock = RobotAppLock()
 
 
 @pytest.mark.asyncio
@@ -68,6 +104,91 @@ async def test_start_calls_start_app() -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
     await _start_startup_app(mgr, "foo")  # type: ignore[arg-type]
     assert mgr.started == ["foo"]
+
+
+def test_antenna_touch_detector_triggers_once_until_release() -> None:
+    detector = _AntennaTouchDetector(press_delta_rad=0.25, release_delta_rad=0.1)
+
+    assert detector.update((0.0, 0.0), (0.0, 0.0)) is False
+    assert detector.update((0.20, 0.0), (0.0, 0.0)) is False
+    assert detector.update((0.26, 0.0), (0.0, 0.0)) is True
+    assert detector.update((0.30, 0.0), (0.0, 0.0)) is False
+    assert detector.update((0.05, 0.0), (0.0, 0.0)) is False
+    assert detector.update((0.0, -0.26), (0.0, 0.0)) is True
+
+
+@pytest.mark.asyncio
+async def test_antenna_touch_start_uses_non_evicting_app_start() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+
+    assert await _start_startup_app_if_idle(mgr, daemon, "foo") is True  # type: ignore[arg-type]
+
+    assert mgr.started == ["foo"]
+    assert mgr.evict_remote_values == [False]
+
+
+@pytest.mark.asyncio
+async def test_antenna_touch_start_skips_when_remote_session_is_active() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+    assert daemon.robot_app_lock.try_acquire_remote("remote") is True
+
+    assert await _start_startup_app_if_idle(mgr, daemon, "foo") is False  # type: ignore[arg-type]
+
+    assert mgr.started == []
+
+
+@pytest.mark.asyncio
+async def test_antenna_watcher_starts_app_on_touch() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+    task = asyncio.create_task(
+        _watch_antennas_for_startup_app(
+            mgr,  # type: ignore[arg-type]
+            daemon,  # type: ignore[arg-type]
+            "foo",
+            idle_poll_interval_s=0.01,
+            blocked_poll_interval_s=0.01,
+        )
+    )
+
+    try:
+        await asyncio.sleep(0.03)
+        daemon.backend.present = [0.30, 0.0]
+        await asyncio.sleep(0.03)
+
+        assert mgr.started == ["foo"]
+        assert mgr.evict_remote_values == [False]
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_antenna_watcher_does_not_start_while_app_is_running() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    mgr.running = True
+    daemon = StubDaemon()
+    daemon.backend.present = [0.30, 0.0]
+    task = asyncio.create_task(
+        _watch_antennas_for_startup_app(
+            mgr,  # type: ignore[arg-type]
+            daemon,  # type: ignore[arg-type]
+            "foo",
+            idle_poll_interval_s=0.01,
+            blocked_poll_interval_s=0.01,
+        )
+    )
+
+    try:
+        await asyncio.sleep(0.05)
+        assert mgr.started == []
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -123,23 +123,31 @@ async def test_start_calls_start_app() -> None:
 def test_antenna_touch_detector_triggers_once_until_release() -> None:
     detector = AntennaTouchDetector(press_delta_rad=0.25, release_delta_rad=0.1)
 
-    assert detector.update((0.0, 0.0), (0.0, 0.0)) is False
-    assert detector.update((0.20, 0.0), (0.0, 0.0)) is False
-    assert detector.update((0.26, 0.0), (0.0, 0.0)) is True
-    assert detector.update((0.30, 0.0), (0.0, 0.0)) is False
-    assert detector.update((0.05, 0.0), (0.0, 0.0)) is False
-    assert detector.update((0.0, -0.26), (0.0, 0.0)) is True
+    assert detector.update((0.0, 0.0)) is False
+    assert detector.update((0.20, 0.0)) is False
+    assert detector.update((0.26, 0.0)) is True
+    assert detector.update((0.30, 0.0)) is False
+    assert detector.update((0.05, 0.0)) is False
+    assert detector.update((0.0, -0.26)) is True
 
 
-def test_antenna_touch_detector_uses_present_baseline_without_target() -> None:
+def test_antenna_touch_detector_uses_present_baseline() -> None:
     detector = AntennaTouchDetector(press_delta_rad=0.25, release_delta_rad=0.1)
 
-    assert detector.update((1.0, -1.0), None) is False
-    assert detector.update((1.2, -1.0), None) is False
-    assert detector.update((1.3, -1.0), None) is True
-    assert detector.update((1.3, -1.0), None) is False
-    assert detector.update((1.05, -1.0), None) is False
-    assert detector.update((1.0, -1.3), None) is True
+    assert detector.update((1.0, -1.0)) is False
+    assert detector.update((1.2, -1.0)) is False
+    assert detector.update((1.3, -1.0)) is True
+    assert detector.update((1.3, -1.0)) is False
+    assert detector.update((1.05, -1.0)) is False
+    assert detector.update((1.0, -1.3)) is True
+
+
+def test_antenna_touch_detector_arms_when_idle_pose_is_offset() -> None:
+    detector = AntennaTouchDetector(press_delta_rad=0.25, release_delta_rad=0.1)
+
+    assert detector.update((0.18, 0.0)) is False
+    assert detector.update((0.40, 0.0)) is False
+    assert detector.update((0.44, 0.0)) is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_robot_app_lock.py
+++ b/tests/unit_tests/test_robot_app_lock.py
@@ -47,6 +47,25 @@ async def test_local_acquire_from_free() -> None:
     assert status.holder_name == "app_a"
 
 
+def test_try_local_acquire_from_free() -> None:
+    """A non-evicting local acquire succeeds only when the lock is free."""
+    lock = RobotAppLock()
+    assert lock.try_acquire_local("app_a") is True
+    status = lock.status()
+    assert status.state == RobotAppLockState.LOCAL_APP
+    assert status.holder_name == "app_a"
+
+
+def test_try_local_acquire_refused_while_remote_held() -> None:
+    """A non-evicting local acquire must not displace a remote session."""
+    lock = RobotAppLock()
+    assert lock.try_acquire_remote("remote") is True
+    assert lock.try_acquire_local("app_a") is False
+    status = lock.status()
+    assert status.state == RobotAppLockState.REMOTE_SESSION
+    assert status.holder_name == "remote"
+
+
 @pytest.mark.asyncio
 async def test_local_release_returns_to_free() -> None:
     """Releasing local returns to free and clears the holder name."""


### PR DESCRIPTION
## Summary

Adds an idle-only antenna watcher for the configured startup app. When the daemon has a startup app installed and no managed local app or remote WebRTC session owns the robot, touching either antenna starts the startup app again.

If Reachy is asleep, the watcher detects antenna movement against the current antenna idle pose, enables motor control, runs the normal wake-up sequence, and then starts the startup app if the app slot is still free.

If Reachy is already awake, the watcher only plays `wake_up.wav`, then starts the startup app. It does not move the head, so it does not fight the user holding the antenna down.

After an app stops, the detector re-baselines on the real current antenna pose instead of the commanded target. That lets it re-arm even when the antenna is held slightly away from target by physical counter-pressure.

The watcher is designed to stay cheap on the Raspberry Pi 4: it sleeps while an app/session is active, samples cached antenna state at 10 Hz only while idle, and uses hysteresis against the idle pose to avoid repeat triggers while held.

## Details

- Adds a non-evicting local acquire path to `RobotAppLock`.
- Lets `AppManager.start_app(..., evict_remote=False)` fail instead of displacing a remote session.
- Moves startup-app install/launch/watch helpers into `daemon/app/startup_app.py`.
- Starts/cancels the startup-app antenna watcher with the daemon lifespan.
- Adds tests for idle-pose baseline mode, sleep wake-up, awake startup sound without movement, offset re-arming, idle-only startup behavior, and the new lock path.

## Validation

- `.venv/bin/python -m pytest tests/unit_tests/test_autostart_app.py tests/unit_tests/test_robot_app_lock.py tests/unit_tests/test_app.py::test_app_manager tests/unit_tests/test_app.py::test_faulty_app -q` — 39 passed
- `.venv/bin/python -m ruff check src/reachy_mini/daemon/app/main.py src/reachy_mini/daemon/app/startup_app.py src/reachy_mini/apps/manager.py src/reachy_mini/daemon/robot_app_lock.py`
- `.venv/bin/python -m mypy src/reachy_mini/daemon/app/main.py src/reachy_mini/daemon/app/startup_app.py src/reachy_mini/apps/manager.py src/reachy_mini/daemon/robot_app_lock.py`

Note: `uv run --locked ...` did not reach pytest because this local `uv` rejected the repo existing `exclude-newer = "7 days"` setting and wanted to update `uv.lock`. Running `tests/unit_tests/test_app.py::test_app` in the existing `.venv` also fails before this change path because the MuJoCo extra is not installed.