### PR TITLE
Proper sleep: keep the robot asleep (and limp) after an app stops

### DIFF
--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -13,6 +13,7 @@ import psutil
 from pydantic import BaseModel
 
 from reachy_mini.daemon.backend.robot import RobotBackend
+from reachy_mini.io.protocol import MotorControlMode
 from reachy_mini.utils.interpolation import distance_between_poses
 
 from . import AppInfo, SourceKind
@@ -308,8 +309,10 @@ class AppManager:
                 backend.get_current_head_pose(), backend.SLEEP_HEAD_POSE
             )
             if dist_to_sleep <= SLEEP_POSE_MAGIC_DISTANCE:
+                # pose check only; ensure limp (idempotent)
+                backend.set_motor_control_mode(MotorControlMode.Disabled)
                 self.logger.getChild("runner").info(
-                    "Robot is asleep; leaving it in the sleep pose."
+                    "Robot is asleep; leaving it limp in the sleep pose."
                 )
             else:
                 if isinstance(backend, RobotBackend):

--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -13,12 +13,16 @@ import psutil
 from pydantic import BaseModel
 
 from reachy_mini.daemon.backend.robot import RobotBackend
+from reachy_mini.utils.interpolation import distance_between_poses
 
 from . import AppInfo, SourceKind
 from .sources import hf_space, local_common_venv
 
 if TYPE_CHECKING:
     from reachy_mini.daemon.daemon import Daemon
+
+# Sleep-pose proximity in magic-mm (mm + deg), matching Backend.goto_sleep.
+SLEEP_POSE_MAGIC_DISTANCE = 10.0
 
 
 class AppState(str, Enum):
@@ -297,27 +301,38 @@ class AppManager:
             except asyncio.CancelledError:
                 pass
 
-        # Return robot to zero position after app stops
+        # Return to zero after an app stops, unless the app left it asleep.
         if self.daemon is not None and self.daemon.backend is not None:
-            if isinstance(self.daemon.backend, RobotBackend):
-                self.daemon.backend.enable_motors()
+            backend = self.daemon.backend
+            _, _, dist_to_sleep = distance_between_poses(
+                backend.get_current_head_pose(), backend.SLEEP_HEAD_POSE
+            )
+            if dist_to_sleep <= SLEEP_POSE_MAGIC_DISTANCE:
+                self.logger.getChild("runner").info(
+                    "Robot is asleep; leaving it in the sleep pose."
+                )
+            else:
+                if isinstance(backend, RobotBackend):
+                    backend.enable_motors()
 
-            try:
-                from reachy_mini.reachy_mini import (
-                    INIT_ANTENNAS_JOINT_POSITIONS,
-                    INIT_HEAD_POSE,
-                )
+                try:
+                    from reachy_mini.reachy_mini import (
+                        INIT_ANTENNAS_JOINT_POSITIONS,
+                        INIT_HEAD_POSE,
+                    )
 
-                self.logger.getChild("runner").info("Returning robot to zero position")
-                await self.daemon.backend.goto_target(
-                    head=INIT_HEAD_POSE,
-                    antennas=np.array(INIT_ANTENNAS_JOINT_POSITIONS),
-                    duration=1.0,
-                )
-            except Exception as e:
-                self.logger.getChild("runner").warning(
-                    f"Could not return to zero position: {e}"
-                )
+                    self.logger.getChild("runner").info(
+                        "Returning robot to zero position"
+                    )
+                    await backend.goto_target(
+                        head=INIT_HEAD_POSE,
+                        antennas=np.array(INIT_ANTENNAS_JOINT_POSITIONS),
+                        duration=1.0,
+                    )
+                except Exception as e:
+                    self.logger.getChild("runner").warning(
+                        f"Could not return to zero position: {e}"
+                    )
 
         self.current_app = None
 

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -1032,6 +1032,9 @@ class Backend:
         self._last_head_pose = self.SLEEP_HEAD_POSE
         await asyncio.sleep(sleep_time)
 
+        # Rest limp at the sleep pose, like a fresh boot.
+        self.set_motor_control_mode(MotorControlMode.Disabled)
+
     # Motor control modes
     @abstractmethod
     def get_motor_control_mode(self) -> MotorControlMode:

--- a/tests/unit_tests/test_app_stop_sleep.py
+++ b/tests/unit_tests/test_app_stop_sleep.py
@@ -1,13 +1,14 @@
 """stop_current_app must not wake a robot the app deliberately put to sleep."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
 import pytest
 
 from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.backend.abstract import Backend
+from reachy_mini.io.protocol import MotorControlMode
 
 
 def _fake_current_app() -> SimpleNamespace:
@@ -25,6 +26,7 @@ def _manager_with_head_pose(head_pose: np.ndarray) -> tuple[AppManager, AsyncMoc
         get_current_head_pose=lambda: head_pose,
         SLEEP_HEAD_POSE=Backend.SLEEP_HEAD_POSE,
         goto_target=goto_target,
+        set_motor_control_mode=MagicMock(),
     )
     mngr = AppManager(daemon=SimpleNamespace(backend=backend))
     mngr.current_app = _fake_current_app()  # type: ignore[assignment]
@@ -36,6 +38,10 @@ async def test_stop_leaves_robot_asleep_when_in_sleep_pose() -> None:
     mngr, goto_target = _manager_with_head_pose(Backend.SLEEP_HEAD_POSE.copy())
     await mngr.stop_current_app()
     goto_target.assert_not_awaited()
+    # left asleep, and made limp
+    mngr.daemon.backend.set_motor_control_mode.assert_called_once_with(
+        MotorControlMode.Disabled
+    )
     assert mngr.current_app is None
 
 

--- a/tests/unit_tests/test_app_stop_sleep.py
+++ b/tests/unit_tests/test_app_stop_sleep.py
@@ -1,0 +1,47 @@
+"""stop_current_app must not wake a robot the app deliberately put to sleep."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon.backend.abstract import Backend
+
+
+def _fake_current_app() -> SimpleNamespace:
+    # returncode set + monitor_task done → skip the kill/cancel paths.
+    return SimpleNamespace(
+        process=SimpleNamespace(returncode=0, pid=0),
+        monitor_task=SimpleNamespace(done=lambda: True),
+        status=SimpleNamespace(state="running", info=SimpleNamespace(name="x")),
+    )
+
+
+def _manager_with_head_pose(head_pose: np.ndarray) -> tuple[AppManager, AsyncMock]:
+    goto_target = AsyncMock()
+    backend = SimpleNamespace(
+        get_current_head_pose=lambda: head_pose,
+        SLEEP_HEAD_POSE=Backend.SLEEP_HEAD_POSE,
+        goto_target=goto_target,
+    )
+    mngr = AppManager(daemon=SimpleNamespace(backend=backend))
+    mngr.current_app = _fake_current_app()  # type: ignore[assignment]
+    return mngr, goto_target
+
+
+@pytest.mark.asyncio
+async def test_stop_leaves_robot_asleep_when_in_sleep_pose() -> None:
+    mngr, goto_target = _manager_with_head_pose(Backend.SLEEP_HEAD_POSE.copy())
+    await mngr.stop_current_app()
+    goto_target.assert_not_awaited()
+    assert mngr.current_app is None
+
+
+@pytest.mark.asyncio
+async def test_stop_returns_to_zero_when_awake() -> None:
+    mngr, goto_target = _manager_with_head_pose(np.eye(4))
+    await mngr.stop_current_app()
+    goto_target.assert_awaited_once()
+    assert mngr.current_app is None


### PR DESCRIPTION
## Summary
Make the robot settle into a real sleep — the same compliant state as a fresh `--no-wake-up-on-start` daemon start — instead of standing back up after an app ends.

- `goto_sleep()` now disables motor torque once it reaches the sleep pose, so the robot rests limp (soft antennas) on every sleep path (app exit, the go-to-sleep tool, the sleep button, REST, daemon stop).
- The app manager no longer returns the robot to the zero pose after an app stops **if it's already in the sleep pose** — so a sleep the app requested isn't immediately overridden.

## Why
Previously, an app ending would send the robot back to the neutral/zero pose with motors held, so it never actually went to sleep and the antennas stayed stiff.

## Notes
- Complements conversation-app PR [#438](https://github.com/pollen-robotics/reachy_mini_conversation_app/pull/438) (which routes the app's exit paths through `goto_sleep`): app asks to sleep → daemon honors it → robot rests like at boot.
- Motor position feedback still works with torque off, so pose reads (e.g. the antenna-touch watcher) are unaffected.
- The stay-asleep check uses a 10 magic-mm tolerance around the sleep pose; if the head droops when it goes limp, that's the knob to loosen.