### PR TITLE
Add get_frame_jpeg() to encode camera frames as jpeg via gstreamer

### DIFF
--- a/src/reachy_mini/media/audio_base.py
+++ b/src/reachy_mini/media/audio_base.py
@@ -62,6 +62,7 @@ class AudioBase(ABC):
 
     def __init__(self, log_level: str = "INFO") -> None:
         """Initialize shared audio attributes (DoA helper)."""
+        Gst.init([])
         self.logger = logging.getLogger(type(self).__module__)
         self.logger.setLevel(log_level)
         self._doa = AudioDoA()

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -109,7 +109,6 @@ class GStreamerAudio(AudioBase):
 
         self._head_wobbler: Optional[HeadWobbler] = None
 
-        Gst.init([])
         self._loop = GLib.MainLoop()
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()

--- a/src/reachy_mini/media/camera_base.py
+++ b/src/reachy_mini/media/camera_base.py
@@ -24,6 +24,7 @@ from reachy_mini.media.camera_constants import (
     MujocoCameraSpecs,
 )
 from reachy_mini.media.camera_utils import scale_intrinsics
+from reachy_mini.media.gstreamer_utils import encode_bgr_to_jpeg
 
 
 class CameraBase(ABC):
@@ -157,6 +158,13 @@ class CameraBase(ABC):
 
         """
         ...
+
+    def read_jpeg(self) -> Optional[bytes]:
+        """Pull the latest frame encoded as JPEG bytes, or ``None`` if unavailable."""
+        frame = self.read()
+        if frame is None:
+            return None
+        return encode_bgr_to_jpeg(frame, self.logger)
 
     @abstractmethod
     def close(self) -> None:

--- a/src/reachy_mini/media/camera_base.py
+++ b/src/reachy_mini/media/camera_base.py
@@ -35,8 +35,9 @@ except ImportError as e:
     ) from e
 
 gi.require_version("Gst", "1.0")
+gi.require_version("GstApp", "1.0")
 
-from gi.repository import Gst  # noqa: E402
+from gi.repository import Gst, GstApp  # noqa: E402
 
 
 class CameraBase(ABC):
@@ -57,9 +58,9 @@ class CameraBase(ABC):
         self.camera_specs: Optional[CameraSpecs] = None
         self.resized_K: Optional[npt.NDArray[np.float64]] = None
         self._jpeg_pipeline: Gst.Pipeline = None
-        self._jpeg_appsrc: Gst.Element = None
-        self._jpeg_appsink: Gst.Element = None
-        self._jpeg_size: Optional[tuple[int, int]] = None
+        self._jpeg_appsrc: GstApp.AppSrc = None
+        self._jpeg_appsink: GstApp.AppSink = None
+        self._jpeg_resolution: Optional[tuple[int, int]] = None
 
     @property
     def resolution(self) -> tuple[int, int]:
@@ -185,17 +186,17 @@ class CameraBase(ABC):
         if frame is None:
             return None
         height, width = frame.shape[:2]
-        if self._jpeg_pipeline is None or self._jpeg_size != (width, height):
+        if self._jpeg_pipeline is None or self._jpeg_resolution != (width, height):
             self._release_jpeg_encoder()
             self._build_jpeg_encoder(width, height)
         self._jpeg_pipeline.set_state(Gst.State.PLAYING)
-        self._jpeg_appsrc.emit("push-buffer", Gst.Buffer.new_wrapped(frame.tobytes()))
+        self._jpeg_appsrc.push_buffer(Gst.Buffer.new_wrapped(frame.tobytes()))
         jpeg = get_sample(self._jpeg_appsink, self.logger)
         self._jpeg_pipeline.set_state(Gst.State.PAUSED)
         return jpeg
 
     def _build_jpeg_encoder(self, width: int, height: int) -> None:
-        """Build the reusable JPEG encoder pipeline for the given frame size."""
+        """Build the reusable JPEG encoder pipeline for the given resolution."""
         pipeline = Gst.Pipeline.new("jpeg_encoder")
         appsrc = Gst.ElementFactory.make("appsrc")
         videoconvert = Gst.ElementFactory.make("videoconvert")
@@ -219,7 +220,7 @@ class CameraBase(ABC):
         self._jpeg_pipeline = pipeline
         self._jpeg_appsrc = appsrc
         self._jpeg_appsink = appsink
-        self._jpeg_size = (width, height)
+        self._jpeg_resolution = (width, height)
 
     def _release_jpeg_encoder(self) -> None:
         """Tear down the JPEG encoder pipeline if one exists."""
@@ -228,7 +229,7 @@ class CameraBase(ABC):
             self._jpeg_pipeline = None
             self._jpeg_appsrc = None
             self._jpeg_appsink = None
-            self._jpeg_size = None
+            self._jpeg_resolution = None
 
     @abstractmethod
     def close(self) -> None:

--- a/src/reachy_mini/media/camera_base.py
+++ b/src/reachy_mini/media/camera_base.py
@@ -24,7 +24,19 @@ from reachy_mini.media.camera_constants import (
     MujocoCameraSpecs,
 )
 from reachy_mini.media.camera_utils import scale_intrinsics
-from reachy_mini.media.gstreamer_utils import encode_bgr_to_jpeg
+from reachy_mini.media.gstreamer_utils import get_sample
+
+try:
+    import gi
+except ImportError as e:
+    raise ImportError(
+        "The 'gi' module is required for CameraBase but could not be imported. "
+        "Please check the gstreamer installation."
+    ) from e
+
+gi.require_version("Gst", "1.0")
+
+from gi.repository import Gst  # noqa: E402
 
 
 class CameraBase(ABC):
@@ -38,11 +50,16 @@ class CameraBase(ABC):
 
     def __init__(self, log_level: str = "INFO") -> None:
         """Initialize shared camera attributes."""
+        Gst.init([])
         self.logger = logging.getLogger(type(self).__module__)
         self.logger.setLevel(log_level)
         self._resolution: Optional[CameraResolution] = None
         self.camera_specs: Optional[CameraSpecs] = None
         self.resized_K: Optional[npt.NDArray[np.float64]] = None
+        self._jpeg_pipeline: Gst.Pipeline = None
+        self._jpeg_appsrc: Gst.Element = None
+        self._jpeg_appsink: Gst.Element = None
+        self._jpeg_size: Optional[tuple[int, int]] = None
 
     @property
     def resolution(self) -> tuple[int, int]:
@@ -160,11 +177,58 @@ class CameraBase(ABC):
         ...
 
     def read_jpeg(self) -> Optional[bytes]:
-        """Pull the latest frame encoded as JPEG bytes, or ``None`` if unavailable."""
+        """Return the latest frame as JPEG bytes, or ``None`` if unavailable.
+
+        For occasional stills only, not optimised for video-rate capture.
+        """
         frame = self.read()
         if frame is None:
             return None
-        return encode_bgr_to_jpeg(frame, self.logger)
+        height, width = frame.shape[:2]
+        if self._jpeg_pipeline is None or self._jpeg_size != (width, height):
+            self._release_jpeg_encoder()
+            self._build_jpeg_encoder(width, height)
+        self._jpeg_pipeline.set_state(Gst.State.PLAYING)
+        self._jpeg_appsrc.emit("push-buffer", Gst.Buffer.new_wrapped(frame.tobytes()))
+        jpeg = get_sample(self._jpeg_appsink, self.logger)
+        self._jpeg_pipeline.set_state(Gst.State.PAUSED)
+        return jpeg
+
+    def _build_jpeg_encoder(self, width: int, height: int) -> None:
+        """Build the reusable JPEG encoder pipeline for the given frame size."""
+        pipeline = Gst.Pipeline.new("jpeg_encoder")
+        appsrc = Gst.ElementFactory.make("appsrc")
+        videoconvert = Gst.ElementFactory.make("videoconvert")
+        jpegenc = Gst.ElementFactory.make("jpegenc")
+        appsink = Gst.ElementFactory.make("appsink")
+        if not all([appsrc, videoconvert, jpegenc, appsink]):
+            raise RuntimeError("Failed to create JPEG encoder elements")
+        for element in (appsrc, videoconvert, jpegenc, appsink):
+            pipeline.add(element)
+        appsrc.link(videoconvert)
+        videoconvert.link(jpegenc)
+        jpegenc.link(appsink)
+        appsrc.set_property(
+            "caps",
+            Gst.Caps.from_string(
+                f"video/x-raw,format=BGR,width={width},height={height},framerate=1/1"
+            ),
+        )
+        appsink.set_property("sync", False)
+        pipeline.set_state(Gst.State.PAUSED)
+        self._jpeg_pipeline = pipeline
+        self._jpeg_appsrc = appsrc
+        self._jpeg_appsink = appsink
+        self._jpeg_size = (width, height)
+
+    def _release_jpeg_encoder(self) -> None:
+        """Tear down the JPEG encoder pipeline if one exists."""
+        if self._jpeg_pipeline is not None:
+            self._jpeg_pipeline.set_state(Gst.State.NULL)
+            self._jpeg_pipeline = None
+            self._jpeg_appsrc = None
+            self._jpeg_appsink = None
+            self._jpeg_size = None
 
     @abstractmethod
     def close(self) -> None:

--- a/src/reachy_mini/media/camera_gstreamer.py
+++ b/src/reachy_mini/media/camera_gstreamer.py
@@ -109,7 +109,6 @@ class GStreamerCamera(CameraBase):
         """
         super().__init__(log_level=log_level)
 
-        Gst.init([])
         self._loop = GLib.MainLoop()
         self._thread_bus_calls: Optional[Thread] = None
 
@@ -271,5 +270,6 @@ class GStreamerCamera(CameraBase):
 
     def close(self) -> None:
         """Stop the pipeline and release resources."""
+        self._release_jpeg_encoder()
         self._loop.quit()
         self.pipeline.set_state(Gst.State.NULL)

--- a/src/reachy_mini/media/gstreamer_utils.py
+++ b/src/reachy_mini/media/gstreamer_utils.py
@@ -3,9 +3,6 @@
 import logging
 from typing import Optional
 
-import numpy as np
-import numpy.typing as npt
-
 try:
     import gi
 except ImportError as e:
@@ -18,7 +15,7 @@ gi.require_version("Gst", "1.0")
 gi.require_version("GstApp", "1.0")
 gi.require_version("GstPbutils", "1.0")
 
-from gi.repository import GLib, Gst, GstApp, GstPbutils  # noqa: E402
+from gi.repository import Gst, GstApp, GstPbutils  # noqa: E402
 
 
 def handle_default_bus_message(
@@ -77,38 +74,6 @@ def get_sample(appsink: GstApp.AppSink, logger: logging.Logger) -> Optional[byte
             logger.warning("Buffer is None")
         data = buf.extract_dup(0, buf.get_size())
     return data
-
-
-def encode_bgr_to_jpeg(
-    frame: npt.NDArray[np.uint8], logger: logging.Logger
-) -> Optional[bytes]:
-    """Encode a BGR frame as JPEG bytes, or ``None`` if encoding fails."""
-    Gst.init([])  # idempotent
-    height, width = frame.shape[:2]
-    try:
-        pipeline = Gst.parse_launch(
-            "appsrc name=src format=time is-live=false "
-            "! videoconvert ! jpegenc ! appsink name=sink sync=false"
-        )
-    except GLib.Error as e:
-        logger.warning(f"Failed to build JPEG encoder pipeline: {e}")
-        return None
-
-    appsrc = pipeline.get_by_name("src")
-    appsink = pipeline.get_by_name("sink")
-    appsrc.set_property(
-        "caps",
-        Gst.Caps.from_string(
-            f"video/x-raw,format=BGR,width={width},height={height},framerate=1/1"
-        ),
-    )
-    pipeline.set_state(Gst.State.PLAYING)
-    try:
-        appsrc.emit("push-buffer", Gst.Buffer.new_wrapped(frame.tobytes()))
-        appsrc.emit("end-of-stream")
-        return get_sample(appsink, logger)
-    finally:
-        pipeline.set_state(Gst.State.NULL)
 
 
 def is_valid_audio_file(path: str) -> bool:

--- a/src/reachy_mini/media/gstreamer_utils.py
+++ b/src/reachy_mini/media/gstreamer_utils.py
@@ -3,6 +3,9 @@
 import logging
 from typing import Optional
 
+import numpy as np
+import numpy.typing as npt
+
 try:
     import gi
 except ImportError as e:
@@ -15,7 +18,7 @@ gi.require_version("Gst", "1.0")
 gi.require_version("GstApp", "1.0")
 gi.require_version("GstPbutils", "1.0")
 
-from gi.repository import Gst, GstApp, GstPbutils  # noqa: E402
+from gi.repository import GLib, Gst, GstApp, GstPbutils  # noqa: E402
 
 
 def handle_default_bus_message(
@@ -74,6 +77,38 @@ def get_sample(appsink: GstApp.AppSink, logger: logging.Logger) -> Optional[byte
             logger.warning("Buffer is None")
         data = buf.extract_dup(0, buf.get_size())
     return data
+
+
+def encode_bgr_to_jpeg(
+    frame: npt.NDArray[np.uint8], logger: logging.Logger
+) -> Optional[bytes]:
+    """Encode a BGR frame as JPEG bytes, or ``None`` if encoding fails."""
+    Gst.init([])  # idempotent
+    height, width = frame.shape[:2]
+    try:
+        pipeline = Gst.parse_launch(
+            "appsrc name=src format=time is-live=false "
+            "! videoconvert ! jpegenc ! appsink name=sink sync=false"
+        )
+    except GLib.Error as e:
+        logger.warning(f"Failed to build JPEG encoder pipeline: {e}")
+        return None
+
+    appsrc = pipeline.get_by_name("src")
+    appsink = pipeline.get_by_name("sink")
+    appsrc.set_property(
+        "caps",
+        Gst.Caps.from_string(
+            f"video/x-raw,format=BGR,width={width},height={height},framerate=1/1"
+        ),
+    )
+    pipeline.set_state(Gst.State.PLAYING)
+    try:
+        appsrc.emit("push-buffer", Gst.Buffer.new_wrapped(frame.tobytes()))
+        appsrc.emit("end-of-stream")
+        return get_sample(appsink, logger)
+    finally:
+        pipeline.set_state(Gst.State.NULL)
 
 
 def is_valid_audio_file(path: str) -> bool:

--- a/src/reachy_mini/media/media_manager.py
+++ b/src/reachy_mini/media/media_manager.py
@@ -254,6 +254,13 @@ class MediaManager:
             return None
         return self.camera.read()
 
+    def get_frame_jpeg(self) -> Optional[bytes]:
+        """Get the current camera frame as JPEG bytes, or ``None`` if unavailable."""
+        if self.camera is None:
+            self.logger.warning("Camera is not initialized.")
+            return None
+        return self.camera.read_jpeg()
+
     def play_sound(self, sound_file: str) -> None:
         """Play a sound file.
 

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -822,6 +822,7 @@ class GstMediaServer:
         capsfilter.set_property("caps", caps_mjpeg)
 
         queue = Gst.ElementFactory.make("queue")
+        # Decode MJPEG to raw so all platforms share one IPC/WebRTC pipeline.
         jpegdec = Gst.ElementFactory.make("jpegdec")
         videoconvert = Gst.ElementFactory.make("videoconvert")
 

--- a/src/reachy_mini/media/webrtc_client_gstreamer.py
+++ b/src/reachy_mini/media/webrtc_client_gstreamer.py
@@ -98,7 +98,6 @@ class GstWebRTCClient(CameraBase, AudioBase):
         CameraBase.__init__(self, log_level=log_level)
         AudioBase.__init__(self, log_level=log_level)
 
-        Gst.init([])
         self._loop = GLib.MainLoop()
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
         self._thread_bus_calls.start()
@@ -349,6 +348,7 @@ class GstWebRTCClient(CameraBase, AudioBase):
 
     def close(self) -> None:
         """Stop the WebRTC pipeline."""
+        self._release_jpeg_encoder()
         self._pipeline_record.set_state(Gst.State.NULL)
 
     def start_recording(self) -> None:

--- a/tests/unit_tests/test_video.py
+++ b/tests/unit_tests/test_video.py
@@ -1,4 +1,5 @@
 import time
+import logging
 from typing import cast
 
 import numpy as np
@@ -12,6 +13,7 @@ from reachy_mini.media.camera_constants import (
     ReachyMiniLiteCamSpecs,
 )
 from reachy_mini.media.media_manager import MediaBackend, MediaManager
+from reachy_mini.media.gstreamer_utils import encode_bgr_to_jpeg
 
 SIGNALING_HOST = "reachy-mini.local"
 
@@ -135,3 +137,19 @@ def test_change_resolution_errors(backend: MediaBackend) -> None:
         media.camera.set_resolution(CameraResolution.R1280x720at30fps)
 
     media.close()
+
+
+@pytest.mark.video
+def test_encode_bgr_to_jpeg_preserves_color() -> None:
+    """A red BGR frame encodes to a JPEG that decodes back to red."""
+    cv2 = pytest.importorskip("cv2")
+
+    frame = np.zeros((32, 32, 3), dtype=np.uint8)
+    frame[:, :, 2] = 255  # BGR red
+    jpeg = encode_bgr_to_jpeg(frame, logging.getLogger(__name__))
+    assert jpeg is not None
+    assert jpeg[:2] == b"\xff\xd8"
+
+    decoded = cv2.imdecode(np.frombuffer(jpeg, np.uint8), cv2.IMREAD_COLOR)
+    blue, green, red = (int(c) for c in decoded[16, 16])
+    assert red > 200 and green < 40 and blue < 40

--- a/tests/unit_tests/test_video.py
+++ b/tests/unit_tests/test_video.py
@@ -1,8 +1,8 @@
 import time
-import logging
 from typing import cast
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from reachy_mini.daemon.utils import is_local_camera_available
@@ -13,7 +13,7 @@ from reachy_mini.media.camera_constants import (
     ReachyMiniLiteCamSpecs,
 )
 from reachy_mini.media.media_manager import MediaBackend, MediaManager
-from reachy_mini.media.gstreamer_utils import encode_bgr_to_jpeg
+from reachy_mini.media.camera_base import CameraBase
 
 SIGNALING_HOST = "reachy-mini.local"
 
@@ -140,13 +140,29 @@ def test_change_resolution_errors(backend: MediaBackend) -> None:
 
 
 @pytest.mark.video
-def test_encode_bgr_to_jpeg_preserves_color() -> None:
-    """A red BGR frame encodes to a JPEG that decodes back to red."""
+def test_read_jpeg_encodes_bgr_frame() -> None:
+    """CameraBase.read_jpeg encodes a BGR frame into a JPEG that decodes back to it."""
     cv2 = pytest.importorskip("cv2")
 
-    frame = np.zeros((32, 32, 3), dtype=np.uint8)
-    frame[:, :, 2] = 255  # BGR red
-    jpeg = encode_bgr_to_jpeg(frame, logging.getLogger(__name__))
+    class _StubCamera(CameraBase):
+        def open(self) -> None: ...
+
+        def read(self) -> npt.NDArray[np.uint8]:
+            frame = np.zeros((32, 32, 3), dtype=np.uint8)
+            frame[:, :, 2] = 255  # BGR red
+            return frame
+
+        def close(self) -> None:
+            self._release_jpeg_encoder()
+
+        def _apply_resolution(self, resolution: CameraResolution) -> None: ...
+
+    camera = _StubCamera()
+    try:
+        jpeg = camera.read_jpeg()
+    finally:
+        camera.close()
+
     assert jpeg is not None
     assert jpeg[:2] == b"\xff\xd8"
 


### PR DESCRIPTION
Adds `MediaManager.get_frame_jpeg()` / `CameraBase.read_jpeg()` encoding the current BGR frame to JPEG with `jpegenc`, so downstream apps don't need their own encoder. Works across LOCAL, WEBRTC and simulation (all deliver BGR at the client). Reuses `get_sample`.

Closes https://github.com/pollen-robotics/reachy_mini/issues/1249