### PR TITLE
Feat/1247 configure startup app

### DIFF
--- a/docs/source/API/openapi.json
+++ b/docs/source/API/openapi.json
@@ -302,6 +302,62 @@
         }
       }
     },
+    "/api/apps/startup-app": {
+      "get": {
+        "summary": "Get Startup App",
+        "description": "Get the app configured to auto-start on wake-up (null if unset).",
+        "operationId": "get_startup_app_api_apps_startup_app_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StartupApp"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Set Startup App",
+        "description": "Set (or clear, with null) the app that auto-starts on wake-up.\n\nMust already be installed (install via /apps/install first). Applied live, so\nno daemon restart is needed.",
+        "operationId": "set_startup_app_api_apps_startup_app_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartupApp"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StartupApp"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/apps/install-private-space": {
       "post": {
         "summary": "Install Private Space",
@@ -3394,6 +3450,24 @@
         ],
         "title": "SourceKind",
         "description": "Kinds of app source."
+      },
+      "StartupApp": {
+        "properties": {
+          "startup_app": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Startup App"
+          }
+        },
+        "type": "object",
+        "title": "StartupApp",
+        "description": "The app configured to auto-start on the robot's first wake-up."
       },
       "TestSoundResponse": {
         "properties": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pyusb>=1.2.1",
     "libusb_package>=1.0.26.3",
     "pip>=26.1",
+    "platformdirs",
     "rich",
     "questionary",
     "websockets>=12,<16",

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -24,6 +24,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon import startup_app_config
 from reachy_mini.daemon.app.middleware import MaxBodySizeMiddleware
 from reachy_mini.daemon.app.routers import (
     apps,
@@ -96,7 +97,6 @@ class Args:
 
     wake_up_on_start: bool = True
     goto_sleep_on_stop: bool = True
-    startup_app: str | None = None  # app name to auto-start after wake-up
     preload_datasets: bool = False
     dataset_update_interval_hours: float = 24.0  # 0 to disable periodic updates
 
@@ -181,14 +181,15 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
             # unit boots asleep (--no-wake-up-on-start), so the app is started by
             # a one-shot hook on the first wake-up rather than here.
             on_wake_up_callback = None
+            startup_app = startup_app_config.get_startup_app()
             startup_app_ready = False
-            if args.autostart and args.startup_app:
+            if args.autostart and startup_app:
                 if await ensure_startup_app_installed(
-                    app.state.app_manager, args.startup_app
+                    app.state.app_manager, startup_app
                 ):
                     startup_app_ready = True
                     on_wake_up_callback = make_startup_app_launcher(
-                        app.state.app_manager, args.startup_app
+                        app.state.app_manager, startup_app
                     )
 
             if args.autostart:
@@ -208,7 +209,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
 
             if (
                 args.autostart
-                and args.startup_app
+                and startup_app
                 and startup_app_ready
                 and app.state.daemon.backend is not None
             ):
@@ -216,11 +217,11 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                     watch_antennas_for_startup_app(
                         app.state.app_manager,
                         app.state.daemon,
-                        args.startup_app,
+                        startup_app,
                     )
                 )
                 logger.info(
-                    f"Startup app antenna watcher started for app: {args.startup_app}"
+                    f"Startup app antenna watcher started for app: {startup_app}"
                 )
 
             # Register mDNS service only after the daemon is ready
@@ -609,15 +610,6 @@ def main() -> None:
         action="store_false",
         dest="wake_up_on_start",
         help="Do not wake up the robot on daemon start (default: False).",
-    )
-    parser.add_argument(
-        "--startup-app",
-        type=str,
-        default=default_args.startup_app,
-        dest="startup_app",
-        help="Name of an app to start automatically after the robot wakes up "
-        "and from an idle antenna touch (installed from the catalog first if "
-        "it isn't already installed).",
     )
     parser.add_argument(
         "--goto-sleep-on-stop",

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -129,7 +129,8 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         """Lifespan context manager for the FastAPI application."""
         args = app.state.args  # type: Args
         dataset_updater_task: asyncio.Task[None] | None = None
-        startup_app_antenna_watcher_task: asyncio.Task[None] | None = None
+        # Held on app.state so the /apps/startup-app endpoint can re-arm it live.
+        app.state.startup_app_antenna_watcher_task = None
 
         mdns = MdnsServiceRegistration(
             args.robot_name,
@@ -213,7 +214,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                 and startup_app_ready
                 and app.state.daemon.backend is not None
             ):
-                startup_app_antenna_watcher_task = asyncio.create_task(
+                app.state.startup_app_antenna_watcher_task = asyncio.create_task(
                     watch_antennas_for_startup_app(
                         app.state.app_manager,
                         app.state.daemon,
@@ -238,13 +239,11 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
                     pass
 
             # Cancel startup app antenna watcher before closing the app manager.
-            if (
-                startup_app_antenna_watcher_task
-                and not startup_app_antenna_watcher_task.done()
-            ):
-                startup_app_antenna_watcher_task.cancel()
+            antenna_watcher_task = app.state.startup_app_antenna_watcher_task
+            if antenna_watcher_task and not antenna_watcher_task.done():
+                antenna_watcher_task.cancel()
                 try:
-                    await startup_app_antenna_watcher_task
+                    await antenna_watcher_task
                 except asyncio.CancelledError:
                     pass
 

--- a/src/reachy_mini/daemon/app/routers/apps.py
+++ b/src/reachy_mini/daemon/app/routers/apps.py
@@ -7,6 +7,7 @@ from fastapi import (
     APIRouter,
     Depends,
     HTTPException,
+    Request,
     WebSocket,
 )
 from pydantic import BaseModel
@@ -16,6 +17,7 @@ from reachy_mini.apps.manager import AppManager, AppStatus
 from reachy_mini.daemon import startup_app_config
 from reachy_mini.daemon.app import bg_job_register
 from reachy_mini.daemon.app.dependencies import get_app_manager
+from reachy_mini.daemon.app.startup_app import rearm_startup_app_watcher
 
 router = APIRouter(prefix="/apps")
 
@@ -174,11 +176,13 @@ async def get_startup_app() -> StartupApp:
 @router.put("/startup-app")
 async def set_startup_app(
     body: StartupApp,
+    request: Request,
     app_manager: "AppManager" = Depends(get_app_manager),
 ) -> StartupApp:
     """Set (or clear, with null) the app that auto-starts on wake-up.
 
-    The app must already be installed; install it via /apps/install first.
+    Must already be installed (install via /apps/install first). Applied live, so
+    no daemon restart is needed.
     """
     name = body.startup_app
     if name:
@@ -189,6 +193,11 @@ async def set_startup_app(
             )
 
     startup_app_config.set_startup_app(name)
+
+    state = request.app.state
+    state.startup_app_antenna_watcher_task = await rearm_startup_app_watcher(
+        app_manager, state.daemon, name, state.startup_app_antenna_watcher_task
+    )
     return StartupApp(startup_app=name)
 
 

--- a/src/reachy_mini/daemon/app/routers/apps.py
+++ b/src/reachy_mini/daemon/app/routers/apps.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from reachy_mini.apps import AppInfo, SourceKind
 from reachy_mini.apps.manager import AppManager, AppStatus
+from reachy_mini.daemon import startup_app_config
 from reachy_mini.daemon.app import bg_job_register
 from reachy_mini.daemon.app.dependencies import get_app_manager
 
@@ -156,6 +157,39 @@ async def current_app_status(
 ) -> AppStatus | None:
     """Get the status of the currently running app, if any."""
     return await app_manager.current_app_status()
+
+
+class StartupApp(BaseModel):
+    """The app configured to auto-start on the robot's first wake-up."""
+
+    startup_app: Optional[str] = None
+
+
+@router.get("/startup-app")
+async def get_startup_app() -> StartupApp:
+    """Get the app configured to auto-start on wake-up (null if unset)."""
+    return StartupApp(startup_app=startup_app_config.get_startup_app())
+
+
+@router.put("/startup-app")
+async def set_startup_app(
+    body: StartupApp,
+    app_manager: "AppManager" = Depends(get_app_manager),
+) -> StartupApp:
+    """Set (or clear, with null) the app that auto-starts on wake-up.
+
+    The app must already be installed; install it via /apps/install first.
+    """
+    name = body.startup_app
+    if name:
+        installed = await app_manager.list_available_apps(SourceKind.INSTALLED)
+        if not any(a.name == name for a in installed):
+            raise HTTPException(
+                status_code=400, detail=f"App '{name}' is not installed"
+            )
+
+    startup_app_config.set_startup_app(name)
+    return StartupApp(startup_app=name)
 
 
 class PrivateSpaceInstallRequest(BaseModel):

--- a/src/reachy_mini/daemon/app/routers/apps.py
+++ b/src/reachy_mini/daemon/app/routers/apps.py
@@ -91,11 +91,21 @@ async def install_app(
 @router.post("/remove/{app_name}")
 async def remove_app(
     app_name: str,
+    request: Request,
     app_manager: "AppManager" = Depends(get_app_manager),
 ) -> dict[str, str]:
     """Remove an installed app by its name (background, returns job_id)."""
     global _update_cache
     _update_cache = None  # Invalidate cache
+
+    # Clear the startup app if it's the one being removed, so the watcher stops
+    # trying to launch (and reinstall) it.
+    if startup_app_config.get_startup_app() == app_name:
+        startup_app_config.set_startup_app(None)
+        state = request.app.state
+        state.startup_app_antenna_watcher_task = await rearm_startup_app_watcher(
+            app_manager, state.daemon, None, state.startup_app_antenna_watcher_task
+        )
 
     job_id = bg_job_register.run_command("remove", app_manager.remove_app, app_name)
     return {"job_id": job_id}

--- a/src/reachy_mini/daemon/app/startup_app.py
+++ b/src/reachy_mini/daemon/app/startup_app.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +19,8 @@ logger = logging.getLogger(__name__)
 
 STARTUP_APP_ANTENNA_IDLE_POLL_INTERVAL_S = 0.1
 STARTUP_APP_ANTENNA_BLOCKED_POLL_INTERVAL_S = 0.5
+# Per-poll target shift above this means a commanded move (not a physical touch).
+STARTUP_APP_ANTENNA_MOTION_EPS_RAD = 0.02
 
 
 async def ensure_startup_app_installed(app_manager: AppManager, name: str) -> bool:
@@ -135,6 +138,20 @@ def _read_current_antenna_pair(backend: Any) -> tuple[float, float] | None:
     return _as_antenna_pair(backend.get_present_antenna_joint_positions())
 
 
+def _antennas_in_commanded_motion(
+    prev: tuple[float, float] | None,
+    cur: tuple[float, float] | None,
+    eps: float = STARTUP_APP_ANTENNA_MOTION_EPS_RAD,
+) -> bool:
+    """Whether the commanded antenna target moved between two polls.
+
+    A commanded move shifts the target; a physical push moves only present.
+    """
+    if prev is None or cur is None:
+        return False
+    return max(abs(c - p) for c, p in zip(cur, prev)) > eps
+
+
 def _startup_app_slot_is_free(app_manager: AppManager, daemon: "Daemon") -> bool:
     """Return whether no managed local or remote app currently owns the robot."""
     return (
@@ -211,12 +228,14 @@ async def watch_antennas_for_startup_app(
     """Start the startup app when an idle robot receives an antenna touch."""
     detector = detector or AntennaTouchDetector()
     detector.reset()
+    prev_target: tuple[float, float] | None = None
 
     while True:
         try:
             backend = daemon.backend
             if backend is None or not backend.ready.is_set():
                 detector.reset()
+                prev_target = None
                 await asyncio.sleep(blocked_poll_interval_s)
                 continue
 
@@ -224,6 +243,18 @@ async def watch_antennas_for_startup_app(
                 detector.reset()
                 await asyncio.sleep(blocked_poll_interval_s)
                 continue
+
+            # Ignore commanded motion (e.g. the go-to-sleep swing) so it isn't
+            # read as a touch.
+            target = _as_antenna_pair(
+                getattr(backend, "target_antenna_joint_positions", None)
+            )
+            if _antennas_in_commanded_motion(prev_target, target):
+                prev_target = target
+                detector.reset()
+                await asyncio.sleep(idle_poll_interval_s)
+                continue
+            prev_target = target
 
             present = _read_current_antenna_pair(backend)
             if present is None:
@@ -248,3 +279,39 @@ async def watch_antennas_for_startup_app(
             logger.warning(f"Startup app antenna watcher error: {e}")
             detector.reset()
             await asyncio.sleep(blocked_poll_interval_s)
+
+
+async def rearm_startup_app_watcher(
+    app_manager: AppManager,
+    daemon: "Daemon",
+    name: str | None,
+    previous_task: asyncio.Task[None] | None,
+) -> asyncio.Task[None] | None:
+    """Apply a startup-app change to a running daemon, no restart needed.
+
+    Cancels the previous watcher, re-sets the one-shot wake launcher, and starts
+    a fresh watcher for ``name``. Returns the new watcher task (or ``None``).
+    """
+    if previous_task is not None and not previous_task.done():
+        previous_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await previous_task
+
+    backend = daemon.backend
+
+    if not name:
+        if backend is not None:
+            backend.set_on_wake_up_callback(lambda: None)  # kill the spent launcher
+        return None
+
+    if not await ensure_startup_app_installed(app_manager, name):
+        return None
+
+    if backend is None:
+        return None  # not started; lifespan arms from config on start
+
+    backend.set_on_wake_up_callback(make_startup_app_launcher(app_manager, name))
+    logger.info(f"Startup app re-armed for app: {name}")
+    return asyncio.create_task(
+        watch_antennas_for_startup_app(app_manager, daemon, name)
+    )

--- a/src/reachy_mini/daemon/startup_app_config.py
+++ b/src/reachy_mini/daemon/startup_app_config.py
@@ -1,0 +1,56 @@
+"""Persisted daemon config for the startup app.
+
+The startup app (launched on the robot's first wake-up) is stored in a small
+JSON file in the user's config dir, so the choice survives reboots and app
+updates, stays per-user (not shared across OS accounts on one machine), and can
+be set over the REST API instead of only via a CLI flag.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import platformdirs
+
+logger = logging.getLogger(__name__)
+
+_KEY = "startup_app"
+
+
+def _config_path() -> Path:
+    """Path to the daemon config file in the user's config dir."""
+    return Path(platformdirs.user_config_dir("reachy_mini")) / "daemon_config.json"
+
+
+def _read() -> dict:  # type: ignore[type-arg]
+    """Load the config dict, or {} if missing/unreadable (best-effort)."""
+    path = _config_path()
+    try:
+        with path.open() as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(f"Ignoring unreadable daemon config {path}: {e}")
+        return {}
+
+
+def get_startup_app() -> str | None:
+    """Return the persisted startup app name, or None if unset."""
+    value = _read().get(_KEY)
+    return value if isinstance(value, str) else None
+
+
+def set_startup_app(name: str | None) -> None:
+    """Persist the startup app name; a falsy name clears it."""
+    config = _read()
+    if name:
+        config[_KEY] = name
+    else:
+        config.pop(_KEY, None)
+
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(config, f, indent=2)

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -1,4 +1,5 @@
 import asyncio
+import types
 from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
@@ -12,9 +13,11 @@ from reachy_mini.daemon import startup_app_config
 from reachy_mini.daemon.app.routers import apps as apps_router
 from reachy_mini.daemon.app.startup_app import (
     AntennaTouchDetector,
+    _antennas_in_commanded_motion,
     ensure_startup_app_installed,
     make_startup_app_launcher,
     play_awake_startup_cue,
+    rearm_startup_app_watcher,
     start_startup_app,
     start_startup_app_if_idle,
     wake_or_start_startup_app_if_idle,
@@ -78,6 +81,9 @@ class StubBackend:
 
     def set_motor_control_mode(self, mode: MotorControlMode) -> None:
         self.motor_control_mode = mode
+
+    def set_on_wake_up_callback(self, callback: Callable[[], None]) -> None:
+        self.on_wake_up_callback = callback
 
     async def wake_up(self) -> None:
         self.wake_up_calls += 1
@@ -424,34 +430,133 @@ def test_config_corrupt_file_reads_as_none(config_file: Path) -> None:
     assert startup_app_config.get_startup_app() is None
 
 
+def _stub_request(daemon: object) -> object:
+    """Minimal Request stand-in exposing app.state.{daemon,watcher task}."""
+    state = types.SimpleNamespace(
+        daemon=daemon, startup_app_antenna_watcher_task=None
+    )
+    return types.SimpleNamespace(app=types.SimpleNamespace(state=state))
+
+
 @pytest.mark.asyncio
 async def test_set_startup_app_endpoint_rejects_uninstalled(config_file: Path) -> None:
     mgr = StubAppManager(installed=["foo"], catalog=["bar"])
+    request = _stub_request(StubDaemon())
     with pytest.raises(HTTPException) as exc:
         await apps_router.set_startup_app(
-            apps_router.StartupApp(startup_app="bar"), mgr  # type: ignore[arg-type]
+            apps_router.StartupApp(startup_app="bar"), request, mgr  # type: ignore[arg-type]
         )
     assert exc.value.status_code == 400
     assert startup_app_config.get_startup_app() is None  # nothing persisted
 
 
 @pytest.mark.asyncio
-async def test_set_startup_app_endpoint_persists_installed(config_file: Path) -> None:
+async def test_set_startup_app_endpoint_persists_and_rearms(config_file: Path) -> None:
     mgr = StubAppManager(installed=["foo"], catalog=[])
+    request = _stub_request(StubDaemon())
     result = await apps_router.set_startup_app(
-        apps_router.StartupApp(startup_app="foo"), mgr  # type: ignore[arg-type]
+        apps_router.StartupApp(startup_app="foo"), request, mgr  # type: ignore[arg-type]
     )
-    assert result.startup_app == "foo"
-    assert startup_app_config.get_startup_app() == "foo"
-    assert (await apps_router.get_startup_app()).startup_app == "foo"
+    task = request.app.state.startup_app_antenna_watcher_task  # type: ignore[attr-defined]
+    try:
+        assert result.startup_app == "foo"
+        assert startup_app_config.get_startup_app() == "foo"
+        assert (await apps_router.get_startup_app()).startup_app == "foo"
+        # Applied live: a watcher was armed without a restart.
+        assert task is not None
+    finally:
+        if task is not None:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
 
 
 @pytest.mark.asyncio
 async def test_set_startup_app_endpoint_clears_with_null(config_file: Path) -> None:
     startup_app_config.set_startup_app("foo")
     mgr = StubAppManager(installed=["foo"], catalog=[])
+    request = _stub_request(StubDaemon())
     result = await apps_router.set_startup_app(
-        apps_router.StartupApp(startup_app=None), mgr  # type: ignore[arg-type]
+        apps_router.StartupApp(startup_app=None), request, mgr  # type: ignore[arg-type]
     )
     assert result.startup_app is None
     assert startup_app_config.get_startup_app() is None
+    assert request.app.state.startup_app_antenna_watcher_task is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_rearm_arms_watcher_and_wake_hook_for_installed_app() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+
+    task = await rearm_startup_app_watcher(mgr, daemon, "foo", None)  # type: ignore[arg-type]
+    try:
+        assert task is not None
+        # The one-shot wake launcher is re-set and starts the new app on wake.
+        assert daemon.backend.on_wake_up_callback is not None
+        await daemon.backend.wake_up()
+        await asyncio.sleep(0)
+        assert mgr.started == ["foo"]
+    finally:
+        if task is not None:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+
+@pytest.mark.asyncio
+async def test_rearm_cancels_previous_watcher() -> None:
+    mgr = StubAppManager(installed=["foo", "bar"], catalog=[])
+    daemon = StubDaemon()
+
+    first = await rearm_startup_app_watcher(mgr, daemon, "foo", None)  # type: ignore[arg-type]
+    second = await rearm_startup_app_watcher(mgr, daemon, "bar", first)  # type: ignore[arg-type]
+    try:
+        assert first is not None and first.cancelled()
+        assert second is not None and not second.done()
+    finally:
+        if second is not None:
+            second.cancel()
+            with suppress(asyncio.CancelledError):
+                await second
+
+
+@pytest.mark.asyncio
+async def test_rearm_with_none_cancels_and_neutralizes_wake_hook() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+
+    first = await rearm_startup_app_watcher(mgr, daemon, "foo", None)  # type: ignore[arg-type]
+    cleared = await rearm_startup_app_watcher(mgr, daemon, None, first)  # type: ignore[arg-type]
+
+    assert cleared is None
+    assert first is not None and first.cancelled()
+    # A later wake must not start anything after the startup app is cleared.
+    await daemon.backend.wake_up()
+    await asyncio.sleep(0)
+    assert mgr.started == []
+
+
+@pytest.mark.asyncio
+async def test_rearm_unknown_app_arms_nothing() -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+
+    task = await rearm_startup_app_watcher(mgr, daemon, "nope", None)  # type: ignore[arg-type]
+    assert task is None
+
+
+def test_commanded_motion_detects_moving_target() -> None:
+    # Sleep swing: target jumps far between polls -> commanded motion.
+    assert _antennas_in_commanded_motion((-0.17, 0.17), (-0.5, 0.5)) is True
+
+
+def test_commanded_motion_false_for_stable_target() -> None:
+    # Idle target barely changes (below eps) -> not commanded motion, so a
+    # physical push (present-only) can still be detected.
+    assert _antennas_in_commanded_motion((-0.17, 0.17), (-0.17, 0.171)) is False
+
+
+def test_commanded_motion_false_when_sample_missing() -> None:
+    assert _antennas_in_commanded_motion(None, (0.0, 0.0)) is False
+    assert _antennas_in_commanded_motion((0.0, 0.0), None) is False

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -47,6 +47,10 @@ class StubAppManager:
         self.installed_calls.append(app.name)
         self._installed.append(app.name)
 
+    async def remove_app(self, name: str, logger: object) -> None:
+        if name in self._installed:
+            self._installed.remove(name)
+
     def is_app_running(self) -> bool:
         return self.running
 
@@ -560,3 +564,30 @@ def test_commanded_motion_false_for_stable_target() -> None:
 def test_commanded_motion_false_when_sample_missing() -> None:
     assert _antennas_in_commanded_motion(None, (0.0, 0.0)) is False
     assert _antennas_in_commanded_motion((0.0, 0.0), None) is False
+
+
+@pytest.mark.asyncio
+async def test_remove_app_clears_startup_app(
+    config_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    startup_app_config.set_startup_app("foo")
+    monkeypatch.setattr(apps_router.bg_job_register, "run_command", lambda *a, **k: "j1")
+    request = _stub_request(StubDaemon())
+    await apps_router.remove_app(
+        "foo", request, StubAppManager(installed=["foo"], catalog=[])  # type: ignore[arg-type]
+    )
+    assert startup_app_config.get_startup_app() is None
+    assert request.app.state.startup_app_antenna_watcher_task is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_remove_other_app_keeps_startup_app(
+    config_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    startup_app_config.set_startup_app("foo")
+    monkeypatch.setattr(apps_router.bg_job_register, "run_command", lambda *a, **k: "j1")
+    request = _stub_request(StubDaemon())
+    await apps_router.remove_app(
+        "bar", request, StubAppManager(installed=["foo", "bar"], catalog=[])  # type: ignore[arg-type]
+    )
+    assert startup_app_config.get_startup_app() == "foo"

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -1,11 +1,15 @@
 import asyncio
 from collections.abc import Callable
 from contextlib import suppress
+from pathlib import Path
 from threading import Event
 
 import pytest
+from fastapi import HTTPException
 
 from reachy_mini.apps import AppInfo, SourceKind
+from reachy_mini.daemon import startup_app_config
+from reachy_mini.daemon.app.routers import apps as apps_router
 from reachy_mini.daemon.app.startup_app import (
     AntennaTouchDetector,
     ensure_startup_app_installed,
@@ -391,3 +395,63 @@ async def test_launcher_starts_app_once_across_multiple_wakes() -> None:
     await asyncio.sleep(0)  # let the scheduled task(s) run
 
     assert mgr.started == ["foo"]
+
+
+@pytest.fixture
+def config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the startup-app config at a temp file."""
+    path = tmp_path / "daemon_config.json"
+    monkeypatch.setattr(startup_app_config, "_config_path", lambda: path)
+    return path
+
+
+def test_config_round_trip(config_file: Path) -> None:
+    assert startup_app_config.get_startup_app() is None  # missing file
+    startup_app_config.set_startup_app("foo")
+    assert startup_app_config.get_startup_app() == "foo"
+    startup_app_config.set_startup_app("bar")
+    assert startup_app_config.get_startup_app() == "bar"
+
+
+def test_config_clear(config_file: Path) -> None:
+    startup_app_config.set_startup_app("foo")
+    startup_app_config.set_startup_app(None)
+    assert startup_app_config.get_startup_app() is None
+
+
+def test_config_corrupt_file_reads_as_none(config_file: Path) -> None:
+    config_file.write_text("{ not json")
+    assert startup_app_config.get_startup_app() is None
+
+
+@pytest.mark.asyncio
+async def test_set_startup_app_endpoint_rejects_uninstalled(config_file: Path) -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=["bar"])
+    with pytest.raises(HTTPException) as exc:
+        await apps_router.set_startup_app(
+            apps_router.StartupApp(startup_app="bar"), mgr  # type: ignore[arg-type]
+        )
+    assert exc.value.status_code == 400
+    assert startup_app_config.get_startup_app() is None  # nothing persisted
+
+
+@pytest.mark.asyncio
+async def test_set_startup_app_endpoint_persists_installed(config_file: Path) -> None:
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    result = await apps_router.set_startup_app(
+        apps_router.StartupApp(startup_app="foo"), mgr  # type: ignore[arg-type]
+    )
+    assert result.startup_app == "foo"
+    assert startup_app_config.get_startup_app() == "foo"
+    assert (await apps_router.get_startup_app()).startup_app == "foo"
+
+
+@pytest.mark.asyncio
+async def test_set_startup_app_endpoint_clears_with_null(config_file: Path) -> None:
+    startup_app_config.set_startup_app("foo")
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    result = await apps_router.set_startup_app(
+        apps_router.StartupApp(startup_app=None), mgr  # type: ignore[arg-type]
+    )
+    assert result.startup_app is None
+    assert startup_app_config.get_startup_app() is None

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-18T11:23:44.841359908Z"
+exclude-newer = "2026-06-25T15:29:50.217114583Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -3386,6 +3386,7 @@ dependencies = [
     { name = "log-throttling" },
     { name = "numpy" },
     { name = "pip" },
+    { name = "platformdirs" },
     { name = "psutil" },
     { name = "pulsectl", marker = "sys_platform == 'linux'" },
     { name = "pycaw", marker = "sys_platform == 'win32'" },
@@ -3499,6 +3500,7 @@ requires-dist = [
     { name = "opencv-python", marker = "extra == 'opencv'", specifier = "<=5.0" },
     { name = "pip", specifier = ">=26.1" },
     { name = "placo", marker = "sys_platform != 'win32' and extra == 'placo-kinematics'", specifier = "==0.9.14" },
+    { name = "platformdirs" },
     { name = "pollen-bmi088-imu-library", marker = "sys_platform == 'linux' and extra == 'wireless-version'" },
     { name = "psutil" },
     { name = "pulsectl", marker = "sys_platform == 'linux'", specifier = ">=24.1.0" },


### PR DESCRIPTION
## Rationale

Closes #1247. PR #1240 added a `--startup-app` **CLI flag**, but the choice lived only in the arg (nothing set it, so no app ever auto-started) and the desktop/mobile apps couldn't read or change it.

This makes the startup app a **persisted, API-configurable** setting:

- **Persisted per-user** as JSON, so it survives reboots/app updates.
- **REST API** `GET`/`PUT /api/apps/startup-app`.
- **Applied live** — a change re-arms the running daemon (wake hook + antenna watcher), no restart needed.
- The `--startup-app` CLI flag is **removed** (config is the single source of truth).
- Antenna-touch launch (from #1244) honors the configured app, and no longer false-triggers on the go-to-sleep motion (the sleep swing was read as a touch).
- OpenAPI spec regenerated (`docs/source/API/openapi.json`).

## Config file location

`platformdirs.user_config_dir("reachy_mini") / "daemon_config.json"` → on Linux `~/.config/reachy_mini/daemon_config.json` (on the wireless robot: `/home/pollen/.config/reachy_mini/daemon_config.json`). Shape:

```json
{ "startup_app": "reachy_mini_conversation_app" }
```

## How to test

Against a running daemon (`localhost:8000`):

```bash
# 1. current value (null when unset)
curl -s localhost:8000/api/apps/startup-app          # -> {"startup_app":null}

# 2. an app that isn't installed is rejected
curl -s -o /dev/null -w '%{http_code}\n' -X PUT localhost:8000/api/apps/startup-app \
  -H 'content-type: application/json' -d '{"startup_app":"not-installed"}'   # -> 400

# 3. pick one that IS installed
curl -s localhost:8000/api/apps/list-available/installed | python3 -m json.tool
curl -s -X PUT localhost:8000/api/apps/startup-app \
  -H 'content-type: application/json' -d '{"startup_app":"reachy_mini_conversation_app"}'

# 4. it persisted to disk (no restart)
cat ~/.config/reachy_mini/daemon_config.json

# 5. clear it
curl -s -X PUT localhost:8000/api/apps/startup-app \
  -H 'content-type: application/json' -d '{"startup_app":null}'
```

Install-then-set for an app that isn't installed yet: `POST /api/apps/install` → poll `GET /api/apps/job-status/{job_id}` → then the `PUT` above.

**Live-apply / hardware checks:**
- After a `PUT`, no daemon restart: on the next wake-up (or an antenna touch on an idle robot) the newly chosen app launches.
- Send the robot to sleep (turn-off) with a startup app set → it completes the sleep motion and **stays asleep** (the sleep swing no longer relaunches the app); a real antenna touch still wakes it and starts the app.