### PR TITLE
Bump version to 1.9.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reachy_mini"
-version = "1.8.4"
+version = "1.9.0rc1"
 authors = [{ name = "Pollen Robotics", email = "contact@pollen-robotics.com" }]
 description = ""
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-18T11:23:44.841359908Z"
+exclude-newer = "2026-06-26T14:56:34.677878034Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -3373,7 +3373,7 @@ wheels = [
 
 [[package]]
 name = "reachy-mini"
-version = "1.8.4"
+version = "1.9.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release candidate for the 1.9.0 line. Publishing (PyPI + npm) is triggered by creating a GitHub prerelease for tag v1.9.0rc1.

Assisted-by: Claude:claude-opus-4-8