### PR TITLE
docs(ci): drop removed custom_container input from doc build

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -26,7 +26,6 @@ jobs:
       repo_owner: pollen-robotics
       commit_sha: ${{ github.sha }}
       package: reachy_mini
-      custom_container: pollenrobotics/reachymini_documentation
       additional_args: >-
         ${{
           (github.event_name == 'release' && format('--version {0}', github.event.release.tag_name)) ||

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -18,4 +18,3 @@ jobs:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}
       package: reachy_mini
-      custom_container: pollenrobotics/reachymini_documentation


### PR DESCRIPTION
## Problem

The `Build HF documentation` workflow fails with `startup_failure` (0 jobs) — e.g. [run 29031240494](https://github.com/pollen-robotics/reachy_mini/actions/runs/29031240494) on the v1.9.0 release.

Cause: `huggingface/doc-builder` removed the `custom_container` input from its reusable build workflows. Passing an undeclared input makes GitHub reject the workflow before any job starts, hence `startup_failure` with no logs.

## Change

Remove the now-invalid `custom_container: pollenrobotics/reachymini_documentation` line. The build runs on the bare `ubuntu-22.04` runner and gets its dependencies via doc-builder's mock-deps registry.

## ⚠️ Depends on

[huggingface/doc-builder#807](https://github.com/huggingface/doc-builder/pull/807) (adds the `reachy_mini` mock-deps registry entry). That must merge **first** — this change alone fixes the startup failure, but the build step would then fail at install until [that PR](https://github.com/huggingface/doc-builder/pull/807) lands. Kept as a draft until then.

Once both land, the `docker_reachymini_documentation` image is unused and can be retired.