### PR TITLE
feat(media): speaker EQ to correct the head-shell "boxy" resonance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,6 +288,3 @@ ts/*.d.ts
 ts/*.d.ts.map
 ts/host/src/**/*.d.ts.map
 !ts/host/src/assets/svg.d.ts
-
-# Speaker EQ calibration measurements (hifiscan exports)
-corr_*

--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,6 @@ ts/*.d.ts
 ts/*.d.ts.map
 ts/host/src/**/*.d.ts.map
 !ts/host/src/assets/svg.d.ts
+
+# Speaker EQ calibration measurements (hifiscan exports)
+corr_*

--- a/docs/assets/speaker_eq_calibration.png
+++ b/docs/assets/speaker_eq_calibration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e677b1bd9300dfb0668b1bc38ffb103d307d384920e9cb575d6a3bf71a2335c5
+size 261743

--- a/docs/source/platforms/reachy_mini/media_advanced_controls.md
+++ b/docs/source/platforms/reachy_mini/media_advanced_controls.md
@@ -142,3 +142,28 @@ python src/reachy_mini/media/audio_control_utils.py DOA_VALUE_RADIANS
 # DOA_VALUE_RADIANS: (0.5410520434379578, 1.0)
 ```
 This feature is also directly available from [the SDK](../../SDK/python-sdk.md#sensors--media).
+
+
+### Speaker equalization
+
+The plastic head shell acts as a small enclosure that colors the speaker output, making it sound a bit "boxy" — a low-mid resonance plus a muffled presence range. To compensate, the daemon inserts a GStreamer [`equalizer-10bands`](https://gstreamer.freedesktop.org/documentation/equalizer/equalizer-10bands.html) on the speaker output and applies a fixed per-band correction.
+
+The correction was derived from a differential acoustic measurement (the speaker response *with* vs. *without* the shell): it cuts the head-cavity bass boom and lifts the muffled 1–8 kHz range. The default gains (dB), one per band, are:
+
+| Band (Hz) | 29 | 59 | 119 | 237 | 474 | 947 | 1889 | 3770 | 7523 | 15011 |
+|-----------|-----|-------|------|------|------|------|------|------|------|-------|
+| Gain (dB) | 0.0 | -13.2 | -5.6 | -4.3 | -4.3 | +5.8 | +4.7 | +4.9 | +3.4 | 0.0 |
+
+![Speaker EQ calibration](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/speaker_eq_calibration.png)
+
+*Top: measured speaker response with the shell on vs. off. Bottom: the shell coloration and the applied 10-band correction — its mirror image.*
+
+You can override these gains — or disable the EQ — through the daemon config file `~/.config/reachy_mini/daemon_config.json` (on the Wireless robot: `/home/pollen/.config/reachy_mini/daemon_config.json`):
+
+```json
+{ "speaker_eq_gains": [0.0, -13.21, -5.55, -4.28, -4.32, 5.80, 4.65, 4.90, 3.41, 0.0] }
+```
+
+Provide exactly 10 values (dB), in the band order above. Set them all to `0.0` to bypass the equalizer entirely, then restart the daemon to apply the change.
+
+To re-derive gains for a different shell or speaker, see the calibration tool at [`src/reachy_mini/tools/speaker_eq_calibration/`](https://github.com/pollen-robotics/reachy_mini/tree/main/src/reachy_mini/tools/speaker_eq_calibration).

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -747,6 +747,13 @@ This is a [known issue](https://www.xmos.com/documentation/XM-014888-PC/html/mod
 </details>
 
 <details>
+<summary><strong>The sound quality is not great / the speaker sounds "boxy".</strong></summary>
+
+The daemon already applies a default equalizer to compensate for the head shell's acoustic coloration. If the sound still isn't to your liking, the per-band gains can be tuned — or the EQ disabled — via the `speaker_eq_gains` entry in the daemon config file. See [Advanced Media Controls → Speaker equalization](platforms/reachy_mini/media_advanced_controls.md#speaker-equalization).
+
+</details>
+
+<details>
 <summary><strong>How do I get camera frames?</strong></summary>
 
 Use the `media` object.

--- a/src/reachy_mini/daemon/startup_app_config.py
+++ b/src/reachy_mini/daemon/startup_app_config.py
@@ -8,6 +8,7 @@ be set over the REST API instead of only via a CLI flag.
 
 import json
 import logging
+import math
 from pathlib import Path
 
 import platformdirs
@@ -16,6 +17,18 @@ logger = logging.getLogger(__name__)
 
 _KEY = "startup_app"
 _EQ_KEY = "speaker_eq_gains"
+# equalizer-10bands accepts per-band gains in [-24, +12] dB.
+_EQ_GAIN_MIN, _EQ_GAIN_MAX = -24.0, 12.0
+
+
+def _is_valid_gain(value: object) -> bool:
+    """Return True for a finite real number within the equalizer dB range."""
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and _EQ_GAIN_MIN <= value <= _EQ_GAIN_MAX
+    )
 
 
 def _config_path() -> Path:
@@ -46,14 +59,15 @@ def get_startup_app() -> str | None:
 def get_speaker_eq_gains() -> list[float] | None:
     """Return the 10 speaker-EQ band gains (dB), or None if unset/invalid.
 
-    Invalid values (wrong length, non-numeric) are treated as unset so the
-    caller falls back to its built-in default.
+    Invalid values (wrong length, non-numeric, NaN/inf, or outside the
+    equalizer-10bands [-24, +12] dB range) are treated as unset so the caller
+    falls back to its built-in default.
     """
     value = _read().get(_EQ_KEY)
     if (
         isinstance(value, list)
         and len(value) == 10
-        and all(isinstance(x, (int, float)) and not isinstance(x, bool) for x in value)
+        and all(_is_valid_gain(x) for x in value)
     ):
         return [float(x) for x in value]
     return None

--- a/src/reachy_mini/daemon/startup_app_config.py
+++ b/src/reachy_mini/daemon/startup_app_config.py
@@ -63,13 +63,24 @@ def get_speaker_eq_gains() -> list[float] | None:
     equalizer-10bands [-24, +12] dB range) are treated as unset so the caller
     falls back to its built-in default.
     """
-    value = _read().get(_EQ_KEY)
+    config = _read()
+    if _EQ_KEY not in config:
+        return None
+    value = config[_EQ_KEY]
     if (
         isinstance(value, list)
         and len(value) == 10
         and all(_is_valid_gain(x) for x in value)
     ):
         return [float(x) for x in value]
+    # Present but malformed: warn so the user knows their values were ignored.
+    logger.warning(
+        "Ignoring invalid '%s' in daemon config (need 10 finite dB gains in "
+        "[%g, %g]); using the built-in defaults.",
+        _EQ_KEY,
+        _EQ_GAIN_MIN,
+        _EQ_GAIN_MAX,
+    )
     return None
 
 

--- a/src/reachy_mini/daemon/startup_app_config.py
+++ b/src/reachy_mini/daemon/startup_app_config.py
@@ -15,6 +15,7 @@ import platformdirs
 logger = logging.getLogger(__name__)
 
 _KEY = "startup_app"
+_EQ_KEY = "speaker_eq_gains"
 
 
 def _config_path() -> Path:
@@ -40,6 +41,22 @@ def get_startup_app() -> str | None:
     """Return the persisted startup app name, or None if unset."""
     value = _read().get(_KEY)
     return value if isinstance(value, str) else None
+
+
+def get_speaker_eq_gains() -> list[float] | None:
+    """Return the 10 speaker-EQ band gains (dB), or None if unset/invalid.
+
+    Invalid values (wrong length, non-numeric) are treated as unset so the
+    caller falls back to its built-in default.
+    """
+    value = _read().get(_EQ_KEY)
+    if (
+        isinstance(value, list)
+        and len(value) == 10
+        and all(isinstance(x, (int, float)) and not isinstance(x, bool) for x in value)
+    ):
+        return [float(x) for x in value]
+    return None
 
 
 def set_startup_app(name: str | None) -> None:

--- a/src/reachy_mini/daemon/startup_app_config.py
+++ b/src/reachy_mini/daemon/startup_app_config.py
@@ -8,7 +8,6 @@ be set over the REST API instead of only via a CLI flag.
 
 import json
 import logging
-import math
 from pathlib import Path
 
 import platformdirs
@@ -22,11 +21,15 @@ _EQ_GAIN_MIN, _EQ_GAIN_MAX = -24.0, 12.0
 
 
 def _is_valid_gain(value: object) -> bool:
-    """Return True for a finite real number within the equalizer dB range."""
+    """Return True for a real number within the equalizer dB range.
+
+    The range comparison also rejects NaN and infinities (they compare False)
+    and oversized ints (exact int/float compare, so no OverflowError) without
+    converting the value.
+    """
     return (
         isinstance(value, (int, float))
         and not isinstance(value, bool)
-        and math.isfinite(value)
         and _EQ_GAIN_MIN <= value <= _EQ_GAIN_MAX
     )
 

--- a/src/reachy_mini/media/audio_base.py
+++ b/src/reachy_mini/media/audio_base.py
@@ -30,7 +30,11 @@ from reachy_mini.media.audio_control_utils import (
     init_respeaker_usb,
 )
 from reachy_mini.media.audio_doa import AudioDoA
-from reachy_mini.media.audio_utils import resolve_speaker_eq_gains
+from reachy_mini.media.audio_utils import (
+    has_reachymini_asoundrc,
+    resolve_speaker_eq_gains,
+)
+from reachy_mini.media.device_detection import get_audio_device
 from reachy_mini.media.gstreamer_utils import get_sample, handle_default_bus_message
 
 gi.require_version("Gst", "1.0")
@@ -47,13 +51,19 @@ AEC_PROBE_NAME = "reachymini_aec_probe"
 def make_speaker_eq(logger: logging.Logger) -> Optional[Gst.Element]:
     """Build an ``equalizer-10bands`` from the configured gains, or ``None``.
 
-    Returns ``None`` (caller keeps the direct link) when all gains are zero or
-    the element is unavailable, so uncalibrated robots stay byte-identical.
-    Callers insert it on the speaker branch only, after the wobbler tee, so head
-    motion is driven by the uncorrected signal.
+    Returns ``None`` (caller keeps the direct link) when all gains are zero,
+    the resolved output is not the Reachy Mini Audio device, or the element is
+    unavailable — so uncalibrated robots (and fallback outputs) stay
+    byte-identical. Callers insert it on the speaker branch only, after the
+    wobbler tee, so head motion is driven by the uncorrected signal.
     """
     gains = resolve_speaker_eq_gains()
     if not any(gains):
+        return None
+    # The correction is tuned for the Reachy head shell + its speaker; skip it
+    # when playback falls back to a different output (autoaudiosink).
+    if not (has_reachymini_asoundrc() or get_audio_device("Sink") is not None):
+        logger.info("Speaker EQ skipped: output is not the Reachy Mini Audio device")
         return None
     eq = Gst.ElementFactory.make("equalizer-10bands")
     if eq is None:

--- a/src/reachy_mini/media/audio_base.py
+++ b/src/reachy_mini/media/audio_base.py
@@ -53,7 +53,7 @@ def make_speaker_eq(logger: logging.Logger) -> Optional[Gst.Element]:
 
     Returns ``None`` (caller keeps the direct link) when all gains are zero,
     the resolved output is not the Reachy Mini Audio device, or the element is
-    unavailable — so uncalibrated robots (and fallback outputs) stay
+    unavailable, so uncalibrated robots (and fallback outputs) stay
     byte-identical. Callers insert it on the speaker branch only, after the
     wobbler tee, so head motion is driven by the uncorrected signal.
     """

--- a/src/reachy_mini/media/audio_base.py
+++ b/src/reachy_mini/media/audio_base.py
@@ -84,9 +84,10 @@ def make_speaker_eq(logger: logging.Logger) -> Optional[Gst.Element]:
         logger.warning("audiodynamic unavailable; speaker EQ runs without a limiter")
         return eq
     in_caps.set_property("caps", Gst.Caps.from_string("audio/x-raw,format=F32LE"))
-    # Hard-knee compressor with a low ratio near full scale = a brickwall limiter.
+    # Hard-knee compressor, ratio 0 = a brickwall limiter that clamps anything
+    # above the threshold to it, so the output never exceeds full scale.
     limiter.set_property("threshold", 0.9)
-    limiter.set_property("ratio", 0.05)
+    limiter.set_property("ratio", 0.0)
 
     eq_bin = Gst.Bin.new("speaker_eq")
     for el in (in_caps, eq, limiter, out_conv):

--- a/src/reachy_mini/media/audio_base.py
+++ b/src/reachy_mini/media/audio_base.py
@@ -71,7 +71,32 @@ def make_speaker_eq(logger: logging.Logger) -> Optional[Gst.Element]:
         return None
     for i, gain in enumerate(gains):
         eq.set_property(f"band{i}", float(gain))
-    return eq
+
+    # Wrap eq + a limiter in a float-internal bin. The EQ boosts must run in
+    # F32 and be limited *before* the final int conversion, otherwise a boosted
+    # peak clips when the sink quantizes it. audiodynamic is memoryless so it
+    # cannot overshoot, guaranteeing no digital clipping for any gains. If it is
+    # unavailable, fall back to the bare EQ (pre-limiter behavior).
+    in_caps = Gst.ElementFactory.make("capsfilter")
+    limiter = Gst.ElementFactory.make("audiodynamic")
+    out_conv = Gst.ElementFactory.make("audioconvert")
+    if in_caps is None or limiter is None or out_conv is None:
+        logger.warning("audiodynamic unavailable; speaker EQ runs without a limiter")
+        return eq
+    in_caps.set_property("caps", Gst.Caps.from_string("audio/x-raw,format=F32LE"))
+    # Hard-knee compressor with a low ratio near full scale = a brickwall limiter.
+    limiter.set_property("threshold", 0.9)
+    limiter.set_property("ratio", 0.05)
+
+    eq_bin = Gst.Bin.new("speaker_eq")
+    for el in (in_caps, eq, limiter, out_conv):
+        eq_bin.add(el)
+    in_caps.link(eq)
+    eq.link(limiter)
+    limiter.link(out_conv)
+    eq_bin.add_pad(Gst.GhostPad.new("sink", in_caps.get_static_pad("sink")))
+    eq_bin.add_pad(Gst.GhostPad.new("src", out_conv.get_static_pad("src")))
+    return eq_bin
 
 
 class AudioBase(ABC):

--- a/src/reachy_mini/media/audio_base.py
+++ b/src/reachy_mini/media/audio_base.py
@@ -30,6 +30,7 @@ from reachy_mini.media.audio_control_utils import (
     init_respeaker_usb,
 )
 from reachy_mini.media.audio_doa import AudioDoA
+from reachy_mini.media.audio_utils import resolve_speaker_eq_gains
 from reachy_mini.media.gstreamer_utils import get_sample, handle_default_bus_message
 
 gi.require_version("Gst", "1.0")
@@ -41,6 +42,26 @@ from gi.repository import Gst  # noqa: E402
 AEC_RATE = 48_000
 AEC_CHANNELS = 2
 AEC_PROBE_NAME = "reachymini_aec_probe"
+
+
+def make_speaker_eq(logger: logging.Logger) -> Optional[Gst.Element]:
+    """Build an ``equalizer-10bands`` from the configured gains, or ``None``.
+
+    Returns ``None`` (caller keeps the direct link) when all gains are zero or
+    the element is unavailable, so uncalibrated robots stay byte-identical.
+    Callers insert it on the speaker branch only, after the wobbler tee, so head
+    motion is driven by the uncorrected signal.
+    """
+    gains = resolve_speaker_eq_gains()
+    if not any(gains):
+        return None
+    eq = Gst.ElementFactory.make("equalizer-10bands")
+    if eq is None:
+        logger.warning("equalizer-10bands unavailable; skipping speaker EQ")
+        return None
+    for i, gain in enumerate(gains):
+        eq.set_property(f"band{i}", float(gain))
+    return eq
 
 
 class AudioBase(ABC):

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -60,11 +60,13 @@ from typing import Optional
 
 import numpy as np
 
-from reachy_mini.media.audio_base import AEC_PROBE_NAME, AEC_RATE, AudioBase
-from reachy_mini.media.audio_utils import (
-    has_reachymini_asoundrc,
-    resolve_speaker_eq_gains,
+from reachy_mini.media.audio_base import (
+    AEC_PROBE_NAME,
+    AEC_RATE,
+    AudioBase,
+    make_speaker_eq,
 )
+from reachy_mini.media.audio_utils import has_reachymini_asoundrc
 from reachy_mini.media.device_detection import get_audio_device
 from reachy_mini.motion.head_wobbler import HeadWobbler, SpeechOffsets
 from reachy_mini.utils.constants import ASSETS_ROOT_PATH
@@ -298,25 +300,6 @@ class GStreamerAudio(AudioBase):
         self._head_wobbler.feed(pcm, time.monotonic_ns())
         return Gst.FlowReturn.OK
 
-    def _make_speaker_eq(self) -> Optional[Gst.Element]:
-        """Build an equalizer-10bands from the configured gains, or None.
-
-        Returns None (caller keeps the direct link) when all gains are zero or
-        the element is unavailable, so uncalibrated robots stay byte-identical.
-        Inserted on the speaker branch only, after the wobbler tee, so head
-        motion is driven by the uncorrected signal.
-        """
-        gains = resolve_speaker_eq_gains()
-        if not any(gains):
-            return None
-        eq = Gst.ElementFactory.make("equalizer-10bands")
-        if eq is None:
-            print("equalizer-10bands unavailable; skipping speaker EQ")
-            return None
-        for i, gain in enumerate(gains):
-            eq.set_property(f"band{i}", float(gain))
-        return eq
-
     def _build_audiosink_tee_bin(self) -> Gst.Bin:
         """Build a Gst.Bin with a tee splitting audio to speaker and wobbler.
 
@@ -338,7 +321,7 @@ class GStreamerAudio(AudioBase):
         queue_speaker = Gst.ElementFactory.make("queue")
         ac_speaker = Gst.ElementFactory.make("audioconvert")
         ar_speaker = Gst.ElementFactory.make("audioresample")
-        eq_speaker = self._make_speaker_eq()
+        eq_speaker = make_speaker_eq(self.logger)
         audiosink = self._build_audiosink_element()
         queue_wobbler = Gst.ElementFactory.make("queue")
         ac_wobbler = Gst.ElementFactory.make("audioconvert")
@@ -413,7 +396,7 @@ class GStreamerAudio(AudioBase):
         queue_speaker = Gst.ElementFactory.make("queue")
         ac_speaker = Gst.ElementFactory.make("audioconvert")
         ar_speaker = Gst.ElementFactory.make("audioresample")
-        eq_speaker = self._make_speaker_eq()
+        eq_speaker = make_speaker_eq(self.logger)
         audiosink = self._build_audiosink_element()
         queue_wobbler = Gst.ElementFactory.make("queue")
         ac_wobbler = Gst.ElementFactory.make("audioconvert")

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -61,7 +61,10 @@ from typing import Optional
 import numpy as np
 
 from reachy_mini.media.audio_base import AEC_PROBE_NAME, AEC_RATE, AudioBase
-from reachy_mini.media.audio_utils import has_reachymini_asoundrc
+from reachy_mini.media.audio_utils import (
+    has_reachymini_asoundrc,
+    resolve_speaker_eq_gains,
+)
 from reachy_mini.media.device_detection import get_audio_device
 from reachy_mini.motion.head_wobbler import HeadWobbler, SpeechOffsets
 from reachy_mini.utils.constants import ASSETS_ROOT_PATH
@@ -295,6 +298,25 @@ class GStreamerAudio(AudioBase):
         self._head_wobbler.feed(pcm, time.monotonic_ns())
         return Gst.FlowReturn.OK
 
+    def _make_speaker_eq(self) -> Optional[Gst.Element]:
+        """Build an equalizer-10bands from the configured gains, or None.
+
+        Returns None (caller keeps the direct link) when all gains are zero or
+        the element is unavailable, so uncalibrated robots stay byte-identical.
+        Inserted on the speaker branch only, after the wobbler tee, so head
+        motion is driven by the uncorrected signal.
+        """
+        gains = resolve_speaker_eq_gains()
+        if not any(gains):
+            return None
+        eq = Gst.ElementFactory.make("equalizer-10bands")
+        if eq is None:
+            print("equalizer-10bands unavailable; skipping speaker EQ")
+            return None
+        for i, gain in enumerate(gains):
+            eq.set_property(f"band{i}", float(gain))
+        return eq
+
     def _build_audiosink_tee_bin(self) -> Gst.Bin:
         """Build a Gst.Bin with a tee splitting audio to speaker and wobbler.
 
@@ -316,6 +338,7 @@ class GStreamerAudio(AudioBase):
         queue_speaker = Gst.ElementFactory.make("queue")
         ac_speaker = Gst.ElementFactory.make("audioconvert")
         ar_speaker = Gst.ElementFactory.make("audioresample")
+        eq_speaker = self._make_speaker_eq()
         audiosink = self._build_audiosink_element()
         queue_wobbler = Gst.ElementFactory.make("queue")
         ac_wobbler = Gst.ElementFactory.make("audioconvert")
@@ -338,7 +361,12 @@ class GStreamerAudio(AudioBase):
         tee.link(queue_speaker)
         queue_speaker.link(ac_speaker)
         ac_speaker.link(ar_speaker)
-        ar_speaker.link(audiosink)
+        if eq_speaker is not None:
+            audio_bin.add(eq_speaker)
+            ar_speaker.link(eq_speaker)
+            eq_speaker.link(audiosink)
+        else:
+            ar_speaker.link(audiosink)
 
         tee.link(queue_wobbler)
         queue_wobbler.link(ac_wobbler)
@@ -385,6 +413,7 @@ class GStreamerAudio(AudioBase):
         queue_speaker = Gst.ElementFactory.make("queue")
         ac_speaker = Gst.ElementFactory.make("audioconvert")
         ar_speaker = Gst.ElementFactory.make("audioresample")
+        eq_speaker = self._make_speaker_eq()
         audiosink = self._build_audiosink_element()
         queue_wobbler = Gst.ElementFactory.make("queue")
         ac_wobbler = Gst.ElementFactory.make("audioconvert")
@@ -409,6 +438,8 @@ class GStreamerAudio(AudioBase):
             appsink_wobbler,
         ):
             pipeline.add(el)
+        if eq_speaker is not None:
+            pipeline.add(eq_speaker)
 
         self._appsrc.link(appsrc_queue)
         appsrc_queue.link(mixer)
@@ -441,7 +472,11 @@ class GStreamerAudio(AudioBase):
         tee.link(queue_speaker)
         queue_speaker.link(ac_speaker)
         ac_speaker.link(ar_speaker)
-        ar_speaker.link(audiosink)
+        if eq_speaker is not None:
+            ar_speaker.link(eq_speaker)
+            eq_speaker.link(audiosink)
+        else:
+            ar_speaker.link(audiosink)
         tee.link(queue_wobbler)
         queue_wobbler.link(ac_wobbler)
         ac_wobbler.link(ar_wobbler)

--- a/src/reachy_mini/media/audio_utils.py
+++ b/src/reachy_mini/media/audio_utils.py
@@ -30,9 +30,7 @@ from pathlib import Path
 import numpy as np
 import numpy.typing as npt
 
-# Speaker EQ gains (dB) correcting the head-shell "boxy" resonance, derived
-# offline by tools/speaker_eq_calibration/. Overridable via the daemon config
-# (speaker_eq_gains); see resolve_speaker_eq_gains and the tool's README.
+# Head-shell "boxy" resonance correction; see tools/speaker_eq_calibration/.
 DEFAULT_SPEAKER_EQ_GAINS = [
     0.0,
     -13.21,

--- a/src/reachy_mini/media/audio_utils.py
+++ b/src/reachy_mini/media/audio_utils.py
@@ -30,6 +30,36 @@ from pathlib import Path
 import numpy as np
 import numpy.typing as npt
 
+# --- Speaker EQ (head-shell "boxy" resonance correction) ----------------------
+# A GStreamer equalizer-10bands on the daemon's speaker branch (see
+# audio_gstreamer.py / media_server.py) corrects the head shell's coloration.
+# The 10 per-band gains (dB) come from the daemon config (speaker_eq_gains in
+# daemon_config.json); with no entry we fall back to DEFAULT_SPEAKER_EQ_GAINS,
+# the tested correction. The gains are produced offline by the calibration tool
+# reachy_mini/tools/speaker_eq_calibration/ — see its README.md.
+
+# Tested boxy-shell correction (differential hifiscan measurement, 16 kHz set).
+DEFAULT_SPEAKER_EQ_GAINS = [
+    0.0,
+    -13.21,
+    -5.55,
+    -4.28,
+    -4.32,
+    5.80,
+    4.65,
+    4.90,
+    3.41,
+    0.0,
+]
+
+
+def resolve_speaker_eq_gains() -> list[float]:
+    """Return the 10 speaker-EQ band gains (dB), from daemon config or the default."""
+    from reachy_mini.daemon.startup_app_config import get_speaker_eq_gains
+
+    gains = get_speaker_eq_gains()
+    return gains if gains is not None else list(DEFAULT_SPEAKER_EQ_GAINS)
+
 
 def _process_card_number_output(output: str) -> int:
     """Process the output of 'arecord -l' to find the ReSpeaker or Reachy Mini Audio card number.

--- a/src/reachy_mini/media/audio_utils.py
+++ b/src/reachy_mini/media/audio_utils.py
@@ -30,15 +30,9 @@ from pathlib import Path
 import numpy as np
 import numpy.typing as npt
 
-# --- Speaker EQ (head-shell "boxy" resonance correction) ----------------------
-# A GStreamer equalizer-10bands on the daemon's speaker branch (see
-# audio_gstreamer.py / media_server.py) corrects the head shell's coloration.
-# The 10 per-band gains (dB) come from the daemon config (speaker_eq_gains in
-# daemon_config.json); with no entry we fall back to DEFAULT_SPEAKER_EQ_GAINS,
-# the tested correction. The gains are produced offline by the calibration tool
-# reachy_mini/tools/speaker_eq_calibration/ — see its README.md.
-
-# Tested boxy-shell correction (differential hifiscan measurement, 16 kHz set).
+# Speaker EQ gains (dB) correcting the head-shell "boxy" resonance, derived
+# offline by tools/speaker_eq_calibration/. Overridable via the daemon config
+# (speaker_eq_gains); see resolve_speaker_eq_gains and the tool's README.
 DEFAULT_SPEAKER_EQ_GAINS = [
     0.0,
     -13.21,

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -41,7 +41,10 @@ from reachy_mini.daemon.utils import (
 )
 from reachy_mini.media.audio_base import AEC_CHANNELS, AEC_PROBE_NAME, AEC_RATE
 from reachy_mini.media.audio_control_utils import init_respeaker_usb
-from reachy_mini.media.audio_utils import has_reachymini_asoundrc
+from reachy_mini.media.audio_utils import (
+    has_reachymini_asoundrc,
+    resolve_speaker_eq_gains,
+)
 from reachy_mini.media.camera_constants import (
     CameraSpecs,
     GenericWebcamSpecs,
@@ -489,6 +492,7 @@ class GstMediaServer:
         queue_speaker = Gst.ElementFactory.make("queue")
         ac_speaker = Gst.ElementFactory.make("audioconvert")
         ar_speaker = Gst.ElementFactory.make("audioresample")
+        eq_speaker = self._make_speaker_eq()
         queue_wobbler = Gst.ElementFactory.make("queue")
         ac_wobbler = Gst.ElementFactory.make("audioconvert")
         ar_wobbler = Gst.ElementFactory.make("audioresample")
@@ -517,6 +521,7 @@ class GstMediaServer:
             *([webrtcechoprobe] if webrtcechoprobe is not None else []),
             ac_speaker,
             ar_speaker,
+            *([eq_speaker] if eq_speaker is not None else []),
             audiosink,
             queue_wobbler,
             ac_wobbler,
@@ -534,7 +539,11 @@ class GstMediaServer:
         else:
             queue_speaker.link(ac_speaker)
         ac_speaker.link(ar_speaker)
-        ar_speaker.link(audiosink)
+        if eq_speaker is not None:
+            ar_speaker.link(eq_speaker)
+            eq_speaker.link(audiosink)
+        else:
+            ar_speaker.link(audiosink)
         tee.link(queue_wobbler)
         queue_wobbler.link(ac_wobbler)
         ac_wobbler.link(ar_wobbler)
@@ -1334,6 +1343,25 @@ class GstMediaServer:
         self._head_wobbler.feed(pcm, time.monotonic_ns())
         return Gst.FlowReturn.OK
 
+    def _make_speaker_eq(self) -> Optional[Gst.Element]:
+        """Build an equalizer-10bands from the configured gains, or None.
+
+        Returns None (caller keeps the direct link) when all gains are zero or
+        the element is unavailable, so uncalibrated robots stay byte-identical.
+        Inserted on the speaker branch only, after the wobbler tee, so head
+        motion is driven by the uncorrected signal.
+        """
+        gains = resolve_speaker_eq_gains()
+        if not any(gains):
+            return None
+        eq = Gst.ElementFactory.make("equalizer-10bands")
+        if eq is None:
+            self._logger.warning("equalizer-10bands unavailable; skipping speaker EQ")
+            return None
+        for i, gain in enumerate(gains):
+            eq.set_property(f"band{i}", float(gain))
+        return eq
+
     def _build_audiosink_tee_bin(self) -> Gst.Bin:
         """Build a Gst.Bin splitting audio to speaker and wobbler appsink.
 
@@ -1354,6 +1382,7 @@ class GstMediaServer:
         queue_speaker = Gst.ElementFactory.make("queue")
         ac_speaker = Gst.ElementFactory.make("audioconvert")
         ar_speaker = Gst.ElementFactory.make("audioresample")
+        eq_speaker = self._make_speaker_eq()
         audiosink = self._build_audiosink_element()
         queue_wobbler = Gst.ElementFactory.make("queue")
         ac_wobbler = Gst.ElementFactory.make("audioconvert")
@@ -1376,7 +1405,12 @@ class GstMediaServer:
         tee.link(queue_speaker)
         queue_speaker.link(ac_speaker)
         ac_speaker.link(ar_speaker)
-        ar_speaker.link(audiosink)
+        if eq_speaker is not None:
+            audio_bin.add(eq_speaker)
+            ar_speaker.link(eq_speaker)
+            eq_speaker.link(audiosink)
+        else:
+            ar_speaker.link(audiosink)
 
         tee.link(queue_wobbler)
         queue_wobbler.link(ac_wobbler)

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -39,12 +39,14 @@ from reachy_mini.daemon.utils import (
     SimulationMode,
     is_local_camera_available,
 )
-from reachy_mini.media.audio_base import AEC_CHANNELS, AEC_PROBE_NAME, AEC_RATE
-from reachy_mini.media.audio_control_utils import init_respeaker_usb
-from reachy_mini.media.audio_utils import (
-    has_reachymini_asoundrc,
-    resolve_speaker_eq_gains,
+from reachy_mini.media.audio_base import (
+    AEC_CHANNELS,
+    AEC_PROBE_NAME,
+    AEC_RATE,
+    make_speaker_eq,
 )
+from reachy_mini.media.audio_control_utils import init_respeaker_usb
+from reachy_mini.media.audio_utils import has_reachymini_asoundrc
 from reachy_mini.media.camera_constants import (
     CameraSpecs,
     GenericWebcamSpecs,
@@ -492,7 +494,7 @@ class GstMediaServer:
         queue_speaker = Gst.ElementFactory.make("queue")
         ac_speaker = Gst.ElementFactory.make("audioconvert")
         ar_speaker = Gst.ElementFactory.make("audioresample")
-        eq_speaker = self._make_speaker_eq()
+        eq_speaker = make_speaker_eq(self._logger)
         queue_wobbler = Gst.ElementFactory.make("queue")
         ac_wobbler = Gst.ElementFactory.make("audioconvert")
         ar_wobbler = Gst.ElementFactory.make("audioresample")
@@ -1343,25 +1345,6 @@ class GstMediaServer:
         self._head_wobbler.feed(pcm, time.monotonic_ns())
         return Gst.FlowReturn.OK
 
-    def _make_speaker_eq(self) -> Optional[Gst.Element]:
-        """Build an equalizer-10bands from the configured gains, or None.
-
-        Returns None (caller keeps the direct link) when all gains are zero or
-        the element is unavailable, so uncalibrated robots stay byte-identical.
-        Inserted on the speaker branch only, after the wobbler tee, so head
-        motion is driven by the uncorrected signal.
-        """
-        gains = resolve_speaker_eq_gains()
-        if not any(gains):
-            return None
-        eq = Gst.ElementFactory.make("equalizer-10bands")
-        if eq is None:
-            self._logger.warning("equalizer-10bands unavailable; skipping speaker EQ")
-            return None
-        for i, gain in enumerate(gains):
-            eq.set_property(f"band{i}", float(gain))
-        return eq
-
     def _build_audiosink_tee_bin(self) -> Gst.Bin:
         """Build a Gst.Bin splitting audio to speaker and wobbler appsink.
 
@@ -1382,7 +1365,7 @@ class GstMediaServer:
         queue_speaker = Gst.ElementFactory.make("queue")
         ac_speaker = Gst.ElementFactory.make("audioconvert")
         ar_speaker = Gst.ElementFactory.make("audioresample")
-        eq_speaker = self._make_speaker_eq()
+        eq_speaker = make_speaker_eq(self._logger)
         audiosink = self._build_audiosink_element()
         queue_wobbler = Gst.ElementFactory.make("queue")
         ac_wobbler = Gst.ElementFactory.make("audioconvert")

--- a/src/reachy_mini/tools/speaker_eq_calibration/README.md
+++ b/src/reachy_mini/tools/speaker_eq_calibration/README.md
@@ -63,6 +63,26 @@ uv run --with matplotlib python \
     -o docs/assets/speaker_eq_calibration.png
 ```
 
+### 4. Verify by re-measuring (recommended)
+
+The band gains are derived by averaging the measured coloration into each
+octave band, which is an **approximation**: the `equalizer-10bands` filter is
+IIR, so adjacent bands overlap and *sum*, and the curve it actually applies is
+not exactly the per-band numbers. So confirm the result empirically rather than
+trusting the derivation:
+
+1. Apply the gains (`speaker_eq_gains` in the daemon config) and restart the
+   daemon.
+2. Re-run hifiscan on the assembled robot **with the EQ active** → `corr_on_eq.pkl`.
+3. Compare against the shell-off reference — e.g. reuse the plot with
+   `corr_on_eq.pkl` in place of `corr_on.pkl`; the residual coloration should be
+   measurably flatter than before.
+4. If a band is over/under-corrected, nudge that gain and repeat.
+
+A closed-loop fit (solving for gains against the element's real summed response
+instead of the naive per-band average) would remove the manual iteration; it is
+a possible future improvement, not implemented here.
+
 ## Caveats
 
 - A 10-band graphic EQ has fixed octave bands, so a narrow resonance may fall
@@ -71,5 +91,4 @@ uv run --with matplotlib python \
   mechanical buzz.
 - On the 16 kHz voice path only bands ≤ 8 kHz carry signal.
 
-Verify by ear and re-measure with the EQ active; the residual coloration should
-be measurably flatter.
+Verify by ear as well; the EQ reduces "boxy," it won't fully eliminate it.

--- a/src/reachy_mini/tools/speaker_eq_calibration/README.md
+++ b/src/reachy_mini/tools/speaker_eq_calibration/README.md
@@ -1,0 +1,75 @@
+# Speaker EQ Calibration for Reachy Mini
+
+The plastic head shell acts as a small enclosure that colors the speaker output
+("boxy" — low-mid resonances and comb peaks). The daemon corrects this with a
+GStreamer `equalizer-10bands` on the speaker branch, driven by 10 per-band gains
+(dB). This directory holds the **offline** tool that derives those gains from
+acoustic measurements. It is not used at runtime; the runtime side (default
+gains + config lookup) lives in `reachy_mini/media/audio_utils.py`.
+
+The gains are stored in the daemon config as `speaker_eq_gains` in
+`~/.config/reachy_mini/daemon_config.json`. With no entry, the daemon falls back
+to the tested default baked into
+`media/audio_utils.py:DEFAULT_SPEAKER_EQ_GAINS`.
+
+## Method: differential measurement
+
+We measure the speaker **with** and **without** the head shell and correct only
+the difference (the shell's contribution), preserving the bare speaker's
+voicing. We use [hifiscan](https://github.com/erdewit/hifiscan) (chirp sweep →
+frequency response). Because we take a differential, the microphone, amplifier
+and room coloration cancel — so a **calibrated mic is not required**; only that
+nothing moves between the two measurements.
+
+## Workflow
+
+### 1. Measure with hifiscan
+
+```bash
+uv pip install hifiscan
+```
+
+Connect an **external** mic at a fixed listening position (not the robot's own
+mic — its XVF3800 DSP would color the measurement). Sweep the robot speaker
+twice at the same volume/position, averaging several sweeps each (a single sweep
+is noisy), and use hifiscan's "save" to write a pickled `Analyzer`:
+
+- shell **on** (assembled robot) → `corr_on.pkl`
+- shell **off** (speaker in its bare case) → `corr_off.pkl`
+
+### 2. Derive the gains
+
+```bash
+uv run python src/reachy_mini/tools/speaker_eq_calibration/calibrate.py \
+    gains corr_on.pkl corr_off.pkl
+```
+
+Put the printed list under `speaker_eq_gains` in `daemon_config.json`, or bake
+it into `DEFAULT_SPEAKER_EQ_GAINS`. Useful flags:
+
+- `--zero-above HZ` — zero bands above this (default `8000`, the voice-path
+  Nyquist). If the speaker/mic geometry shifted more than ~1 cm between sweeps,
+  the treble differential is unreliable; pass e.g. `3000`.
+- `--max-boost DB` — cap positive gains (default `12`); noisy differentials can
+  ask for unrealistic boosts that only add hiss.
+- `--smoothing N` — hifiscan spectral smoothing (default `15`).
+
+### 3. (Optional) Plot the calibration figure
+
+```bash
+uv run --with matplotlib python \
+    src/reachy_mini/tools/speaker_eq_calibration/calibrate.py plot \
+    corr_on.pkl corr_off.pkl corr_on_16k.pkl corr_off_16k.pkl \
+    -o docs/assets/speaker_eq_calibration.png
+```
+
+## Caveats
+
+- A 10-band graphic EQ has fixed octave bands, so a narrow resonance may fall
+  between centers.
+- It corrects the magnitude response only — not time-domain ringing or
+  mechanical buzz.
+- On the 16 kHz voice path only bands ≤ 8 kHz carry signal.
+
+Verify by ear and re-measure with the EQ active; the residual coloration should
+be measurably flatter.

--- a/src/reachy_mini/tools/speaker_eq_calibration/calibrate.py
+++ b/src/reachy_mini/tools/speaker_eq_calibration/calibrate.py
@@ -38,8 +38,6 @@ ringing or mechanical buzz); and on the 16 kHz voice path only bands <= 8 kHz
 carry signal (top bands are zeroed via ``--zero-above``).
 """
 
-from __future__ import annotations
-
 import argparse
 
 import numpy as np

--- a/src/reachy_mini/tools/speaker_eq_calibration/calibrate.py
+++ b/src/reachy_mini/tools/speaker_eq_calibration/calibrate.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Derive Reachy Mini speaker-EQ gains from hifiscan measurements.
+
+The plastic head shell colors the speaker output ("boxy" — low-mid resonances +
+comb peaks). A GStreamer ``equalizer-10bands`` on the daemon's speaker branch
+corrects it; this offline tool computes the 10 per-band gains (dB) to put under
+``speaker_eq_gains`` in the daemon config (``daemon_config.json``). It is not
+used at runtime and users are unlikely to need it. See ``README.md``.
+
+Workflow:
+
+1. ``uv pip install hifiscan`` and connect an *external* mic at a fixed
+   listening position (not the robot's own mic — its XVF3800 DSP colors the
+   measurement). Because we take a *differential*, the mic/amp/room coloration
+   cancels, so a calibrated mic is not required — only that nothing moves.
+2. Run hifiscan and sweep the robot speaker twice, same volume/position,
+   averaging several sweeps each (a single sweep is noisy):
+     - shell **on**  (assembled robot) -> hifiscan "save" -> ``corr_on.pkl``
+     - shell **off** (speaker in its bare case)          -> ``corr_off.pkl``
+3. Derive the gains::
+
+     uv run python src/reachy_mini/tools/speaker_eq_calibration/calibrate.py \
+         gains corr_on.pkl corr_off.pkl
+
+   Put the printed list under ``speaker_eq_gains`` in the daemon config
+   (``~/.config/reachy_mini/daemon_config.json``), or bake it into
+   ``reachy_mini.media.audio_utils.DEFAULT_SPEAKER_EQ_GAINS``.
+4. Optionally render the calibration figure (needs matplotlib)::
+
+     uv run --with matplotlib python \
+         src/reachy_mini/tools/speaker_eq_calibration/calibrate.py plot \
+         corr_on.pkl corr_off.pkl corr_on_16k.pkl corr_off_16k.pkl \
+         -o docs/assets/speaker_eq_calibration.png
+
+Caveats: a 10-band graphic EQ has fixed octave bands, so a narrow resonance may
+fall between centers; it corrects the magnitude response only (not time-domain
+ringing or mechanical buzz); and on the 16 kHz voice path only bands <= 8 kHz
+carry signal (top bands are zeroed via ``--zero-above``).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import numpy.typing as npt
+
+# equalizer-10bands ISO octave band centers (Hz) and per-band gain range (dB).
+BAND_CENTERS = (
+    29.0,
+    59.0,
+    119.0,
+    237.0,
+    474.0,
+    947.0,
+    1889.0,
+    3770.0,
+    7523.0,
+    15011.0,
+)
+GAIN_MIN, GAIN_MAX = -24.0, 12.0
+
+_SMOOTH = 15.0  # hifiscan spectral smoothing before octave-band averaging
+
+
+def bin_to_bands(
+    freqs: npt.NDArray[np.float64], mag_db: npt.NDArray[np.float64]
+) -> list[float]:
+    """Average a magnitude-response curve (dB vs Hz) into the 10 EQ bands.
+
+    Each band takes the mean dB over a +/- half-octave window around its center.
+    """
+    out = []
+    for center in BAND_CENTERS:
+        lo, hi = center / 2**0.5, center * 2**0.5
+        mask = (freqs >= lo) & (freqs < hi)
+        out.append(float(np.mean(mag_db[mask])) if mask.any() else 0.0)
+    return out
+
+
+def band_gains_from_responses(
+    freqs: npt.NDArray[np.float64],
+    resp_on_db: npt.NDArray[np.float64],
+    resp_off_db: npt.NDArray[np.float64],
+    zero_above: float | None = None,
+    max_boost: float = GAIN_MAX,
+) -> list[float]:
+    """Compute the 10 EQ band gains (dB) that cancel the shell's coloration.
+
+    ``resp_on_db`` / ``resp_off_db`` are the measured magnitude responses (dB) of
+    the speaker with the head shell on and off. What the shell adds is::
+
+        coloration(f) = resp_on(f) - resp_off(f)
+
+    and the correcting gain is its negative. We recenter by the median of the
+    trusted bands (the two measurements differ by an arbitrary overall level we
+    must not apply as broadband gain), clamp to the element's range, and zero
+    bands above ``zero_above`` (untrusted treble and/or beyond the voice-path
+    Nyquist). ``max_boost`` caps positive gains (noisy differentials can ask for
+    unrealistic boosts that only add hiss and eat headroom).
+    """
+    gains = bin_to_bands(freqs, resp_off_db - resp_on_db)  # = -coloration
+
+    trusted = [
+        g
+        for center, g in zip(BAND_CENTERS, gains)
+        if zero_above is None or center <= zero_above
+    ]
+    if trusted:
+        offset = float(np.median(trusted))
+        gains = [g - offset for g in gains]
+
+    ceiling = min(max_boost, GAIN_MAX)
+    clamped = [min(max(g, GAIN_MIN), ceiling) for g in gains]
+    if zero_above is not None:
+        clamped = [
+            g if center <= zero_above else 0.0
+            for center, g in zip(BAND_CENTERS, clamped)
+        ]
+    return clamped
+
+
+def _load_response(
+    path: str, smoothing: float = _SMOOTH
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return (freqs, magnitude_dB) from a hifiscan "save" (pickled Analyzer)."""
+    import pickle
+
+    with open(path, "rb") as fh:
+        analyzer = pickle.load(fh)
+    spectrum = analyzer.spectrum(smoothing)
+    return spectrum.x, spectrum.y
+
+
+def _coloration(
+    on: str, off: str
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return (freqs, coloration_dB) with the overall level removed.
+
+    Centered on the band-median (<=8 kHz) so it mirrors the net-zero EQ.
+    """
+    freqs, resp_on = _load_response(on)
+    freqs_off, resp_off = _load_response(off)
+    col = resp_on - np.interp(freqs, freqs_off, resp_off)
+    bands = bin_to_bands(freqs, col)
+    med = float(np.median([g for c, g in zip(BAND_CENTERS, bands) if c <= 8000]))
+    return freqs, col - med
+
+
+def _cmd_gains(
+    on: str, off: str, zero_above: float, max_boost: float, smoothing: float
+) -> None:
+    """Print the 10 EQ band gains and a daemon_config.json snippet."""
+    freqs_on, resp_on = _load_response(on, smoothing)
+    freqs_off, resp_off = _load_response(off, smoothing)
+    if not np.array_equal(freqs_on, freqs_off):  # same chirp/rate -> same axis
+        resp_off = np.interp(freqs_on, freqs_off, resp_off)
+
+    gains = band_gains_from_responses(
+        freqs_on, resp_on, resp_off, zero_above=zero_above, max_boost=max_boost
+    )
+    print("Band gains (dB):")
+    for center, gain in zip(BAND_CENTERS, gains):
+        print(f"  {center:8.0f} Hz : {gain:+6.2f}")
+    snippet = ", ".join(f"{g:.2f}" for g in gains)
+    print(f'\ndaemon_config.json:  "speaker_eq_gains": [{snippet}]')
+
+
+def _cmd_plot(on44: str, off44: str, on16: str, off16: str, out: str) -> None:
+    """Render the two-panel calibration figure (measured response + correction)."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    ref, boxy, fix, col_c = "#5b6b7a", "#d1495b", "#2a9d8f", "#e9c46a"
+
+    # Panel 1: raw responses (44.1 kHz), level-matched over 100 Hz-8 kHz.
+    freqs, resp_on = _load_response(on44)
+    freqs_off, resp_off = _load_response(off44)
+    resp_off = np.interp(freqs, freqs_off, resp_off)
+    band = (freqs >= 100) & (freqs <= 8000)
+    resp_on = resp_on - resp_on[band].mean()
+    resp_off = resp_off - resp_off[band].mean()
+
+    # Panel 2: coloration (level-removed) + applied EQ (16 kHz voice set).
+    fc44, col44 = _coloration(on44, off44)
+    fc16, col16 = _coloration(on16, off16)
+    f16, y16on = _load_response(on16)
+    fo16, y16off = _load_response(off16)
+    eq = band_gains_from_responses(
+        f16, y16on, np.interp(f16, fo16, y16off), zero_above=8000.0
+    )
+    edges, steps = [], []
+    for center, gain in zip(BAND_CENTERS, eq):
+        edges += [center / 2**0.5, center * 2**0.5]
+        steps += [gain, gain]
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 8), sharex=True)
+
+    ax1.semilogx(freqs, resp_off, color=ref, lw=1.8, label="Shell off (bare case)")
+    ax1.semilogx(
+        freqs, resp_on, color=boxy, lw=1.8, label="Shell on (assembled — boxy)"
+    )
+    ax1.set_title("Reachy Mini speaker: measured response (44.1 kHz, level-matched)")
+    ax1.set_ylabel("Relative level (dB)")
+    ax1.legend(loc="lower center", ncol=2, frameon=False)
+    ax1.grid(True, which="both", alpha=0.25)
+
+    ax2.axhline(0, color="#999", lw=0.8)
+    ax2.fill_between(
+        fc16, col16, color=col_c, alpha=0.45, label="Shell coloration, 16 kHz"
+    )
+    ax2.semilogx(
+        fc44, col44, color="#8a6d3b", lw=1.0, ls=":", label="Shell coloration, 44.1 kHz"
+    )
+    ax2.step(edges, steps, where="post", color=fix, lw=2.2, label="Applied 10-band EQ")
+    for center in BAND_CENTERS:
+        ax2.axvline(center, color="#ccc", lw=0.5, alpha=0.5)
+    ax2.set_title("Shell coloration vs. applied correction (EQ ≈ −coloration)")
+    ax2.set_xlabel("Frequency (Hz)")
+    ax2.set_ylabel("Gain (dB)")
+    ax2.set_xlim(20, 20000)
+    ax2.legend(loc="lower center", ncol=2, frameon=False)
+    ax2.grid(True, which="both", alpha=0.25)
+
+    fig.tight_layout()
+    fig.savefig(out, dpi=130)
+    print("saved", out)
+
+
+def main() -> None:
+    """CLI: derive EQ gains from, or plot, two hifiscan measurements."""
+    parser = argparse.ArgumentParser(
+        description="Reachy Mini speaker EQ calibration (offline reference tool)."
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    g = sub.add_parser("gains", help="print the 10 EQ band gains")
+    g.add_argument("on", help="hifiscan measurement, shell ON")
+    g.add_argument("off", help="hifiscan measurement, shell OFF")
+    g.add_argument("--zero-above", type=float, default=8000.0)
+    g.add_argument("--max-boost", type=float, default=12.0)
+    g.add_argument("--smoothing", type=float, default=_SMOOTH)
+
+    p = sub.add_parser("plot", help="render the calibration figure (needs matplotlib)")
+    p.add_argument("on44")
+    p.add_argument("off44")
+    p.add_argument("on16")
+    p.add_argument("off16")
+    p.add_argument("-o", "--out", default="docs/assets/speaker_eq_calibration.png")
+
+    args = parser.parse_args()
+    if args.cmd == "gains":
+        _cmd_gains(args.on, args.off, args.zero_above, args.max_boost, args.smoothing)
+    else:
+        _cmd_plot(args.on44, args.off44, args.on16, args.off16, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/reachy_mini/tools/speaker_eq_calibration/calibrate.py
+++ b/src/reachy_mini/tools/speaker_eq_calibration/calibrate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Derive Reachy Mini speaker-EQ gains from hifiscan measurements.
 
-The plastic head shell colors the speaker output ("boxy" — low-mid resonances +
+The plastic head shell colors the speaker output ("boxy": low-mid resonances +
 comb peaks). A GStreamer ``equalizer-10bands`` on the daemon's speaker branch
 corrects it; this offline tool computes the 10 per-band gains (dB) to put under
 ``speaker_eq_gains`` in the daemon config (``daemon_config.json``). It is not
@@ -10,9 +10,9 @@ used at runtime and users are unlikely to need it. See ``README.md``.
 Workflow:
 
 1. ``uv pip install hifiscan`` and connect an *external* mic at a fixed
-   listening position (not the robot's own mic — its XVF3800 DSP colors the
+   listening position (not the robot's own mic; its XVF3800 DSP colors the
    measurement). Because we take a *differential*, the mic/amp/room coloration
-   cancels, so a calibrated mic is not required — only that nothing moves.
+   cancels, so a calibrated mic is not required, only that nothing moves.
 2. Run hifiscan and sweep the robot speaker twice, same volume/position,
    averaging several sweeps each (a single sweep is noisy):
      - shell **on**  (assembled robot) -> hifiscan "save" -> ``corr_on.pkl``

--- a/tests/unit_tests/test_speaker_eq.py
+++ b/tests/unit_tests/test_speaker_eq.py
@@ -1,8 +1,10 @@
 """Unit tests for the runtime speaker-EQ gains resolution and element builder."""
 
 import logging
+import types
 
 import gi
+import numpy as np
 import pytest
 
 gi.require_version("Gst", "1.0")
@@ -10,6 +12,7 @@ from gi.repository import Gst  # noqa: E402
 
 from reachy_mini.daemon import startup_app_config  # noqa: E402
 from reachy_mini.media.audio_base import make_speaker_eq  # noqa: E402
+from reachy_mini.media.audio_gstreamer import GStreamerAudio  # noqa: E402
 from reachy_mini.media.audio_utils import (  # noqa: E402
     DEFAULT_SPEAKER_EQ_GAINS,
     resolve_speaker_eq_gains,
@@ -128,3 +131,83 @@ def test_make_speaker_eq_noop_when_all_zero(monkeypatch: pytest.MonkeyPatch) -> 
     """All-zero gains disable the EQ (returns None, direct link kept)."""
     monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: [0.0] * 10)
     assert make_speaker_eq(_LOG) is None
+
+
+def _force_reachy_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: None)
+    monkeypatch.setattr(
+        "reachy_mini.media.audio_base.has_reachymini_asoundrc", lambda: True
+    )
+
+
+def test_eq_bin_prevents_clipping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A full-scale tone in a boosted band comes out of the EQ bin without clipping."""
+    _force_reachy_output(monkeypatch)
+    eq_bin = make_speaker_eq(_LOG)
+    assert eq_bin is not None
+
+    pipeline = Gst.Pipeline.new("clip-test")
+    appsrc = Gst.ElementFactory.make("appsrc")
+    appsink = Gst.ElementFactory.make("appsink")
+    caps = Gst.Caps.from_string(
+        "audio/x-raw,format=F32LE,rate=16000,channels=1,layout=interleaved"
+    )
+    appsrc.set_property("caps", caps)
+    appsink.set_property("caps", caps)
+    appsink.set_property("sync", False)
+    for el in (appsrc, eq_bin, appsink):
+        pipeline.add(el)
+    appsrc.link(eq_bin)
+    eq_bin.link(appsink)
+
+    pipeline.set_state(Gst.State.PLAYING)
+    # Full-scale sine at 3770 Hz — the band the reviewer measured boosting ~+8 dB,
+    # so without the limiter the output would exceed full scale and clip.
+    n = 8192
+    t = np.arange(n) / 16000.0
+    sine = np.sin(2 * np.pi * 3770.0 * t).astype(np.float32)
+    appsrc.emit("push-buffer", Gst.Buffer.new_wrapped(sine.tobytes()))
+    appsrc.emit("end-of-stream")
+
+    peak = 0.0
+    while True:
+        sample = appsink.emit("try-pull-sample", Gst.SECOND)
+        if sample is None:
+            break
+        buf = sample.get_buffer()
+        ok, info = buf.map(Gst.MapFlags.READ)
+        if ok:
+            out = np.frombuffer(info.data, dtype=np.float32)
+            if out.size:
+                peak = max(peak, float(np.abs(out).max()))
+            buf.unmap(info)
+    pipeline.set_state(Gst.State.NULL)
+
+    assert peak > 0.0  # audio actually flowed through the bin
+    assert peak <= 1.0  # limiter kept the boosted tone from clipping
+
+
+def _build_tee_bin(monkeypatch: pytest.MonkeyPatch) -> Gst.Bin:
+    monkeypatch.setattr(
+        "reachy_mini.media.audio_base.has_reachymini_asoundrc", lambda: True
+    )
+    inst = object.__new__(GStreamerAudio)
+    inst.logger = _LOG
+    # Satisfy the wobbler callback and __del__/cleanup on this half-built instance.
+    inst._head_wobbler = None
+    inst._doa = types.SimpleNamespace(close=lambda: None)
+    inst._loop = types.SimpleNamespace(quit=lambda: None)
+    inst._bus = types.SimpleNamespace(remove_watch=lambda: None)
+    return GStreamerAudio._build_audiosink_tee_bin(inst)
+
+
+def test_playback_path_includes_eq(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The real speaker branch carries the EQ when gains are non-zero."""
+    monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: None)
+    assert _find_element(_build_tee_bin(monkeypatch), "equalizer-10bands") is not None
+
+
+def test_playback_path_skips_eq_when_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The real speaker branch has no EQ when all gains are zero."""
+    monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: [0.0] * 10)
+    assert _find_element(_build_tee_bin(monkeypatch), "equalizer-10bands") is None

--- a/tests/unit_tests/test_speaker_eq.py
+++ b/tests/unit_tests/test_speaker_eq.py
@@ -87,10 +87,28 @@ def test_invalid_config_warns(
 def test_make_speaker_eq_default_active(monkeypatch: pytest.MonkeyPatch) -> None:
     """With no config the tested default is applied (EQ active out of the box)."""
     monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: None)
+    # Pretend the Reachy Mini Audio output is present so the device gate passes.
+    monkeypatch.setattr(
+        "reachy_mini.media.audio_base.has_reachymini_asoundrc", lambda: True
+    )
     eq = make_speaker_eq(_LOG)
     assert eq is not None
     assert eq.get_factory().get_name() == "equalizer-10bands"
     assert eq.get_property("band1") == pytest.approx(DEFAULT_SPEAKER_EQ_GAINS[1])
+
+
+def test_make_speaker_eq_skipped_off_reachy_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """EQ is skipped when the output is not the Reachy Mini Audio device."""
+    monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: None)
+    monkeypatch.setattr(
+        "reachy_mini.media.audio_base.has_reachymini_asoundrc", lambda: False
+    )
+    monkeypatch.setattr(
+        "reachy_mini.media.audio_base.get_audio_device", lambda _kind: None
+    )
+    assert make_speaker_eq(_LOG) is None
 
 
 def test_make_speaker_eq_noop_when_all_zero(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit_tests/test_speaker_eq.py
+++ b/tests/unit_tests/test_speaker_eq.py
@@ -161,7 +161,7 @@ def test_eq_bin_prevents_clipping(monkeypatch: pytest.MonkeyPatch) -> None:
     eq_bin.link(appsink)
 
     pipeline.set_state(Gst.State.PLAYING)
-    # Full-scale sine at 3770 Hz — the band the reviewer measured boosting ~+8 dB,
+    # Full-scale sine at 3770 Hz, the band the reviewer measured boosting ~+8 dB,
     # so without the limiter the output would exceed full scale and clip.
     n = 8192
     t = np.arange(n) / 16000.0

--- a/tests/unit_tests/test_speaker_eq.py
+++ b/tests/unit_tests/test_speaker_eq.py
@@ -1,6 +1,6 @@
 """Unit tests for the runtime speaker-EQ gains resolution and element builder."""
 
-from typing import cast
+import logging
 
 import gi
 import pytest
@@ -9,13 +9,14 @@ gi.require_version("Gst", "1.0")
 from gi.repository import Gst  # noqa: E402
 
 from reachy_mini.daemon import startup_app_config  # noqa: E402
-from reachy_mini.media.audio_gstreamer import GStreamerAudio  # noqa: E402
+from reachy_mini.media.audio_base import make_speaker_eq  # noqa: E402
 from reachy_mini.media.audio_utils import (  # noqa: E402
     DEFAULT_SPEAKER_EQ_GAINS,
     resolve_speaker_eq_gains,
 )
 
 Gst.init([])
+_LOG = logging.getLogger(__name__)
 
 
 def test_resolve_gains_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -51,17 +52,14 @@ def test_config_gains_validation(
 
 def test_make_speaker_eq_default_active(monkeypatch: pytest.MonkeyPatch) -> None:
     """With no config the tested default is applied (EQ active out of the box)."""
-    # _make_speaker_eq ignores self, so a dummy instance is enough to exercise it.
     monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: None)
-    dummy = cast(GStreamerAudio, object())
-    eq = GStreamerAudio._make_speaker_eq(dummy)
+    eq = make_speaker_eq(_LOG)
     assert eq is not None
     assert eq.get_factory().get_name() == "equalizer-10bands"
     assert eq.get_property("band1") == pytest.approx(DEFAULT_SPEAKER_EQ_GAINS[1])
 
 
 def test_make_speaker_eq_noop_when_all_zero(monkeypatch: pytest.MonkeyPatch) -> None:
-    """All-zero gains disable the EQ (helper returns None, direct link kept)."""
+    """All-zero gains disable the EQ (returns None, direct link kept)."""
     monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: [0.0] * 10)
-    dummy = cast(GStreamerAudio, object())
-    assert GStreamerAudio._make_speaker_eq(dummy) is None
+    assert make_speaker_eq(_LOG) is None

--- a/tests/unit_tests/test_speaker_eq.py
+++ b/tests/unit_tests/test_speaker_eq.py
@@ -49,6 +49,19 @@ def test_config_gains_validation(
     cfg.write_text(json.dumps({"speaker_eq_gains": "nope"}))  # not a list
     assert startup_app_config.get_speaker_eq_gains() is None
 
+    # NaN / Infinity (json parses these) and out-of-range are rejected.
+    cfg.write_text(json.dumps({"speaker_eq_gains": [0.0] * 9 + [float("nan")]}))
+    assert startup_app_config.get_speaker_eq_gains() is None
+
+    cfg.write_text(json.dumps({"speaker_eq_gains": [0.0] * 9 + [float("inf")]}))
+    assert startup_app_config.get_speaker_eq_gains() is None
+
+    cfg.write_text(json.dumps({"speaker_eq_gains": [0.0] * 9 + [13.0]}))  # > +12 dB
+    assert startup_app_config.get_speaker_eq_gains() is None
+
+    cfg.write_text(json.dumps({"speaker_eq_gains": [-30.0] + [0.0] * 9}))  # < -24 dB
+    assert startup_app_config.get_speaker_eq_gains() is None
+
 
 def test_make_speaker_eq_default_active(monkeypatch: pytest.MonkeyPatch) -> None:
     """With no config the tested default is applied (EQ active out of the box)."""

--- a/tests/unit_tests/test_speaker_eq.py
+++ b/tests/unit_tests/test_speaker_eq.py
@@ -19,6 +19,17 @@ Gst.init([])
 _LOG = logging.getLogger(__name__)
 
 
+def _find_element(bin_: Gst.Bin, factory_name: str) -> Gst.Element | None:
+    """Return the first child element built from ``factory_name``, or None."""
+    it = bin_.iterate_recurse()
+    while True:
+        result, elem = it.next()
+        if result != Gst.IteratorResult.OK:
+            return None
+        if elem.get_factory().get_name() == factory_name:
+            return elem
+
+
 def test_resolve_gains_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     """Falls back to the tested default when the config has no entry."""
     monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: None)
@@ -91,10 +102,12 @@ def test_make_speaker_eq_default_active(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(
         "reachy_mini.media.audio_base.has_reachymini_asoundrc", lambda: True
     )
-    eq = make_speaker_eq(_LOG)
+    eq_bin = make_speaker_eq(_LOG)
+    assert eq_bin is not None
+    eq = _find_element(eq_bin, "equalizer-10bands")
     assert eq is not None
-    assert eq.get_factory().get_name() == "equalizer-10bands"
     assert eq.get_property("band1") == pytest.approx(DEFAULT_SPEAKER_EQ_GAINS[1])
+    assert _find_element(eq_bin, "audiodynamic") is not None  # limiter present
 
 
 def test_make_speaker_eq_skipped_off_reachy_output(

--- a/tests/unit_tests/test_speaker_eq.py
+++ b/tests/unit_tests/test_speaker_eq.py
@@ -1,0 +1,67 @@
+"""Unit tests for the runtime speaker-EQ gains resolution and element builder."""
+
+from typing import cast
+
+import gi
+import pytest
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst  # noqa: E402
+
+from reachy_mini.daemon import startup_app_config  # noqa: E402
+from reachy_mini.media.audio_gstreamer import GStreamerAudio  # noqa: E402
+from reachy_mini.media.audio_utils import (  # noqa: E402
+    DEFAULT_SPEAKER_EQ_GAINS,
+    resolve_speaker_eq_gains,
+)
+
+Gst.init([])
+
+
+def test_resolve_gains_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Falls back to the tested default when the config has no entry."""
+    monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: None)
+    assert resolve_speaker_eq_gains() == DEFAULT_SPEAKER_EQ_GAINS
+
+    monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: [1.5] * 10)
+    assert resolve_speaker_eq_gains() == [1.5] * 10
+
+
+def test_config_gains_validation(
+    tmp_path: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The daemon-config reader accepts a 10-float list and rejects the rest."""
+    import json
+    from pathlib import Path
+
+    cfg = Path(str(tmp_path)) / "daemon_config.json"
+    monkeypatch.setattr(startup_app_config, "_config_path", lambda: cfg)
+
+    assert startup_app_config.get_speaker_eq_gains() is None  # missing file
+
+    cfg.write_text(json.dumps({"speaker_eq_gains": [float(i) for i in range(10)]}))
+    assert startup_app_config.get_speaker_eq_gains() == [float(i) for i in range(10)]
+
+    cfg.write_text(json.dumps({"speaker_eq_gains": [1.0, 2.0, 3.0]}))  # wrong length
+    assert startup_app_config.get_speaker_eq_gains() is None
+
+    cfg.write_text(json.dumps({"speaker_eq_gains": "nope"}))  # not a list
+    assert startup_app_config.get_speaker_eq_gains() is None
+
+
+def test_make_speaker_eq_default_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no config the tested default is applied (EQ active out of the box)."""
+    # _make_speaker_eq ignores self, so a dummy instance is enough to exercise it.
+    monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: None)
+    dummy = cast(GStreamerAudio, object())
+    eq = GStreamerAudio._make_speaker_eq(dummy)
+    assert eq is not None
+    assert eq.get_factory().get_name() == "equalizer-10bands"
+    assert eq.get_property("band1") == pytest.approx(DEFAULT_SPEAKER_EQ_GAINS[1])
+
+
+def test_make_speaker_eq_noop_when_all_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """All-zero gains disable the EQ (helper returns None, direct link kept)."""
+    monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: [0.0] * 10)
+    dummy = cast(GStreamerAudio, object())
+    assert GStreamerAudio._make_speaker_eq(dummy) is None

--- a/tests/unit_tests/test_speaker_eq.py
+++ b/tests/unit_tests/test_speaker_eq.py
@@ -76,6 +76,10 @@ def test_config_gains_validation(
     cfg.write_text(json.dumps({"speaker_eq_gains": [-30.0] + [0.0] * 9}))  # < -24 dB
     assert startup_app_config.get_speaker_eq_gains() is None
 
+    # A JSON int too large to fit a float must be rejected, not crash.
+    cfg.write_text(json.dumps({"speaker_eq_gains": [10**400] + [0.0] * 9}))
+    assert startup_app_config.get_speaker_eq_gains() is None
+
 
 def test_invalid_config_warns(
     tmp_path: object, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture

--- a/tests/unit_tests/test_speaker_eq.py
+++ b/tests/unit_tests/test_speaker_eq.py
@@ -63,6 +63,27 @@ def test_config_gains_validation(
     assert startup_app_config.get_speaker_eq_gains() is None
 
 
+def test_invalid_config_warns(
+    tmp_path: object, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A present-but-invalid entry logs a warning; an absent key stays silent."""
+    import json
+    from pathlib import Path
+
+    cfg = Path(str(tmp_path)) / "daemon_config.json"
+    monkeypatch.setattr(startup_app_config, "_config_path", lambda: cfg)
+
+    cfg.write_text(json.dumps({"other": 1}))  # key absent
+    with caplog.at_level(logging.WARNING):
+        assert startup_app_config.get_speaker_eq_gains() is None
+    assert not caplog.records
+
+    cfg.write_text(json.dumps({"speaker_eq_gains": [99.0] * 10}))  # present, invalid
+    with caplog.at_level(logging.WARNING):
+        assert startup_app_config.get_speaker_eq_gains() is None
+    assert any("speaker_eq_gains" in r.message for r in caplog.records)
+
+
 def test_make_speaker_eq_default_active(monkeypatch: pytest.MonkeyPatch) -> None:
     """With no config the tested default is applied (EQ active out of the box)."""
     monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: None)

--- a/tests/unit_tests/test_speaker_eq_calibration.py
+++ b/tests/unit_tests/test_speaker_eq_calibration.py
@@ -1,0 +1,62 @@
+"""Unit tests for the offline speaker-EQ calibration band math."""
+
+import numpy as np
+import pytest
+
+from reachy_mini.tools.speaker_eq_calibration.calibrate import (
+    BAND_CENTERS,
+    GAIN_MAX,
+    GAIN_MIN,
+    band_gains_from_responses,
+)
+
+# Dense linear freq axis up to 20 kHz so every band window is populated.
+FREQS = np.linspace(0.0, 20_000.0, 20_001)
+
+
+def _band_mask(center: float) -> np.ndarray:
+    return (FREQS >= center / 2**0.5) & (FREQS < center * 2**0.5)
+
+
+def test_shell_bump_becomes_matching_cut() -> None:
+    """A shell resonance in one band maps to an equal cut in that band."""
+    # Shell-on response is 6 dB hotter than shell-off around the 237 Hz band
+    # (the shell adds a boxy bump) -> the EQ should cut 6 dB there.
+    resp_off = np.zeros_like(FREQS)
+    resp_on = np.zeros_like(FREQS)
+    resp_on[_band_mask(237.0)] = +6.0
+
+    gains = band_gains_from_responses(FREQS, resp_on, resp_off, zero_above=8000.0)
+
+    idx = BAND_CENTERS.index(237.0)
+    assert gains[idx] == pytest.approx(-6.0, abs=0.5)
+
+
+def test_out_of_range_is_clamped() -> None:
+    """Gains outside the element's range are clamped to [GAIN_MIN, GAIN_MAX]."""
+    resp_off = np.zeros_like(FREQS)
+    resp_on = np.zeros_like(FREQS)
+    resp_on[_band_mask(474.0)] = +100.0  # huge shell bump -> huge cut
+    resp_on[_band_mask(947.0)] = -100.0  # huge shell dip -> huge boost
+
+    gains = band_gains_from_responses(FREQS, resp_on, resp_off, zero_above=8000.0)
+
+    assert gains[BAND_CENTERS.index(474.0)] == GAIN_MIN
+    assert gains[BAND_CENTERS.index(947.0)] == GAIN_MAX
+    assert all(GAIN_MIN <= g <= GAIN_MAX for g in gains)
+
+
+def test_zero_above_and_max_boost() -> None:
+    """Bands above zero_above are forced to 0 dB and boosts are capped."""
+    resp_off = np.zeros_like(FREQS)
+    resp_on = np.zeros_like(FREQS)
+    resp_on[_band_mask(474.0)] = -20.0  # shell dip -> wants a big +20 boost
+
+    gains = band_gains_from_responses(
+        FREQS, resp_on, resp_off, zero_above=3000.0, max_boost=6.0
+    )
+
+    assert gains[BAND_CENTERS.index(474.0)] == pytest.approx(6.0)  # capped
+    for center, gain in zip(BAND_CENTERS, gains):
+        if center > 3000.0:
+            assert gain == 0.0


### PR DESCRIPTION
## Rationale

Audio from Reachy Mini's speaker sounds a bit "boxy": the plastic head shell acts as a small enclosure that colors the output, a low-mid resonance (bass boom) plus a muffled 1-8 kHz presence range. This adds a fixed graphic-EQ correction on the daemon's speaker output to compensate.

## What it does

- Inserts a GStreamer [`equalizer-10bands`](https://gstreamer.freedesktop.org/documentation/equalizer/equalizer-10bands.html) on **every** speaker output branch, `GStreamerAudio` (voice push + file playback) and `GstMediaServer` (WebRTC + file playback), always **after the wobbler tee**, so head motion is still driven by the uncorrected signal.
- Gains come from the daemon config (`speaker_eq_gains` in `daemon_config.json`, reusing the store added in #1254), falling back to a tested default. **All-zero gains bypass the equalizer** (pipeline byte-identical to before).
- The default cuts the head-cavity bass boom and lifts the muffled presence range.

## Calibration

The default gains were derived offline from a **differential** measurement (speaker response *with* vs *without* the shell, so mic/amp/room coloration cancels) using [hifiscan](https://github.com/erdewit/hifiscan). The reusable tool lives in `src/reachy_mini/tools/speaker_eq_calibration/` (mirroring `camera_calibration/`), it is not used at runtime.

![Speaker EQ calibration](https://github.com/pollen-robotics/reachy_mini/raw/speaker-eq-shell-correction/docs/assets/speaker_eq_calibration.png)

*Top: measured speaker response, shell on vs off. Bottom: the shell coloration (16 kHz and 44.1 kHz measurements agree) and the applied 10-band correction, its mirror image.*

## Tuning

Override or disable via `~/.config/reachy_mini/daemon_config.json` (Wireless: `/home/pollen/.config/...`):

```json
{ "speaker_eq_gains": [0.0, -13.21, -5.55, -4.28, -4.32, 5.80, 4.65, 4.90, 3.41, 0.0] }
```

Ten dB values, one per band; all `0.0` disables the EQ. Restart the daemon to apply. Documented in *Advanced Media Controls → Speaker equalization* and a *Troubleshooting → Vision & Audio* entry.

## Testing

- New unit tests (`test_speaker_eq.py`, `test_speaker_eq_calibration.py`): gains resolution + config validation, `equalizer-10bands` element build (default active / all-zero no-op), and the calibration band math. `uv run pytest` green (pre-existing WEBRTC/network-dependent tests aside).
- Default gains derived from averaged hifiscan sweeps (shell on/off, at both 16 kHz and 44.1 kHz) on a **Reachy Mini Lite**.
- To A/B: set `speaker_eq_gains` to ten zeros and restart to hear the uncorrected output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
