### PR TITLE
feat: add adaptive face tracking filter

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -316,11 +316,9 @@ class Backend:
         self._tracking_requested_weight = 1.0
         self._tracking_weight = 0.0
         self._tracking_alpha = 0.15
-        self._tracking_deadband = 0.03
         self._tracking_lost_timeout = 2.0
         self._tracking_aim: Annotated[NDArray[np.float64], (4, 4)] | None = None
         self._tracking_target_pose: Annotated[NDArray[np.float64], (4, 4)] | None = None
-        self._tracking_last_center: tuple[float, float] | None = None
         self._last_face_seen: float | None = None
         self._tracker: FaceTracker | None = None
         self._tracking_lock = threading.Lock()
@@ -632,7 +630,6 @@ class Backend:
         self._tracking_aim = None
         self._tracking_target_pose = None
         self._tracking_weight = 0.0
-        self._tracking_last_center = None
         self._last_face_seen = None
         self._face_target = FaceTarget()
         self.ik_required = True
@@ -705,14 +702,6 @@ class Backend:
             roll=roll,
             ts=timestamp,
         )
-
-        # Deadband sub-threshold jitter so a still person keeps a still head.
-        if self._tracking_last_center is not None and (
-            abs(x_norm - self._tracking_last_center[0]) < self._tracking_deadband
-            and abs(y_norm - self._tracking_last_center[1]) < self._tracking_deadband
-        ):
-            return
-        self._tracking_last_center = (x_norm, y_norm)
 
         u = (x_norm + 1.0) * 0.5 * max(width - 1, 1)
         v = (y_norm + 1.0) * 0.5 * max(height - 1, 1)

--- a/src/reachy_mini/vision/face_tracking.py
+++ b/src/reachy_mini/vision/face_tracking.py
@@ -41,34 +41,15 @@ class FaceObservation:
     timestamp: float
 
 
-class AdaptiveCenterFilter:
-    """Smooth normalized face centers while remaining responsive to large motion.
+class _AdaptiveCenterFilter:
+    """Internal face-center smoother with fixed tracking parameters."""
 
-    Small changes are held inside a dead zone. Outside it, an exponential moving
-    average uses ``alpha`` for ordinary motion and ``fast_alpha`` when consecutive
-    raw observations move farther than ``movement_threshold``.
-    """
+    _ALPHA = 0.3
+    _FAST_ALPHA = 0.6
+    _MOVEMENT_THRESHOLD = 0.15
+    _DEAD_ZONE = 0.02
 
-    def __init__(
-        self,
-        alpha: float = 0.3,
-        fast_alpha: float = 0.6,
-        movement_threshold: float = 0.15,
-        dead_zone: float = 0.02,
-    ) -> None:
-        """Configure the filter in normalized image coordinates."""
-        if not 0.0 < alpha <= 1.0:
-            raise ValueError("alpha must be in (0, 1]")
-        if not 0.0 < fast_alpha <= 1.0:
-            raise ValueError("fast_alpha must be in (0, 1]")
-        if movement_threshold < 0.0:
-            raise ValueError("movement_threshold must be non-negative")
-        if dead_zone < 0.0:
-            raise ValueError("dead_zone must be non-negative")
-        self._alpha = alpha
-        self._fast_alpha = fast_alpha
-        self._movement_threshold = movement_threshold
-        self._dead_zone = dead_zone
+    def __init__(self) -> None:
         self._value: NDArray[np.float64] | None = None
         self._previous_input: NDArray[np.float64] | None = None
 
@@ -83,10 +64,10 @@ class AdaptiveCenterFilter:
         movement = float(np.linalg.norm(current - self._previous_input))
         self._previous_input = current.copy()
         delta = current - self._value
-        if float(np.linalg.norm(delta)) < self._dead_zone:
+        if float(np.linalg.norm(delta)) < self._DEAD_ZONE:
             return (float(self._value[0]), float(self._value[1]))
 
-        alpha = self._fast_alpha if movement > self._movement_threshold else self._alpha
+        alpha = self._FAST_ALPHA if movement > self._MOVEMENT_THRESHOLD else self._ALPHA
         self._value += alpha * delta
         return (float(self._value[0]), float(self._value[1]))
 
@@ -198,6 +179,8 @@ class FaceTracker:
         self._stop = threading.Event()
         self._active = threading.Event()
         self._observations: queue.SimpleQueue[FaceObservation] = queue.SimpleQueue()
+        self._selector = Tracker()
+        self._center_filter = _AdaptiveCenterFilter()
 
     def start(self, camera_specs: CameraSpecs) -> None:
         """Start the detector thread if it is not already running."""
@@ -206,6 +189,8 @@ class FaceTracker:
         self._stop.clear()
         # Drop observations left over from a previous run.
         self._observations = queue.SimpleQueue()
+        self._selector = Tracker()
+        self._center_filter.reset()
         self._thread = threading.Thread(
             target=self._run, args=(camera_specs,), daemon=True, name="face-tracker"
         )
@@ -236,6 +221,26 @@ class FaceTracker:
             logger.warning("Face tracker thread did not stop in time.")
         else:
             self._thread = None
+
+    def _process_detections(
+        self,
+        faces: list[Face],
+        width: int,
+        height: int,
+        camera_matrix: NDArray[np.float64],
+        distortion: NDArray[np.float64],
+        timestamp: float,
+    ) -> None:
+        """Select, filter, and emit one observation from a detection frame."""
+        face = self._selector.select(faces, width, height)
+        if face is None and not self._selector.has_target:
+            self._center_filter.reset()
+        observation = to_observation(
+            face, width, height, camera_matrix, distortion, timestamp
+        )
+        if observation.center is not None:
+            observation.center = self._center_filter.update(observation.center)
+        self._observations.put(observation)
 
     def _run(self, camera_specs: CameraSpecs) -> None:
         # Lowest priority (Linux-only per-thread nice) so the detector yields CPU to the rest of the daemon.
@@ -295,11 +300,9 @@ class FaceTracker:
         feed_lost = False
         try:
             detector = FaceDetector()
-            tracker = Tracker()
-            center_filter = AdaptiveCenterFilter()
             while not self._stop.is_set():
                 if not self._active.is_set():
-                    center_filter.reset()
+                    self._center_filter.reset()
                     if playing:
                         # Disconnect while paused so the daemon serves nothing to this client.
                         pipeline.set_state(Gst.State.NULL)
@@ -336,20 +339,14 @@ class FaceTracker:
                     camera_matrix = intrinsics_for_size(
                         camera_specs.K, crop_scale, (frame_width, frame_height)
                     )
-                face = tracker.select(detector.detect(frame), frame_width, frame_height)
-                if face is None and not tracker.has_target:
-                    center_filter.reset()
-                observation = to_observation(
-                    face,
+                self._process_detections(
+                    detector.detect(frame),
                     frame_width,
                     frame_height,
                     camera_matrix,
                     camera_specs.D,
                     time.monotonic(),
                 )
-                if observation.center is not None:
-                    observation.center = center_filter.update(observation.center)
-                self._observations.put(observation)
         except Exception:
             # With no process boundary left, this is the only place a detector crash gets reported.
             logger.exception("Face tracker crashed.")

--- a/src/reachy_mini/vision/face_tracking.py
+++ b/src/reachy_mini/vision/face_tracking.py
@@ -41,6 +41,61 @@ class FaceObservation:
     timestamp: float
 
 
+class AdaptiveCenterFilter:
+    """Smooth normalized face centers while remaining responsive to large motion.
+
+    Small changes are held inside a dead zone. Outside it, an exponential moving
+    average uses ``alpha`` for ordinary motion and ``fast_alpha`` when consecutive
+    raw observations move farther than ``movement_threshold``.
+    """
+
+    def __init__(
+        self,
+        alpha: float = 0.3,
+        fast_alpha: float = 0.6,
+        movement_threshold: float = 0.15,
+        dead_zone: float = 0.02,
+    ) -> None:
+        """Configure the filter in normalized image coordinates."""
+        if not 0.0 < alpha <= 1.0:
+            raise ValueError("alpha must be in (0, 1]")
+        if not 0.0 < fast_alpha <= 1.0:
+            raise ValueError("fast_alpha must be in (0, 1]")
+        if movement_threshold < 0.0:
+            raise ValueError("movement_threshold must be non-negative")
+        if dead_zone < 0.0:
+            raise ValueError("dead_zone must be non-negative")
+        self._alpha = alpha
+        self._fast_alpha = fast_alpha
+        self._movement_threshold = movement_threshold
+        self._dead_zone = dead_zone
+        self._value: NDArray[np.float64] | None = None
+        self._previous_input: NDArray[np.float64] | None = None
+
+    def update(self, center: tuple[float, float]) -> tuple[float, float]:
+        """Consume one raw center and return the filtered center."""
+        current = np.asarray(center, dtype=np.float64)
+        if self._value is None or self._previous_input is None:
+            self._value = current.copy()
+            self._previous_input = current.copy()
+            return center
+
+        movement = float(np.linalg.norm(current - self._previous_input))
+        self._previous_input = current.copy()
+        delta = current - self._value
+        if float(np.linalg.norm(delta)) < self._dead_zone:
+            return (float(self._value[0]), float(self._value[1]))
+
+        alpha = self._fast_alpha if movement > self._movement_threshold else self._alpha
+        self._value += alpha * delta
+        return (float(self._value[0]), float(self._value[1]))
+
+    def reset(self) -> None:
+        """Forget filter history so the next observation is accepted immediately."""
+        self._value = None
+        self._previous_input = None
+
+
 def _area(face: Face) -> float:
     return face.bbox[2] * face.bbox[3]
 
@@ -97,6 +152,11 @@ class Tracker:
         self._misses += 1
         if self._misses > self._max_misses:
             self._center = None
+
+    @property
+    def has_target(self) -> bool:
+        """Whether the tracker is still associated with a face."""
+        return self._center is not None
 
 
 def to_observation(
@@ -236,8 +296,10 @@ class FaceTracker:
         try:
             detector = FaceDetector()
             tracker = Tracker()
+            center_filter = AdaptiveCenterFilter()
             while not self._stop.is_set():
                 if not self._active.is_set():
+                    center_filter.reset()
                     if playing:
                         # Disconnect while paused so the daemon serves nothing to this client.
                         pipeline.set_state(Gst.State.NULL)
@@ -275,16 +337,19 @@ class FaceTracker:
                         camera_specs.K, crop_scale, (frame_width, frame_height)
                     )
                 face = tracker.select(detector.detect(frame), frame_width, frame_height)
-                self._observations.put(
-                    to_observation(
-                        face,
-                        frame_width,
-                        frame_height,
-                        camera_matrix,
-                        camera_specs.D,
-                        time.monotonic(),
-                    )
+                if face is None and not tracker.has_target:
+                    center_filter.reset()
+                observation = to_observation(
+                    face,
+                    frame_width,
+                    frame_height,
+                    camera_matrix,
+                    camera_specs.D,
+                    time.monotonic(),
                 )
+                if observation.center is not None:
+                    observation.center = center_filter.update(observation.center)
+                self._observations.put(observation)
         except Exception:
             # With no process boundary left, this is the only place a detector crash gets reported.
             logger.exception("Face tracker crashed.")

--- a/tests/unit_tests/test_face_tracking.py
+++ b/tests/unit_tests/test_face_tracking.py
@@ -7,12 +7,7 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 import pytest
 
-from reachy_mini.vision.face_tracking import (
-    AdaptiveCenterFilter,
-    FaceTracker,
-    Tracker,
-    to_observation,
-)
+from reachy_mini.vision.face_tracking import FaceTracker, Tracker, to_observation
 
 if TYPE_CHECKING:
     from reachy_mini.media.camera_constants import CameraSpecs
@@ -49,49 +44,63 @@ def test_to_observation_normalizes_nose_and_roll() -> None:
     assert obs.roll == float(np.arctan2(2.0, 2.0))
 
 
-def test_adaptive_filter_smooths_ordinary_motion() -> None:
-    """Ordinary motion uses the slow EMA coefficient."""
-    center_filter = AdaptiveCenterFilter(
-        alpha=0.25, fast_alpha=0.8, movement_threshold=1.0, dead_zone=0.0
+def test_face_tracker_filters_emitted_detection_sequence() -> None:
+    """FaceTracker applies its slow, fast, and dead-zone paths to emitted observations."""
+    face_tracker = FaceTracker()
+    camera_matrix = np.eye(3)
+    distortion = np.zeros(5)
+
+    def emit(nose_x: float, timestamp: float) -> tuple[float, float] | None:
+        face = _face(
+            (nose_x - 5.0, 45.0, 10.0, 10.0),
+            (nose_x - 2.0, 48.0),
+            (nose_x + 2.0, 48.0),
+            (nose_x, 50.0),
+        )
+        face_tracker._process_detections(
+            [face], 101, 101, camera_matrix, distortion, timestamp
+        )
+        observation = face_tracker.latest()
+        assert observation is not None
+        return observation.center
+
+    assert emit(50.0, 1.0) == (0.0, 0.0)
+    assert emit(50.5, 2.0) == (0.0, 0.0)  # radial dead zone
+    assert emit(55.0, 3.0) == pytest.approx((0.03, 0.0))  # slow EMA
+    assert emit(75.0, 4.0) == pytest.approx((0.312, 0.0))  # fast EMA
+
+
+def test_face_tracker_resets_filter_after_target_loss() -> None:
+    """A reacquired face is emitted immediately instead of blending with stale aim."""
+    face_tracker = FaceTracker()
+    camera_matrix = np.eye(3)
+    distortion = np.zeros(5)
+    old_face = _face(
+        (45.0, 45.0, 10.0, 10.0),
+        (48.0, 48.0),
+        (52.0, 48.0),
+        (50.0, 50.0),
+    )
+    new_face = _face(
+        (5.0, 45.0, 10.0, 10.0),
+        (8.0, 48.0),
+        (12.0, 48.0),
+        (10.0, 50.0),
+    )
+    face_tracker._process_detections(
+        [old_face], 101, 101, camera_matrix, distortion, 1.0
+    )
+    for timestamp in range(2, 23):
+        face_tracker._process_detections(
+            [], 101, 101, camera_matrix, distortion, float(timestamp)
+        )
+    face_tracker._process_detections(
+        [new_face], 101, 101, camera_matrix, distortion, 23.0
     )
 
-    assert center_filter.update((0.0, 0.0)) == (0.0, 0.0)
-    assert center_filter.update((0.4, -0.4)) == pytest.approx((0.1, -0.1))
-    assert center_filter.update((0.4, -0.4)) == pytest.approx((0.175, -0.175))
-
-
-def test_adaptive_filter_uses_fast_alpha_for_large_motion() -> None:
-    """A large frame-to-frame jump selects the responsive EMA coefficient."""
-    center_filter = AdaptiveCenterFilter(
-        alpha=0.25, fast_alpha=0.75, movement_threshold=0.5, dead_zone=0.0
-    )
-    center_filter.update((0.0, 0.0))
-
-    assert center_filter.update((0.8, 0.0)) == pytest.approx((0.6, 0.0))
-
-
-def test_adaptive_filter_holds_motion_inside_dead_zone() -> None:
-    """Sub-threshold target jitter keeps the last filtered center unchanged."""
-    center_filter = AdaptiveCenterFilter(
-        alpha=0.5, fast_alpha=0.5, movement_threshold=1.0, dead_zone=0.05
-    )
-    center_filter.update((0.0, 0.0))
-
-    assert center_filter.update((0.03, 0.02)) == (0.0, 0.0)
-    assert center_filter.update((0.06, 0.0)) == pytest.approx((0.03, 0.0))
-
-
-def test_adaptive_filter_reset_accepts_next_center_immediately() -> None:
-    """Reset removes EMA history rather than blending a reacquired face with stale aim."""
-    center_filter = AdaptiveCenterFilter(
-        alpha=0.1, fast_alpha=0.1, movement_threshold=1.0, dead_zone=0.0
-    )
-    center_filter.update((0.0, 0.0))
-    center_filter.update((0.5, 0.0))
-
-    center_filter.reset()
-
-    assert center_filter.update((-0.5, 0.25)) == (-0.5, 0.25)
+    observation = face_tracker.latest()
+    assert observation is not None
+    assert observation.center == pytest.approx((-0.8, 0.0))
 
 
 def test_tracker_acquires_largest_above_min_size() -> None:

--- a/tests/unit_tests/test_face_tracking.py
+++ b/tests/unit_tests/test_face_tracking.py
@@ -7,7 +7,12 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 import pytest
 
-from reachy_mini.vision.face_tracking import FaceTracker, Tracker, to_observation
+from reachy_mini.vision.face_tracking import (
+    AdaptiveCenterFilter,
+    FaceTracker,
+    Tracker,
+    to_observation,
+)
 
 if TYPE_CHECKING:
     from reachy_mini.media.camera_constants import CameraSpecs
@@ -42,6 +47,51 @@ def test_to_observation_normalizes_nose_and_roll() -> None:
     )
     assert obs.center == (0.0, 0.0)
     assert obs.roll == float(np.arctan2(2.0, 2.0))
+
+
+def test_adaptive_filter_smooths_ordinary_motion() -> None:
+    """Ordinary motion uses the slow EMA coefficient."""
+    center_filter = AdaptiveCenterFilter(
+        alpha=0.25, fast_alpha=0.8, movement_threshold=1.0, dead_zone=0.0
+    )
+
+    assert center_filter.update((0.0, 0.0)) == (0.0, 0.0)
+    assert center_filter.update((0.4, -0.4)) == pytest.approx((0.1, -0.1))
+    assert center_filter.update((0.4, -0.4)) == pytest.approx((0.175, -0.175))
+
+
+def test_adaptive_filter_uses_fast_alpha_for_large_motion() -> None:
+    """A large frame-to-frame jump selects the responsive EMA coefficient."""
+    center_filter = AdaptiveCenterFilter(
+        alpha=0.25, fast_alpha=0.75, movement_threshold=0.5, dead_zone=0.0
+    )
+    center_filter.update((0.0, 0.0))
+
+    assert center_filter.update((0.8, 0.0)) == pytest.approx((0.6, 0.0))
+
+
+def test_adaptive_filter_holds_motion_inside_dead_zone() -> None:
+    """Sub-threshold target jitter keeps the last filtered center unchanged."""
+    center_filter = AdaptiveCenterFilter(
+        alpha=0.5, fast_alpha=0.5, movement_threshold=1.0, dead_zone=0.05
+    )
+    center_filter.update((0.0, 0.0))
+
+    assert center_filter.update((0.03, 0.02)) == (0.0, 0.0)
+    assert center_filter.update((0.06, 0.0)) == pytest.approx((0.03, 0.0))
+
+
+def test_adaptive_filter_reset_accepts_next_center_immediately() -> None:
+    """Reset removes EMA history rather than blending a reacquired face with stale aim."""
+    center_filter = AdaptiveCenterFilter(
+        alpha=0.1, fast_alpha=0.1, movement_threshold=1.0, dead_zone=0.0
+    )
+    center_filter.update((0.0, 0.0))
+    center_filter.update((0.5, 0.0))
+
+    center_filter.reset()
+
+    assert center_filter.update((-0.5, 0.25)) == (-0.5, 0.25)
 
 
 def test_tracker_acquires_largest_above_min_size() -> None:

--- a/tests/unit_tests/test_head_tracking_backend.py
+++ b/tests/unit_tests/test_head_tracking_backend.py
@@ -217,30 +217,6 @@ def test_tracking_face_loss_holds_last_target() -> None:
     assert backend._tracking_target_pose is target
 
 
-def test_tracking_deadband_ignores_subthreshold_motion() -> None:
-    """Sub-deadband jitter does not retarget, so a still person holds a still head."""
-    backend = _make_backend()
-    backend._tracking_enabled = True
-    cam = np.array(
-        [[640.0, 0.0, 320.0], [0.0, 640.0, 240.0], [0.0, 0.0, 1.0]], dtype=np.float64
-    )
-    dist = np.zeros(5, dtype=np.float64)
-
-    backend.set_tracking_face((0.2, 0.2), 0.0, 640, 480, cam, dist, 1.0)
-    first = backend._tracking_target_pose
-    assert first is not None
-
-    backend.set_tracking_face(
-        (0.2 + backend._tracking_deadband / 2, 0.2), 0.0, 640, 480, cam, dist, 2.0
-    )
-    assert backend._tracking_target_pose is first  # held: jitter below deadband
-
-    backend.set_tracking_face(
-        (0.2 + backend._tracking_deadband * 2, 0.2), 0.0, 640, 480, cam, dist, 3.0
-    )
-    assert backend._tracking_target_pose is not first  # moved: beyond deadband
-
-
 def test_tracking_sustained_loss_recenters_to_neutral() -> None:
     """After the lost timeout the aim target returns to the neutral head pose."""
     backend = _make_backend()


### PR DESCRIPTION
## Summary

Ports the adaptive smoothing ideas from pollen-robotics/reachy_mini_conversation_app#339 to the SDK's current daemon-side face-tracking architecture, following the maintainer guidance in that PR.

The SDK now filters normalized face centers before they reach `look_at_image_pose()`, reducing small target jitter while retaining a faster response to meaningful movement.

## Changes

- Add a small stateful `AdaptiveCenterFilter` with:
  - EMA smoothing for ordinary motion
  - a faster alpha for large frame-to-frame movement
  - a radial dead zone for sub-threshold jitter
  - explicit reset behavior on target loss or tracking pause
- Wire the filter into the actual `FaceTracker` detector path
- Preserve filter state across transient misses, but reset it when the tracker drops its target association
- Remove the backend's duplicate center deadband so target filtering has one owner
- Add focused unit tests for slow smoothing, fast adaptation, dead-zone behavior, and reacquisition/reset

## Architecture notes

The old conversation-app patch also changed camera loop rate, tracking gain, loss delay, and neutral interpolation. Those parts are intentionally not ported:

- camera IPC and detector pacing now own capture cadence;
- the daemon already owns transient-loss holding and sustained-loss recentering;
- calibrated `look_at_image_pose()` plus the existing tracking weight replace the old raw translation/rotation gain.

## Validation

- `pytest tests/unit_tests/test_face_tracking.py tests/unit_tests/test_head_tracking_backend.py -q` — 19 passed
- Ruff lint — passed
- Ruff format check — passed
- targeted mypy — passed
- `git diff --check` — passed

Supersedes pollen-robotics/reachy_mini_conversation_app#339.
