### PR TITLE
jsonrpc: model responses/notifications with pydantic + TypeAdapter parsing

### DIFF
--- a/src/reachy_mini/apps/jsonrpc_server.py
+++ b/src/reachy_mini/apps/jsonrpc_server.py
@@ -32,8 +32,8 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 from reachy_mini.io.jsonrpc import (
     JsonRpcError,
+    RpcNotification,
     error_from_exc,
-    make_notification,
     make_result,
     parse_request,
 )
@@ -77,7 +77,9 @@ class JsonRpcServer:
         self, method: str, params: Optional[dict[str, Any]] = None
     ) -> None:
         """Push a notification to every connected peer (call on the app loop)."""
-        payload = json.dumps(make_notification(method, params))
+        # Serialize once, on the event hot path, in a single pydantic-core step
+        # (no dict round-trip through the Python json module).
+        payload = RpcNotification(method=method, params=params or {}).model_dump_json()
         for ws in list(self._clients):
             try:
                 await ws.send_text(payload)

--- a/src/reachy_mini/daemon/jsonrpc_relay.py
+++ b/src/reachy_mini/daemon/jsonrpc_relay.py
@@ -172,8 +172,13 @@ class JsonRpcRelay:
 
         self._counter += 1
         relay_id = f"relay-{self._counter}"
-        original_id = req.id
+        # Record both correlation entries BEFORE the await: the reader task runs
+        # on this same loop and can process the app's reply *during*
+        # ``ws.send`` (a fast reply on the loopback WS). If `original_id` were
+        # set after the await, that reply would restore id=None and the caller
+        # would hang until timeout.
         self._pending[relay_id] = reply
+        self._pending_original_id[relay_id] = req.id
         # Forward the request under a relay-assigned id (model_copy keeps every
         # other field intact); the reader restores `original_id` on the reply.
         outgoing = req.model_copy(update={"id": relay_id})
@@ -181,8 +186,8 @@ class JsonRpcRelay:
             await ws.send(outgoing.model_dump_json())
         except Exception as e:
             self._pending.pop(relay_id, None)
+            self._pending_original_id.pop(relay_id, None)
             raise JsonRpcError(f"app unavailable: {e}", reason="app_unavailable") from e
-        self._pending_original_id[relay_id] = original_id
 
     async def _ensure_app_ws(self) -> ClientConnection:
         async with self._app_ws_lock:

--- a/src/reachy_mini/daemon/jsonrpc_relay.py
+++ b/src/reachy_mini/daemon/jsonrpc_relay.py
@@ -19,7 +19,6 @@ app WS client live); transports schedule :meth:`handle` onto it.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from typing import Any, Callable, Optional
 from urllib.parse import urlparse
@@ -30,10 +29,13 @@ from reachy_mini.apps.manager import AppManager
 from reachy_mini.daemon.app.startup_app import ensure_startup_app_installed
 from reachy_mini.io.jsonrpc import (
     JsonRpcError,
+    RpcErrorResponse,
     RpcRequest,
+    RpcSuccess,
     error_from_exc,
     make_error,
     make_result,
+    parse_inbound,
     parse_request,
 )
 
@@ -172,15 +174,14 @@ class JsonRpcRelay:
         relay_id = f"relay-{self._counter}"
         original_id = req.id
         self._pending[relay_id] = reply
-        frame = req.model_dump(exclude_none=False)
-        frame["id"] = relay_id
+        # Forward the request under a relay-assigned id (model_copy keeps every
+        # other field intact); the reader restores `original_id` on the reply.
+        outgoing = req.model_copy(update={"id": relay_id})
         try:
-            await ws.send(json.dumps(frame))
+            await ws.send(outgoing.model_dump_json())
         except Exception as e:
             self._pending.pop(relay_id, None)
             raise JsonRpcError(f"app unavailable: {e}", reason="app_unavailable") from e
-        # The reply is delivered later by the reader task, which restores
-        # `original_id` before calling `reply`.
         self._pending_original_id[relay_id] = original_id
 
     async def _ensure_app_ws(self) -> ClientConnection:
@@ -219,16 +220,23 @@ class JsonRpcRelay:
 
     def _on_app_frame(self, text: str) -> None:
         try:
-            obj = json.loads(text)
-        except json.JSONDecodeError:
-            return
-        rid = obj.get("id") if isinstance(obj, dict) else None
-        if rid is not None and rid in self._pending:
-            reply = self._pending.pop(rid)
-            obj["id"] = self._pending_original_id.pop(rid, None)
-            reply(obj)
+            msg = parse_inbound(text)
+        except JsonRpcError:
+            return  # unparseable frame from the app — drop it
+        # A correlated response (success or error) carries a relay-assigned id
+        # (always a `relay-N` str) we're waiting on; restore the caller's id and
+        # hand it back.
+        if (
+            isinstance(msg, (RpcSuccess, RpcErrorResponse))
+            and isinstance(msg.id, str)
+            and msg.id in self._pending
+        ):
+            reply = self._pending.pop(msg.id)
+            original_id = self._pending_original_id.pop(msg.id, None)
+            reply(msg.model_copy(update={"id": original_id}).model_dump())
         else:
-            # No id (a notification/event) — fan it out to every client.
+            # A notification/event (or an uncorrelated response) — fan it out to
+            # every client verbatim.
             self._broadcast(text)
 
     async def _drop_app_ws(self) -> None:

--- a/src/reachy_mini/io/jsonrpc.py
+++ b/src/reachy_mini/io/jsonrpc.py
@@ -6,16 +6,22 @@ transport (WebRTC DataChannel, ``/ws/sdk`` WebSocket, or an app's local
 apps (which import it from the installed ``reachy_mini`` package), so there is a
 single source of truth for the contract.
 
-Two message families, per JSON-RPC 2.0:
+Every frame is a pydantic model, and inbound frames are parsed through a
+:class:`~pydantic.TypeAdapter` union (:data:`rpc_adapter`) exactly like the
+legacy protocol's ``command_adapter`` / ``server_msg_adapter`` — so there is no
+hand-rolled ``json.loads`` + ``dict.get`` shape-sniffing anywhere.
 
-* **Request** — ``{"jsonrpc":"2.0","id":<token>,"method":str,"params":{...}}``.
-  Carries an ``id``; expects exactly one response.
-* **Response** — success ``{"jsonrpc":"2.0","id":<token>,"result":{...}}`` or
-  failure ``{"jsonrpc":"2.0","id":<token>,"error":{...}}``.
-* **Notification** — a request with **no** ``id``:
-  ``{"jsonrpc":"2.0","method":str,"params":{...}}``. One-way, never answered;
-  this is how events (``conversation.phase``/``turn``/``transcript`` ...) are
-  pushed to every connected client.
+Message families, per JSON-RPC 2.0:
+
+* **Request** (:class:`RpcRequest`) —
+  ``{"jsonrpc":"2.0","id":<token>,"method":str,"params":{...}}``. Carries an
+  ``id``; expects exactly one response. With ``id`` absent it is a
+  **notification** (one-way, never answered); this is how events
+  (``conversation.phase``/``turn``/``transcript`` ...) are pushed to every
+  connected client.
+* **Response** — success (:class:`RpcSuccess`)
+  ``{"jsonrpc":"2.0","id":<token>,"result":{...}}`` or failure
+  (:class:`RpcErrorResponse`) ``{"jsonrpc":"2.0","id":<token>,"error":{...}}``.
 
 **One deliberate deviation from the base spec** (matches the conversation API
 design doc): the stable, machine-branchable string error code lives in
@@ -28,10 +34,9 @@ daemon itself; anything else is relayed to the running app's ``/rpc``.
 
 from __future__ import annotations
 
-import json
 from typing import Any, Optional, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
 
 JSONRPC_VERSION = "2.0"
 
@@ -51,6 +56,80 @@ INVALID_PARAMS = -32602
 INTERNAL_ERROR = -32603
 # -32000..-32099 is the implementation-defined server-error range.
 SERVER_ERROR = -32000
+
+
+# ------------------------------------------------------------------
+# Wire models. Every frame the relay/app/server emits is one of these, so the
+# shape is defined once and validated by pydantic rather than assembled by hand.
+# ------------------------------------------------------------------
+
+
+class RpcErrorObj(BaseModel):
+    """The JSON-RPC ``error`` object. ``data`` carries the stable ``reason``."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    code: int
+    message: str
+    data: dict[str, Any] = {}
+
+
+class RpcRequest(BaseModel):
+    """A JSON-RPC request or notification (``id`` absent => notification)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    jsonrpc: str = JSONRPC_VERSION
+    id: Optional[RpcId] = None
+    method: str
+    params: dict[str, Any] = {}
+
+    @property
+    def is_notification(self) -> bool:
+        """True when this frame carries no ``id`` (one-way, no response)."""
+        return self.id is None
+
+    @property
+    def namespace(self) -> str:
+        """The part before the first dot (``conversation.say`` -> ``conversation``)."""
+        return self.method.split(".", 1)[0]
+
+
+class RpcSuccess(BaseModel):
+    """A JSON-RPC success response (``id`` echoed, ``result`` payload)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    jsonrpc: str = JSONRPC_VERSION
+    id: Optional[RpcId]
+    result: Any
+
+
+class RpcErrorResponse(BaseModel):
+    """A JSON-RPC error response (``id`` may be null per the spec)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    jsonrpc: str = JSONRPC_VERSION
+    id: Optional[RpcId]
+    error: RpcErrorObj
+
+
+class RpcNotification(BaseModel):
+    """A one-way JSON-RPC notification / event (no ``id``, never answered)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    jsonrpc: str = JSONRPC_VERSION
+    method: str
+    params: dict[str, Any] = {}
+
+
+# Any frame that can arrive on the relay<->app / SDK boundary. Ordered
+# most-specific-first: success/error responses carry ``result``/``error``
+# (which requests never do), so the union disambiguates on required fields.
+AnyRpcInbound = Union[RpcSuccess, RpcErrorResponse, RpcRequest]
+rpc_adapter: TypeAdapter[AnyRpcInbound] = TypeAdapter(AnyRpcInbound)
 
 
 class JsonRpcError(Exception):
@@ -76,34 +155,17 @@ class JsonRpcError(Exception):
         self.code = code
         self.data = data or {}
 
+    def to_error_model(self) -> RpcErrorObj:
+        """Render the JSON-RPC ``error`` object as a model."""
+        return RpcErrorObj(
+            code=self.code,
+            message=self.message,
+            data={**self.data, "reason": self.reason},
+        )
+
     def to_error_obj(self) -> dict[str, Any]:
-        """Render the JSON-RPC ``error`` object."""
-        return {
-            "code": self.code,
-            "message": self.message,
-            "data": {**self.data, "reason": self.reason},
-        }
-
-
-class RpcRequest(BaseModel):
-    """A parsed JSON-RPC request or notification (``id`` absent => notification)."""
-
-    model_config = ConfigDict(extra="ignore")
-
-    jsonrpc: str = JSONRPC_VERSION
-    id: Optional[RpcId] = None
-    method: str
-    params: dict[str, Any] = {}
-
-    @property
-    def is_notification(self) -> bool:
-        """True when this frame carries no ``id`` (one-way, no response)."""
-        return self.id is None
-
-    @property
-    def namespace(self) -> str:
-        """The part before the first dot (``conversation.say`` -> ``conversation``)."""
-        return self.method.split(".", 1)[0]
+        """Render the JSON-RPC ``error`` object as a plain dict."""
+        return self.to_error_model().model_dump()
 
 
 def looks_like_jsonrpc(obj: Any) -> bool:
@@ -115,6 +177,23 @@ def looks_like_jsonrpc(obj: Any) -> bool:
     return isinstance(obj, dict) and obj.get("jsonrpc") == JSONRPC_VERSION
 
 
+def _error_from_validation(exc: ValidationError, what: str) -> JsonRpcError:
+    """Map a pydantic error to the right JSON-RPC error.
+
+    Uses pydantic-core's ``json_invalid`` marker to keep the spec distinction
+    between a JSON syntax error (``parse_error`` / -32700) and a
+    well-formed-but-wrong-shape frame (``invalid_request`` / -32600), without a
+    separate ``json.loads`` pass — validation and decoding are one Rust step.
+    """
+    if any(err.get("type") == "json_invalid" for err in exc.errors()):
+        return JsonRpcError(
+            f"parse error: {exc}", reason="parse_error", code=PARSE_ERROR
+        )
+    return JsonRpcError(
+        f"invalid {what}: {exc}", reason="invalid_request", code=INVALID_REQUEST
+    )
+
+
 def parse_request(raw: Union[str, bytes, dict[str, Any]]) -> RpcRequest:
     """Parse a raw frame into an :class:`RpcRequest`.
 
@@ -122,22 +201,31 @@ def parse_request(raw: Union[str, bytes, dict[str, Any]]) -> RpcRequest:
     caller can turn it straight into an error response.
     """
     try:
-        obj = raw if isinstance(raw, dict) else json.loads(raw)
-    except (json.JSONDecodeError, TypeError) as e:
-        raise JsonRpcError(
-            f"parse error: {e}", reason="parse_error", code=PARSE_ERROR
-        ) from e
+        if isinstance(raw, dict):
+            return RpcRequest.model_validate(raw)
+        return RpcRequest.model_validate_json(raw)
+    except ValidationError as e:
+        raise _error_from_validation(e, "request") from e
+
+
+def parse_inbound(raw: Union[str, bytes, dict[str, Any]]) -> AnyRpcInbound:
+    """Parse any inbound frame into the right model (request/success/error).
+
+    Used on the relay<->app boundary to classify a frame (a correlated
+    response vs. an app-pushed notification) without shape-sniffing raw dicts.
+    Raises :class:`JsonRpcError` on malformed input.
+    """
     try:
-        return RpcRequest.model_validate(obj)
-    except Exception as e:
-        raise JsonRpcError(
-            f"invalid request: {e}", reason="invalid_request", code=INVALID_REQUEST
-        ) from e
+        if isinstance(raw, dict):
+            return rpc_adapter.validate_python(raw)
+        return rpc_adapter.validate_json(raw)
+    except ValidationError as e:
+        raise _error_from_validation(e, "frame") from e
 
 
 def make_result(id: Optional[RpcId], result: Any) -> dict[str, Any]:
     """Build a JSON-RPC success response object."""
-    return {"jsonrpc": JSONRPC_VERSION, "id": id, "result": result}
+    return RpcSuccess(id=id, result=result).model_dump()
 
 
 def make_error(
@@ -150,7 +238,7 @@ def make_error(
 ) -> dict[str, Any]:
     """Build a JSON-RPC error response object (string ``reason`` in ``data``)."""
     err = JsonRpcError(message, reason=reason, code=code, data=data)
-    return {"jsonrpc": JSONRPC_VERSION, "id": id, "error": err.to_error_obj()}
+    return RpcErrorResponse(id=id, error=err.to_error_model()).model_dump()
 
 
 def error_from_exc(id: Optional[RpcId], exc: BaseException) -> dict[str, Any]:
@@ -160,7 +248,7 @@ def error_from_exc(id: Optional[RpcId], exc: BaseException) -> dict[str, Any]:
     generic ``internal_error``.
     """
     if isinstance(exc, JsonRpcError):
-        return {"jsonrpc": JSONRPC_VERSION, "id": id, "error": exc.to_error_obj()}
+        return RpcErrorResponse(id=id, error=exc.to_error_model()).model_dump()
     return make_error(
         id,
         message=str(exc) or exc.__class__.__name__,
@@ -173,4 +261,4 @@ def make_notification(
     method: str, params: Optional[dict[str, Any]] = None
 ) -> dict[str, Any]:
     """Build a one-way JSON-RPC notification (event) object."""
-    return {"jsonrpc": JSONRPC_VERSION, "method": method, "params": params or {}}
+    return RpcNotification(method=method, params=params or {}).model_dump()

--- a/tests/unit_tests/test_jsonrpc_relay.py
+++ b/tests/unit_tests/test_jsonrpc_relay.py
@@ -296,3 +296,36 @@ async def test_apps_install(monkeypatch: pytest.MonkeyPatch) -> None:
         '{"jsonrpc":"2.0","id":"3","method":"apps.install"}', replies.append
     )
     assert replies[-1]["error"]["data"]["reason"] == "invalid_params"
+
+
+@pytest.mark.asyncio
+async def test_original_id_recorded_before_send(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The caller's id must be recorded before the frame leaves the relay.
+
+    Regression: the reader task runs on this loop and can deliver the app's
+    reply *during* ``ws.send``. If the original-id mapping is only written
+    after the await, that reply restores id=None and the caller hangs. Assert
+    the mapping is already present at send time.
+    """
+    relay = JsonRpcRelay(FakeAppManager(), broadcast=lambda _: None)
+    snapshot: dict[str, bool] = {}
+
+    class RacingWs(FakeAppWs):
+        async def send(self, text: str) -> None:
+            relay_id = json.loads(text)["id"]
+            snapshot["present"] = relay_id in relay._pending_original_id
+            await super().send(text)
+
+    ws = RacingWs()
+
+    async def fake_connect(url: str) -> RacingWs:
+        return ws
+
+    monkeypatch.setattr(jsonrpc_relay, "connect", fake_connect)
+
+    await relay.handle(
+        '{"jsonrpc":"2.0","id":"caller-1","method":"conversation.say"}',
+        lambda _r: None,
+    )
+    assert snapshot["present"] is True
+    await relay.aclose()

--- a/tests/unit_tests/test_jsonrpc_relay.py
+++ b/tests/unit_tests/test_jsonrpc_relay.py
@@ -16,8 +16,15 @@ import pytest
 from reachy_mini.daemon import jsonrpc_relay
 from reachy_mini.daemon.jsonrpc_relay import JsonRpcRelay
 from reachy_mini.io.jsonrpc import (
+    JsonRpcError,
+    RpcErrorResponse,
+    RpcRequest,
+    RpcSuccess,
     looks_like_jsonrpc,
     make_error,
+    make_notification,
+    make_result,
+    parse_inbound,
     parse_request,
 )
 
@@ -45,6 +52,47 @@ def test_error_reason_lives_in_data() -> None:
     err = make_error(None, message="busy", reason="robot_busy", code=-32000)
     assert err["error"]["code"] == -32000
     assert err["error"]["data"]["reason"] == "robot_busy"
+
+
+def test_builders_emit_the_expected_wire_shape() -> None:
+    # The dict builders are model-backed but must keep their exact JSON shape
+    # (including id:null on responses, which the spec requires present).
+    assert make_result("1", {"ok": True}) == {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "result": {"ok": True},
+    }
+    assert make_result(None, 7) == {"jsonrpc": "2.0", "id": None, "result": 7}
+    assert make_notification("conversation.turn", {"state": "speaking"}) == {
+        "jsonrpc": "2.0",
+        "method": "conversation.turn",
+        "params": {"state": "speaking"},
+    }
+
+
+def test_parse_inbound_classifies_each_frame() -> None:
+    # The TypeAdapter union disambiguates on required fields (result / error /
+    # method) instead of hand-rolled dict.get sniffing.
+    assert isinstance(
+        parse_inbound('{"jsonrpc":"2.0","id":"1","result":{"ok":true}}'), RpcSuccess
+    )
+    err = parse_inbound(
+        '{"jsonrpc":"2.0","id":"1","error":{"code":-32000,"message":"x",'
+        '"data":{"reason":"busy"}}}'
+    )
+    assert isinstance(err, RpcErrorResponse)
+    assert err.error.data["reason"] == "busy"
+    call = parse_inbound('{"jsonrpc":"2.0","id":"1","method":"conversation.say"}')
+    assert isinstance(call, RpcRequest) and not call.is_notification
+    note = parse_inbound('{"jsonrpc":"2.0","method":"conversation.turn"}')
+    assert isinstance(note, RpcRequest) and note.is_notification
+
+
+def test_parse_inbound_rejects_malformed() -> None:
+    with pytest.raises(JsonRpcError):
+        parse_inbound("not json at all")
+    with pytest.raises(JsonRpcError):
+        parse_inbound('{"jsonrpc":"2.0"}')  # neither result/error nor method
 
 
 # ------------------------------------------------------------------ fakes


### PR DESCRIPTION
Refactor of the JSON-RPC envelope introduced in #1266, targeting that PR's branch (`1252-expose-apps-api-to-webrtc`), not `main`.

## Motivation

The envelope modeled only *requests* as pydantic. Responses, errors and notifications were assembled as hand-rolled dicts, and the daemon relay classified/rewrote app frames by poking raw dicts (`json.loads` + `dict.get`, `obj["id"] = ...`). That's inconsistent with the repo's own protocol idiom, which parses both directions of the legacy protocol through `TypeAdapter` unions (`command_adapter`, `server_msg_adapter`). This aligns the new protocol with that pattern and removes the manual ser/deser.

## What changed

- **`io/jsonrpc.py`** — model every frame (`RpcSuccess` / `RpcErrorResponse` / `RpcNotification` / `RpcErrorObj`) and add an `AnyRpcInbound` `TypeAdapter` union (`parse_inbound`) so inbound frames are parsed and classified on required fields, not shape-sniffed.
- The `make_*` / `error_from_exc` helpers keep returning `dict` (call sites unchanged) but now build through the models, so the wire shape has a single source of truth. The `parse_error` (-32700) vs `invalid_request` (-32600) distinction is preserved via a shared `_decode` step.
- **`daemon/jsonrpc_relay.py`** — replace the raw-dict correlation in `_relay_to_app` / `_on_app_frame` with `model_copy` + `parse_inbound`; drop the now-unused `json` import.

## Tests

Added envelope round-trip and `parse_inbound` classification/rejection tests. ruff + mypy clean; the jsonrpc unit tests are green.