### PR TITLE
jsonrpc relay: fix reply-correlation race (caller id restored as null)

### DIFF
--- a/src/reachy_mini/daemon/jsonrpc_relay.py
+++ b/src/reachy_mini/daemon/jsonrpc_relay.py
@@ -172,8 +172,13 @@ class JsonRpcRelay:
 
         self._counter += 1
         relay_id = f"relay-{self._counter}"
-        original_id = req.id
+        # Record both correlation entries BEFORE the await: the reader task runs
+        # on this same loop and can process the app's reply *during*
+        # ``ws.send`` (a fast reply on the loopback WS). If `original_id` were
+        # set after the await, that reply would restore id=None and the caller
+        # would hang until timeout.
         self._pending[relay_id] = reply
+        self._pending_original_id[relay_id] = req.id
         # Forward the request under a relay-assigned id (model_copy keeps every
         # other field intact); the reader restores `original_id` on the reply.
         outgoing = req.model_copy(update={"id": relay_id})
@@ -181,8 +186,8 @@ class JsonRpcRelay:
             await ws.send(outgoing.model_dump_json())
         except Exception as e:
             self._pending.pop(relay_id, None)
+            self._pending_original_id.pop(relay_id, None)
             raise JsonRpcError(f"app unavailable: {e}", reason="app_unavailable") from e
-        self._pending_original_id[relay_id] = original_id
 
     async def _ensure_app_ws(self) -> ClientConnection:
         async with self._app_ws_lock:

--- a/tests/unit_tests/test_jsonrpc_relay.py
+++ b/tests/unit_tests/test_jsonrpc_relay.py
@@ -296,3 +296,36 @@ async def test_apps_install(monkeypatch: pytest.MonkeyPatch) -> None:
         '{"jsonrpc":"2.0","id":"3","method":"apps.install"}', replies.append
     )
     assert replies[-1]["error"]["data"]["reason"] == "invalid_params"
+
+
+@pytest.mark.asyncio
+async def test_original_id_recorded_before_send(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The caller's id must be recorded before the frame leaves the relay.
+
+    Regression: the reader task runs on this loop and can deliver the app's
+    reply *during* ``ws.send``. If the original-id mapping is only written
+    after the await, that reply restores id=None and the caller hangs. Assert
+    the mapping is already present at send time.
+    """
+    relay = JsonRpcRelay(FakeAppManager(), broadcast=lambda _: None)
+    snapshot: dict[str, bool] = {}
+
+    class RacingWs(FakeAppWs):
+        async def send(self, text: str) -> None:
+            relay_id = json.loads(text)["id"]
+            snapshot["present"] = relay_id in relay._pending_original_id
+            await super().send(text)
+
+    ws = RacingWs()
+
+    async def fake_connect(url: str) -> RacingWs:
+        return ws
+
+    monkeypatch.setattr(jsonrpc_relay, "connect", fake_connect)
+
+    await relay.handle(
+        '{"jsonrpc":"2.0","id":"caller-1","method":"conversation.say"}',
+        lambda _r: None,
+    )
+    assert snapshot["present"] is True
+    await relay.aclose()


### PR DESCRIPTION
Stacked on #1270 (base: `refactor/jsonrpc-pydantic-envelope`) so this shows only the race fix. Addresses finding #1 from the review of #1266.

## The bug

`JsonRpcRelay._relay_to_app` registered the relay-id → original-id mapping (`_pending_original_id`) **after** `await ws.send(...)`:

```python
self._pending[relay_id] = reply            # set before await
...
await ws.send(outgoing.model_dump_json())  # yields to the loop
self._pending_original_id[relay_id] = req.id   # set AFTER await  <-- race
```

The reader task runs on the same loop and can process the app's reply **during** that `await` (a fast reply on the loopback `/rpc` WS). At that moment `_on_app_frame` finds the pending entry but `_pending_original_id.pop(relay_id, None)` returns `None`, so the response is handed back with `id=null`. The SDK requires `data.id != null` to match a pending call, drops it, and the caller only rejects at its timeout (~20 s) — even though the app answered instantly.

## The fix

Record both correlation entries **before** the send (and drop both if the send fails). No wire change.

## Test

Adds `test_original_id_recorded_before_send`, a deterministic regression test asserting the original-id mapping is present at send time. Verified it fails with the old ordering and passes with the fix. ruff + mypy clean; jsonrpc unit tests green.