### PR TITLE
ci(npm-publish): normalize PEP 440 version to semver before npm version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -76,11 +76,40 @@ jobs:
         id: ver
         run: |
           py_ver=$(grep -E '^version' ../pyproject.toml | head -1 | sed -E 's/version *= *"([^"]+)"/\1/')
+          # pyproject.toml uses PEP 440 (e.g. 1.10.0.dev0, 1.9.0rc1); npm
+          # requires semver. Normalize the prerelease/dev suffix into a
+          # single dot-separated semver prerelease before `npm version`:
+          #   1.10.0.dev0    -> 1.10.0-dev.0
+          #   1.9.0rc1       -> 1.9.0-rc.1
+          #   1.9.0rc1.dev0  -> 1.9.0-rc.1.dev.0
+          #   1.10.0         -> 1.10.0 (unchanged)
+          semver=$(python3 - "$py_ver" <<'PY'
+          import re, sys
+          v = sys.argv[1]
+          m = re.match(r'^(\d+\.\d+\.\d+)(?:(a|b|rc)(\d+))?(?:\.dev(\d+))?$', v)
+          if not m:
+              print(v); sys.exit(0)
+          base, pre, pren, dev = m.groups()
+          parts = []
+          if pre:
+              parts += [pre, pren]
+          if dev is not None:
+              parts += ['dev', dev]
+          print(base + ('-' + '.'.join(parts) if parts else ''))
+          PY
+          )
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
             sha=$(echo "${{ github.sha }}" | cut -c1-7)
-            ver="${py_ver}-main.${sha}"
+            # semver permits only one '-': when the normalized version
+            # already carries a prerelease, append the build marker as
+            # extra dot-separated identifiers instead of a second '-'.
+            if [[ "$semver" == *-* ]]; then
+              ver="${semver}.main.${sha}"
+            else
+              ver="${semver}-main.${sha}"
+            fi
           else
-            ver="${py_ver}"
+            ver="${semver}"
           fi
           if [[ "$py_ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             release_tag="latest"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,12 @@ a single `workflow_dispatch` with a `release_type` dropdown. The version lives
 statically in `pyproject.toml` (single source of truth): `main` carries
 `X.Y.Z.dev0`; each `vX.Y-release` branch carries its released `X.Y.Z`.
 
+> **Note:** `main` intentionally carries a [PEP 440](https://peps.python.org/pep-0440/)
+> `.dev0` version (e.g. `1.10.0.dev0`), which is **not** valid semver. Any tooling that
+> reads the version out of `pyproject.toml` must handle non-semver PEP 440 forms
+> (`.devN`, `rcN`, etc.) — e.g. the npm-publish CI normalizes the version to semver
+> before calling `npm version`.
+
 ## The three modes
 
 | Mode | Trigger from | What it does |


### PR DESCRIPTION
## Problem

The `publish` job fails on any push/PR touching `ts/**` (or the workflow file) whenever `main`'s `pyproject.toml` version is a PEP 440 dev/prerelease form:

```
Computed version: 1.10.0.dev0-main.<sha> (event=pull_request, release_tag=rc)
npm error Invalid version: 1.10.0.dev0-main.<sha>
```

`pyproject.toml` is the single source of truth for the version and uses **PEP 440** (`1.10.0.dev0`, `1.9.0rc1`). The workflow fed that string straight to `npm version`, which requires **semver** and rejects those forms. It only ever produced valid semver for a clean `X.Y.Z`.

This currently red-lights CI on PR #1266 (first PR to touch `ts/**` since `main` was bumped to `1.10.0.dev0`).

Note: PRs never actually publish — the `npm publish` steps are gated to `release`/`push`. The PR path only builds + `npm pack --dry-run`. The version-compute step just happened to be fatal for everyone.

## Fix

Normalize the PEP 440 prerelease/dev suffix into a single dot-separated semver prerelease before `npm version`:

| pyproject (PEP 440) | npm (semver) |
|---|---|
| `1.10.0.dev0` | `1.10.0-dev.0` |
| `1.9.0rc1` | `1.9.0-rc.1` |
| `1.9.0rc1.dev0` | `1.9.0-rc.1.dev.0` |
| `1.10.0` | `1.10.0` (unchanged) |

The `-main.<sha>` build marker is appended as extra dot-separated identifiers when a prerelease already exists, so we never emit a second `-` (which semver forbids).

## Verification

Ran the exact workflow step (YAML-loaded, heredoc indentation preserved) across `{1.10.0.dev0, 1.9.0rc1, 1.10.0}` × `{pull_request, release, push}` — all produce valid semver and pass `npm version`. Confirmed the old string `1.10.0.dev0-main.<sha>` still fails `npm version`, i.e. the fix directly addresses the failure.

Once merged, PR #1266's `publish` job picks up the fixed workflow automatically (it reads the version from the PR-merged-into-`main` tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)