### PR TITLE
test: coverage sweep — daemon backend + low-% routers/utils

### DIFF
--- a/src/reachy_mini/utils/wireless_version/update_available.py
+++ b/src/reachy_mini/utils/wireless_version/update_available.py
@@ -4,6 +4,7 @@ For now, this only checks if a new version of "reachy_mini" is available on PyPI
 """
 
 import json
+import re
 from importlib.metadata import distribution, version
 
 import requests
@@ -67,19 +68,30 @@ def get_local_version(package_name: str) -> semver.Version:
     return _semver_version(version(package_name))
 
 
+# PEP 440 pre-release / dev markers that sort *before* the release, matching
+# semver pre-release ordering. `.postN` is intentionally excluded: it sorts
+# after the release, which a semver pre-release token cannot represent.
+_PEP440_SUFFIX = re.compile(
+    r"^(?P<base>\d+\.\d+\.\d+)\.?(?P<kind>a|b|c|rc|alpha|beta|dev)\.?(?P<num>\d+)$"
+)
+
+
 def _semver_version(v: str) -> semver.Version:
-    """Convert a version string to a semver.Version object, handling pypi pre-release formats."""
+    """Convert a version string to a semver.Version object, handling pypi pre-release formats.
+
+    ``semver.Version.parse`` only accepts strict semver, so PEP 440 suffixes
+    such as ``1.2.3rc4`` (attached) and ``1.10.0.dev0`` (dot-separated) are
+    normalized to a semver pre-release (``1.2.3-rc.4`` / ``1.10.0-dev.0``)
+    first. The package ships ``X.Y.Z.dev0`` on main, so this path is hit by
+    ``get_local_version`` on any from-source / from-git-ref install.
+    """
     try:
         return semver.Version.parse(v)
     except ValueError:
-        version_parts = v.split(".")
-        if len(version_parts) < 3:
-            raise ValueError(f"Invalid version string: {v}")
+        pass
 
-        patch_part = version_parts[2]
-        if "rc" in patch_part:
-            patch, rc = patch_part.split("rc", 1)
-            v_clean = f"{version_parts[0]}.{version_parts[1]}.{patch}-rc.{rc}"
-            return semver.Version.parse(v_clean)
+    m = _PEP440_SUFFIX.match(v)
+    if m is None:
+        raise ValueError(f"Invalid version string: {v}")
 
-    raise ValueError(f"Invalid version string: {v}")
+    return semver.Version.parse(f"{m['base']}-{m['kind']}.{m['num']}")

--- a/src/reachy_mini/utils/wireless_version/update_available.py
+++ b/src/reachy_mini/utils/wireless_version/update_available.py
@@ -52,7 +52,7 @@ def get_pypi_version(package_name: str, pre_release: bool) -> semver.Version:
     response.raise_for_status()
     data = response.json()
 
-    version = data["info"]["version"]
+    version = _semver_version(data["info"]["version"])
 
     if pre_release:
         releases = list(data["releases"].keys())
@@ -60,7 +60,7 @@ def get_pypi_version(package_name: str, pre_release: bool) -> semver.Version:
         if pre_version > version:
             return pre_version
 
-    return _semver_version(version)
+    return version
 
 
 def get_local_version(package_name: str) -> semver.Version:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -54,6 +54,7 @@ def pytest_collection_modifyitems(
         if item.get_closest_marker("webrtc") is not None:
             item.add_marker(skip)
 
+
 try:
     # Hack: import placo before reachy mini to fix an error with the Ubuntu CI
     import placo
@@ -230,7 +231,13 @@ class _FakeXVF3800:
         self._ctx = types.SimpleNamespace(dispose=lambda dev: None)
 
     def ctrl_transfer(
-        self, bmRequestType, bRequest, wValue=0, wIndex=0, data_or_wLength=None, timeout=0
+        self,
+        bmRequestType,
+        bRequest,
+        wValue=0,
+        wIndex=0,
+        data_or_wLength=None,
+        timeout=0,
     ):
         key = (wIndex, wValue & 0x7F)  # (resid, cmdid); read sets 0x80 on cmdid
         if bmRequestType & usb.util.CTRL_IN:
@@ -250,3 +257,63 @@ def fake_respeaker() -> ReSpeaker:
     dev = _FakeXVF3800()
     dev.regs[(20, 19)] = struct.pack("<ff", 1.57, 1.0)  # angle=1.57 rad, speech=True
     return ReSpeaker(dev)
+
+
+@pytest.fixture()
+def sim_backend() -> Generator[object, None, None]:
+    """Yield a headless ``MockupSimBackend(use_audio=False)`` — no hardware, no audio.
+
+    Its FK/IK use the pure-Python analytical kinematics; ``_media_server`` is a
+    MagicMock (with ``camera_specs``) so the media-delegating and head-tracking
+    branches are exercisable without a camera. ``current_head_pose`` is seeded so
+    ``get_present_head_pose()`` doesn't assert. This is the shared vehicle for
+    the ``daemon/backend/abstract.py`` tests (replaces the ad-hoc per-file
+    ``_make_backend()`` helpers).
+    """
+    from unittest.mock import MagicMock
+
+    import numpy as np
+
+    from reachy_mini.daemon.backend.mockup_sim.backend import MockupSimBackend
+
+    backend = MockupSimBackend(use_audio=False)
+    backend._media_server = MagicMock()
+    backend.current_head_pose = np.eye(4)
+    try:
+        yield backend
+    finally:
+        backend.close()
+
+
+@pytest.fixture()
+def router_app():
+    """Build a TestClient with a single router mounted on a bare FastAPI app.
+
+    Removes the need for a real daemon: pass ``backend`` / ``daemon`` stubs and
+    they're wired both via ``app.dependency_overrides`` (for ``Depends`` seams)
+    and on ``app.state.daemon`` (for routers that read it directly). Extra
+    dependency overrides can be passed as ``overrides={dep_fn: provider}``.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from reachy_mini.daemon.app.dependencies import (
+        get_backend,
+        get_daemon,
+        ws_get_backend,
+    )
+
+    def _make(router, *, backend=None, daemon=None, overrides=None) -> TestClient:
+        app = FastAPI()
+        app.include_router(router)
+        if backend is not None:
+            app.dependency_overrides[get_backend] = lambda: backend
+            app.dependency_overrides[ws_get_backend] = lambda: backend
+        if daemon is not None:
+            app.dependency_overrides[get_daemon] = lambda: daemon
+            app.state.daemon = daemon
+        for dep, provider in (overrides or {}).items():
+            app.dependency_overrides[dep] = provider
+        return TestClient(app)
+
+    return _make

--- a/tests/unit_tests/test_app_metadata.py
+++ b/tests/unit_tests/test_app_metadata.py
@@ -2,7 +2,16 @@ import json
 from dataclasses import dataclass
 from datetime import datetime
 
-from reachy_mini.apps.sources.hf_space import _to_plain_json
+from reachy_mini.apps import AppInfo, SourceKind
+from reachy_mini.apps.sources.hf_space import (
+    _build_app_info,
+    _coerce_space_data,
+    _coerce_space_list,
+    _get_card_data,
+    _get_string,
+    _normalize_space_data,
+    _to_plain_json,
+)
 
 
 @dataclass
@@ -25,3 +34,111 @@ def test_to_plain_json_normalizes_hf_objects() -> None:
     json.dumps(plain)  # must not raise
     assert plain["siblings"][0]["rfilename"] == "app/__main__.py"
     assert plain["created_at"] == "2024-01-02T03:04:05"
+
+
+def test_coerce_space_data_stringifies_keys() -> None:
+    # Non-string keys become strings; values pass through untouched.
+    assert _coerce_space_data({1: "a", "b": 2}) == {"1": "a", "b": 2}
+
+
+def test_coerce_space_data_rejects_non_dict() -> None:
+    assert _coerce_space_data(["not", "a", "dict"]) is None
+    assert _coerce_space_data(None) is None
+
+
+def test_coerce_space_list_keeps_only_dicts() -> None:
+    # Dict items survive (with stringified keys); non-dict items are dropped.
+    raw = [{"id": "a"}, "skip", 42, {"id": "b"}]
+    assert _coerce_space_list(raw) == [{"id": "a"}, {"id": "b"}]
+
+
+def test_coerce_space_list_rejects_non_list() -> None:
+    assert _coerce_space_list({"id": "a"}) == []
+
+
+def test_get_string_returns_string_values() -> None:
+    assert _get_string({"id": "owner/app"}, "id") == "owner/app"
+
+
+def test_get_string_none_for_missing_or_non_string() -> None:
+    assert _get_string({"id": 123}, "id") is None
+    assert _get_string({}, "id") is None
+
+
+def test_get_card_data_returns_dict() -> None:
+    card = {"short_description": "hi"}
+    assert _get_card_data({"cardData": card}) == card
+
+
+def test_get_card_data_defaults_to_empty_dict() -> None:
+    assert _get_card_data({"cardData": "not a dict"}) == {}
+    assert _get_card_data({}) == {}
+
+
+def test_normalize_space_data_renames_snake_case_keys() -> None:
+    # HfApi snake_case fields are moved to the app-store camelCase names.
+    normalized = _normalize_space_data(
+        {
+            "id": "owner/app",
+            "created_at": "2024-01-02",
+            "last_modified": "2024-03-04",
+            "card_data": {"short_description": "desc"},
+        }
+    )
+
+    assert normalized == {
+        "id": "owner/app",
+        "createdAt": "2024-01-02",
+        "lastModified": "2024-03-04",
+        "cardData": {"short_description": "desc"},
+    }
+
+
+def test_normalize_space_data_keeps_existing_camel_case() -> None:
+    # Existing camelCase values win; snake_case duplicates are dropped.
+    normalized = _normalize_space_data(
+        {
+            "createdAt": "keep",
+            "created_at": "drop",
+            "lastModified": "keep",
+            "last_modified": "drop",
+            "cardData": {"short_description": "keep"},
+            "card_data": {"short_description": "drop"},
+        }
+    )
+
+    assert normalized == {
+        "createdAt": "keep",
+        "lastModified": "keep",
+        "cardData": {"short_description": "keep"},
+    }
+
+
+def test_build_app_info_none_for_missing_input() -> None:
+    assert _build_app_info(None) is None
+
+
+def test_build_app_info_none_without_id() -> None:
+    assert _build_app_info({"cardData": {"short_description": "x"}}) is None
+
+
+def test_build_app_info_builds_full_metadata() -> None:
+    app = _build_app_info(
+        {"id": "owner/my-app", "cardData": {"short_description": "A nice app"}}
+    )
+
+    assert app is not None
+    assert app.name == "my-app"
+    assert app.description == "A nice app"
+    assert app.url == "https://huggingface.co/spaces/owner/my-app"
+    assert app.source_kind == SourceKind.HF_SPACE
+    assert app.extra["id"] == "owner/my-app"
+    assert isinstance(app, AppInfo)
+
+
+def test_build_app_info_defaults_empty_description() -> None:
+    # No cardData short_description -> description falls back to "".
+    app = _build_app_info({"id": "owner/app"})
+
+    assert app is not None
+    assert app.description == ""

--- a/tests/unit_tests/test_apps_hf_auth.py
+++ b/tests/unit_tests/test_apps_hf_auth.py
@@ -1,0 +1,286 @@
+"""Tests for the HuggingFace auth source module (in-memory, no network).
+
+Covers the OAuth-session lifecycle on the module-global `_oauth_sessions`
+dict, the pure helpers, and the token functions with `huggingface_hub`
+symbols monkeypatched. The real aiohttp token POST in
+`exchange_code_for_token` is not exercised; only its early error branches.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from huggingface_hub.errors import HfHubHTTPError
+
+from reachy_mini.apps.sources import hf_auth
+
+
+@pytest.fixture(autouse=True)
+def _clear_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset the module-global session dict before every test."""
+    monkeypatch.setattr(hf_auth, "_oauth_sessions", {})
+
+
+# ---- Pure helpers
+
+
+def test_generate_user_code_format() -> None:
+    """User code is 4 letters, dash, 4 digits, no ambiguous letters."""
+    code = hf_auth._generate_user_code()
+    letters, numbers = code.split("-")
+    assert len(letters) == 4 and letters.isalpha()
+    assert len(numbers) == 4 and numbers.isdigit()
+    assert not set(letters) & set("IO")
+
+
+def test_generate_pkce_pair_distinct_urlsafe() -> None:
+    """PKCE pair is two distinct URL-safe strings (no padding on challenge)."""
+    verifier, challenge = hf_auth._generate_pkce_pair()
+    assert verifier != challenge
+    assert len(verifier) >= 43
+    assert not challenge.endswith("=")
+
+
+def test_get_oauth_redirect_uri_variants() -> None:
+    """Redirect URI honours wireless flag and localhost override."""
+    assert hf_auth.get_oauth_redirect_uri(True) == hf_auth.OAUTH_REDIRECT_URI_WIRELESS
+    assert hf_auth.get_oauth_redirect_uri(False) == hf_auth.OAUTH_REDIRECT_URI_LITE
+    assert (
+        hf_auth.get_oauth_redirect_uri(True, use_localhost=True)
+        == hf_auth.OAUTH_REDIRECT_URI_LITE
+    )
+
+
+def test_is_oauth_configured_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """is_oauth_configured reflects the client-id constant."""
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "some-id")
+    assert hf_auth.is_oauth_configured() is True
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "")
+    assert hf_auth.is_oauth_configured() is False
+
+
+def test_configure_oauth_sets_globals(monkeypatch: pytest.MonkeyPatch) -> None:
+    """configure_oauth overwrites the module OAuth globals."""
+    # Guard originals so mutation of module state doesn't leak.
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", None)
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_SECRET", None)
+    monkeypatch.setattr(hf_auth, "OAUTH_SCOPES", "")
+    hf_auth.configure_oauth("cid", client_secret="secret", scopes="openid")
+    assert hf_auth.OAUTH_CLIENT_ID == "cid"
+    assert hf_auth.OAUTH_CLIENT_SECRET == "secret"
+    assert hf_auth.OAUTH_SCOPES == "openid"
+
+
+# ---- OAuth-session lifecycle
+
+
+def test_create_oauth_session_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A configured session yields an auth URL and registers the session."""
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
+    result = hf_auth.create_oauth_session(wireless_version=True)
+    assert result["status"] == "success"
+    assert result["auth_url"].startswith("https://huggingface.co/oauth/authorize?")
+    assert result["redirect_uri"] == hf_auth.OAUTH_REDIRECT_URI_WIRELESS
+    assert result["expires_in"] == 600
+    assert result["session_id"] in hf_auth._oauth_sessions
+
+
+def test_create_oauth_session_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No client id short-circuits with an error and stores nothing."""
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "")
+    result = hf_auth.create_oauth_session(wireless_version=False)
+    assert result["status"] == "error"
+    assert "OAuth not configured" in result["message"]
+    assert hf_auth._oauth_sessions == {}
+
+
+def test_get_oauth_session_and_by_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sessions are retrievable by id and by state."""
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
+    sid = hf_auth.create_oauth_session(wireless_version=True)["session_id"]
+    session = hf_auth.get_oauth_session(sid)
+    assert session is not None
+    assert hf_auth.get_session_by_state(session.state) is session
+    assert hf_auth.get_oauth_session("nope") is None
+    assert hf_auth.get_session_by_state("nope") is None
+
+
+def test_get_oauth_session_status_states(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Status polling surfaces pending, authorized (+username) and error."""
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
+    sid = hf_auth.create_oauth_session(wireless_version=True)["session_id"]
+
+    assert hf_auth.get_oauth_session_status(sid) == {"status": "pending"}
+
+    session = hf_auth.get_oauth_session(sid)
+    assert session is not None
+    session.status = "authorized"
+    session.username = "alice"
+    assert hf_auth.get_oauth_session_status(sid) == {
+        "status": "authorized",
+        "username": "alice",
+    }
+
+    session.status = "error"
+    session.error_message = "boom"
+    assert hf_auth.get_oauth_session_status(sid) == {
+        "status": "error",
+        "message": "boom",
+    }
+
+    assert hf_auth.get_oauth_session_status("missing")["status"] == "expired"
+
+
+def test_cancel_oauth_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cancelling removes the session; a second cancel returns False."""
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
+    sid = hf_auth.create_oauth_session(wireless_version=True)["session_id"]
+    assert hf_auth.cancel_oauth_session(sid) is True
+    assert sid not in hf_auth._oauth_sessions
+    assert hf_auth.cancel_oauth_session(sid) is False
+
+
+def test_cleanup_expired_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Expired sessions are pruned; live ones remain."""
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
+    live = hf_auth.create_oauth_session(wireless_version=True)["session_id"]
+    stale = hf_auth.create_oauth_session(wireless_version=True)["session_id"]
+    hf_auth._oauth_sessions[stale].expires_at = time.time() - 1
+
+    hf_auth._cleanup_expired_sessions()
+    assert live in hf_auth._oauth_sessions
+    assert stale not in hf_auth._oauth_sessions
+
+
+def test_expired_session_not_returned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Getters trigger cleanup, so an expired session reads as gone."""
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
+    sid = hf_auth.create_oauth_session(wireless_version=True)["session_id"]
+    hf_auth._oauth_sessions[sid].expires_at = time.time() - 1
+    assert hf_auth.get_oauth_session(sid) is None
+    assert hf_auth.get_oauth_session_status(sid)["status"] == "expired"
+
+
+# ---- exchange_code_for_token early error branches (no aiohttp)
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_invalid_session() -> None:
+    """Unknown state returns an invalid-session error before any network."""
+    result = await hf_auth.exchange_code_for_token("code", "unknown-state", True)
+    assert result["status"] == "error"
+    assert "Invalid or expired session" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A valid session but missing client id fails as not configured."""
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
+    sid = hf_auth.create_oauth_session(wireless_version=True)["session_id"]
+    session = hf_auth.get_oauth_session(sid)
+    assert session is not None
+
+    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "")
+    result = await hf_auth.exchange_code_for_token("code", session.state, True)
+    assert result == {"status": "error", "message": "OAuth not configured"}
+    assert session.status == "error"
+
+
+# ---- Token functions (huggingface_hub monkeypatched)
+
+
+def test_save_hf_token_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Valid token validates, persists via login, and returns the username."""
+    api = MagicMock()
+    api.whoami.return_value = {"name": "alice"}
+    hf_api = MagicMock(return_value=api)
+    login = MagicMock()
+    monkeypatch.setattr(hf_auth, "HfApi", hf_api)
+    monkeypatch.setattr(hf_auth, "login", login)
+    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *a: None)
+
+    result = hf_auth.save_hf_token("tok")
+    assert result == {"status": "success", "username": "alice"}
+    hf_api.assert_called_once_with(token="tok")
+    login.assert_called_once_with(token="tok", add_to_git_credential=False)
+
+
+def test_save_hf_token_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HfHubHTTPError/ValueError maps to the generic invalid-token message."""
+    api = MagicMock()
+    api.whoami.side_effect = ValueError("bad")
+    monkeypatch.setattr(hf_auth, "HfApi", MagicMock(return_value=api))
+    monkeypatch.setattr(hf_auth, "login", MagicMock())
+    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *a: None)
+
+    result = hf_auth.save_hf_token("tok")
+    assert result == {"status": "error", "message": "Invalid token or network error"}
+
+
+def test_save_hf_token_unexpected_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Other exceptions surface their string in the error message."""
+    api = MagicMock()
+    api.whoami.side_effect = RuntimeError("kaboom")
+    monkeypatch.setattr(hf_auth, "HfApi", MagicMock(return_value=api))
+    monkeypatch.setattr(hf_auth, "login", MagicMock())
+    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *a: None)
+
+    result = hf_auth.save_hf_token("tok")
+    assert result == {"status": "error", "message": "kaboom"}
+
+
+def test_save_hf_token_hfhub_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HfHubHTTPError from login maps to the invalid-token message."""
+    api = MagicMock()
+    api.whoami.return_value = {"name": "alice"}
+    login = MagicMock(side_effect=HfHubHTTPError("nope", response=MagicMock()))
+    monkeypatch.setattr(hf_auth, "HfApi", MagicMock(return_value=api))
+    monkeypatch.setattr(hf_auth, "login", login)
+    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *a: None)
+
+    result = hf_auth.save_hf_token("tok")
+    assert result == {"status": "error", "message": "Invalid token or network error"}
+
+
+def test_get_hf_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_hf_token delegates to huggingface_hub.get_token."""
+    monkeypatch.setattr(hf_auth, "get_token", MagicMock(return_value="tok"))
+    assert hf_auth.get_hf_token() == "tok"
+
+
+def test_delete_hf_token_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful logout returns True and notifies the relay of no token."""
+    logout = MagicMock()
+    notify = MagicMock()
+    monkeypatch.setattr(hf_auth, "logout", logout)
+    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", notify)
+    assert hf_auth.delete_hf_token() is True
+    logout.assert_called_once_with()
+    notify.assert_called_once_with(None)
+
+
+def test_delete_hf_token_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A logout error is swallowed and returns False."""
+    monkeypatch.setattr(hf_auth, "logout", MagicMock(side_effect=RuntimeError("x")))
+    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *a: None)
+    assert hf_auth.delete_hf_token() is False
+
+
+def test_check_token_status_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No stored token means logged out."""
+    monkeypatch.setattr(hf_auth, "get_token", MagicMock(return_value=None))
+    assert hf_auth.check_token_status() == {"is_logged_in": False, "username": None}
+
+
+def test_check_token_status_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A valid token reports logged in with the username."""
+    monkeypatch.setattr(hf_auth, "get_token", MagicMock(return_value="tok"))
+    monkeypatch.setattr(hf_auth, "whoami", MagicMock(return_value={"name": "alice"}))
+    assert hf_auth.check_token_status() == {"is_logged_in": True, "username": "alice"}
+
+
+def test_check_token_status_whoami_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A whoami failure downgrades to logged out."""
+    monkeypatch.setattr(hf_auth, "get_token", MagicMock(return_value="tok"))
+    monkeypatch.setattr(hf_auth, "whoami", MagicMock(side_effect=RuntimeError("x")))
+    assert hf_auth.check_token_status() == {"is_logged_in": False, "username": None}

--- a/tests/unit_tests/test_backend_media_uploads.py
+++ b/tests/unit_tests/test_backend_media_uploads.py
@@ -1,0 +1,394 @@
+"""Cover the inline-move / audio upload, play, and cancel handlers.
+
+Exercises ``daemon/backend/abstract.py``'s fire-and-forget upload state
+machine (start/chunk/finish for moves and audio), the stale-slot
+eviction, and the play/cancel paths — all with no hardware or network.
+"""
+
+import base64
+import gzip
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+
+from reachy_mini.daemon.backend.abstract import _PlaybackCancelToken
+from reachy_mini.io.protocol import (
+    CancelAudioCmd,
+    CancelMoveCmd,
+    PlayUploadedAudioCmd,
+    PlayUploadedMoveCmd,
+    UploadAudioChunkCmd,
+    UploadAudioFinishCmd,
+    UploadAudioStartCmd,
+    UploadMoveChunkCmd,
+    UploadMoveFinishCmd,
+    UploadMoveStartCmd,
+)
+from reachy_mini.motion.recorded_move import RecordedMove
+
+
+def _minimal_move_dict() -> dict:
+    """Smallest RecordedMove-parsable dict: 2 frames, identity head poses."""
+    return {
+        "description": "unit-test move",
+        "time": [0.0, 0.1],
+        "set_target_data": [
+            {"head": np.eye(4).tolist(), "antennas": [0.0, 0.0], "body_yaw": 0.0},
+            {"head": np.eye(4).tolist(), "antennas": [0.0, 0.0], "body_yaw": 0.0},
+        ],
+    }
+
+
+def _split(payload: str, n: int) -> list[str]:
+    """Split a string into n roughly-equal contiguous chunks (>=1 each)."""
+    size = max(1, len(payload) // n + 1)
+    parts = [payload[i : i + size] for i in range(0, len(payload), size)]
+    return parts or [""]
+
+
+def _feed_move(backend, upload_id, chunks, encoding) -> None:
+    """Drive start + in-order chunks for a move upload slot."""
+    backend._handle_upload_start(
+        UploadMoveStartCmd(
+            upload_id=upload_id, total_chunks=len(chunks), encoding=encoding
+        )
+    )
+    for i, part in enumerate(chunks):
+        backend._handle_upload_chunk(
+            UploadMoveChunkCmd(upload_id=upload_id, chunk_index=i, chunk=part)
+        )
+
+
+# --------------------------------------------------------------------------
+# Move upload — happy paths
+# --------------------------------------------------------------------------
+
+
+def test_move_upload_json_happy(sim_backend):
+    """JSON-encoded move assembled from >=2 chunks parses into a RecordedMove."""
+    payload = json.dumps(_minimal_move_dict())
+    chunks = _split(payload, 2)
+    assert len(chunks) >= 2
+    _feed_move(sim_backend, "m-json", chunks, "json")
+    sim_backend._handle_upload_finish(UploadMoveFinishCmd(upload_id="m-json"))
+    move = sim_backend._uploaded_moves["m-json"]
+    assert isinstance(move, RecordedMove)
+    # slot state is cleaned up on finish
+    assert "m-json" not in sim_backend._upload_chunks
+
+
+def test_move_upload_gzip_base64_happy(sim_backend):
+    """gzip+base64 move round-trips through decode + decompress."""
+    raw = gzip.compress(json.dumps(_minimal_move_dict()).encode())
+    payload = base64.b64encode(raw).decode()
+    chunks = _split(payload, 2)
+    assert len(chunks) >= 2
+    _feed_move(sim_backend, "m-gz", chunks, "gzip+base64")
+    sim_backend._handle_upload_finish(UploadMoveFinishCmd(upload_id="m-gz"))
+    assert isinstance(sim_backend._uploaded_moves["m-gz"], RecordedMove)
+
+
+# --------------------------------------------------------------------------
+# Move upload — error branches
+# --------------------------------------------------------------------------
+
+
+def test_move_chunk_no_slot_dropped(sim_backend):
+    """Chunk for an unopened slot is dropped without crashing."""
+    sim_backend._handle_upload_chunk(
+        UploadMoveChunkCmd(upload_id="ghost", chunk_index=0, chunk="x")
+    )
+    assert "ghost" not in sim_backend._upload_chunks
+
+
+def test_move_chunk_out_of_order_drops_slot(sim_backend):
+    """A misordered chunk discards the whole slot."""
+    sim_backend._handle_upload_start(
+        UploadMoveStartCmd(upload_id="ooo", total_chunks=2)
+    )
+    sim_backend._handle_upload_chunk(
+        UploadMoveChunkCmd(upload_id="ooo", chunk_index=1, chunk="x")
+    )
+    assert "ooo" not in sim_backend._upload_chunks
+    assert "ooo" not in sim_backend._upload_meta
+
+
+def test_move_chunk_index_exceeds_total_drops_slot(sim_backend):
+    """A chunk_index past the declared total discards the slot."""
+    sim_backend._handle_upload_start(
+        UploadMoveStartCmd(upload_id="ovf", total_chunks=1)
+    )
+    sim_backend._handle_upload_chunk(
+        UploadMoveChunkCmd(upload_id="ovf", chunk_index=0, chunk="a")
+    )
+    # index 1 == expected len, but >= total_chunks (1) -> dropped
+    sim_backend._handle_upload_chunk(
+        UploadMoveChunkCmd(upload_id="ovf", chunk_index=1, chunk="b")
+    )
+    assert "ovf" not in sim_backend._upload_chunks
+
+
+def test_move_finish_count_mismatch_stores_nothing(sim_backend):
+    """Finishing with fewer chunks than declared stores no move."""
+    sim_backend._handle_upload_start(
+        UploadMoveStartCmd(upload_id="mm", total_chunks=2)
+    )
+    sim_backend._handle_upload_chunk(
+        UploadMoveChunkCmd(upload_id="mm", chunk_index=0, chunk="{}")
+    )
+    sim_backend._handle_upload_finish(UploadMoveFinishCmd(upload_id="mm"))
+    assert "mm" not in sim_backend._uploaded_moves
+
+
+def test_move_finish_unknown_slot(sim_backend):
+    """Finishing an id that was never started is a no-op."""
+    sim_backend._handle_upload_finish(UploadMoveFinishCmd(upload_id="nope"))
+    assert "nope" not in sim_backend._uploaded_moves
+
+
+def test_move_finish_unknown_encoding_stores_nothing(sim_backend):
+    """An unrecognized encoding on finish drops the slot."""
+    _feed_move(sim_backend, "enc", ["{}"], "json")
+    sim_backend._upload_meta["enc"]["encoding"] = "bogus"
+    sim_backend._handle_upload_finish(UploadMoveFinishCmd(upload_id="enc"))
+    assert "enc" not in sim_backend._uploaded_moves
+
+
+def test_move_start_too_many_active_slots_refused(sim_backend):
+    """A second slot is refused when the active-slot cap is reached."""
+    sim_backend._upload_max_active_slots = 1
+    sim_backend._handle_upload_start(UploadMoveStartCmd(upload_id="s1", total_chunks=1))
+    sim_backend._handle_upload_start(UploadMoveStartCmd(upload_id="s2", total_chunks=1))
+    assert "s1" in sim_backend._upload_chunks
+    assert "s2" not in sim_backend._upload_chunks
+
+
+def test_move_evict_stale_uploads(sim_backend):
+    """Slots older than the TTL are evicted."""
+    sim_backend._handle_upload_start(UploadMoveStartCmd(upload_id="old", total_chunks=1))
+    sim_backend._upload_ts["old"] = 0.0  # epoch -> ancient
+    sim_backend._upload_ttl_s = 1.0
+    sim_backend._evict_stale_uploads()
+    assert "old" not in sim_backend._upload_chunks
+    assert "old" not in sim_backend._upload_meta
+    assert "old" not in sim_backend._upload_ts
+
+
+# --------------------------------------------------------------------------
+# Audio upload
+# --------------------------------------------------------------------------
+
+
+def test_audio_upload_happy(sim_backend, tmp_path):
+    """Base64 audio assembled from chunks is written under the temp dir."""
+    sim_backend._audio_temp_dir = str(tmp_path)
+    raw = b"RIFF----WAVEfake-pcm-bytes"
+    payload = base64.b64encode(raw).decode()
+    chunks = _split(payload, 2)
+    sim_backend._handle_audio_start(
+        UploadAudioStartCmd(upload_id="a1", total_chunks=len(chunks))
+    )
+    for i, part in enumerate(chunks):
+        sim_backend._handle_audio_chunk(
+            UploadAudioChunkCmd(upload_id="a1", chunk_index=i, chunk=part)
+        )
+    sim_backend._handle_audio_finish(UploadAudioFinishCmd(upload_id="a1"))
+    path = sim_backend._uploaded_audios["a1"]
+    assert os.path.dirname(path) == str(tmp_path)
+    assert path.endswith(".wav")
+    with open(path, "rb") as f:
+        assert f.read() == raw
+
+
+def test_audio_chunk_no_slot_dropped(sim_backend):
+    """Audio chunk for an unopened slot is dropped."""
+    sim_backend._handle_audio_chunk(
+        UploadAudioChunkCmd(upload_id="ghost", chunk_index=0, chunk="x")
+    )
+    assert "ghost" not in sim_backend._audio_chunks
+
+
+def test_audio_chunk_out_of_order_drops_slot(sim_backend):
+    """A misordered audio chunk discards the slot."""
+    sim_backend._handle_audio_start(
+        UploadAudioStartCmd(upload_id="ooo", total_chunks=2)
+    )
+    sim_backend._handle_audio_chunk(
+        UploadAudioChunkCmd(upload_id="ooo", chunk_index=1, chunk="x")
+    )
+    assert "ooo" not in sim_backend._audio_chunks
+
+
+def test_audio_chunk_index_exceeds_total_drops_slot(sim_backend):
+    """An audio chunk_index past the declared total discards the slot."""
+    sim_backend._handle_audio_start(
+        UploadAudioStartCmd(upload_id="ovf", total_chunks=1)
+    )
+    sim_backend._handle_audio_chunk(
+        UploadAudioChunkCmd(upload_id="ovf", chunk_index=0, chunk="a")
+    )
+    sim_backend._handle_audio_chunk(
+        UploadAudioChunkCmd(upload_id="ovf", chunk_index=1, chunk="b")
+    )
+    assert "ovf" not in sim_backend._audio_chunks
+
+
+def test_audio_finish_count_mismatch_writes_nothing(sim_backend, tmp_path):
+    """Audio finish with the wrong chunk count writes no file."""
+    sim_backend._audio_temp_dir = str(tmp_path)
+    sim_backend._handle_audio_start(
+        UploadAudioStartCmd(upload_id="mm", total_chunks=2)
+    )
+    sim_backend._handle_audio_chunk(
+        UploadAudioChunkCmd(upload_id="mm", chunk_index=0, chunk="AA==")
+    )
+    sim_backend._handle_audio_finish(UploadAudioFinishCmd(upload_id="mm"))
+    assert "mm" not in sim_backend._uploaded_audios
+
+
+def test_audio_evict_stale_slots_and_orphan_file(sim_backend, tmp_path):
+    """In-progress slots and orphaned finished files past TTL are evicted."""
+    sim_backend._audio_temp_dir = str(tmp_path)
+    sim_backend._upload_ttl_s = 1.0
+    # in-progress stale slot
+    sim_backend._handle_audio_start(
+        UploadAudioStartCmd(upload_id="old", total_chunks=1)
+    )
+    sim_backend._audio_ts["old"] = 0.0
+    # orphaned finished audio file, aged past TTL
+    orphan = tmp_path / "orphan.wav"
+    orphan.write_bytes(b"data")
+    os.utime(orphan, (0, 0))  # mtime at epoch
+    sim_backend._uploaded_audios["orph"] = str(orphan)
+
+    sim_backend._evict_stale_audios()
+
+    assert "old" not in sim_backend._audio_chunks
+    assert "orph" not in sim_backend._uploaded_audios
+    assert not orphan.exists()
+
+
+# --------------------------------------------------------------------------
+# play / cancel audio
+# --------------------------------------------------------------------------
+
+
+def test_play_uploaded_audio_no_such_audio(sim_backend, monkeypatch):
+    """Playing an unknown audio id broadcasts an error."""
+    sent: list[dict] = []
+    monkeypatch.setattr(
+        sim_backend, "broadcast_to_all_clients", lambda p: sent.append(json.loads(p))
+    )
+    monkeypatch.setattr(sim_backend, "play_sound", MagicMock())
+    sim_backend._handle_play_uploaded_audio(PlayUploadedAudioCmd(upload_id="none"))
+    assert sent[-1]["error"] == "no such uploaded audio"
+    assert sim_backend._active_audio_upload_id is None
+
+
+def test_play_uploaded_audio_happy(sim_backend, monkeypatch):
+    """A known audio id broadcasts started, plays, and claims the active slot."""
+    sent: list[dict] = []
+    play = MagicMock()
+    monkeypatch.setattr(
+        sim_backend, "broadcast_to_all_clients", lambda p: sent.append(json.loads(p))
+    )
+    monkeypatch.setattr(sim_backend, "play_sound", play)
+    sim_backend._uploaded_audios["a"] = "/tmp/a.wav"
+    sim_backend._handle_play_uploaded_audio(PlayUploadedAudioCmd(upload_id="a"))
+    assert sent[-1]["started"] is True
+    play.assert_called_once_with("/tmp/a.wav")
+    assert sim_backend._active_audio_upload_id == "a"
+
+
+def test_play_uploaded_audio_play_sound_raises(sim_backend, monkeypatch):
+    """A play_sound failure broadcasts an error and clears the active slot."""
+    sent: list[dict] = []
+    monkeypatch.setattr(
+        sim_backend, "broadcast_to_all_clients", lambda p: sent.append(json.loads(p))
+    )
+    monkeypatch.setattr(
+        sim_backend, "play_sound", MagicMock(side_effect=RuntimeError("boom"))
+    )
+    sim_backend._uploaded_audios["a"] = "/tmp/a.wav"
+    sim_backend._handle_play_uploaded_audio(PlayUploadedAudioCmd(upload_id="a"))
+    assert sent[-1]["error"] == "boom"
+    assert sim_backend._active_audio_upload_id is None
+
+
+def test_cancel_audio_matching(sim_backend, monkeypatch):
+    """cancel_audio for the active id stops sound and clears the slot."""
+    stop = MagicMock()
+    monkeypatch.setattr(sim_backend, "stop_sound", stop)
+    sim_backend._active_audio_upload_id = "a"
+    sim_backend._handle_cancel_audio(CancelAudioCmd(upload_id="a"))
+    stop.assert_called_once()
+    assert sim_backend._active_audio_upload_id is None
+
+
+def test_cancel_audio_non_matching_noop(sim_backend, monkeypatch):
+    """cancel_audio for a different id is a no-op."""
+    stop = MagicMock()
+    monkeypatch.setattr(sim_backend, "stop_sound", stop)
+    sim_backend._active_audio_upload_id = "a"
+    sim_backend._handle_cancel_audio(CancelAudioCmd(upload_id="other"))
+    stop.assert_not_called()
+    assert sim_backend._active_audio_upload_id == "a"
+
+
+# --------------------------------------------------------------------------
+# cancel move
+# --------------------------------------------------------------------------
+
+
+def test_cancel_move_matching(sim_backend):
+    """cancel_move flips the active token when its upload_id matches."""
+    token = _PlaybackCancelToken("m1")
+    sim_backend._active_move_token = token
+    sim_backend._handle_cancel_move(CancelMoveCmd(upload_id="m1"))
+    assert token.cancelled is True
+
+
+def test_cancel_move_non_matching_noop(sim_backend):
+    """cancel_move leaves a non-matching token untouched."""
+    token = _PlaybackCancelToken("m1")
+    sim_backend._active_move_token = token
+    sim_backend._handle_cancel_move(CancelMoveCmd(upload_id="other"))
+    assert token.cancelled is False
+
+
+# --------------------------------------------------------------------------
+# async play uploaded move
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_play_uploaded_move_no_such_move(sim_backend, monkeypatch):
+    """Playing an unknown move id broadcasts an error."""
+    sent: list[dict] = []
+    monkeypatch.setattr(
+        sim_backend, "broadcast_to_all_clients", lambda p: sent.append(json.loads(p))
+    )
+    await sim_backend._async_play_uploaded_move(PlayUploadedMoveCmd(upload_id="none"))
+    assert sent[-1]["error"].startswith("no such uploaded move")
+
+
+@pytest.mark.asyncio
+async def test_async_play_uploaded_move_happy(sim_backend, monkeypatch):
+    """A known move broadcasts started then finished; token installed then cleared."""
+    sent: list[dict] = []
+    monkeypatch.setattr(
+        sim_backend, "broadcast_to_all_clients", lambda p: sent.append(json.loads(p))
+    )
+    play = AsyncMock()
+    monkeypatch.setattr(sim_backend, "play_move", play)
+    sim_backend._uploaded_moves["m1"] = RecordedMove(_minimal_move_dict())
+
+    await sim_backend._async_play_uploaded_move(PlayUploadedMoveCmd(upload_id="m1"))
+
+    play.assert_awaited_once()
+    assert sent[0]["started"] is True
+    assert sent[-1]["finished"] is True
+    assert sim_backend._active_move_token is None

--- a/tests/unit_tests/test_backend_motion.py
+++ b/tests/unit_tests/test_backend_motion.py
@@ -1,0 +1,241 @@
+"""Hardware-free tests for Backend target setters, IK, recording and async wrappers."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+
+from reachy_mini.io.protocol import RecordedDataMsg
+
+
+# Target setters
+
+
+def test_set_target_head_pose_sets_ik_required(sim_backend) -> None:
+    """set_target_head_pose stores the pose and requests IK."""
+    sim_backend.ik_required = False
+    pose = np.eye(4)
+    sim_backend.set_target_head_pose(pose)
+    assert np.array_equal(sim_backend.target_head_pose, pose)
+    assert sim_backend.ik_required is True
+
+
+def test_set_target_head_pose_full_tracking_weight_skips_ik(sim_backend) -> None:
+    """Full-weight tracking short-circuits IK: ik_required stays False."""
+    sim_backend.ik_required = False
+    sim_backend._tracking_aim = np.eye(4)
+    sim_backend._tracking_weight = 1.0
+    sim_backend.set_target_head_pose(np.eye(4))
+    assert sim_backend.ik_required is False
+
+
+def test_set_target_body_yaw_sets_ik_required(sim_backend) -> None:
+    """set_target_body_yaw stores the yaw and requests IK."""
+    sim_backend.ik_required = False
+    sim_backend.set_target_body_yaw(0.5)
+    assert sim_backend.target_body_yaw == 0.5
+    assert sim_backend.ik_required is True
+
+
+def test_set_target_body_yaw_noop_when_unchanged(sim_backend) -> None:
+    """A yaw within 1e-9 of the current value is a no-op (no IK)."""
+    sim_backend.set_target_body_yaw(0.5)
+    sim_backend.ik_required = False
+    sim_backend.set_target_body_yaw(0.5 + 1e-12)
+    assert sim_backend.ik_required is False
+
+
+def test_set_target_head_joint_positions_clears_ik(sim_backend) -> None:
+    """Setting joints directly bypasses IK."""
+    sim_backend.ik_required = True
+    positions = np.zeros(7)
+    sim_backend.set_target_head_joint_positions(positions)
+    assert np.array_equal(sim_backend.target_head_joint_positions, positions)
+    assert sim_backend.ik_required is False
+
+
+def test_set_target_antenna_joint_positions(sim_backend) -> None:
+    """Antenna setter stores the positions."""
+    positions = np.array([0.1, -0.2])
+    sim_backend.set_target_antenna_joint_positions(positions)
+    assert np.array_equal(sim_backend.target_antenna_joint_positions, positions)
+
+
+def test_set_target_composite_dispatch(sim_backend) -> None:
+    """set_target dispatches to head, antenna and body-yaw setters."""
+    sim_backend.ik_required = False
+    head = np.eye(4)
+    antennas = np.array([0.3, 0.4])
+    sim_backend.set_target(head=head, antennas=antennas, body_yaw=0.7)
+    assert np.array_equal(sim_backend.target_head_pose, head)
+    assert np.array_equal(sim_backend.target_antenna_joint_positions, antennas)
+    assert sim_backend.target_body_yaw == 0.7
+    assert sim_backend.ik_required is True
+
+
+def test_set_speech_offsets_sets_ik_required(sim_backend) -> None:
+    """set_speech_offsets stores the tuple and requests IK."""
+    sim_backend.ik_required = False
+    offsets = (0.01, 0.0, 0.0, 0.0, 0.0, 0.0)
+    sim_backend.set_speech_offsets(offsets)
+    assert sim_backend._speech_offsets == offsets
+    assert sim_backend.ik_required is True
+
+
+# IK
+
+
+def test_update_target_head_joints_from_ik(sim_backend) -> None:
+    """IK on identity pose yields joints and records the last target pose."""
+    sim_backend.update_target_head_joints_from_ik(pose=np.eye(4))
+    assert sim_backend.target_head_joint_positions is not None
+    assert np.array_equal(sim_backend._last_target_head_pose, np.eye(4))
+
+
+def test_update_target_head_joints_from_ik_with_speech_offsets(sim_backend) -> None:
+    """Non-zero speech offsets are composed into the pose before IK."""
+    sim_backend._speech_offsets = (0.005, 0.0, 0.0, 0.0, 0.0, 0.1)
+    sim_backend.update_target_head_joints_from_ik(pose=np.eye(4))
+    assert sim_backend.target_head_joint_positions is not None
+    # Composed pose differs from the raw identity input.
+    assert not np.array_equal(sim_backend._last_target_head_pose, np.eye(4))
+
+
+def test_update_target_head_joints_from_ik_unreachable_raises(sim_backend) -> None:
+    """A None IK result (collision/unreachable) raises ValueError."""
+    sim_backend.head_kinematics.ik = MagicMock(return_value=None)
+    with pytest.raises(ValueError):
+        sim_backend.update_target_head_joints_from_ik(pose=np.eye(4))
+
+
+# Recording
+
+
+def test_start_recording(sim_backend) -> None:
+    """start_recording arms recording with an empty buffer."""
+    sim_backend.start_recording()
+    assert sim_backend.is_recording is True
+    assert sim_backend.recorded_data == []
+
+
+def test_append_record_while_recording(sim_backend) -> None:
+    """append_record stores records only while recording is active."""
+    sim_backend.start_recording()
+    sim_backend.append_record({"t": 1})
+    assert sim_backend.recorded_data == [{"t": 1}]
+
+
+def test_append_record_noop_when_stopped(sim_backend) -> None:
+    """append_record is a no-op when not recording."""
+    sim_backend.is_recording = False
+    sim_backend.recorded_data = []
+    sim_backend.append_record({"t": 1})
+    assert sim_backend.recorded_data == []
+
+
+def test_stop_recording_publishes(sim_backend) -> None:
+    """stop_recording swaps the buffer and publishes a RecordedDataMsg."""
+    publisher = MagicMock()
+    sim_backend.set_recording_publisher(publisher)
+    sim_backend.start_recording()
+    sim_backend.append_record({"t": 1})
+    sim_backend.stop_recording()
+    assert sim_backend.is_recording is False
+    assert sim_backend.recorded_data == []
+    publisher.put.assert_called_once()
+    msg = publisher.put.call_args.args[0]
+    assert isinstance(msg, RecordedDataMsg)
+    assert msg.data == [{"t": 1}]
+
+
+def test_stop_recording_without_publisher_warns(sim_backend) -> None:
+    """stop_recording with no publisher warns instead of crashing."""
+    sim_backend.recording_publisher = None
+    sim_backend.start_recording()
+    sim_backend.append_record({"t": 1})
+    sim_backend.stop_recording()  # must not raise
+    assert sim_backend.is_recording is False
+
+
+# Publisher setters
+
+
+def test_publisher_setters_store_object(sim_backend) -> None:
+    """Each publisher setter stores the given object on the backend."""
+    joints, pose, imu, rec = (MagicMock() for _ in range(4))
+    sim_backend.set_joint_positions_publisher(joints)
+    sim_backend.set_pose_publisher(pose)
+    sim_backend.set_imu_publisher(imu)
+    sim_backend.set_recording_publisher(rec)
+    assert sim_backend.joint_positions_publisher is joints
+    assert sim_backend.pose_publisher is pose
+    assert sim_backend.imu_publisher is imu
+    assert sim_backend.recording_publisher is rec
+
+
+# Present-pose getters
+
+
+def test_get_present_body_yaw(sim_backend) -> None:
+    """Present body yaw is the first head joint position."""
+    expected = sim_backend.get_present_head_joint_positions()[0]
+    assert sim_backend.get_present_body_yaw() == expected
+
+
+def test_get_present_head_pose(sim_backend) -> None:
+    """Present head pose returns the seeded current pose."""
+    assert np.array_equal(sim_backend.get_present_head_pose(), np.eye(4))
+
+
+def test_get_current_head_pose(sim_backend) -> None:
+    """get_current_head_pose delegates to get_present_head_pose."""
+    assert np.array_equal(sim_backend.get_current_head_pose(), np.eye(4))
+
+
+# Async wrappers.
+# The wake_up / goto_sleep success paths run through these wrappers via the
+# process_command WakeUp/GotoSleep dispatch tests, so here we only add the
+# error branches (and the _async_goto pair, which nothing else exercises).
+
+
+@pytest.mark.asyncio
+async def test_async_goto_ok(sim_backend) -> None:
+    """_async_goto reports completion when goto_target succeeds."""
+    sim_backend.goto_target = AsyncMock()
+    send_response = MagicMock()
+    await sim_backend._async_goto(send_response, np.eye(4), None, 1.0, None)
+    resp = send_response.call_args.args[0]
+    assert resp == {"status": "ok", "command": "goto_target", "completed": True}
+
+
+@pytest.mark.asyncio
+async def test_async_goto_error(sim_backend) -> None:
+    """_async_goto reports the error when goto_target raises."""
+    sim_backend.goto_target = AsyncMock(side_effect=RuntimeError("boom"))
+    send_response = MagicMock()
+    await sim_backend._async_goto(send_response, np.eye(4), None, 1.0, None)
+    resp = send_response.call_args.args[0]
+    assert resp["command"] == "goto_target"
+    assert resp["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_async_wake_up_error(sim_backend) -> None:
+    """_async_wake_up reports the error when wake_up raises."""
+    sim_backend.wake_up = AsyncMock(side_effect=RuntimeError("boom"))
+    send_response = MagicMock()
+    await sim_backend._async_wake_up(send_response)
+    resp = send_response.call_args.args[0]
+    assert resp["command"] == "wake_up"
+    assert resp["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_async_goto_sleep_error(sim_backend) -> None:
+    """_async_goto_sleep reports the error when goto_sleep raises."""
+    sim_backend.goto_sleep = AsyncMock(side_effect=RuntimeError("boom"))
+    send_response = MagicMock()
+    await sim_backend._async_goto_sleep(send_response)
+    resp = send_response.call_args.args[0]
+    assert resp["command"] == "goto_sleep"
+    assert resp["error"] == "boom"

--- a/tests/unit_tests/test_backend_process_command.py
+++ b/tests/unit_tests/test_backend_process_command.py
@@ -1,0 +1,629 @@
+"""Tests for Backend.process_command dispatch across command families.
+
+Covers the transport-agnostic command dispatcher in
+``daemon/backend/abstract.py`` for the Set*/Get*/audio/recording/log/
+lifecycle command families. The GotoTargetCmd reshape and the WebRTC
+message entry point are covered separately in ``test_process_command.py``
+and are not duplicated here.
+
+All tests run headless: no hardware, no network. Media, volume, respeaker,
+and hardware-id seams are patched with in-memory stubs.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import numpy as np
+import pytest
+
+from reachy_mini.io.protocol import (
+    AppendRecordCmd,
+    ApplyAudioConfigCmd,
+    AudioParamPair,
+    ClearIncomingAudioCmd,
+    GetHardwareIdCmd,
+    GetMicrophoneVolumeCmd,
+    GetMotorModeCmd,
+    GetStateCmd,
+    GetTrackedFaceCmd,
+    GetVersionCmd,
+    GetVolumeCmd,
+    GotoSleepCmd,
+    PlaySoundCmd,
+    ReadAudioParameterCmd,
+    RestartDaemonCmd,
+    SetAntennasCmd,
+    SetAutomaticBodyYawCmd,
+    SetBodyYawCmd,
+    SetFullTargetCmd,
+    SetGravityCompensationCmd,
+    SetHeadJointsCmd,
+    SetHeadTrackingCmd,
+    SetMicrophoneVolumeCmd,
+    SetMotorModeCmd,
+    SetSpeechOffsetsCmd,
+    SetTargetCmd,
+    SetTorqueCmd,
+    SetVolumeCmd,
+    SetWobblingCmd,
+    StartRecordingCmd,
+    StartUpdateCmd,
+    StopRecordingCmd,
+    SubscribeLogsCmd,
+    UnsubscribeLogsCmd,
+    WakeUpCmd,
+)
+
+
+def _dispatch(backend: Any, cmd: Any, peer_id: str | None = None) -> list[dict]:
+    """Dispatch a command, collecting responses into a list."""
+    responses: list[dict] = []
+    backend.process_command(cmd, send_response=responses.append, peer_id=peer_id)
+    return responses
+
+
+# ------------------------------------------------------------------
+# Set* target commands
+# ------------------------------------------------------------------
+
+
+def test_set_target_updates_head_pose(sim_backend: Any) -> None:
+    """SetTargetCmd reshapes the flat head and updates target_head_pose."""
+    pose = np.eye(4)
+    pose[:3, 3] = [0.1, 0.2, 0.3]
+    responses = _dispatch(sim_backend, SetTargetCmd(head=pose.flatten().tolist()))
+    assert responses == [{"status": "ok", "command": "set_target"}]
+    np.testing.assert_array_equal(sim_backend.target_head_pose, pose)
+
+
+def test_set_head_joints_updates_target(sim_backend: Any) -> None:
+    """SetHeadJointsCmd updates target_head_joint_positions."""
+    joints = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+    responses = _dispatch(sim_backend, SetHeadJointsCmd(joints=joints))
+    assert responses == [{"status": "ok", "command": "set_head_joints"}]
+    np.testing.assert_array_equal(
+        sim_backend.target_head_joint_positions, np.array(joints)
+    )
+
+
+def test_set_body_yaw_updates_target(sim_backend: Any) -> None:
+    """SetBodyYawCmd updates target_body_yaw."""
+    responses = _dispatch(sim_backend, SetBodyYawCmd(body_yaw=0.42))
+    assert responses == [{"status": "ok", "command": "set_body_yaw"}]
+    assert sim_backend.target_body_yaw == 0.42
+
+
+def test_set_antennas_updates_target(sim_backend: Any) -> None:
+    """SetAntennasCmd updates target_antenna_joint_positions."""
+    responses = _dispatch(sim_backend, SetAntennasCmd(antennas=[0.3, -0.3]))
+    assert responses == [{"status": "ok", "command": "set_antennas"}]
+    np.testing.assert_array_equal(
+        sim_backend.target_antenna_joint_positions, np.array([0.3, -0.3])
+    )
+
+
+def test_set_full_target_partial_fields(sim_backend: Any) -> None:
+    """SetFullTargetCmd applies only the fields provided, leaving head untouched."""
+    sim_backend.target_head_pose = None
+    responses = _dispatch(
+        sim_backend, SetFullTargetCmd(body_yaw=0.15, antennas=[0.1, 0.2])
+    )
+    assert responses == [{"status": "ok", "command": "set_full_target"}]
+    assert sim_backend.target_head_pose is None  # head omitted -> untouched
+    assert sim_backend.target_body_yaw == 0.15
+    np.testing.assert_array_equal(
+        sim_backend.target_antenna_joint_positions, np.array([0.1, 0.2])
+    )
+
+
+def test_set_full_target_all_fields(sim_backend: Any) -> None:
+    """SetFullTargetCmd with head set reshapes it to 4x4."""
+    pose = np.eye(4)
+    pose[0, 3] = 0.5
+    responses = _dispatch(
+        sim_backend, SetFullTargetCmd(head=pose.flatten().tolist(), body_yaw=0.2)
+    )
+    assert responses == [{"status": "ok", "command": "set_full_target"}]
+    np.testing.assert_array_equal(sim_backend.target_head_pose, pose)
+
+
+def test_set_target_ignored_when_move_running(sim_backend: Any) -> None:
+    """A running move blocks target updates but the command still acks ok."""
+    sim_backend.target_head_pose = None
+    sim_backend._active_move_depth = 1  # makes is_move_running True
+    assert sim_backend.is_move_running
+    responses = _dispatch(sim_backend, SetTargetCmd(head=np.eye(4).flatten().tolist()))
+    assert responses == [{"status": "ok", "command": "set_target"}]
+    assert sim_backend.target_head_pose is None  # target left unchanged
+
+
+# ------------------------------------------------------------------
+# Lifecycle: wake_up / goto_sleep (create asyncio tasks)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wake_up_completes(sim_backend: Any) -> None:
+    """WakeUpCmd awaits wake_up and acks a completed response."""
+    sim_backend.wake_up = AsyncMock()
+    responses = _dispatch(sim_backend, WakeUpCmd())
+    await asyncio.sleep(0)
+    sim_backend.wake_up.assert_awaited_once()
+    assert responses == [{"status": "ok", "command": "wake_up", "completed": True}]
+
+
+@pytest.mark.asyncio
+async def test_goto_sleep_completes(sim_backend: Any) -> None:
+    """GotoSleepCmd awaits goto_sleep and acks a completed response."""
+    sim_backend.goto_sleep = AsyncMock()
+    responses = _dispatch(sim_backend, GotoSleepCmd())
+    await asyncio.sleep(0)
+    sim_backend.goto_sleep.assert_awaited_once()
+    assert responses == [{"status": "ok", "command": "goto_sleep", "completed": True}]
+
+
+# ------------------------------------------------------------------
+# Audio playback commands
+# ------------------------------------------------------------------
+
+
+def test_play_sound_delegates(sim_backend: Any) -> None:
+    """PlaySoundCmd forwards the file name to play_sound."""
+    sim_backend.play_sound = Mock()
+    responses = _dispatch(sim_backend, PlaySoundCmd(file="wake_up.wav"))
+    sim_backend.play_sound.assert_called_once_with("wake_up.wav")
+    assert responses == [{"status": "ok", "command": "play_sound"}]
+
+
+def test_clear_incoming_audio_delegates(sim_backend: Any) -> None:
+    """ClearIncomingAudioCmd forwards to clear_incoming_audio."""
+    sim_backend.clear_incoming_audio = Mock()
+    responses = _dispatch(sim_backend, ClearIncomingAudioCmd())
+    sim_backend.clear_incoming_audio.assert_called_once_with()
+    assert responses == [{"status": "ok", "command": "clear_incoming_audio"}]
+
+
+# ------------------------------------------------------------------
+# Speech offsets / wobbling / head tracking
+# ------------------------------------------------------------------
+
+
+def test_set_speech_offsets_six_values(sim_backend: Any) -> None:
+    """Six offsets update _speech_offsets."""
+    offsets = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+    responses = _dispatch(sim_backend, SetSpeechOffsetsCmd(offsets=offsets))
+    assert responses == [{"status": "ok", "command": "set_speech_offsets"}]
+    assert sim_backend._speech_offsets == tuple(offsets)
+
+
+def test_set_speech_offsets_wrong_length_ignored(sim_backend: Any) -> None:
+    """A non-6 offsets payload is ignored but still acks ok."""
+    before = sim_backend._speech_offsets
+    responses = _dispatch(sim_backend, SetSpeechOffsetsCmd(offsets=[0.1, 0.2, 0.3]))
+    assert responses == [{"status": "ok", "command": "set_speech_offsets"}]
+    assert sim_backend._speech_offsets == before
+
+
+def test_set_wobbling_enabled(sim_backend: Any) -> None:
+    """SetWobblingCmd enabled calls the media server's enable_wobbling."""
+    responses = _dispatch(sim_backend, SetWobblingCmd(enabled=True))
+    sim_backend._media_server.enable_wobbling.assert_called_once()
+    assert responses == [{"status": "ok", "command": "set_wobbling"}]
+
+
+def test_set_wobbling_disabled(sim_backend: Any) -> None:
+    """SetWobblingCmd disabled calls disable_wobbling and zeroes offsets."""
+    sim_backend._speech_offsets = (1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+    responses = _dispatch(sim_backend, SetWobblingCmd(enabled=False))
+    sim_backend._media_server.disable_wobbling.assert_called_once()
+    assert sim_backend._speech_offsets == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    assert responses == [{"status": "ok", "command": "set_wobbling"}]
+
+
+def test_set_head_tracking_enabled_available(sim_backend: Any) -> None:
+    """Enabling head tracking reports enabled=True when the backend accepts it."""
+    sim_backend.enable_head_tracking = Mock(return_value=True)
+    responses = _dispatch(sim_backend, SetHeadTrackingCmd(enabled=True, weight=0.5))
+    sim_backend.enable_head_tracking.assert_called_once_with(weight=0.5)
+    assert responses == [
+        {"status": "ok", "command": "set_head_tracking", "enabled": True}
+    ]
+
+
+def test_set_head_tracking_enabled_unavailable(sim_backend: Any) -> None:
+    """Enabling head tracking reports unavailable when the backend declines."""
+    sim_backend.enable_head_tracking = Mock(return_value=False)
+    responses = _dispatch(sim_backend, SetHeadTrackingCmd(enabled=True))
+    assert responses == [
+        {"status": "unavailable", "command": "set_head_tracking", "enabled": False}
+    ]
+
+
+def test_set_head_tracking_disabled(sim_backend: Any) -> None:
+    """Disabling head tracking calls disable_head_tracking and reports False."""
+    sim_backend.disable_head_tracking = Mock()
+    responses = _dispatch(sim_backend, SetHeadTrackingCmd(enabled=False))
+    sim_backend.disable_head_tracking.assert_called_once_with()
+    assert responses == [
+        {"status": "ok", "command": "set_head_tracking", "enabled": False}
+    ]
+
+
+def test_get_tracked_face(sim_backend: Any) -> None:
+    """GetTrackedFaceCmd returns the serialized face target."""
+    responses = _dispatch(sim_backend, GetTrackedFaceCmd())
+    assert len(responses) == 1
+    assert responses[0]["command"] == "get_tracked_face"
+    assert "face_target" in responses[0]
+    assert "detected" in responses[0]["face_target"]
+
+
+# ------------------------------------------------------------------
+# Motor mode / torque / gravity compensation
+# ------------------------------------------------------------------
+
+
+def test_set_motor_mode(sim_backend: Any) -> None:
+    """SetMotorModeCmd applies the requested control mode."""
+    responses = _dispatch(sim_backend, SetMotorModeCmd(mode="disabled"))
+    assert responses == [{"motor_mode": "disabled", "status": "ok"}]
+    assert sim_backend.get_motor_control_mode().value == "disabled"
+
+
+def test_get_motor_mode(sim_backend: Any) -> None:
+    """GetMotorModeCmd returns the current control mode value."""
+    responses = _dispatch(sim_backend, GetMotorModeCmd())
+    assert responses == [{"motor_mode": "enabled"}]
+
+
+def test_set_torque_with_ids(sim_backend: Any) -> None:
+    """SetTorqueCmd with ids delegates to set_motor_torque_ids."""
+    sim_backend.set_motor_torque_ids = Mock()
+    responses = _dispatch(sim_backend, SetTorqueCmd(on=True, ids=["a", "b"]))
+    sim_backend.set_motor_torque_ids.assert_called_once_with(["a", "b"], True)
+    assert responses == [{"status": "ok", "command": "set_torque"}]
+
+
+def test_set_torque_on_global(sim_backend: Any) -> None:
+    """SetTorqueCmd on without ids enables all motors."""
+    responses = _dispatch(sim_backend, SetTorqueCmd(on=True))
+    assert responses == [{"status": "ok", "command": "set_torque"}]
+    assert sim_backend.get_motor_control_mode().value == "enabled"
+
+
+def test_set_torque_off_global(sim_backend: Any) -> None:
+    """SetTorqueCmd off without ids disables all motors."""
+    responses = _dispatch(sim_backend, SetTorqueCmd(on=False))
+    assert responses == [{"status": "ok", "command": "set_torque"}]
+    assert sim_backend.get_motor_control_mode().value == "disabled"
+
+
+def test_set_gravity_compensation_enabled(sim_backend: Any) -> None:
+    """SetGravityCompensationCmd enabled switches to gravity-comp mode."""
+    responses = _dispatch(sim_backend, SetGravityCompensationCmd(enabled=True))
+    assert responses == [{"status": "ok", "command": "set_gravity_compensation"}]
+    assert sim_backend.get_motor_control_mode().value == "gravity_compensation"
+
+
+def test_set_gravity_compensation_disabled(sim_backend: Any) -> None:
+    """SetGravityCompensationCmd disabled switches back to enabled mode."""
+    responses = _dispatch(sim_backend, SetGravityCompensationCmd(enabled=False))
+    assert responses == [{"status": "ok", "command": "set_gravity_compensation"}]
+    assert sim_backend.get_motor_control_mode().value == "enabled"
+
+
+def test_set_gravity_compensation_value_error(sim_backend: Any) -> None:
+    """A ValueError from mode switching is surfaced as an error response."""
+    sim_backend.set_motor_control_mode = Mock(side_effect=ValueError("no grav comp"))
+    responses = _dispatch(sim_backend, SetGravityCompensationCmd(enabled=True))
+    assert responses == [
+        {"error": "no grav comp", "command": "set_gravity_compensation"}
+    ]
+
+
+def test_set_automatic_body_yaw(sim_backend: Any) -> None:
+    """SetAutomaticBodyYawCmd forwards the flag to set_automatic_body_yaw."""
+    sim_backend.set_automatic_body_yaw = Mock()
+    responses = _dispatch(sim_backend, SetAutomaticBodyYawCmd(enabled=True))
+    sim_backend.set_automatic_body_yaw.assert_called_once_with(True)
+    assert responses == [{"status": "ok", "command": "set_automatic_body_yaw"}]
+
+
+# ------------------------------------------------------------------
+# State / version / hardware id
+# ------------------------------------------------------------------
+
+
+def test_get_state(sim_backend: Any) -> None:
+    """GetStateCmd returns a state dict with the expected keys."""
+    responses = _dispatch(sim_backend, GetStateCmd())
+    assert len(responses) == 1
+    state = responses[0]["state"]
+    for key in (
+        "head_pose",
+        "antennas",
+        "body_yaw",
+        "motor_mode",
+        "is_recording",
+        "is_move_running",
+        "face_target",
+    ):
+        assert key in state
+    assert state["is_recording"] is False
+    assert state["is_move_running"] is False
+
+
+def test_get_version(sim_backend: Any) -> None:
+    """GetVersionCmd returns the installed reachy_mini version string."""
+    responses = _dispatch(sim_backend, GetVersionCmd())
+    assert len(responses) == 1
+    assert isinstance(responses[0]["version"], str)
+
+
+def test_get_hardware_id(sim_backend: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """GetHardwareIdCmd returns the value from get_hardware_id."""
+    import reachy_mini.utils.hardware_id as hw
+
+    monkeypatch.setattr(hw, "get_hardware_id", lambda: "HW-1234")
+    responses = _dispatch(sim_backend, GetHardwareIdCmd())
+    assert responses == [{"hardware_id": "HW-1234"}]
+
+
+# ------------------------------------------------------------------
+# Volume / microphone commands
+# ------------------------------------------------------------------
+
+
+def _patch_volume_control(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Install a stub VolumeControl and return it."""
+    import reachy_mini.daemon.app.routers.volume_control as vcmod
+
+    vc = MagicMock()
+    monkeypatch.setattr(vcmod, "get_volume_control", lambda: vc)
+    return vc
+
+
+def test_set_volume_ok(sim_backend: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """SetVolumeCmd echoes the requested volume when the control accepts it."""
+    vc = _patch_volume_control(monkeypatch)
+    vc.set_output_volume.return_value = True
+    responses = _dispatch(sim_backend, SetVolumeCmd(volume=42))
+    vc.set_output_volume.assert_called_once_with(42)
+    assert responses == [{"status": "ok", "command": "set_volume", "volume": 42}]
+
+
+def test_set_volume_failure_returns_current(
+    sim_backend: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rejected SetVolumeCmd reports error and the actual current volume."""
+    vc = _patch_volume_control(monkeypatch)
+    vc.set_output_volume.return_value = False
+    vc.get_output_volume.return_value = 10
+    responses = _dispatch(sim_backend, SetVolumeCmd(volume=42))
+    assert responses == [{"status": "error", "command": "set_volume", "volume": 10}]
+
+
+def test_get_volume(sim_backend: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """GetVolumeCmd returns the current output volume."""
+    vc = _patch_volume_control(monkeypatch)
+    vc.get_output_volume.return_value = 55
+    responses = _dispatch(sim_backend, GetVolumeCmd())
+    assert responses == [{"command": "get_volume", "volume": 55}]
+
+
+def test_set_microphone_volume_ok(
+    sim_backend: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SetMicrophoneVolumeCmd echoes the requested input volume on success."""
+    vc = _patch_volume_control(monkeypatch)
+    vc.set_input_volume.return_value = True
+    responses = _dispatch(sim_backend, SetMicrophoneVolumeCmd(volume=30))
+    vc.set_input_volume.assert_called_once_with(30)
+    assert responses == [
+        {"status": "ok", "command": "set_microphone_volume", "volume": 30}
+    ]
+
+
+def test_get_microphone_volume(
+    sim_backend: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GetMicrophoneVolumeCmd returns the current input volume."""
+    vc = _patch_volume_control(monkeypatch)
+    vc.get_input_volume.return_value = 20
+    responses = _dispatch(sim_backend, GetMicrophoneVolumeCmd())
+    assert responses == [{"command": "get_microphone_volume", "volume": 20}]
+
+
+def test_volume_control_unavailable(
+    sim_backend: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failing get_volume_control yields an error response, not a crash."""
+    import reachy_mini.daemon.app.routers.volume_control as vcmod
+
+    def _raise() -> None:
+        raise RuntimeError("no audio stack")
+
+    monkeypatch.setattr(vcmod, "get_volume_control", _raise)
+    responses = _dispatch(sim_backend, GetVolumeCmd())
+    assert len(responses) == 1
+    assert responses[0]["command"] == "get_volume"
+    assert "no audio stack" in responses[0]["error"]
+
+
+# ------------------------------------------------------------------
+# ReSpeaker audio config commands
+# ------------------------------------------------------------------
+
+
+def test_apply_audio_config_ok(
+    sim_backend: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ApplyAudioConfigCmd writes config through a respeaker and reports applied."""
+    import reachy_mini.media.audio_control_utils as acu
+
+    respeaker = MagicMock()
+    respeaker.apply_audio_config.return_value = True
+    monkeypatch.setattr(acu, "init_respeaker_usb", lambda: respeaker)
+    cmd = ApplyAudioConfigCmd(
+        config=[AudioParamPair(name="AGCGAIN", values=[1.0])], verify=False
+    )
+    responses = _dispatch(sim_backend, cmd)
+    respeaker.apply_audio_config.assert_called_once_with([("AGCGAIN", [1.0])], verify=False)
+    respeaker.close.assert_called_once()
+    assert responses == [
+        {"status": "ok", "command": "apply_audio_config", "applied": True}
+    ]
+
+
+def test_read_audio_parameter_ok(
+    sim_backend: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ReadAudioParameterCmd returns the values read from the respeaker."""
+    import reachy_mini.media.audio_control_utils as acu
+
+    respeaker = MagicMock()
+    respeaker.read_values.return_value = [1.0, 2.0]
+    monkeypatch.setattr(acu, "init_respeaker_usb", lambda: respeaker)
+    responses = _dispatch(sim_backend, ReadAudioParameterCmd(name="AGCGAIN"))
+    respeaker.close.assert_called_once()
+    assert responses == [
+        {"command": "read_audio_parameter", "name": "AGCGAIN", "values": [1.0, 2.0]}
+    ]
+
+
+def test_audio_config_board_not_available(
+    sim_backend: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A None respeaker yields a 'not available' error response."""
+    import reachy_mini.media.audio_control_utils as acu
+
+    monkeypatch.setattr(acu, "init_respeaker_usb", lambda: None)
+    responses = _dispatch(sim_backend, ReadAudioParameterCmd(name="AGCGAIN"))
+    assert len(responses) == 1
+    assert responses[0]["command"] == "read_audio_parameter"
+    assert responses[0]["error"] == "ReSpeaker audio board not available"
+
+
+def test_audio_config_init_raises(
+    sim_backend: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failing respeaker init yields an init-failed error response."""
+    import reachy_mini.media.audio_control_utils as acu
+
+    def _raise() -> None:
+        raise RuntimeError("usb down")
+
+    monkeypatch.setattr(acu, "init_respeaker_usb", _raise)
+    responses = _dispatch(sim_backend, ReadAudioParameterCmd(name="AGCGAIN"))
+    assert len(responses) == 1
+    assert "usb down" in responses[0]["error"]
+
+
+# ------------------------------------------------------------------
+# Recording commands
+# ------------------------------------------------------------------
+
+
+def test_start_recording(sim_backend: Any) -> None:
+    """StartRecordingCmd flips is_recording on and acks."""
+    responses = _dispatch(sim_backend, StartRecordingCmd())
+    assert sim_backend.is_recording is True
+    assert responses == [
+        {"status": "ok", "command": "start_recording", "is_recording": True}
+    ]
+
+
+def test_stop_recording(sim_backend: Any) -> None:
+    """StopRecordingCmd flips is_recording off and publishes recorded data."""
+    sim_backend.recording_publisher = MagicMock()
+    sim_backend.start_recording()
+    responses = _dispatch(sim_backend, StopRecordingCmd())
+    assert sim_backend.is_recording is False
+    sim_backend.recording_publisher.put.assert_called_once()
+    assert responses == [
+        {"status": "ok", "command": "stop_recording", "is_recording": False}
+    ]
+
+
+def test_append_record(sim_backend: Any) -> None:
+    """AppendRecordCmd appends to the buffer while recording."""
+    sim_backend.start_recording()
+    responses = _dispatch(sim_backend, AppendRecordCmd(record={"t": 0.0}))
+    assert responses == [{"status": "ok", "command": "append_record"}]
+    assert sim_backend.recorded_data == [{"t": 0.0}]
+
+
+# ------------------------------------------------------------------
+# Log subscription
+# ------------------------------------------------------------------
+
+
+def test_subscribe_logs_without_peer(sim_backend: Any) -> None:
+    """Subscribing without a peer id fails: log streams are peer-scoped."""
+    responses = _dispatch(sim_backend, SubscribeLogsCmd(), peer_id=None)
+    assert len(responses) == 1
+    assert responses[0]["type"] == "log_stream_error"
+    assert "peer-aware" in responses[0]["error"]
+
+
+def test_unsubscribe_logs_without_peer(sim_backend: Any) -> None:
+    """Unsubscribing without a peer id is a silent no-op."""
+    responses = _dispatch(sim_backend, UnsubscribeLogsCmd(), peer_id=None)
+    assert responses == []
+
+
+# ------------------------------------------------------------------
+# Restart / update lifecycle
+# ------------------------------------------------------------------
+
+
+def test_restart_daemon_unsupported(sim_backend: Any) -> None:
+    """RestartDaemonCmd errors when no restart callback is registered."""
+    sim_backend._restart_daemon_callback = None
+    responses = _dispatch(sim_backend, RestartDaemonCmd())
+    assert len(responses) == 1
+    assert responses[0]["command"] == "restart_daemon"
+    assert "not supported" in responses[0]["error"]
+
+
+def test_restart_daemon_ok(sim_backend: Any) -> None:
+    """RestartDaemonCmd acks ok and invokes the restart callback."""
+    callback = Mock()
+    sim_backend._restart_daemon_callback = callback
+    responses = _dispatch(sim_backend, RestartDaemonCmd())
+    callback.assert_called_once_with()
+    assert responses == [{"status": "ok", "command": "restart_daemon"}]
+
+
+def test_start_update_unsupported(sim_backend: Any) -> None:
+    """StartUpdateCmd errors when no update callback is registered."""
+    sim_backend._start_update_callback = None
+    responses = _dispatch(sim_backend, StartUpdateCmd())
+    assert len(responses) == 1
+    assert responses[0]["command"] == "start_update"
+    assert "not supported" in responses[0]["error"]
+
+
+def test_start_update_accepted(sim_backend: Any) -> None:
+    """StartUpdateCmd acks ok when the callback accepts (returns None)."""
+    sim_backend._start_update_callback = Mock(return_value=None)
+    responses = _dispatch(sim_backend, StartUpdateCmd(pre_release=True))
+    sim_backend._start_update_callback.assert_called_once_with(True)
+    assert responses == [{"status": "ok", "command": "start_update"}]
+
+
+def test_start_update_refused(sim_backend: Any) -> None:
+    """A refusal string from the callback is surfaced as an error."""
+    sim_backend._start_update_callback = Mock(return_value="already running")
+    responses = _dispatch(sim_backend, StartUpdateCmd())
+    assert responses == [{"error": "already running", "command": "start_update"}]
+
+
+def test_start_update_raises(sim_backend: Any) -> None:
+    """An exception from the update callback is surfaced as an error."""
+    sim_backend._start_update_callback = Mock(side_effect=RuntimeError("boom"))
+    responses = _dispatch(sim_backend, StartUpdateCmd())
+    assert len(responses) == 1
+    assert responses[0]["command"] == "start_update"
+    assert "boom" in responses[0]["error"]

--- a/tests/unit_tests/test_daemon_utils.py
+++ b/tests/unit_tests/test_daemon_utils.py
@@ -1,0 +1,215 @@
+"""Tests for reachy_mini.daemon.utils.
+
+Pure helpers plus branch coverage for the serial/camera/daemon utilities,
+with all serial, psutil, subprocess, socket and filesystem access mocked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from reachy_mini.daemon import utils
+
+
+class _FakePort:
+    """Minimal stand-in for a serial.tools.list_ports port object."""
+
+    def __init__(self, device: str, hwid: str) -> None:
+        self.device = device
+        self.hwid = hwid
+
+
+class _FakeProc:
+    """Minimal stand-in for a psutil.Process yielded by process_iter."""
+
+    def __init__(self, pid: int, cmdline: list[str] | None) -> None:
+        self.pid = pid
+        self.info = {"pid": pid, "name": "python", "cmdline": cmdline}
+
+
+@pytest.mark.parametrize(
+    "ip",
+    ["127.0.0.1", "127.0.0.53", "::1", "localhost", "0.0.0.0"],
+)
+def test_is_localhost_true(ip: str) -> None:
+    """Recognized localhost addresses return True."""
+    assert utils.is_localhost(ip) is True
+
+
+@pytest.mark.parametrize(
+    "ip",
+    ["192.168.1.10", "example.com", "", "10.0.0.1", "128.0.0.1"],
+)
+def test_is_localhost_false(ip: str) -> None:
+    """Non-localhost addresses return False."""
+    assert utils.is_localhost(ip) is False
+
+
+def test_is_localhost_none() -> None:
+    """None returns False."""
+    assert utils.is_localhost(None) is False
+
+
+def test_find_serial_port_wireless_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wireless version returns the UART path when it exists."""
+    monkeypatch.setattr(utils.os.path, "exists", lambda p: p == "/dev/ttyAMA3")
+    assert utils.find_serial_port(wireless_version=True) == ["/dev/ttyAMA3"]
+
+
+def test_find_serial_port_wireless_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wireless version returns empty list when the UART is absent."""
+    monkeypatch.setattr(utils.os.path, "exists", lambda p: False)
+    assert utils.find_serial_port(wireless_version=True) == []
+
+
+def test_find_serial_port_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lite version returns matching device by VID:PID in hwid."""
+    ports = [
+        _FakePort("/dev/ttyUSB0", "USB VID:PID=1A86:55D3 SER=123"),
+        _FakePort("/dev/ttyUSB1", "USB VID:PID=DEAD:BEEF"),
+    ]
+    monkeypatch.setattr(utils.serial.tools.list_ports, "comports", lambda: ports)
+    assert utils.find_serial_port() == ["/dev/ttyUSB0"]
+
+
+def test_find_serial_port_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lite version returns empty list when no port matches."""
+    ports = [_FakePort("/dev/ttyUSB1", "USB VID:PID=DEAD:BEEF")]
+    monkeypatch.setattr(utils.serial.tools.list_ports, "comports", lambda: ports)
+    assert utils.find_serial_port() == []
+
+
+def test_is_local_camera_available_linux_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Linux socket present means camera available."""
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(
+        utils.os.path, "exists", lambda p: p == utils.CAMERA_SOCKET_PATH
+    )
+    assert utils.is_local_camera_available() is True
+
+
+def test_is_local_camera_available_linux_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Linux socket absent means camera unavailable."""
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(utils.os.path, "exists", lambda p: False)
+    assert utils.is_local_camera_available() is False
+
+
+def test_daemon_check_no_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nothing happens when spawn_daemon is False."""
+    called = {"popen": False}
+    monkeypatch.setattr(
+        utils.psutil, "process_iter", lambda *a, **k: iter([])
+    )
+    monkeypatch.setattr(
+        utils.subprocess,
+        "Popen",
+        lambda *a, **k: called.__setitem__("popen", True),
+    )
+    utils.daemon_check(spawn_daemon=False, use_sim=False)
+    assert called["popen"] is False
+
+
+def test_daemon_check_already_running_same_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Matching running daemon means no new spawn."""
+    procs = [_FakeProc(42, ["reachy-mini-daemon"])]
+    called = {"popen": False}
+    monkeypatch.setattr(utils.psutil, "process_iter", lambda *a, **k: iter(procs))
+    monkeypatch.setattr(
+        utils.subprocess,
+        "Popen",
+        lambda *a, **k: called.__setitem__("popen", True),
+    )
+    utils.daemon_check(spawn_daemon=True, use_sim=False)
+    assert called["popen"] is False
+
+
+def test_daemon_check_different_config_kills_and_respawns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Running daemon with a different config is killed then respawned."""
+    procs = [_FakeProc(42, ["reachy-mini-daemon", "--sim"])]
+    killed = {}
+    spawned = {}
+    monkeypatch.setattr(utils.psutil, "process_iter", lambda *a, **k: iter(procs))
+    monkeypatch.setattr(
+        utils.os, "kill", lambda pid, sig: killed.update(pid=pid, sig=sig)
+    )
+    monkeypatch.setattr(utils.time, "sleep", lambda s: None)
+    monkeypatch.setattr(
+        utils.subprocess, "Popen", lambda cmd, **k: spawned.update(cmd=cmd)
+    )
+    utils.daemon_check(spawn_daemon=True, use_sim=False)
+    assert killed == {"pid": 42, "sig": 9}
+    assert spawned["cmd"] == ["reachy-mini-daemon"]
+
+
+def test_daemon_check_not_running_spawns_sim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No daemon running spawns a new one with the --sim flag."""
+    procs = [_FakeProc(1, ["something-else"]), _FakeProc(2, None)]
+    spawned = {}
+    monkeypatch.setattr(utils.psutil, "process_iter", lambda *a, **k: iter(procs))
+    monkeypatch.setattr(utils.time, "sleep", lambda s: None)
+    monkeypatch.setattr(
+        utils.subprocess, "Popen", lambda cmd, **k: spawned.update(cmd=cmd)
+    )
+    utils.daemon_check(spawn_daemon=True, use_sim=True)
+    assert spawned["cmd"] == ["reachy-mini-daemon", "--sim"]
+
+
+def test_daemon_check_skips_inaccessible_proc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Processes raising psutil errors are skipped, still leading to a spawn."""
+
+    class _RaisingProc:
+        pid = 99
+
+        @property
+        def info(self) -> dict:
+            raise utils.psutil.AccessDenied(self.pid)
+
+    procs = [_RaisingProc()]
+    spawned = {}
+    monkeypatch.setattr(utils.psutil, "process_iter", lambda *a, **k: iter(procs))
+    monkeypatch.setattr(
+        utils.subprocess, "Popen", lambda cmd, **k: spawned.update(cmd=cmd)
+    )
+    utils.daemon_check(spawn_daemon=True, use_sim=False)
+    assert spawned["cmd"] == ["reachy-mini-daemon"]
+
+
+def test_get_ip_address_linux_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Linux ioctl failure returns None."""
+    import socket
+
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    class _FakeSock:
+        def fileno(self) -> int:
+            return 0
+
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: _FakeSock())
+    import fcntl
+
+    def _raise(*a: object, **k: object) -> None:
+        raise OSError("no such interface")
+
+    monkeypatch.setattr(fcntl, "ioctl", _raise)
+    assert utils.get_ip_address("wlan0") is None
+
+
+def test_get_ip_address_unsupported_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsupported platform returns None."""
+    monkeypatch.setattr("platform.system", lambda: "SunOS")
+    assert utils.get_ip_address() is None

--- a/tests/unit_tests/test_router_cache.py
+++ b/tests/unit_tests/test_router_cache.py
@@ -1,0 +1,66 @@
+"""Unit tests for the cache management router (clear-hf, reset-apps)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini.daemon.app.routers import cache
+
+
+def _patch(monkeypatch, *, exists: bool, rmtree=None):
+    """Steer cache.Path existence and stub cache.shutil.rmtree."""
+    monkeypatch.setattr(cache, "Path", lambda _p: MagicMock(exists=lambda: exists))
+    rmtree = rmtree or MagicMock()
+    monkeypatch.setattr(cache.shutil, "rmtree", rmtree)
+    return rmtree
+
+
+ENDPOINTS = [
+    ("/cache/clear-hf", "HuggingFace cache cleared", "Cache directory already empty"),
+    (
+        "/cache/reset-apps",
+        "Applications virtual environment removed",
+        "Virtual environment directory already empty",
+    ),
+]
+
+
+@pytest.mark.parametrize("route,msg_removed,_msg_empty", ENDPOINTS)
+def test_path_exists_rmtree_called(monkeypatch, router_app, route, msg_removed, _msg_empty):
+    """Existing path -> rmtree runs, 200 with success message."""
+    rmtree = _patch(monkeypatch, exists=True)
+    client = router_app(cache.router)
+
+    resp = client.post(route)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "success", "message": msg_removed}
+    rmtree.assert_called_once()
+
+
+@pytest.mark.parametrize("route,_msg_removed,msg_empty", ENDPOINTS)
+def test_path_missing_no_rmtree(monkeypatch, router_app, route, _msg_removed, msg_empty):
+    """Missing path -> 200, rmtree not called."""
+    rmtree = _patch(monkeypatch, exists=False)
+    client = router_app(cache.router)
+
+    resp = client.post(route)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "success", "message": msg_empty}
+    rmtree.assert_not_called()
+
+
+@pytest.mark.parametrize("route,_msg_removed,_msg_empty", ENDPOINTS)
+def test_rmtree_oserror_returns_500(monkeypatch, router_app, route, _msg_removed, _msg_empty):
+    """rmtree raising OSError -> 500 with failure detail."""
+    rmtree = _patch(
+        monkeypatch, exists=True, rmtree=MagicMock(side_effect=OSError("boom"))
+    )
+    client = router_app(cache.router)
+
+    resp = client.post(route)
+
+    assert resp.status_code == 500
+    assert "boom" in resp.json()["detail"]
+    rmtree.assert_called_once()

--- a/tests/unit_tests/test_router_hf_auth.py
+++ b/tests/unit_tests/test_router_hf_auth.py
@@ -1,0 +1,237 @@
+"""Unit tests for the HuggingFace auth router (delegating to apps.sources.hf_auth)."""
+
+import types
+
+import pytest
+
+from reachy_mini.apps.sources import hf_auth as src
+from reachy_mini.daemon.app.routers import hf_auth
+
+# The router does ``from reachy_mini.apps.sources import hf_auth`` and calls
+# ``hf_auth.<fn>``, so the delegated functions live on the source module (``src``);
+# patch there, not on the router namespace.
+
+
+def _daemon(wireless_version=False):
+    """Minimal app.state.daemon stub the handlers read."""
+    return types.SimpleNamespace(wireless_version=wireless_version)
+
+
+def test_save_token_success(monkeypatch, router_app):
+    """Valid token -> 200 with username echoed back."""
+    monkeypatch.setattr(
+        src,
+        "save_hf_token",
+        lambda tok: {"status": "success", "username": "alice"},
+    )
+    client = router_app(hf_auth.router)
+
+    resp = client.post("/hf-auth/save-token", json={"token": "hf_x"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "success", "username": "alice", "message": None}
+
+
+def test_save_token_failure(monkeypatch, router_app):
+    """Rejected token -> 400 with error detail."""
+    monkeypatch.setattr(
+        src,
+        "save_hf_token",
+        lambda tok: {"status": "error", "message": "bad token"},
+    )
+    client = router_app(hf_auth.router)
+
+    resp = client.post("/hf-auth/save-token", json={"token": "nope"})
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "bad token"
+
+
+def test_status(monkeypatch, router_app):
+    """/status returns whatever check_token_status reports."""
+    payload = {"authenticated": True, "username": "bob"}
+    monkeypatch.setattr(src, "check_token_status", lambda: payload)
+    client = router_app(hf_auth.router)
+
+    resp = client.get("/hf-auth/status")
+
+    assert resp.status_code == 200
+    assert resp.json() == payload
+
+
+def test_relay_status_lite_early_return(router_app):
+    """Non-wireless daemon short-circuits to the 'coming soon' payload."""
+    client = router_app(hf_auth.router, daemon=_daemon(wireless_version=False))
+
+    resp = client.get("/hf-auth/relay-status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["state"] == "unavailable"
+    assert body["is_connected"] is False
+
+
+def test_relay_status_wireless(monkeypatch, router_app):
+    """Wireless daemon delegates to central_signaling_relay.get_relay_status."""
+    from reachy_mini.media import central_signaling_relay
+
+    monkeypatch.setattr(
+        central_signaling_relay,
+        "get_relay_status",
+        lambda: {"state": "connected", "is_connected": True},
+    )
+    client = router_app(hf_auth.router, daemon=_daemon(wireless_version=True))
+
+    resp = client.get("/hf-auth/relay-status")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"state": "connected", "is_connected": True}
+
+
+def test_delete_token_success(monkeypatch, router_app):
+    """Delete succeeds -> 200 success."""
+    monkeypatch.setattr(src, "delete_hf_token", lambda: True)
+    client = router_app(hf_auth.router)
+
+    resp = client.delete("/hf-auth/token")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "success"}
+
+
+def test_delete_token_failure(monkeypatch, router_app):
+    """Delete fails -> 500."""
+    monkeypatch.setattr(src, "delete_hf_token", lambda: False)
+    client = router_app(hf_auth.router)
+
+    resp = client.delete("/hf-auth/token")
+
+    assert resp.status_code == 500
+
+
+def test_oauth_configured(monkeypatch, router_app):
+    """/oauth/configured wraps is_oauth_configured in a dict."""
+    monkeypatch.setattr(src, "is_oauth_configured", lambda: True)
+    client = router_app(hf_auth.router)
+
+    resp = client.get("/hf-auth/oauth/configured")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"configured": True}
+
+
+def test_oauth_start_success(monkeypatch, router_app):
+    """/oauth/start returns the created session on success."""
+    result = {"status": "success", "session_id": "s1", "auth_url": "https://hf/authz"}
+    monkeypatch.setattr(src, "create_oauth_session", lambda **kw: result)
+    client = router_app(hf_auth.router, daemon=_daemon(wireless_version=True))
+
+    resp = client.get("/hf-auth/oauth/start")
+
+    assert resp.status_code == 200
+    assert resp.json() == result
+
+
+def test_oauth_start_error(monkeypatch, router_app):
+    """/oauth/start surfaces a session-creation error as 500."""
+    monkeypatch.setattr(
+        src,
+        "create_oauth_session",
+        lambda **kw: {"status": "error", "message": "no config"},
+    )
+    client = router_app(hf_auth.router, daemon=_daemon(wireless_version=False))
+
+    resp = client.get("/hf-auth/oauth/start")
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "no config"
+
+
+def test_oauth_begin_redirects(monkeypatch, router_app):
+    """/oauth/begin 307-redirects to the session auth_url."""
+    monkeypatch.setattr(
+        src,
+        "create_oauth_session",
+        lambda **kw: {"status": "success", "auth_url": "https://hf/authz"},
+    )
+    client = router_app(hf_auth.router, daemon=_daemon(wireless_version=True))
+
+    resp = client.get("/hf-auth/oauth/begin", follow_redirects=False)
+
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "https://hf/authz"
+
+
+def test_oauth_status(monkeypatch, router_app):
+    """/oauth/status/{id} passes the id through to get_oauth_session_status."""
+    monkeypatch.setattr(
+        src,
+        "get_oauth_session_status",
+        lambda sid: {"session_id": sid, "status": "pending"},
+    )
+    client = router_app(hf_auth.router)
+
+    resp = client.get("/hf-auth/oauth/status/abc")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"session_id": "abc", "status": "pending"}
+
+
+def test_oauth_session_delete_success(monkeypatch, router_app):
+    """Cancelling a known session -> 200 success."""
+    monkeypatch.setattr(src, "cancel_oauth_session", lambda sid: True)
+    client = router_app(hf_auth.router)
+
+    resp = client.delete("/hf-auth/oauth/session/abc")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "success"}
+
+
+def test_oauth_session_delete_not_found(monkeypatch, router_app):
+    """Cancelling an unknown session -> 404."""
+    monkeypatch.setattr(src, "cancel_oauth_session", lambda sid: False)
+    client = router_app(hf_auth.router)
+
+    resp = client.delete("/hf-auth/oauth/session/missing")
+
+    assert resp.status_code == 404
+
+
+def test_central_robot_status_no_token(monkeypatch, router_app):
+    """No stored token -> early return, no aiohttp/network involved."""
+    monkeypatch.setattr(src, "get_hf_token", lambda: None)
+    client = router_app(hf_auth.router)
+
+    resp = client.get("/hf-auth/central-robot-status")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "available": False,
+        "robots": [],
+        "reason": "not_authenticated",
+    }
+
+
+def test_oauth_callback_error_param(monkeypatch, router_app):
+    """Callback with an OAuth error renders the failure page (no network)."""
+    monkeypatch.setattr(src, "get_session_by_state", lambda state: None)
+    client = router_app(hf_auth.router)
+
+    resp = client.get(
+        "/hf-auth/oauth/callback",
+        params={"error": "access_denied", "error_description": "user said no"},
+    )
+
+    assert resp.status_code == 200
+    assert "user said no" in resp.text
+
+
+def test_oauth_callback_missing_code(router_app):
+    """Callback without code/state -> 400 failure page (no network)."""
+    client = router_app(hf_auth.router)
+
+    resp = client.get("/hf-auth/oauth/callback")
+
+    assert resp.status_code == 400
+    assert "Missing authorization code or state" in resp.text

--- a/tests/unit_tests/test_router_update.py
+++ b/tests/unit_tests/test_router_update.py
@@ -1,0 +1,245 @@
+"""Unit tests for the update router (install-source, available, info, refs, start)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from reachy_mini.daemon.app import bg_job_register
+from reachy_mini.daemon.app.bg_job_register import JobInfo, JobStatus
+from reachy_mini.daemon.app.routers import update
+
+
+@pytest.fixture(autouse=True)
+def _release_lock():
+    """Ensure busy_lock starts unlocked for each test."""
+    if update.busy_lock.locked():
+        update.busy_lock.release()
+    yield
+    if update.busy_lock.locked():
+        update.busy_lock.release()
+
+
+def test_install_source(monkeypatch, router_app):
+    """install-source returns the helper's dict verbatim."""
+    src = {"version": "1.2.3", "source": "pypi", "ref": ""}
+    monkeypatch.setattr(update, "get_install_source", lambda pkg: src)
+    client = router_app(update.router)
+
+    resp = client.get("/update/install-source")
+
+    assert resp.status_code == 200
+    assert resp.json() == src
+
+
+def test_available(monkeypatch, router_app):
+    """available reports current/available versions and the update flag."""
+    monkeypatch.setattr(update, "get_local_version", lambda pkg: "1.0.0")
+    monkeypatch.setattr(update, "is_update_available", lambda pkg, pre: True)
+    monkeypatch.setattr(update, "get_pypi_version", lambda pkg, pre: "1.1.0")
+    client = router_app(update.router)
+
+    resp = client.get("/update/available")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "update": {
+            "reachy_mini": {
+                "is_available": True,
+                "current_version": "1.0.0",
+                "available_version": "1.1.0",
+            }
+        }
+    }
+
+
+def test_available_connection_error(monkeypatch, router_app):
+    """available degrades to 'unknown' when the PyPI check can't connect."""
+    monkeypatch.setattr(update, "get_local_version", lambda pkg: "1.0.0")
+
+    def _boom(pkg, pre):
+        raise requests.exceptions.ConnectionError
+
+    monkeypatch.setattr(update, "is_update_available", _boom)
+    client = router_app(update.router)
+
+    resp = client.get("/update/available")
+
+    assert resp.status_code == 200
+    entry = resp.json()["update"]["reachy_mini"]
+    assert entry["is_available"] is False
+    assert entry["available_version"] == "unknown"
+
+
+def test_available_busy(router_app):
+    """available refuses while an update holds busy_lock."""
+    update.busy_lock.acquire()
+    client = router_app(update.router)
+
+    resp = client.get("/update/available")
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Update is in progress"
+
+
+def test_info_found(monkeypatch, router_app):
+    """info returns the job's JobInfo."""
+    info = JobInfo(command="update_reachy_mini", status=JobStatus.DONE, logs=["ok"])
+    monkeypatch.setattr(bg_job_register, "get_info", lambda jid: info)
+    client = router_app(update.router)
+
+    resp = client.get("/update/info", params={"job_id": "abc"})
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "done"
+    assert resp.json()["logs"] == ["ok"]
+
+
+def test_info_not_found(monkeypatch, router_app):
+    """Unknown job id -> 404."""
+
+    def _boom(jid):
+        raise ValueError("Job ID not found")
+
+    monkeypatch.setattr(bg_job_register, "get_info", _boom)
+    client = router_app(update.router)
+
+    resp = client.get("/update/info", params={"job_id": "nope"})
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Job ID not found"
+
+
+def _fake_resp(status_code):
+    """Build a stand-in requests.Response with a status code."""
+    r = MagicMock()
+    r.status_code = status_code
+    return r
+
+
+def test_validate_ref_valid(monkeypatch, router_app):
+    """A ref GitHub knows -> valid=True."""
+    monkeypatch.setattr(update.requests, "get", lambda url, timeout: _fake_resp(200))
+    client = router_app(update.router)
+
+    resp = client.get("/update/validate-ref", params={"git_ref": "v1.0.0"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"valid": True, "ref": "v1.0.0"}
+
+
+def test_validate_ref_invalid(monkeypatch, router_app):
+    """A ref GitHub returns 404 for -> valid=False with an error message."""
+    monkeypatch.setattr(update.requests, "get", lambda url, timeout: _fake_resp(404))
+    client = router_app(update.router)
+
+    resp = client.get("/update/validate-ref", params={"git_ref": "ghost"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert "ghost" in body["error"]
+
+
+def test_validate_ref_empty(router_app):
+    """Blank ref -> 400 before any network call."""
+    client = router_app(update.router)
+
+    resp = client.get("/update/validate-ref", params={"git_ref": "  "})
+
+    assert resp.status_code == 400
+
+
+def test_validate_ref_github_down(monkeypatch, router_app):
+    """A RequestException from GitHub -> 503."""
+
+    def _boom(url, timeout):
+        raise requests.RequestException("timeout")
+
+    monkeypatch.setattr(update.requests, "get", _boom)
+    client = router_app(update.router)
+
+    resp = client.get("/update/validate-ref", params={"git_ref": "v1.0.0"})
+
+    assert resp.status_code == 503
+
+
+def test_start(monkeypatch, router_app):
+    """start schedules the job (no pip) and returns its id."""
+    monkeypatch.setattr(update, "is_update_available", lambda pkg, pre: True)
+    run = MagicMock(return_value="job-1")
+    monkeypatch.setattr(bg_job_register, "run_command", run)
+    client = router_app(update.router)
+
+    resp = client.post("/update/start")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"job_id": "job-1"}
+    run.assert_called_once()
+    assert run.call_args[0][0] == "update_reachy_mini"
+
+
+def test_start_no_update(monkeypatch, router_app):
+    """start refuses when no update is available."""
+    monkeypatch.setattr(update, "is_update_available", lambda pkg, pre: False)
+    run = MagicMock()
+    monkeypatch.setattr(bg_job_register, "run_command", run)
+    client = router_app(update.router)
+
+    resp = client.post("/update/start")
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "No update available"
+    run.assert_not_called()
+
+
+def test_start_busy(monkeypatch, router_app):
+    """start refuses while busy_lock is held."""
+    run = MagicMock()
+    monkeypatch.setattr(bg_job_register, "run_command", run)
+    update.busy_lock.acquire()
+    client = router_app(update.router)
+
+    resp = client.post("/update/start")
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Update already in progress"
+    run.assert_not_called()
+
+
+def test_start_from_ref(monkeypatch, router_app):
+    """start-from-ref schedules the job (no pip) and returns its id."""
+    run = MagicMock(return_value="job-2")
+    monkeypatch.setattr(bg_job_register, "run_command", run)
+    client = router_app(update.router)
+
+    resp = client.post("/update/start-from-ref", params={"git_ref": "v2.0.0"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"job_id": "job-2"}
+    run.assert_called_once()
+
+
+def test_start_from_ref_empty(monkeypatch, router_app):
+    """start-from-ref refuses a blank ref."""
+    run = MagicMock()
+    monkeypatch.setattr(bg_job_register, "run_command", run)
+    client = router_app(update.router)
+
+    resp = client.post("/update/start-from-ref", params={"git_ref": " "})
+
+    assert resp.status_code == 400
+    run.assert_not_called()
+
+
+def test_start_from_ref_busy(monkeypatch, router_app):
+    """start-from-ref refuses while busy_lock is held."""
+    run = MagicMock()
+    monkeypatch.setattr(bg_job_register, "run_command", run)
+    update.busy_lock.acquire()
+    client = router_app(update.router)
+
+    resp = client.post("/update/start-from-ref", params={"git_ref": "v2.0.0"})
+
+    assert resp.status_code == 400
+    run.assert_not_called()

--- a/tests/unit_tests/test_router_volume.py
+++ b/tests/unit_tests/test_router_volume.py
@@ -1,0 +1,212 @@
+"""Unit tests for the volume router (speaker + microphone + test sound)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini.daemon.app.routers import volume
+
+
+class _Device:
+    """Audio device stand-in exposing only a name."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _StubVolumeControl:
+    """In-memory VolumeControl — no audio hardware, fully scriptable."""
+
+    def __init__(self, output: int = 42, mic: int = 30, set_ok: bool = True) -> None:
+        self._output = output
+        self._mic = mic
+        self._set_ok = set_ok
+        self.platform_name = "TestOS"
+        self.output_device = _Device("Speaker")
+        self.input_device = _Device("Mic")
+
+    def get_output_volume(self) -> int:
+        """Return the scripted output volume."""
+        return self._output
+
+    def set_output_volume(self, volume: int) -> bool:
+        """Record the write and report the scripted outcome."""
+        self._output = volume
+        return self._set_ok
+
+    def get_input_volume(self) -> int:
+        """Return the scripted input volume."""
+        return self._mic
+
+    def set_input_volume(self, volume: int) -> bool:
+        """Record the write and report the scripted outcome."""
+        self._mic = volume
+        return self._set_ok
+
+
+def _patch_vc(monkeypatch, stub: _StubVolumeControl) -> None:
+    """Route the module accessor to the stub."""
+    monkeypatch.setattr(volume, "_get_volume_control", lambda: stub)
+
+
+def test_get_current_output_volume(monkeypatch, router_app):
+    """GET /volume/current -> 200 with the stub's output value."""
+    _patch_vc(monkeypatch, _StubVolumeControl(output=42))
+    client = router_app(volume.router)
+
+    resp = client.get("/volume/current")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"volume": 42, "platform": "TestOS", "device": "Speaker"}
+
+
+def test_get_microphone_volume(monkeypatch, router_app):
+    """GET /volume/microphone/current -> 200 with the stub's input value."""
+    _patch_vc(monkeypatch, _StubVolumeControl(mic=30))
+    client = router_app(volume.router)
+
+    resp = client.get("/volume/microphone/current")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"volume": 30, "platform": "TestOS", "device": "Mic"}
+
+
+def test_get_output_volume_failure(monkeypatch, router_app):
+    """Negative read -> 500 failure detail."""
+    _patch_vc(monkeypatch, _StubVolumeControl(output=-1))
+    client = router_app(volume.router)
+
+    resp = client.get("/volume/current")
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to get volume"
+
+
+def test_get_microphone_volume_failure(monkeypatch, router_app):
+    """Negative mic read -> 500 failure detail."""
+    _patch_vc(monkeypatch, _StubVolumeControl(mic=-1))
+    client = router_app(volume.router)
+
+    resp = client.get("/volume/microphone/current")
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to get microphone volume"
+
+
+def test_set_output_volume_success(monkeypatch, router_app):
+    """POST /volume/set with a working setter and no daemon -> 200."""
+    _patch_vc(monkeypatch, _StubVolumeControl(set_ok=True))
+    client = router_app(volume.router)
+
+    resp = client.post("/volume/set", json={"volume": 55})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"volume": 55, "platform": "TestOS", "device": "Speaker"}
+
+
+def test_set_output_volume_plays_test_sound(monkeypatch, router_app):
+    """A ready backend on app.state triggers a test sound after the set."""
+    _patch_vc(monkeypatch, _StubVolumeControl(set_ok=True))
+    daemon = MagicMock()
+    daemon.backend.ready.is_set.return_value = True
+    client = router_app(volume.router, daemon=daemon)
+
+    resp = client.post("/volume/set", json={"volume": 55})
+
+    assert resp.status_code == 200
+    daemon.backend.play_sound.assert_called_once_with("impatient1.wav")
+
+
+def test_set_output_volume_test_sound_failure_ignored(monkeypatch, router_app):
+    """A failing test sound is swallowed — the set still returns 200."""
+    _patch_vc(monkeypatch, _StubVolumeControl(set_ok=True))
+    daemon = MagicMock()
+    daemon.backend.ready.is_set.return_value = True
+    daemon.backend.play_sound.side_effect = RuntimeError("boom")
+    client = router_app(volume.router, daemon=daemon)
+
+    resp = client.post("/volume/set", json={"volume": 55})
+
+    assert resp.status_code == 200
+
+
+def test_set_output_volume_failure(monkeypatch, router_app):
+    """Setter returning False -> 500."""
+    _patch_vc(monkeypatch, _StubVolumeControl(set_ok=False))
+    client = router_app(volume.router)
+
+    resp = client.post("/volume/set", json={"volume": 55})
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to set volume"
+
+
+def test_set_microphone_volume_success(monkeypatch, router_app):
+    """POST /volume/microphone/set with a working setter -> 200."""
+    _patch_vc(monkeypatch, _StubVolumeControl(set_ok=True))
+    client = router_app(volume.router)
+
+    resp = client.post("/volume/microphone/set", json={"volume": 20})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"volume": 20, "platform": "TestOS", "device": "Mic"}
+
+
+def test_set_microphone_volume_failure(monkeypatch, router_app):
+    """Mic setter returning False -> 500."""
+    _patch_vc(monkeypatch, _StubVolumeControl(set_ok=False))
+    client = router_app(volume.router)
+
+    resp = client.post("/volume/microphone/set", json={"volume": 20})
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to set microphone volume"
+
+
+@pytest.mark.parametrize("route", ["/volume/set", "/volume/microphone/set"])
+@pytest.mark.parametrize("bad", [-5, 150])
+def test_set_volume_out_of_range_rejected(monkeypatch, router_app, route, bad):
+    """Out-of-range volume is rejected by validation -> 422."""
+    _patch_vc(monkeypatch, _StubVolumeControl())
+    client = router_app(volume.router)
+
+    resp = client.post(route, json={"volume": bad})
+
+    assert resp.status_code == 422
+
+
+def test_test_sound_success(router_app):
+    """POST /volume/test-sound plays the sound -> 200 ok."""
+    backend = MagicMock()
+    client = router_app(volume.router, backend=backend)
+
+    resp = client.post("/volume/test-sound")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "message": "Test sound played"}
+    backend.play_sound.assert_called_once_with("impatient1.wav")
+
+
+@pytest.mark.parametrize("msg", ["Device unavailable", "error -9985 occurred"])
+def test_test_sound_device_busy(router_app, msg):
+    """A busy audio device -> 200 busy, sound skipped."""
+    backend = MagicMock()
+    backend.play_sound.side_effect = RuntimeError(msg)
+    client = router_app(volume.router, backend=backend)
+
+    resp = client.post("/volume/test-sound")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "busy"
+
+
+def test_test_sound_error(router_app):
+    """An unexpected playback error -> 500."""
+    backend = MagicMock()
+    backend.play_sound.side_effect = RuntimeError("boom")
+    client = router_app(volume.router, backend=backend)
+
+    resp = client.post("/volume/test-sound")
+
+    assert resp.status_code == 500
+    assert "Failed to play test sound" in resp.json()["detail"]

--- a/tests/unit_tests/test_wireless_version.py
+++ b/tests/unit_tests/test_wireless_version.py
@@ -119,6 +119,35 @@ def test_semver_unparseable_three_parts_raises():
         update_available._semver_version("1.2.x")
 
 
+def test_semver_pep440_dev():
+    """PEP 440 `.devN` normalizes to a semver pre-release.
+
+    The package's own version on main is `X.Y.Z.dev0` (pyproject), so any
+    from-source / from-git-ref install reports a `.dev0` string to
+    `get_local_version` -> `_semver_version`.
+    """
+    v = update_available._semver_version("1.10.0.dev0")
+    assert (v.major, v.minor, v.patch) == (1, 10, 0)
+    assert v.prerelease == "dev.0"
+
+
+# --- get_local_version ---
+
+
+def test_get_local_version_pep440_dev(monkeypatch):
+    """Regression: a `.dev0` install must not crash the version check.
+
+    `get_local_version` feeds `importlib.metadata.version(...)` straight into
+    `_semver_version`. On a from-ref / from-source install that string is the
+    `1.10.0.dev0` marker, and `_semver_version` raises ValueError today —
+    breaking `/available`, the `/update` gating, and the daemon update flow.
+    """
+    monkeypatch.setattr(update_available, "version", lambda _pkg: "1.10.0.dev0")
+    v = update_available.get_local_version("reachy_mini")
+    assert (v.major, v.minor, v.patch) == (1, 10, 0)
+    assert v.prerelease == "dev.0"
+
+
 # --- get_pypi_version ---
 
 

--- a/tests/unit_tests/test_wireless_version.py
+++ b/tests/unit_tests/test_wireless_version.py
@@ -181,6 +181,22 @@ def test_get_pypi_version_prerelease(monkeypatch):
     assert (v.major, v.minor, v.patch) == (2, 1, 0)
 
 
+def test_get_pypi_version_prerelease_pep440_info_version(monkeypatch):
+    """Regression: pre-release compare must not crash on a PEP 440 info.version.
+
+    `pre_version > version` compared a parsed Version against the RAW
+    info.version string; semver coerces the RHS with strict parse, so a
+    non-semver info.version (e.g. an rc release) raised ValueError.
+    """
+    payload = {"info": {"version": "2.0.0rc1"}, "releases": {"1.9.0": [], "2.0.0rc2": []}}
+    monkeypatch.setattr(
+        update_available.requests, "get", lambda *a, **k: _FakeResponse(payload)
+    )
+    v = update_available.get_pypi_version("reachy-mini", pre_release=True)
+    assert (v.major, v.minor, v.patch) == (2, 0, 0)  # rc2 is newer -> returned
+    assert v.prerelease == "rc.2"
+
+
 def test_get_pypi_version_http_error(monkeypatch):
     """HTTP errors propagate out of get_pypi_version."""
     resp = _FakeResponse({}, error=requests.HTTPError("boom"))

--- a/tests/unit_tests/test_wireless_version.py
+++ b/tests/unit_tests/test_wireless_version.py
@@ -1,0 +1,262 @@
+"""Unit tests for the wireless_version update helpers."""
+
+import shlex
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+import requests
+import semver
+
+from reachy_mini.utils.wireless_version import update, update_available, utils
+
+# --- build_install_command ---
+
+
+def test_build_pypi_version_uv(monkeypatch):
+    """PyPI pinned version via uv, with upgrade flag."""
+    monkeypatch.setattr(utils, "_check_uv_available", lambda: True)
+    cmd, env = utils.build_install_command("wireless-version", version="1.2.3", upgrade=True)
+    tokens = shlex.split(cmd)
+    assert tokens[:3] == ["uv", "pip", "install"]
+    assert "reachy-mini[wireless-version]==1.2.3" in tokens
+    assert "--upgrade" in tokens
+    assert env == {}
+
+
+def test_build_pypi_prerelease_pip_fallback(monkeypatch):
+    """PyPI latest pre-release falls back to bare pip when uv is missing."""
+    monkeypatch.setattr(utils, "_check_uv_available", lambda: False)
+    cmd, env = utils.build_install_command("wireless-version", pre_release=True)
+    tokens = shlex.split(cmd)
+    assert tokens[:2] == ["pip", "install"]
+    assert "reachy-mini[wireless-version]" in tokens
+    assert "--pre" in tokens
+    assert "--upgrade" not in tokens
+    assert env == {}
+
+
+def test_build_verbose_flag(monkeypatch):
+    """Verbose adds -vvv to the base command."""
+    monkeypatch.setattr(utils, "_check_uv_available", lambda: True)
+    cmd, _ = utils.build_install_command("gstreamer", verbose=True)
+    assert "-vvv" in shlex.split(cmd)
+
+
+def test_build_external_venv_uv(monkeypatch):
+    """External venv install targets --python when uv is available."""
+    monkeypatch.setattr(utils, "_check_uv_available", lambda: True)
+    py = Path("/venvs/apps_venv/bin/python")
+    cmd, _ = utils.build_install_command("", python=py, upgrade=True)
+    tokens = shlex.split(cmd)
+    assert tokens[:5] == ["uv", "pip", "install", "--python", str(py)]
+
+
+def test_build_external_venv_pip_fallback(monkeypatch):
+    """External venv without uv uses that venv's own pip binary."""
+    monkeypatch.setattr(utils, "_check_uv_available", lambda: False)
+    py = Path("/venvs/apps_venv/bin/python")
+    cmd, _ = utils.build_install_command("", python=py)
+    tokens = shlex.split(cmd)
+    assert tokens[:2] == [str(py.parent / "pip"), "install"]
+
+
+def test_build_git_ref_uv(monkeypatch):
+    """Git ref install chains three steps and sets the LFS env var (uv)."""
+    monkeypatch.setattr(utils, "_check_uv_available", lambda: True)
+    cmd, env = utils.build_install_command("wireless-version", git_ref="main")
+    assert env == {"GIT_LFS_SKIP_SMUDGE": "1"}
+
+    step1, rest = cmd.split(" && ", 1)
+    step2, step3 = rest.split(" || ", 1)
+
+    t1 = shlex.split(step1)
+    assert "--force-reinstall" in t1 and "--no-deps" in t1 and "--no-cache-dir" in t1
+    assert any("git+https://github.com/pollen-robotics/reachy_mini.git@main" in tok for tok in t1)
+
+    assert shlex.split(step2) == ["uv", "pip", "check"]
+
+    t3 = shlex.split(step3)
+    assert "--upgrade" in t3
+    assert "--upgrade-strategy" not in t3  # uv path omits the strategy flag
+
+
+def test_build_git_ref_pip_fallback(monkeypatch):
+    """Git ref via pip appends the only-if-needed upgrade strategy."""
+    monkeypatch.setattr(utils, "_check_uv_available", lambda: False)
+    cmd, _ = utils.build_install_command("wireless-version", git_ref="dev")
+    _, rest = cmd.split(" && ", 1)
+    step2, step3 = rest.split(" || ", 1)
+    assert shlex.split(step2) == ["pip", "check"]
+    t3 = shlex.split(step3)
+    assert "--upgrade-strategy" in t3 and "only-if-needed" in t3
+
+
+# --- _semver_version ---
+
+
+def test_semver_plain():
+    """Plain semver strings parse directly."""
+    assert update_available._semver_version("1.2.3") == semver.Version.parse("1.2.3")
+
+
+def test_semver_rc():
+    """PyPI-style rc suffix is normalized to a semver pre-release."""
+    v = update_available._semver_version("1.2.3rc4")
+    assert (v.major, v.minor, v.patch) == (1, 2, 3)
+    assert v.prerelease == "rc.4"
+
+
+def test_semver_invalid_raises():
+    """Unparseable strings raise ValueError."""
+    with pytest.raises(ValueError):
+        update_available._semver_version("not-a-version")
+
+
+def test_semver_unparseable_three_parts_raises():
+    """A 3-part string that still won't parse (no rc suffix) raises ValueError."""
+    with pytest.raises(ValueError):
+        update_available._semver_version("1.2.x")
+
+
+# --- get_pypi_version ---
+
+
+class _FakeResponse:
+    """Minimal stand-in for a requests Response."""
+
+    def __init__(self, payload, error=None):
+        self._payload = payload
+        self._error = error
+
+    def raise_for_status(self):
+        if self._error:
+            raise self._error
+
+    def json(self):
+        return self._payload
+
+
+def test_get_pypi_version_stable(monkeypatch):
+    """Stable lookup returns info.version."""
+    payload = {"info": {"version": "2.0.0"}, "releases": {}}
+    monkeypatch.setattr(update_available.requests, "get", lambda *a, **k: _FakeResponse(payload))
+    assert update_available.get_pypi_version("reachy-mini", pre_release=False) == semver.Version.parse("2.0.0")
+
+
+def test_get_pypi_version_prerelease(monkeypatch):
+    """Pre-release lookup prefers a newer trailing release entry."""
+    payload = {"info": {"version": "2.0.0"}, "releases": {"1.9.0": [], "2.1.0rc1": []}}
+    monkeypatch.setattr(update_available.requests, "get", lambda *a, **k: _FakeResponse(payload))
+    v = update_available.get_pypi_version("reachy-mini", pre_release=True)
+    assert (v.major, v.minor, v.patch) == (2, 1, 0)
+
+
+def test_get_pypi_version_http_error(monkeypatch):
+    """HTTP errors propagate out of get_pypi_version."""
+    resp = _FakeResponse({}, error=requests.HTTPError("boom"))
+    monkeypatch.setattr(update_available.requests, "get", lambda *a, **k: resp)
+    with pytest.raises(requests.HTTPError):
+        update_available.get_pypi_version("reachy-mini", pre_release=False)
+
+
+# --- get_install_source ---
+
+
+class _FakeDist:
+    """Fake importlib.metadata Distribution."""
+
+    def __init__(self, text, raise_missing=False):
+        self._text = text
+        self._raise = raise_missing
+
+    def read_text(self, name):
+        if self._raise:
+            raise FileNotFoundError(name)
+        return self._text
+
+
+def _patch_source(monkeypatch, dist, ver="1.0.0"):
+    """Wire up distribution/version for get_install_source."""
+    monkeypatch.setattr(update_available, "distribution", lambda name: dist)
+    monkeypatch.setattr(update_available, "version", lambda name: ver)
+
+
+def test_install_source_pypi_no_direct_url(monkeypatch):
+    """No direct_url.json text means a PyPI install."""
+    _patch_source(monkeypatch, _FakeDist(None))
+    result = update_available.get_install_source("reachy-mini")
+    assert result == {"version": "1.0.0", "source": "pypi"}
+
+
+def test_install_source_editable(monkeypatch):
+    """dir_info.editable marks an editable install."""
+    text = '{"dir_info": {"editable": true}, "url": "file:///x"}'
+    _patch_source(monkeypatch, _FakeDist(text))
+    assert update_available.get_install_source("reachy-mini")["source"] == "editable"
+
+
+def test_install_source_git(monkeypatch):
+    """vcs_info yields git source with ref and short commit."""
+    text = '{"vcs_info": {"requested_revision": "main", "commit_id": "abcdef1234567890"}}'
+    _patch_source(monkeypatch, _FakeDist(text))
+    result = update_available.get_install_source("reachy-mini")
+    assert result["source"] == "git"
+    assert result["git_ref"] == "main"
+    assert result["commit"] == "abcdef12"
+
+
+def test_install_source_file_not_found(monkeypatch):
+    """A missing direct_url.json falls back to PyPI."""
+    _patch_source(monkeypatch, _FakeDist(None, raise_missing=True))
+    assert update_available.get_install_source("reachy-mini")["source"] == "pypi"
+
+
+# --- is_update_available ---
+
+
+def test_is_update_available_true(monkeypatch):
+    """Newer PyPI version reports an available update."""
+    monkeypatch.setattr(update_available, "get_pypi_version", lambda p, pr: semver.Version.parse("2.0.0"))
+    monkeypatch.setattr(update_available, "get_local_version", lambda p: semver.Version.parse("1.0.0"))
+    assert update_available.is_update_available("reachy-mini", False) is True
+
+
+def test_is_update_available_false(monkeypatch):
+    """Equal versions report no update."""
+    monkeypatch.setattr(update_available, "get_pypi_version", lambda p, pr: semver.Version.parse("1.0.0"))
+    monkeypatch.setattr(update_available, "get_local_version", lambda p: semver.Version.parse("1.0.0"))
+    assert update_available.is_update_available("reachy-mini", False) is False
+
+
+# --- update_reachy_mini ---
+
+
+@pytest.mark.asyncio
+async def test_update_with_apps_venv(monkeypatch):
+    """Update installs daemon + apps venv, then restarts the daemon."""
+    calls = AsyncMock()
+    monkeypatch.setattr(update, "call_logger_wrapper", calls)
+    monkeypatch.setattr(update.Path, "exists", lambda self: True)
+
+    import logging
+
+    await update.update_reachy_mini(logging.getLogger("test"))
+
+    assert calls.call_count == 3
+    assert calls.await_args_list[-1].args[0] == "sudo systemctl restart reachy-mini-daemon"
+
+
+@pytest.mark.asyncio
+async def test_update_without_apps_venv(monkeypatch):
+    """Missing apps venv skips the second install step."""
+    calls = AsyncMock()
+    monkeypatch.setattr(update, "call_logger_wrapper", calls)
+    monkeypatch.setattr(update.Path, "exists", lambda self: False)
+
+    import logging
+
+    await update.update_reachy_mini(logging.getLogger("test"), pre_release=True)
+
+    assert calls.call_count == 2
+    assert calls.await_args_list[-1].args[0] == "sudo systemctl restart reachy-mini-daemon"


### PR DESCRIPTION
## What

Raises CI unit-test coverage for the biggest remaining low-% modules, following the same constraint as the prior coverage PRs (#1271, #1274): **all new tests run in the default pytest job with no robot hardware and no real network** (mocks, `MockupSimBackend`, FastAPI `TestClient` + `dependency_overrides`, `tmp_path`).

Overall coverage was **44%** before this PR.

## Scope

**Deep — `daemon/backend/abstract.py`** (was 34%, 650 missing — the biggest single lever), driven through a new headless `MockupSimBackend(use_audio=False)` fixture:
- `process_command` dispatcher (all Set*/Get*/motor/gravity/wobbling/head-tracking/recording/volume/audio-config/state/version/hardware-id/log/restart/update branches).
- Move + audio upload handlers (chunk reassembly, out-of-order / count-mismatch / unknown-encoding / too-many-slots / TTL eviction) and play/cancel move+audio.
- Target setters, IK compose, recording buffer, present-pose getters, async goto/wake/sleep wrappers.

**Broad — near-0% routers and pure-logic utils:**
- Routers via `TestClient` + `dependency_overrides` (a new seam): `cache` (0%), `update` (0%), `volume`, `hf_auth`.
- Utils: `hf_space` Space→AppInfo normalization, `wireless_version/*` (0% — build-command / semver / pypi / install-source / async update), `apps/sources/hf_auth` (OAuth sessions + token fns), `daemon/utils`.

## Shared fixtures (`conftest.py`)

- `sim_backend` — headless `MockupSimBackend(use_audio=False)` with a mock media server.
- `router_app` — mounts one router on a bare FastAPI app and wires backend/daemon stubs via `dependency_overrides` + `app.state`.

## Not in this PR

Deferred (heavier, a clean follow-up): `volume_control_linux` ALSA parsing, `startup_check`, routers `state`/`move`/`media`/`logs`. Skipped: `volume_control_macos/windows` (ctypes/pycaw — won't import on Linux CI), `parse_urdf_for_kinematics` (would just exercise Placo's solver, already covered).

## Testing

- ~240 new tests, one file per target module (one commit per file).
- Full suite: `610 passed, 64 deselected` under the default CI selection (`-m 'not audio and not video and not wireless and not webrtc'`); ruff check + format clean.
- Coverage % lands on the CI Allure/coverage run (can't be measured locally — PyGObject + coverage.py crash).