### PR TITLE
fix: publish live robot backend status

### DIFF
--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -321,6 +321,8 @@ class RobotBackend(Backend):
 
     def get_status(self) -> "RobotBackendStatus":
         """Get the current status of the robot backend."""
+        self._status.ready = self.ready.is_set() and not self.should_stop.is_set()
+        self._status.last_alive = self.last_alive
         self._status.error = self.error
         self._status.motor_control_mode = self.motor_control_mode
         return self._status

--- a/tests/unit_tests/test_robot_backend_status.py
+++ b/tests/unit_tests/test_robot_backend_status.py
@@ -1,0 +1,33 @@
+"""Regression tests for robot backend status reporting."""
+
+from threading import Event
+
+from reachy_mini.daemon.backend.robot.backend import RobotBackend
+from reachy_mini.io.protocol import MotorControlMode, RobotBackendStatus
+
+
+def test_robot_backend_status_reflects_live_readiness() -> None:
+    """Cached status should reflect the live backend lifecycle events."""
+    backend = object.__new__(RobotBackend)
+    backend.ready = Event()
+    backend.ready.set()
+    backend.should_stop = Event()
+    backend.last_alive = 123.5
+    backend.error = None
+    backend.motor_control_mode = MotorControlMode.Enabled
+    backend._status = RobotBackendStatus(
+        ready=False,
+        motor_control_mode=MotorControlMode.Disabled,
+        last_alive=None,
+        control_loop_stats={},
+    )
+
+    status = RobotBackend.get_status(backend)
+
+    assert status.ready is True
+    assert status.last_alive == 123.5
+    assert status.motor_control_mode == MotorControlMode.Enabled
+
+    backend.should_stop.set()
+
+    assert RobotBackend.get_status(backend).ready is False


### PR DESCRIPTION
## Summary
- refresh cached robot backend readiness from the live lifecycle events
- publish the latest control-loop heartbeat through `last_alive`
- add a regression test for ready and stopping transitions

Closes #1278.

## Verification
- `uv run pytest tests/unit_tests/test_robot_backend_status.py -q` — passed
- `uv run ruff check <changed files>` — passed
- `uv run mypy src/reachy_mini/daemon/backend/robot/backend.py` — passed
- `git diff --check` — passed

The broader unit collection on this ARM64 host reaches an unrelated environment dependency: `test_wifi_connect_retry.py` imports optional `nmcli`; installing the complete wireless extra then requires the system `liblgpio` library. Hosted CI should exercise that environment-specific lane.