### PR TITLE
fix: honor Hugging Face token path

### DIFF
--- a/src/reachy_mini/apps/sources/hf_auth.py
+++ b/src/reachy_mini/apps/sources/hf_auth.py
@@ -6,10 +6,12 @@ import os
 import secrets
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Optional
 
 import aiohttp
 from huggingface_hub import HfApi, get_token, login, logout, whoami
+from huggingface_hub.constants import HF_TOKEN_PATH
 from huggingface_hub.errors import HfHubHTTPError
 
 logger = logging.getLogger(__name__)
@@ -287,11 +289,10 @@ async def exchange_code_for_token(
     # Save token directly to HuggingFace token file
     # (login() doesn't work well with OAuth tokens)
     try:
-        from pathlib import Path
-
-        token_path = Path.home() / ".cache" / "huggingface" / "token"
+        token_path = Path(HF_TOKEN_PATH)
         token_path.parent.mkdir(parents=True, exist_ok=True)
         token_path.write_text(access_token)
+        token_path.chmod(0o600)
     except Exception as e:
         session.status = "error"
         session.error_message = f"Failed to save token: {type(e).__name__}: {e}"

--- a/src/reachy_mini/apps/sources/hf_auth.py
+++ b/src/reachy_mini/apps/sources/hf_auth.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import secrets
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -288,15 +289,31 @@ async def exchange_code_for_token(
 
     # Save token directly to HuggingFace token file
     # (login() doesn't work well with OAuth tokens)
+    temporary_path: Optional[Path] = None
     try:
         token_path = Path(HF_TOKEN_PATH)
         token_path.parent.mkdir(parents=True, exist_ok=True)
-        token_path.write_text(access_token)
-        token_path.chmod(0o600)
+        fd, temporary_name = tempfile.mkstemp(
+            dir=token_path.parent,
+            prefix=f".{token_path.name}.",
+            text=True,
+        )
+        temporary_path = Path(temporary_name)
+        os.close(fd)
+        temporary_path.chmod(0o600)
+        with temporary_path.open("w") as token_file:
+            token_file.write(access_token)
+            token_file.flush()
+            os.fsync(token_file.fileno())
+        os.replace(temporary_path, token_path)
+        temporary_path = None
     except Exception as e:
         session.status = "error"
         session.error_message = f"Failed to save token: {type(e).__name__}: {e}"
         return {"status": "error", "message": session.error_message}
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
 
     # Get username
     username = ""

--- a/tests/unit_tests/test_hf_auth.py
+++ b/tests/unit_tests/test_hf_auth.py
@@ -1,5 +1,6 @@
 """Tests for Hugging Face authentication persistence."""
 
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -51,6 +52,14 @@ async def test_oauth_token_uses_huggingface_configured_path(
     monkeypatch.setattr(hf_auth.aiohttp, "ClientSession", _ClientSession)
     monkeypatch.setattr(hf_auth, "whoami", lambda **_kwargs: {"name": "tester"})
     monkeypatch.setattr(central_signaling_relay, "notify_token_change", AsyncMock())
+    real_replace = os.replace
+    replacement_observation: dict[str, int] = {}
+
+    def observe_secure_replace(source: str | Path, destination: str | Path) -> None:
+        replacement_observation["mode"] = Path(source).stat().st_mode & 0o777
+        real_replace(source, destination)
+
+    monkeypatch.setattr(hf_auth.os, "replace", observe_secure_replace)
 
     try:
         result = await hf_auth.exchange_code_for_token("code", "state", False)
@@ -58,5 +67,39 @@ async def test_oauth_token_uses_huggingface_configured_path(
         hf_auth._oauth_sessions.clear()
 
     assert result == {"status": "success", "username": "tester"}
+    assert replacement_observation == {"mode": 0o600}
     assert token_path.read_text() == "oauth-token"
     assert token_path.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.asyncio
+async def test_oauth_token_is_not_retained_when_permissions_cannot_be_enforced(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Permission failure must happen before token bytes reach persistent storage."""
+    token_path = tmp_path / "private-hf-home" / "token"
+    session = hf_auth.OAuthSession(
+        session_id="session",
+        user_code="",
+        state="state",
+        code_verifier="verifier",
+        wireless_version=False,
+    )
+    hf_auth._oauth_sessions[session.session_id] = session
+    monkeypatch.setattr(hf_auth, "HF_TOKEN_PATH", str(token_path))
+    monkeypatch.setattr(hf_auth.aiohttp, "ClientSession", _ClientSession)
+
+    def deny_chmod(_path: Path, _mode: int) -> None:
+        raise PermissionError("permissions unavailable")
+
+    monkeypatch.setattr(Path, "chmod", deny_chmod)
+
+    try:
+        result = await hf_auth.exchange_code_for_token("code", "state", False)
+    finally:
+        hf_auth._oauth_sessions.clear()
+
+    assert result["status"] == "error"
+    assert result["message"].startswith("Failed to save token: PermissionError")
+    assert not token_path.exists()
+    assert list(token_path.parent.iterdir()) == []

--- a/tests/unit_tests/test_hf_auth.py
+++ b/tests/unit_tests/test_hf_auth.py
@@ -1,0 +1,62 @@
+"""Tests for Hugging Face authentication persistence."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from reachy_mini.apps.sources import hf_auth
+from reachy_mini.media import central_signaling_relay
+
+
+class _TokenResponse:
+    status = 200
+
+    async def __aenter__(self) -> "_TokenResponse":
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        pass
+
+    async def text(self) -> str:
+        return '{"access_token": "oauth-token"}'
+
+
+class _ClientSession:
+    async def __aenter__(self) -> "_ClientSession":
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        pass
+
+    def post(self, _url: str, **_kwargs: object) -> _TokenResponse:
+        return _TokenResponse()
+
+
+@pytest.mark.asyncio
+async def test_oauth_token_uses_huggingface_configured_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """OAuth persistence should honor the path selected by huggingface_hub."""
+    token_path = tmp_path / "private-hf-home" / "token"
+    session = hf_auth.OAuthSession(
+        session_id="session",
+        user_code="",
+        state="state",
+        code_verifier="verifier",
+        wireless_version=False,
+    )
+    hf_auth._oauth_sessions[session.session_id] = session
+    monkeypatch.setattr(hf_auth, "HF_TOKEN_PATH", str(token_path))
+    monkeypatch.setattr(hf_auth.aiohttp, "ClientSession", _ClientSession)
+    monkeypatch.setattr(hf_auth, "whoami", lambda **_kwargs: {"name": "tester"})
+    monkeypatch.setattr(central_signaling_relay, "notify_token_change", AsyncMock())
+
+    try:
+        result = await hf_auth.exchange_code_for_token("code", "state", False)
+    finally:
+        hf_auth._oauth_sessions.clear()
+
+    assert result == {"status": "success", "username": "tester"}
+    assert token_path.read_text() == "oauth-token"
+    assert token_path.stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
## Summary
- persist OAuth credentials to the path selected by `huggingface_hub`
- create the configured parent directory and restrict the token file to mode `0600`
- add an async regression test covering the complete token exchange persistence path

Closes #1279.

## Verification
- `uv run pytest tests/unit_tests/test_hf_auth.py -q` — passed
- `uv run ruff check <changed files>` — passed
- `uv run mypy src/reachy_mini/apps/sources/hf_auth.py` — passed
- `git diff --check` — passed