### PR TITLE
feat(control): add atomic non-evicting app start route

### DIFF
--- a/docs/source/API/openapi.json
+++ b/docs/source/API/openapi.json
@@ -239,6 +239,46 @@
         }
       }
     },
+    "/api/apps/start-app/{app_name}/no-evict": {
+      "post": {
+        "summary": "Start App No Evict",
+        "description": "Start an app only when the managed robot slot can be acquired atomically.",
+        "operationId": "start_app_no_evict_api_apps_start_app__app_name__no_evict_post",
+        "parameters": [
+          {
+            "name": "app_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "App Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppStatus"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/apps/restart-current-app": {
       "post": {
         "summary": "Restart App",

--- a/src/reachy_mini/daemon/app/routers/apps.py
+++ b/src/reachy_mini/daemon/app/routers/apps.py
@@ -141,6 +141,18 @@ async def start_app(
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@router.post("/start-app/{app_name}/no-evict")
+async def start_app_no_evict(
+    app_name: str,
+    app_manager: "AppManager" = Depends(get_app_manager),
+) -> AppStatus:
+    """Start an app only when the managed robot slot can be acquired atomically."""
+    try:
+        return await app_manager.start_app(app_name, evict_remote=False)
+    except RuntimeError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 @router.post("/restart-current-app")
 async def restart_app(
     app_manager: "AppManager" = Depends(get_app_manager),

--- a/tests/unit_tests/test_router_apps.py
+++ b/tests/unit_tests/test_router_apps.py
@@ -1,0 +1,53 @@
+"""Unit tests for ownership-sensitive application lifecycle routes."""
+
+from typing import Any
+
+from reachy_mini.apps import AppInfo, SourceKind
+from reachy_mini.apps.manager import AppState, AppStatus
+from reachy_mini.daemon.app.dependencies import get_app_manager
+from reachy_mini.daemon.app.routers import apps
+
+
+class _AppManager:
+    def __init__(self, *, error: str | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def start_app(self, name: str, **kwargs: Any) -> AppStatus:
+        self.calls.append((name, kwargs))
+        if self.error is not None:
+            raise RuntimeError(self.error)
+        return AppStatus(
+            info=AppInfo(name=name, source_kind=SourceKind.INSTALLED),
+            state=AppState.STARTING,
+        )
+
+
+def test_no_evict_start_uses_atomic_app_manager_contract(router_app) -> None:
+    """The dedicated route passes the non-evicting manager option atomically."""
+    manager = _AppManager()
+    client = router_app(
+        apps.router,
+        overrides={get_app_manager: lambda: manager},
+    )
+
+    response = client.post("/apps/start-app/reachy_agent/no-evict")
+
+    assert response.status_code == 200
+    assert response.json()["state"] == "starting"
+    assert manager.calls == [("reachy_agent", {"evict_remote": False})]
+
+
+def test_no_evict_start_reports_busy_managed_slot(router_app) -> None:
+    """A managed-slot conflict remains a visible HTTP 400 response."""
+    manager = _AppManager(error="The robot app slot is already in use")
+    client = router_app(
+        apps.router,
+        overrides={get_app_manager: lambda: manager},
+    )
+
+    response = client.post("/apps/start-app/reachy_agent/no-evict")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "The robot app slot is already in use"}
+    assert manager.calls == [("reachy_agent", {"evict_remote": False})]


### PR DESCRIPTION
## Summary

- expose a dedicated Control route that starts a local app with `evict_remote=False`
- preserve the existing start route and its remote-eviction behavior
- cover successful delegation and busy-slot HTTP 400 behavior

This gives boot/recovery clients a fail-closed, atomic native operation. A separate lock-status preflight is insufficient because a remote WebRTC session can acquire the managed slot between the read and the existing evicting start request.

## Validation

- Ruff format/check on changed files
- 59 focused app-lock, startup watcher, and route tests