### PR TITLE
Cap FaceTracker detection rate independently of the IPC feed (hardening for #1263)

### DIFF
--- a/src/reachy_mini/vision/face_tracking.py
+++ b/src/reachy_mini/vision/face_tracking.py
@@ -27,6 +27,14 @@ logger = logging.getLogger(__name__)
 # Detector input width; smaller trades recall for CPU.
 _TRACKING_WIDTH = 320
 
+# FaceTracker's own detection-rate cap, enforced with a videorate element in the
+# GStreamer graph so surplus frames are dropped before colour-convert and the pull.
+# The local IPC feed already caps at 10 FPS today, so this is currently redundant;
+# it becomes load-bearing once the IPC rate is configurable
+# (see https://github.com/pollen-robotics/reachy_mini/issues/1263), at which point
+# this constant should read that config instead of being hardcoded.
+_DETECTION_FPS = 10
+
 
 @dataclass
 class FaceObservation:
@@ -250,6 +258,11 @@ class FaceTracker:
         windows = platform.system() == "Windows"
         source = Gst.ElementFactory.make("win32ipcvideosrc" if windows else "unixfdsrc")
         queue_frames = Gst.ElementFactory.make("queue")
+        # Cap the detection rate here, before colour-convert, so frames above
+        # _DETECTION_FPS are dropped ahead of the (possibly hardware) convert and
+        # the appsink pull rather than detected on.
+        videorate = Gst.ElementFactory.make("videorate")
+        framerate_caps = Gst.ElementFactory.make("capsfilter")
         # Prefer v4l2convert: on the RPi the ISP does the scale + convert in hardware.
         convert_chain = [Gst.ElementFactory.make("v4l2convert")]
         if convert_chain[0] is None:
@@ -259,7 +272,15 @@ class FaceTracker:
             ]
         capsfilter = Gst.ElementFactory.make("capsfilter")
         appsink = Gst.ElementFactory.make("appsink")
-        chain = [source, queue_frames, *convert_chain, capsfilter, appsink]
+        chain = [
+            source,
+            queue_frames,
+            videorate,
+            framerate_caps,
+            *convert_chain,
+            capsfilter,
+            appsink,
+        ]
         if any(element is None for element in chain):
             logger.warning("Face tracking unavailable: missing GStreamer plugins.")
             return
@@ -269,6 +290,13 @@ class FaceTracker:
             source.set_property("socket-path", CAMERA_SOCKET_PATH)
         queue_frames.set_property("leaky", 2)
         queue_frames.set_property("max-size-buffers", 1)
+        # drop-only so a feed slower than _DETECTION_FPS passes straight through
+        # instead of videorate duplicating frames to hit the target rate.
+        videorate.set_property("drop-only", True)
+        framerate_caps.set_property(
+            "caps",
+            Gst.Caps.from_string(f"video/x-raw,framerate={_DETECTION_FPS}/1"),
+        )
         src_w, src_h = camera_specs.default_resolution.value[:2]
         width = min(_TRACKING_WIDTH, src_w)
         height = max(2, round(width * src_h / src_w / 2) * 2)


### PR DESCRIPTION
## Context

Follow-up to the discussion below. The original framing of this PR — that `FaceTracker` runs detection at *camera* rate and starves the 50 Hz motor control loop — was wrong. On current `main` (and on 1.9.0) the local IPC feed is already capped at 10 FPS (`media_server.py`'s `IPC_FPS`), and `FaceTracker` consumes that feed via `unixfdsrc`, so detection is already feed-bounded to ~10 Hz. The earlier python timer therefore just duplicated an existing cap. Thanks to @alozowski for catching that.

What still holds: once the IPC rate becomes configurable (#1263), `FaceTracker` will need its own independent rate limit so a faster feed doesn't drag detection — YuNet inference on the shared Python process/GIL — up with it.

## Change

Reframed as hardening for configurable IPC rates. Instead of the python timer, add a tracker-local `videorate` (`drop-only`) + framerate capsfilter right after `source`/`queue`, before the colour-convert chain — so frames above the target rate are dropped *before* the (possibly hardware) convert and the appsink pull, rather than pulled and detected on.

- Target rate is a module constant `_DETECTION_FPS = 10`, with a comment pointing at #1263 so it's a one-line change to read the IPC-rate config once that lands.
- `drop-only` so a feed slower than the target passes straight through without `videorate` duplicating frames to hit the rate.
- No-op against today's 10 FPS IPC feed; load-bearing only once the feed can run faster.

## Verification

`ruff check` / `ruff format`, `mypy`, and `tests/unit_tests/test_face_tracking.py` (9 passed) pass locally. Not yet exercised against a live camera feed on hardware — the element placement is standard, but a run on a wireless would be the real end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
