### PR TITLE
fix(daemon): reset robot to idle when the app slot becomes free

### DIFF
--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -153,11 +153,17 @@ class AppManager:
             if keep_remote:
                 self.daemon.robot_app_lock.acquire_local_keeping_remote(app_name)
             elif evict_remote:
-                await self.daemon.robot_app_lock.acquire_local_evicting_remote(
-                    app_name
-                )
+                await self.daemon.robot_app_lock.acquire_local_evicting_remote(app_name)
             elif not self.daemon.robot_app_lock.try_acquire_local(app_name):
                 raise RuntimeError("The robot app slot is already in use")
+
+            # We now own the app slot. Cancel any idle reset the daemon
+            # scheduled when the slot last became free: this local app runs its
+            # own wake/motion sequence and must not fight a stale goto_sleep.
+            # Threadsafe; no-op if the backend loop isn't up.
+            backend = getattr(self.daemon, "backend", None)
+            if backend is not None:
+                backend.cancel_idle_reset()
 
         try:
             # Get module name and Python path for subprocess execution.
@@ -263,9 +269,7 @@ class AppManager:
                 if self.current_app is not None:
                     if returncode == 0:
                         self.current_app.status.state = AppState.DONE
-                        self.logger.getChild("runner").info(
-                            f"App {app_name} finished"
-                        )
+                        self.logger.getChild("runner").info(f"App {app_name} finished")
                     else:
                         self.current_app.status.state = AppState.ERROR
                         error_msg = "\n".join(stderr_lines[-10:])  # Last 10 lines

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -380,6 +380,12 @@ class Backend:
         # wakes (however the wake was triggered: on-start, button, or REST).
         self._on_wake_up_callback: Optional[Callable[[], None]] = None
 
+        # In-flight "return to a clean idle state" task, scheduled by
+        # request_idle_reset() when the managed app slot becomes free. Kept so a
+        # fast reconnect (or a local app grabbing the robot) can cancel it
+        # instead of letting a stale goto_sleep fight the new session.
+        self._idle_reset_task: Optional["asyncio.Task[None]"] = None
+
     # Life cycle methods
     def wrapped_run(self) -> None:
         """Run the backend in a try-except block to store errors."""
@@ -2406,6 +2412,11 @@ class Backend:
         self._jsonrpc_handler = handler
 
     def _handle_webrtc_message(self, peer_id: str, message: str) -> None:
+        # A fresh command means someone owns the robot again: cancel any pending
+        # idle-reset goto_sleep so it doesn't fight the new session. Runs on the
+        # same loop as the task, so the cancel is race-free.
+        self._cancel_idle_reset()
+
         def send(resp: dict[str, Any]) -> None:
             self._send_webrtc_response(peer_id, resp)
 
@@ -2435,3 +2446,72 @@ class Backend:
     def _send_webrtc_response(self, peer_id: str, response: dict[str, Any]) -> None:
         if self._send_message_to_webrtc:
             self._send_message_to_webrtc(peer_id, json.dumps(response))
+
+    # ------------------------------------------------------------------
+    # Idle reset (clean state when no managed app owns the robot)
+    # ------------------------------------------------------------------
+
+    def request_idle_reset(self) -> None:
+        """Return the robot to a clean idle state when no managed app owns it.
+
+        Called by the daemon when the shared ``RobotAppLock`` transitions to
+        ``free`` (a remote WebRTC session ended or dropped, or a local app
+        exited). The daemon never resets motor state on session teardown, and
+        clients are not guaranteed to run a clean leave sequence: a crash, a
+        buggy app, or a lost Wi-Fi link all skip it. Without this, whatever
+        motor mode the last app left behind - notably ``gravity_compensation`` -
+        survives into the next session, where the client's ``ensureAwake()``
+        sees ``isAwake() == true`` and skips the wake animation, leaving the
+        robot parked in a weird state.
+
+        Threadsafe and non-blocking: hops onto the backend's own event loop (the
+        one that also handles data-channel commands) and returns immediately.
+        No-op when that loop isn't up yet (e.g. ``--no-media`` daemons, which
+        have no remote sessions anyway).
+        """
+        loop = getattr(self, "_log_loop", None)
+        if loop is None:
+            return
+        loop.call_soon_threadsafe(self._maybe_start_idle_reset)
+
+    def _cancel_idle_reset(self) -> None:
+        """Cancel an in-flight idle reset. Must run on the backend loop."""
+        task = self._idle_reset_task
+        if task is not None and not task.done():
+            task.cancel()
+        self._idle_reset_task = None
+
+    def _maybe_start_idle_reset(self) -> None:
+        """Kick off a goto_sleep if the robot is still awake. Runs on the loop."""
+        try:
+            if not self.ready.is_set() or self.is_shutting_down:
+                return
+            # Already limp / asleep: a well-behaved client (e.g. the mobile app,
+            # which sleeps + disables on leave) leaves nothing to do, so we skip
+            # the redundant trajectory + sound.
+            if self.get_motor_control_mode() == MotorControlMode.Disabled:
+                return
+            self._cancel_idle_reset()
+            self._idle_reset_task = asyncio.create_task(self._async_idle_reset())
+        except Exception:
+            self.logger.warning("Idle reset scheduling failed", exc_info=True)
+
+    async def _async_idle_reset(self) -> None:
+        """Graceful return to the sleep pose, which ends with motors disabled.
+
+        Mirrors the reference leave behaviour clients already run by hand
+        (gotoSleep -> motors off). ``goto_sleep()`` finishes with
+        ``set_motor_control_mode(Disabled)``, which also clears
+        ``gravity_compensation_mode`` - so the next session's ``ensureAwake()``
+        correctly triggers a fresh wake.
+        """
+        try:
+            await self.goto_sleep()
+        except asyncio.CancelledError:
+            # A new session (or local app) grabbed the robot mid-reset: let it
+            # take over without noise.
+            raise
+        except Exception:
+            self.logger.warning("Idle reset goto_sleep failed", exc_info=True)
+        finally:
+            self._idle_reset_task = None

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -2451,6 +2451,14 @@ class Backend:
     # Idle reset (clean state when no managed app owns the robot)
     # ------------------------------------------------------------------
 
+    # Grace period before an idle reset actually moves the robot. A transient
+    # drop (Wi-Fi blip, fast session hand-off, quick app switch) frees the lock
+    # and immediately reschedules a new owner; waiting this long before starting
+    # goto_sleep lets that reconnect cancel the reset *before* any motion, so we
+    # don't start a trajectory only to yank it mid-flight and leave the robot in
+    # an intermediate pose.
+    IDLE_RESET_DEBOUNCE_S: float = 1.5
+
     def request_idle_reset(self) -> None:
         """Return the robot to a clean idle state when no managed app owns it.
 
@@ -2473,6 +2481,20 @@ class Backend:
         if loop is None:
             return
         loop.call_soon_threadsafe(self._maybe_start_idle_reset)
+
+    def cancel_idle_reset(self) -> None:
+        """Cancel a pending/in-flight idle reset from any thread.
+
+        Called when a new owner grabs the robot from a path that doesn't go
+        through the data channel - notably a local Python app acquiring the app
+        slot (``AppManager.start_app``) - so the daemon's teardown goto_sleep
+        doesn't fight the app's own wake/motion. Threadsafe: hops onto the
+        backend loop that owns the reset task. No-op when that loop isn't up yet.
+        """
+        loop = getattr(self, "_log_loop", None)
+        if loop is None:
+            return
+        loop.call_soon_threadsafe(self._cancel_idle_reset)
 
     def _cancel_idle_reset(self) -> None:
         """Cancel an in-flight idle reset. Must run on the backend loop."""
@@ -2499,6 +2521,11 @@ class Backend:
     async def _async_idle_reset(self) -> None:
         """Graceful return to the sleep pose, which ends with motors disabled.
 
+        Starts with a short debounce (``IDLE_RESET_DEBOUNCE_S``): a fast
+        reconnect or a local app grabbing the robot cancels the task during that
+        window, so no motion happens at all on transient drops. Only if the slot
+        stays free past the grace period do we actually goto_sleep.
+
         Mirrors the reference leave behaviour clients already run by hand
         (gotoSleep -> motors off). ``goto_sleep()`` finishes with
         ``set_motor_control_mode(Disabled)``, which also clears
@@ -2506,12 +2533,25 @@ class Backend:
         correctly triggers a fresh wake.
         """
         try:
+            await asyncio.sleep(self.IDLE_RESET_DEBOUNCE_S)
+            # Conditions may have changed during the grace period (shutdown
+            # started, or the robot was already put to sleep by whoever briefly
+            # held the slot). Re-check before committing to the trajectory.
+            if self.is_shutting_down:
+                return
+            if self.get_motor_control_mode() == MotorControlMode.Disabled:
+                return
             await self.goto_sleep()
         except asyncio.CancelledError:
-            # A new session (or local app) grabbed the robot mid-reset: let it
-            # take over without noise.
+            # A new session (or local app) grabbed the robot before/mid-reset:
+            # let it take over without noise.
             raise
         except Exception:
             self.logger.warning("Idle reset goto_sleep failed", exc_info=True)
         finally:
-            self._idle_reset_task = None
+            # Only clear the handle if it still points at *this* task: a
+            # concurrent _cancel_idle_reset()+reschedule may have already
+            # installed a newer task, and blindly nulling would orphan it
+            # (a later cancel would then miss it).
+            if self._idle_reset_task is asyncio.current_task():
+                self._idle_reset_task = None

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -250,6 +250,25 @@ class Daemon:
         except Exception as e:
             self.logger.debug(f"Error stopping central signaling relay: {e}")
 
+    def _on_robot_slot_free(self) -> None:
+        """Return the robot to a clean idle state when the app slot frees.
+
+        Wired into ``robot_app_lock`` so that when a remote session ends/drops
+        or a local app exits, the daemon - not the client - guarantees the robot
+        doesn't stay parked awake (enabled / gravity_compensation) across
+        sessions. Best-effort, non-blocking; the actual work is scheduled
+        threadsafely on the backend's loop. Fires on both graceful and abnormal
+        teardown (crash, killed tab, lost Wi-Fi), which is the whole point:
+        those paths run no client-side cleanup.
+        """
+        backend = self.backend
+        if backend is None:
+            return
+        try:
+            backend.request_idle_reset()
+        except Exception as e:
+            self.logger.warning(f"Idle reset request failed: {e}")
+
     async def start(
         self,
         sim: bool = False,
@@ -379,6 +398,13 @@ class Daemon:
                 # Start central signaling relay for remote WebRTC access
                 await self._start_central_signaling_relay()
 
+            # Reset the robot to a clean idle state whenever the managed app
+            # slot becomes free (remote session end/drop or local app exit), so
+            # no client can leave it parked awake across sessions. Registered
+            # after the backend loop is up (setup_media_server) so
+            # `request_idle_reset()` has a loop to hop onto.
+            self.robot_app_lock.set_on_became_free_handler(self._on_robot_slot_free)
+
             # Wire the wake-up hook before any wake can fire (on-start below, or
             # later via button/REST on the wireless unit, which boots asleep).
             if on_wake_up_callback is not None:
@@ -448,6 +474,12 @@ class Daemon:
             self._status.state = DaemonState.STOPPING
             self.backend.is_shutting_down = True
             self._thread_event_publish_status.set()
+
+            # Unwire the idle-reset hook before tearing down the relay: stopping
+            # the relay releases the remote hold on `robot_app_lock`, which would
+            # otherwise fire `_on_robot_slot_free` and race the explicit
+            # goto_sleep below with a second one.
+            self.robot_app_lock.set_on_became_free_handler(None)
 
             # Close the JSON-RPC app relay (drops the app /rpc connection and
             # fails any in-flight calls) before tearing the backend down.
@@ -672,7 +704,9 @@ class Daemon:
 
         backend = self.backend
 
-        def _broadcast(status: str, *, line: str | None = None, error: str | None = None) -> None:
+        def _broadcast(
+            status: str, *, line: str | None = None, error: str | None = None
+        ) -> None:
             if backend is None:
                 return
             payload: dict[str, Any] = {"type": "update_progress", "status": status}

--- a/src/reachy_mini/daemon/robot_app_lock.py
+++ b/src/reachy_mini/daemon/robot_app_lock.py
@@ -84,6 +84,14 @@ class RobotAppLock:
         # different thread, add a mutex here.
         self._on_remote_evicted: Optional[Callable[[], Awaitable[None]]] = None
 
+        # Synchronous callback invoked whenever the slot transitions to FREE
+        # (a remote session ended / disconnected, or a local app exited).
+        # Registered by the daemon to reset the robot to a clean idle state so
+        # no app leaves it parked awake (enabled / gravity_compensation) across
+        # sessions. Called *outside* the mutex, must return promptly and MUST
+        # NOT re-enter the lock (would deadlock).
+        self._on_became_free: Optional[Callable[[], None]] = None
+
     # ------------------------------------------------------------------
     # Registration
     # ------------------------------------------------------------------
@@ -98,6 +106,26 @@ class RobotAppLock:
         Pass ``None`` to clear.
         """
         self._on_remote_evicted = handler
+
+    def set_on_became_free_handler(self, handler: Optional[Callable[[], None]]) -> None:
+        """Register (or clear) the callback fired when the slot becomes FREE.
+
+        Fired once per FREE transition, from either ``release_local`` or
+        ``release_remote``, *after* the internal mutex is released. The handler
+        must return promptly and must not call back into this lock. Pass
+        ``None`` to clear.
+        """
+        self._on_became_free = handler
+
+    def _fire_became_free(self) -> None:
+        """Invoke the FREE-transition handler outside the mutex. Best-effort."""
+        handler = self._on_became_free
+        if handler is None:
+            return
+        try:
+            handler()
+        except Exception:
+            logger.warning("RobotAppLock: on_became_free handler raised", exc_info=True)
 
     # ------------------------------------------------------------------
     # Introspection
@@ -238,6 +266,8 @@ class RobotAppLock:
             self._holder_name = None
             logger.info("RobotAppLock: released by local app %r", released_name)
 
+        self._fire_became_free()
+
     # ------------------------------------------------------------------
     # Remote acquire / release
     # ------------------------------------------------------------------
@@ -279,3 +309,5 @@ class RobotAppLock:
             self._state = RobotAppLockState.FREE
             self._holder_name = None
             logger.info("RobotAppLock: released by remote session %r", released_name)
+
+        self._fire_became_free()

--- a/tests/unit_tests/test_backend_idle_reset.py
+++ b/tests/unit_tests/test_backend_idle_reset.py
@@ -1,0 +1,100 @@
+"""Backend idle-reset behaviour: debounce, post-grace skip, and the
+finally-guard that must not orphan a freshly rescheduled task.
+
+The idle-reset methods live on the abstract ``Backend`` and only touch a
+handful of ``self`` attributes, so we exercise them as unbound methods against
+a lightweight fake ``self`` (same approach as ``test_app_stop_sleep``) instead
+of standing up a full backend.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from reachy_mini.daemon.backend.abstract import Backend
+from reachy_mini.io.protocol import MotorControlMode
+
+
+def _fake_backend(
+    *,
+    motor_mode: MotorControlMode = MotorControlMode.Enabled,
+    shutting_down: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        IDLE_RESET_DEBOUNCE_S=0.02,
+        is_shutting_down=shutting_down,
+        get_motor_control_mode=lambda: motor_mode,
+        goto_sleep=AsyncMock(),
+        logger=SimpleNamespace(warning=lambda *a, **k: None),
+        _idle_reset_task=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_idle_reset_sleeps_after_debounce() -> None:
+    """When the slot stays free past the grace period, goto_sleep runs."""
+    fake = _fake_backend()
+    task = asyncio.ensure_future(Backend._async_idle_reset(fake))
+    fake._idle_reset_task = task
+    await task
+    fake.goto_sleep.assert_awaited_once()
+    assert fake._idle_reset_task is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_debounce_skips_motion() -> None:
+    """A reconnect within the grace period cancels the reset before any motion."""
+    fake = _fake_backend()
+    task = asyncio.ensure_future(Backend._async_idle_reset(fake))
+    fake._idle_reset_task = task
+    await asyncio.sleep(0)  # let the task reach the debounce sleep
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    fake.goto_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_idle_reset_skips_when_already_disabled() -> None:
+    """Re-check after the grace period: skip goto_sleep if already limp."""
+    fake = _fake_backend(motor_mode=MotorControlMode.Disabled)
+    task = asyncio.ensure_future(Backend._async_idle_reset(fake))
+    fake._idle_reset_task = task
+    await task
+    fake.goto_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_idle_reset_skips_when_shutting_down() -> None:
+    """Re-check after the grace period: skip goto_sleep if shutdown started."""
+    fake = _fake_backend(shutting_down=True)
+    task = asyncio.ensure_future(Backend._async_idle_reset(fake))
+    fake._idle_reset_task = task
+    await task
+    fake.goto_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_finally_does_not_clobber_newer_task() -> None:
+    """A cancelled task's finally must not orphan a freshly rescheduled one.
+
+    Regression guard: without the ``is current_task()`` check, the old task's
+    ``finally`` would blindly null ``_idle_reset_task``, so a later
+    ``_cancel_idle_reset`` would miss the newer in-flight goto_sleep.
+    """
+    fake = _fake_backend()
+    task_a = asyncio.ensure_future(Backend._async_idle_reset(fake))
+    fake._idle_reset_task = task_a
+    await asyncio.sleep(0)  # let task_a reach the debounce sleep
+
+    # Simulate _cancel_idle_reset() + reschedule installing a newer handle.
+    task_a.cancel()
+    sentinel = object()
+    fake._idle_reset_task = sentinel
+
+    with pytest.raises(asyncio.CancelledError):
+        await task_a
+
+    assert fake._idle_reset_task is sentinel

--- a/tests/unit_tests/test_robot_app_lock.py
+++ b/tests/unit_tests/test_robot_app_lock.py
@@ -18,7 +18,6 @@ import pytest
 
 from reachy_mini.daemon.robot_app_lock import RobotAppLock, RobotAppLockState
 
-
 # ---------------------------------------------------------------------------
 # Starting state
 # ---------------------------------------------------------------------------
@@ -300,3 +299,96 @@ def test_keep_remote_acquire_raises_if_local_held() -> None:
     lock.acquire_local_keeping_remote("a")
     with pytest.raises(RuntimeError):
         lock.acquire_local_keeping_remote("b")
+
+
+# ---------------------------------------------------------------------------
+# Became-free handler: daemon-side idle reset trigger
+# ---------------------------------------------------------------------------
+
+
+def test_became_free_handler_fires_on_remote_release() -> None:
+    """Releasing a remote session fires the FREE-transition handler once."""
+    lock = RobotAppLock()
+    calls: list[str] = []
+    lock.set_on_became_free_handler(lambda: calls.append("free"))
+
+    assert lock.try_acquire_remote("client1") is True
+    assert calls == []  # acquiring must not fire it
+    lock.release_remote()
+    assert calls == ["free"]
+
+
+def test_became_free_handler_fires_on_local_release() -> None:
+    """Releasing a local app fires the FREE-transition handler once."""
+    lock = RobotAppLock()
+    calls: list[str] = []
+    lock.set_on_became_free_handler(lambda: calls.append("free"))
+
+    assert lock.try_acquire_local("app_a") is True
+    lock.release_local("app_a")
+    assert calls == ["free"]
+
+
+def test_became_free_handler_sees_free_state() -> None:
+    """When the handler runs, the lock is already FREE (post-transition)."""
+    lock = RobotAppLock()
+    seen: list[RobotAppLockState] = []
+    lock.set_on_became_free_handler(lambda: seen.append(lock.status().state))
+
+    lock.try_acquire_remote("client1")
+    lock.release_remote()
+    assert seen == [RobotAppLockState.FREE]
+
+
+def test_became_free_handler_not_fired_on_noop_release() -> None:
+    """A release that doesn't actually free the slot must not fire the handler."""
+    lock = RobotAppLock()
+    calls: list[str] = []
+    lock.set_on_became_free_handler(lambda: calls.append("free"))
+
+    # No hold at all: release is a no-op.
+    lock.release_remote()
+    lock.release_local("nobody")
+    assert calls == []
+
+    # Remote held, but release_local must not free it.
+    lock.try_acquire_remote("client1")
+    lock.release_local("some_app")
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_became_free_handler_not_fired_on_eviction() -> None:
+    """Evicting a remote for a local app goes REMOTE→LOCAL, never through FREE."""
+    lock = RobotAppLock()
+    calls: list[str] = []
+    lock.set_on_became_free_handler(lambda: calls.append("free"))
+
+    assert lock.try_acquire_remote("client1") is True
+    await lock.acquire_local_evicting_remote("app_a")
+    assert calls == []
+
+
+def test_became_free_handler_exception_is_swallowed() -> None:
+    """A raising FREE handler must not break the release path."""
+    lock = RobotAppLock()
+
+    def handler() -> None:
+        raise RuntimeError("boom")
+
+    lock.set_on_became_free_handler(handler)
+    lock.try_acquire_remote("client1")
+    lock.release_remote()  # must not raise
+    assert lock.status().state == RobotAppLockState.FREE
+
+
+def test_clearing_became_free_handler_disables_it() -> None:
+    """Passing ``None`` clears the FREE-transition handler."""
+    lock = RobotAppLock()
+    calls: list[str] = []
+    lock.set_on_became_free_handler(lambda: calls.append("free"))
+    lock.set_on_became_free_handler(None)
+
+    lock.try_acquire_remote("client1")
+    lock.release_remote()
+    assert calls == []


### PR DESCRIPTION
Extracted from #1286 as a standalone, self-contained correctness fix (part of splitting that PR into reviewable pieces — see the scope discussion there).

## What

When the shared `RobotAppLock` transitions to **FREE** — a remote WebRTC session ended/dropped, or a local Python app exited — the daemon now returns the robot to a clean idle state via `goto_sleep` (which ends with motors disabled, clearing `gravity_compensation`).

## Why

The daemon never reset motor state on session teardown, and clients aren't guaranteed to run a clean leave sequence: a crash, a buggy app, or a lost Wi-Fi link all skip it. Without this, whatever motor mode the last app left behind — notably `gravity_compensation` — survives into the next session, where the client's `ensureAwake()` sees `isAwake() == true`, skips the wake animation, and leaves the robot parked in a weird state.

Firing on **both graceful and abnormal teardown** is the whole point: those paths run no client-side cleanup.

## How

- `RobotAppLock` gains a `set_on_became_free_handler` hook, fired once per FREE transition (from `release_local`/`release_remote`), outside the mutex.
- The daemon wires `_on_robot_slot_free` → `backend.request_idle_reset()`, scheduled threadsafely on the backend loop.
- The reset is **cancelled** when a fresh command grabs the robot again (`_handle_webrtc_message`), and **skipped** when the robot is already limp (motors disabled).
- Unwired in `stop()` before the relay is torn down, so releasing the remote hold can't race the explicit shutdown `goto_sleep` with a second one.

## Tests

`tests/unit_tests/test_robot_app_lock.py` covers the became-free handler: fires on local/remote release, sees FREE state, not fired on no-op release or on eviction (REMOTE→LOCAL never passes through FREE), exception-swallowing, and clearing.

## Notes

- Purely additive to `main`; no behavior change for the existing lock callers.
- `--no-media` daemons have no backend loop and no remote sessions, so `request_idle_reset()` is a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
