### PR TITLE
feat(daemon): live pose stream over an unreliable data channel

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -72,7 +72,9 @@ from reachy_mini.io.protocol import (
     StartUpdateCmd,
     StopRecordingCmd,
     SubscribeLogsCmd,
+    SubscribePoseCmd,
     UnsubscribeLogsCmd,
+    UnsubscribePoseCmd,
     UploadAudioChunkCmd,
     UploadAudioFinishCmd,
     UploadAudioStartCmd,
@@ -349,6 +351,12 @@ class Backend:
         # sends `subscribe_logs`, cancelled on `unsubscribe_logs` or
         # peer disconnect (the latter is wired in setup_media_server).
         self._log_tasks: dict[str, "asyncio.Task[None]"] = {}
+        # Monotonic sequence number stamped on every pushed pose frame so the
+        # client can drop out-of-order/stale frames that arrive on the
+        # unordered `pose` data channel (see `build_state_json`). Bumped only
+        # from the media server's GLib thread (single writer), so a plain int
+        # is safe.
+        self._pose_seq = 0
         # Asyncio loop on which the log-streaming tasks run. Captured
         # in setup_media_server alongside the WebRTC handler loop, so
         # cross-thread cleanup (peer disconnect fires from gstreamer's
@@ -1277,6 +1285,59 @@ class Backend:
         }
 
     # ------------------------------------------------------------------
+    # State snapshot (shared by get_state replies and the pose push)
+    # ------------------------------------------------------------------
+
+    def build_state_dict(self) -> dict[str, Any]:
+        """Build the present-state snapshot sent to clients.
+
+        Single source of truth for both the polled ``get_state`` reply and
+        the pushed pose stream (see :meth:`build_state_json`). All getters
+        read cached motor values (``get_last_position``), so this is cheap
+        and safe to call from a thread other than the motor loop.
+        """
+        return {
+            "head_pose": self.get_present_head_pose().tolist()
+            if self.current_head_pose is not None
+            else None,
+            "antennas": self.get_present_antenna_joint_positions().tolist()
+            if self.current_antenna_joint_positions is not None
+            else None,
+            # Per-motor joint positions (7 head incl. body yaw at [0], 2
+            # antennas), so WebRTC clients can check the physical pose motor
+            # by motor without the LAN /ws/sdk stream.
+            "head_joint_positions": self.get_present_head_joint_positions().tolist()
+            if self.current_head_joint_positions is not None
+            else None,
+            "antennas_joint_positions": self.get_present_antenna_joint_positions().tolist()
+            if self.current_antenna_joint_positions is not None
+            else None,
+            "body_yaw": self.get_present_body_yaw(),
+            "motor_mode": self.get_motor_control_mode().value,
+            "is_recording": self.is_recording,
+            "is_move_running": self.is_move_running,
+            "face_target": self.get_tracked_face().model_dump(),
+        }
+
+    def build_state_json(self) -> Optional[str]:
+        """Serialize the present state as the client-facing envelope.
+
+        Returns the ``{"state": ...}`` payload, or ``None`` if it can't be
+        built yet. Wired into the media server as the pose-stream provider
+        (``set_pose_provider``) so the daemon can *push* pose over the
+        unreliable/unordered ``pose`` data channel at a steady rate instead
+        of the client round-tripping ``get_state`` over Wi-Fi. Returning
+        ``None`` (e.g. before the first kinematics update, or during
+        shutdown) simply skips that tick.
+        """
+        try:
+            state = self.build_state_dict()
+        except Exception:
+            return None
+        self._pose_seq += 1
+        return json.dumps({"state": state, "seq": self._pose_seq})
+
+    # ------------------------------------------------------------------
     # Transport-agnostic command processing
     # ------------------------------------------------------------------
 
@@ -1447,20 +1508,7 @@ class Backend:
             send_response({"status": "ok", "command": "set_automatic_body_yaw"})
 
         elif isinstance(cmd, GetStateCmd):
-            state = {
-                "head_pose": self.get_present_head_pose().tolist()
-                if self.current_head_pose is not None
-                else None,
-                "antennas": self.get_present_antenna_joint_positions().tolist()
-                if self.current_antenna_joint_positions is not None
-                else None,
-                "body_yaw": self.get_present_body_yaw(),
-                "motor_mode": self.get_motor_control_mode().value,
-                "is_recording": self.is_recording,
-                "is_move_running": self.is_move_running,
-                "face_target": self.get_tracked_face().model_dump(),
-            }
-            send_response({"state": state})
+            send_response({"state": self.build_state_dict()})
 
         elif isinstance(cmd, GetVersionCmd):
             from importlib.metadata import version
@@ -1599,6 +1647,13 @@ class Backend:
             self._start_log_subscription(peer_id, send_response)
         elif isinstance(cmd, UnsubscribeLogsCmd):
             self._cancel_log_subscription(peer_id)
+
+        elif isinstance(cmd, SubscribePoseCmd):
+            self._set_pose_subscription(peer_id, True)
+            send_response({"status": "ok", "command": "subscribe_pose"})
+        elif isinstance(cmd, UnsubscribePoseCmd):
+            self._set_pose_subscription(peer_id, False)
+            send_response({"status": "ok", "command": "unsubscribe_pose"})
 
         elif isinstance(cmd, RestartDaemonCmd):
             # Ack BEFORE triggering the restart: the WebRTC transport
@@ -2063,6 +2118,18 @@ class Backend:
         if task is not None and not task.done():
             task.cancel()
 
+    def _set_pose_subscription(self, peer_id: Optional[str], enabled: bool) -> None:
+        """Enable/disable the pushed pose stream for a peer.
+
+        Delegated to the media server, which owns the per-peer ``pose`` data
+        channels and the push timer. No-op without a peer id (non-multiplexed
+        transports) or on an older media server lacking the hook.
+        """
+        if peer_id is None or self._media_server is None:
+            return
+        if hasattr(self._media_server, "set_pose_subscription"):
+            self._media_server.set_pose_subscription(peer_id, enabled)
+
     def _on_peer_disconnect(self, peer_id: str) -> None:
         """Cancel any per-peer state when the WebRTC peer goes away.
 
@@ -2398,6 +2465,13 @@ class Backend:
         if hasattr(media_server, "set_peer_disconnect_handler"):
             media_server.set_peer_disconnect_handler(self._on_peer_disconnect)
         self._send_message_to_webrtc = media_server.send_data_message
+        # Feed the media server the present-state snapshot so it can *push*
+        # pose over the unreliable/unordered `pose` data channel at a steady
+        # rate (immune to Wi-Fi jitter), instead of the client polling
+        # `get_state` on the reliable-ordered channel. No-op on older media
+        # servers that don't expose the hook (falls back to polling).
+        if hasattr(media_server, "set_pose_provider"):
+            media_server.set_pose_provider(self.build_state_json)
 
     def set_jsonrpc_handler(
         self, handler: Callable[[str, Callable[[dict[str, Any]], None]], None]

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -52,6 +52,7 @@ from reachy_mini.io.protocol import (
     PlaySoundCmd,
     PlayUploadedAudioCmd,
     PlayUploadedMoveCmd,
+    PoseFrame,
     ReadAudioParameterCmd,
     RecordedDataMsg,
     RestartDaemonCmd,
@@ -73,6 +74,7 @@ from reachy_mini.io.protocol import (
     SetWobblingCmd,
     StartRecordingCmd,
     StartUpdateCmd,
+    StateSnapshot,
     StopRecordingCmd,
     SubscribeLogsCmd,
     SubscribePoseCmd,
@@ -1302,7 +1304,7 @@ class Backend:
     # State snapshot (shared by get_state replies and the pose push)
     # ------------------------------------------------------------------
 
-    def build_state_dict(self) -> dict[str, Any]:
+    def build_state_snapshot(self) -> StateSnapshot:
         """Build the present-state snapshot sent to clients.
 
         Single source of truth for both the polled ``get_state`` reply and
@@ -1310,46 +1312,52 @@ class Backend:
         read cached motor values (``get_last_position``), so this is cheap
         and safe to call from a thread other than the motor loop.
         """
-        return {
-            "head_pose": self.get_present_head_pose().tolist()
+        return StateSnapshot(
+            head_pose=self.get_present_head_pose().tolist()
             if self.current_head_pose is not None
             else None,
-            "antennas": self.get_present_antenna_joint_positions().tolist()
+            antennas=self.get_present_antenna_joint_positions().tolist()
             if self.current_antenna_joint_positions is not None
             else None,
-            # Per-motor joint positions (7 head incl. body yaw at [0], 2
-            # antennas), so WebRTC clients can check the physical pose motor
-            # by motor without the LAN /ws/sdk stream.
-            "head_joint_positions": self.get_present_head_joint_positions().tolist()
+            # Per-motor head values (7, body yaw at [0]) so WebRTC clients
+            # can check the physical pose motor by motor without the LAN
+            # /ws/sdk stream. The antennas need no twin field: `antennas`
+            # already is the two motor values.
+            head_joint_positions=self.get_present_head_joint_positions().tolist()
             if self.current_head_joint_positions is not None
             else None,
-            "antennas_joint_positions": self.get_present_antenna_joint_positions().tolist()
-            if self.current_antenna_joint_positions is not None
-            else None,
-            "body_yaw": self.get_present_body_yaw(),
-            "motor_mode": self.get_motor_control_mode().value,
-            "is_recording": self.is_recording,
-            "is_move_running": self.is_move_running,
-            "face_target": self.get_tracked_face().model_dump(),
-        }
+            body_yaw=self.get_present_body_yaw(),
+            motor_mode=self.get_motor_control_mode(),
+            is_recording=self.is_recording,
+            is_move_running=self.is_move_running,
+            face_target=self.get_tracked_face(),
+        )
+
+    def build_state_dict(self) -> dict[str, Any]:
+        """JSON-safe dict view of :meth:`build_state_snapshot`.
+
+        Used by the ``get_state`` reply, whose envelope is assembled by the
+        transport as a plain dict.
+        """
+        return self.build_state_snapshot().model_dump(mode="json")
 
     def build_state_json(self) -> Optional[str]:
         """Serialize the present state as the client-facing envelope.
 
-        Returns the ``{"state": ...}`` payload, or ``None`` if it can't be
-        built yet. Wired into the media server as the pose-stream provider
-        (``set_pose_provider``) so the daemon can *push* pose over the
-        unreliable/unordered ``pose`` data channel at a steady rate instead
-        of the client round-tripping ``get_state`` over Wi-Fi. Returning
-        ``None`` (e.g. before the first kinematics update, or during
-        shutdown) simply skips that tick.
+        Returns the ``{"state": ..., "seq": ...}`` payload, or ``None`` if
+        it can't be built yet. Wired into the media server as the
+        pose-stream provider (``set_pose_provider``) so the daemon can
+        *push* pose over the unreliable/unordered ``pose`` data channel at
+        a steady rate instead of the client round-tripping ``get_state``
+        over Wi-Fi. Returning ``None`` (e.g. before the first kinematics
+        update, or during shutdown) simply skips that tick.
         """
         try:
-            state = self.build_state_dict()
+            snapshot = self.build_state_snapshot()
         except Exception:
             return None
         self._pose_seq += 1
-        return json.dumps({"state": state, "seq": self._pose_seq})
+        return PoseFrame(state=snapshot, seq=self._pose_seq).model_dump_json()
 
     # ------------------------------------------------------------------
     # Transport-agnostic command processing

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -8,7 +8,8 @@ Client->Server command types:
     set_motor_mode, set_torque, get_motor_mode,
     set_gravity_compensation, set_automatic_body_yaw,
     get_state, get_version, start_recording, stop_recording, append_record,
-    subscribe_logs, unsubscribe_logs, restart_daemon, start_update,
+    subscribe_logs, unsubscribe_logs, subscribe_pose, unsubscribe_pose,
+    restart_daemon, start_update,
     upload_move_start, upload_move_chunk, upload_move_finish,
     upload_audio_start, upload_audio_chunk, upload_audio_finish,
     play_uploaded_move, cancel_move,
@@ -349,6 +350,26 @@ class UnsubscribeLogsCmd(BaseModel):
     """Stop the calling peer's log subscription. No-op if no stream."""
 
     type: Literal["unsubscribe_logs"] = "unsubscribe_logs"
+
+
+class SubscribePoseCmd(BaseModel):
+    """Subscribe the calling peer to the pushed pose stream.
+
+    While subscribed, the daemon pushes the robot's present state (same
+    envelope as ``get_state``, plus a monotonic ``seq``) to this peer over
+    the dedicated unreliable/unordered ``pose`` data channel at ~30 Hz. This
+    replaces polling ``get_state`` for a live mirror: pushing is immune to
+    the Wi-Fi round-trip latency and head-of-line blocking that make polling
+    lag. Idempotent - safe to send again on reconnect.
+    """
+
+    type: Literal["subscribe_pose"] = "subscribe_pose"
+
+
+class UnsubscribePoseCmd(BaseModel):
+    """Stop the calling peer's pose stream. No-op if not subscribed."""
+
+    type: Literal["unsubscribe_pose"] = "unsubscribe_pose"
 
 
 # XVF3800 audio-board configuration over the DataChannel.
@@ -755,6 +776,8 @@ AnyCommand = Annotated[
     | GetMicrophoneVolumeCmd
     | SubscribeLogsCmd
     | UnsubscribeLogsCmd
+    | SubscribePoseCmd
+    | UnsubscribePoseCmd
     | RestartDaemonCmd
     | StartUpdateCmd
     | UploadMoveStartCmd

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -97,6 +97,41 @@ class FaceTarget(BaseModel):
     ts: float | None = None
 
 
+class StateSnapshot(BaseModel):
+    """Present-state snapshot sent to WebRTC clients.
+
+    Payload of both the polled ``get_state`` reply (``{"state": ...}``)
+    and the pushed pose-stream frames (see :class:`PoseFrame`). The field
+    names are the wire contract already parsed by released JS SDKs —
+    keep them stable.
+
+    ``head_joint_positions`` carries the 7 per-motor head values (body
+    yaw at index 0), which is genuinely distinct from the ``head_pose``
+    matrix; the antennas need no such twin since ``antennas`` already IS
+    the two motor values.
+    """
+
+    head_pose: Optional[list[list[float]]] = None
+    antennas: Optional[list[float]] = None
+    head_joint_positions: Optional[list[float]] = None
+    body_yaw: float
+    motor_mode: MotorControlMode
+    is_recording: bool
+    is_move_running: bool
+    face_target: FaceTarget
+
+
+class PoseFrame(BaseModel):
+    """One pushed pose-stream frame.
+
+    The state snapshot plus a monotonic ``seq`` so clients can drop
+    stale/out-of-order frames on the unordered ``pose`` channel.
+    """
+
+    state: StateSnapshot
+    seq: int
+
+
 class DaemonStatus(BaseModel):
     """Status of the Reachy Mini daemon."""
 

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -154,6 +154,13 @@ class GstMediaServer:
     # end-to-end latency is the metric we watch closest.
     RX_JITTER_LATENCY_MS = 300
 
+    # Pose push cadence (ms) over the unreliable/unordered `pose` data
+    # channel. ~30 Hz gives the 3D mirror fresh targets to interpolate
+    # without flooding the SCTP send queue; because the channel drops
+    # (max-retransmits=0) rather than retransmits, a lost frame is simply
+    # superseded by the next one 33 ms later instead of stalling the stream.
+    POSE_PUSH_INTERVAL_MS = 33
+
     # Send-side Opus loss resilience for the robot mic -> phone leg (the
     # audio that feeds the realtime backend / STT). webrtcsink builds the
     # opusenc with defaults (inband-fec off, packet-loss-percentage 0), so
@@ -220,6 +227,19 @@ class GstMediaServer:
 
         self._data_channels: dict[str, Gst.Element] = {}  # peer_id -> channel
         self._on_data_message: Optional[Callable[[str, str], None]] = None
+        # Second, unreliable/unordered data channel per peer used to *push*
+        # the robot pose at a steady rate (see `_setup_pose_channel` /
+        # `_push_pose`). Kept separate from `_data_channels` so a stale pose
+        # frame is never head-of-line-blocking a reliable control message.
+        self._pose_channels: dict[str, Gst.Element] = {}  # peer_id -> channel
+        # Peers that have opted into the pose stream via `subscribe_pose`. We
+        # only build+push a frame while this set is non-empty, so an idle
+        # session (no 3D mirror on screen) costs nothing.
+        self._pose_subscribers: set[str] = set()
+        # Callback returning the JSON pose frame to push (set by the backend
+        # via `set_pose_provider`), and the GLib source id of the push timer.
+        self._pose_provider: Optional[Callable[[], Optional[str]]] = None
+        self._pose_push_source_id: Optional[int] = None
         # Optional callback fired on the GStreamer thread when a peer
         # leaves; used by the backend to free per-peer resources such
         # as the journalctl subprocess for a `subscribe_logs` stream.
@@ -270,6 +290,9 @@ class GstMediaServer:
     def close(self) -> None:
         """Release GStreamer resources (MainLoop, bus watch)."""
         self._logger.debug("Cleaning up GstMediaServer")
+        if self._pose_push_source_id is not None:
+            GLib.source_remove(self._pose_push_source_id)
+            self._pose_push_source_id = None
         self._loop.quit()
         self._bus_sender.remove_watch()
 
@@ -1738,6 +1761,93 @@ class GstMediaServer:
             channel.connect("on-error", self._on_data_channel_error, peer_id)
         else:
             self._logger.error(f"Failed to create data channel for peer {peer_id}")
+
+        # Second channel for the pushed pose stream. Created right after the
+        # control channel (before the SDP offer) so it rides the same SCTP
+        # association; additional data channels are negotiated in-band via
+        # DCEP, so this needs no separate renegotiation.
+        self._setup_pose_channel(peer_id, webrtcbin)
+
+    def set_pose_provider(
+        self, provider: Optional[Callable[[], Optional[str]]]
+    ) -> None:
+        """Register the callback that yields the JSON pose frame to push.
+
+        The backend passes ``build_state_json`` here. The provider is polled
+        on the GLib main loop at :attr:`POSE_PUSH_INTERVAL_MS`; returning
+        ``None`` skips a tick (e.g. before the first kinematics update).
+        """
+        self._pose_provider = provider
+
+    def set_pose_subscription(self, peer_id: str, enabled: bool) -> None:
+        """Add/remove a peer from the pushed pose stream (see `_push_pose`).
+
+        Driven by the backend's `subscribe_pose`/`unsubscribe_pose` handling.
+        Idempotent.
+        """
+        if enabled:
+            self._pose_subscribers.add(peer_id)
+            self._logger.info(f"Pose stream subscribed by peer {peer_id}")
+        else:
+            self._pose_subscribers.discard(peer_id)
+            self._logger.info(f"Pose stream unsubscribed by peer {peer_id}")
+
+    def _setup_pose_channel(self, peer_id: str, webrtcbin: Gst.Element) -> None:
+        # Unreliable + unordered: pose is a "latest value wins" stream, so we
+        # never want a lost frame to be retransmitted (it'd already be stale)
+        # nor to head-of-line-block the frames behind it.
+        options = Gst.Structure.from_string("options,ordered=false,max-retransmits=0")[
+            0
+        ]
+        channel = webrtcbin.emit("create-data-channel", "pose", options)
+        if not channel:
+            self._logger.error(f"Failed to create pose channel for peer {peer_id}")
+            return
+        self._logger.debug(f"Pose channel created for peer {peer_id}")
+        self._pose_channels[peer_id] = channel
+        channel.connect("on-open", self._on_pose_channel_open, peer_id)
+        channel.connect("on-close", self._on_pose_channel_close, peer_id)
+        channel.connect("on-error", self._on_data_channel_error, peer_id)
+        self._ensure_pose_push_started()
+
+    def _ensure_pose_push_started(self) -> None:
+        """Arm the periodic pose-push timer once (idempotent)."""
+        if self._pose_push_source_id is not None:
+            return
+        self._pose_push_source_id = GLib.timeout_add(
+            self.POSE_PUSH_INTERVAL_MS, self._push_pose
+        )
+
+    def _push_pose(self) -> bool:
+        """Broadcast the latest pose frame to every open pose channel.
+
+        Runs on the GLib main loop. Returns ``True`` to stay scheduled;
+        it's a cheap no-op while nobody is subscribed or no provider is set,
+        so we keep it alive for the media server's lifetime rather than
+        churning the timer as peers come and go.
+        """
+        if not self._pose_subscribers or self._pose_provider is None:
+            return True
+        message = self._pose_provider()
+        if message is None:
+            return True
+        for peer_id in list(self._pose_subscribers):
+            channel = self._pose_channels.get(peer_id)
+            if channel is None:
+                continue
+            try:
+                channel.emit("send-string", message)
+            except Exception as e:
+                self._logger.debug(f"Pose push to {peer_id} failed: {e}")
+        return True
+
+    def _on_pose_channel_open(self, channel: Gst.Element, peer_id: str) -> None:
+        self._logger.info(f"Pose channel opened for peer {peer_id}")
+
+    def _on_pose_channel_close(self, channel: Gst.Element, peer_id: str) -> None:
+        self._logger.info(f"Pose channel closed for peer {peer_id}")
+        self._pose_channels.pop(peer_id, None)
+        self._pose_subscribers.discard(peer_id)
 
     def _on_data_channel_open(self, channel: Gst.Element, peer_id: str) -> None:
         self._logger.info(f"Data channel opened for peer {peer_id}")

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -1844,6 +1844,10 @@ class GstMediaServer:
         Runs on the GLib main loop (scheduled by `set_pose_subscription`),
         which also serialises the check-then-create against a second
         subscribe. Returns ``False`` so the idle source fires once.
+
+        A peer we can't open a channel for is dropped from the subscribers:
+        leaving it there would keep the timer armed, building a state frame
+        30 times a second and sending it nowhere until the peer disconnects.
         """
         if peer_id in self._pose_channels:
             return False
@@ -1852,11 +1856,13 @@ class GstMediaServer:
             self._logger.warning(
                 f"No webrtcbin for peer {peer_id}, cannot open pose channel"
             )
+            self._drop_pose_subscription(peer_id)
             return False
-        self._setup_pose_channel(peer_id, webrtcbin)
+        if not self._setup_pose_channel(peer_id, webrtcbin):
+            self._drop_pose_subscription(peer_id)
         return False
 
-    def _setup_pose_channel(self, peer_id: str, webrtcbin: Gst.Element) -> None:
+    def _setup_pose_channel(self, peer_id: str, webrtcbin: Gst.Element) -> bool:
         # Opened mid-session, after the SDP exchange: extra data channels are
         # negotiated in-band via DCEP, so this needs no renegotiation and the
         # client just sees another `ondatachannel`.
@@ -1870,12 +1876,13 @@ class GstMediaServer:
         channel = webrtcbin.emit("create-data-channel", "pose", options)
         if not channel:
             self._logger.error(f"Failed to create pose channel for peer {peer_id}")
-            return
+            return False
         self._logger.debug(f"Pose channel created for peer {peer_id}")
         self._pose_channels[peer_id] = channel
         channel.connect("on-open", self._on_pose_channel_open, peer_id)
         channel.connect("on-close", self._on_pose_channel_close, peer_id)
         channel.connect("on-error", self._on_data_channel_error, peer_id)
+        return True
 
     def _arm_pose_push_locked(self) -> None:
         """Arm the periodic pose-push timer (idempotent).
@@ -1936,6 +1943,10 @@ class GstMediaServer:
         whose pose channel closed can still re-subscribe.
         """
         self._pose_channels.pop(peer_id, None)
+        self._drop_pose_subscription(peer_id)
+
+    def _drop_pose_subscription(self, peer_id: str) -> None:
+        """Forget a peer's pose subscription."""
         with self._pose_lock:
             self._pose_subscribers.discard(peer_id)
 

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -232,14 +232,20 @@ class GstMediaServer:
         # `_push_pose`). Kept separate from `_data_channels` so a stale pose
         # frame is never head-of-line-blocking a reliable control message.
         self._pose_channels: dict[str, Gst.Element] = {}  # peer_id -> channel
-        # Peers that have opted into the pose stream via `subscribe_pose`. We
-        # only build+push a frame while this set is non-empty, so an idle
-        # session (no 3D mirror on screen) costs nothing.
+        # Peers that have opted into the pose stream via `subscribe_pose`. The
+        # push timer only exists while this set is non-empty, so an idle
+        # session (no 3D mirror on screen) costs nothing - not even a wakeup.
         self._pose_subscribers: set[str] = set()
         # Callback returning the JSON pose frame to push (set by the backend
         # via `set_pose_provider`), and the GLib source id of the push timer.
         self._pose_provider: Optional[Callable[[], Optional[str]]] = None
         self._pose_push_source_id: Optional[int] = None
+        # The three fields above are read/written from two threads: the GLib
+        # main loop (`_push_pose` disarming itself) and the backend's asyncio
+        # thread (`set_pose_subscription` re-arming on subscribe). Without a
+        # lock, a subscribe interleaved with a disarm could observe a stale
+        # source id, skip the re-arm, and leave the stream permanently dead.
+        self._pose_lock = Lock()
         # Optional callback fired on the GStreamer thread when a peer
         # leaves; used by the backend to free per-peer resources such
         # as the journalctl subprocess for a `subscribe_logs` stream.
@@ -288,13 +294,26 @@ class GstMediaServer:
         self._logger.debug("Pipeline built")
 
     def close(self) -> None:
-        """Release GStreamer resources (MainLoop, bus watch)."""
+        """Release GStreamer resources (MainLoop, bus watch).
+
+        Reached from `__del__`, so it has to tolerate a half-built instance:
+        `__init__` raises before any of these attributes exist when the camera
+        resolution can't be determined, and a bare attribute access here would
+        bury that real error under an unraisable `AttributeError`.
+        """
         self._logger.debug("Cleaning up GstMediaServer")
-        if self._pose_push_source_id is not None:
-            GLib.source_remove(self._pose_push_source_id)
-            self._pose_push_source_id = None
-        self._loop.quit()
-        self._bus_sender.remove_watch()
+        # A non-None source id implies a completed `__init__`, hence a lock.
+        if getattr(self, "_pose_push_source_id", None) is not None:
+            with self._pose_lock:
+                if self._pose_push_source_id is not None:
+                    GLib.source_remove(self._pose_push_source_id)
+                    self._pose_push_source_id = None
+        loop = getattr(self, "_loop", None)
+        if loop is not None:
+            loop.quit()
+        bus_sender = getattr(self, "_bus_sender", None)
+        if bus_sender is not None:
+            bus_sender.remove_watch()
 
     def __del__(self) -> None:
         """Destructor to ensure gstreamer resources are released."""
@@ -431,6 +450,7 @@ class GstMediaServer:
     ) -> None:
         self._logger.info(f"consumer removed: {peer_id}")
         self._cleanup_incoming_audio(peer_id)
+        self._drop_pose_peer(peer_id)
         # Cancel any outstanding watchdog for this peer; the consumer
         # is gone so there's nothing left to police.
         self._teardown_negotiation_watchdog(peer_id)
@@ -1776,20 +1796,34 @@ class GstMediaServer:
         The backend passes ``build_state_json`` here. The provider is polled
         on the GLib main loop at :attr:`POSE_PUSH_INTERVAL_MS`; returning
         ``None`` skips a tick (e.g. before the first kinematics update).
+
+        Wiring a provider re-arms the timer if peers are already subscribed,
+        for the (unusual) case where the provider lands after the backend has
+        started accepting `subscribe_pose`.
         """
-        self._pose_provider = provider
+        with self._pose_lock:
+            self._pose_provider = provider
+            if provider is not None and self._pose_subscribers:
+                self._arm_pose_push_locked()
 
     def set_pose_subscription(self, peer_id: str, enabled: bool) -> None:
         """Add/remove a peer from the pushed pose stream (see `_push_pose`).
 
-        Driven by the backend's `subscribe_pose`/`unsubscribe_pose` handling.
-        Idempotent.
+        Driven by the backend's `subscribe_pose`/`unsubscribe_pose` handling,
+        so this runs on the backend's asyncio thread rather than the GLib main
+        loop. Idempotent. Subscribing arms the push timer; the timer disarms
+        itself once the last subscriber leaves.
         """
+        with self._pose_lock:
+            if enabled:
+                self._pose_subscribers.add(peer_id)
+                if self._pose_provider is not None:
+                    self._arm_pose_push_locked()
+            else:
+                self._pose_subscribers.discard(peer_id)
         if enabled:
-            self._pose_subscribers.add(peer_id)
             self._logger.info(f"Pose stream subscribed by peer {peer_id}")
         else:
-            self._pose_subscribers.discard(peer_id)
             self._logger.info(f"Pose stream unsubscribed by peer {peer_id}")
 
     def _setup_pose_channel(self, peer_id: str, webrtcbin: Gst.Element) -> None:
@@ -1808,10 +1842,13 @@ class GstMediaServer:
         channel.connect("on-open", self._on_pose_channel_open, peer_id)
         channel.connect("on-close", self._on_pose_channel_close, peer_id)
         channel.connect("on-error", self._on_data_channel_error, peer_id)
-        self._ensure_pose_push_started()
 
-    def _ensure_pose_push_started(self) -> None:
-        """Arm the periodic pose-push timer once (idempotent)."""
+    def _arm_pose_push_locked(self) -> None:
+        """Arm the periodic pose-push timer (idempotent).
+
+        Caller must hold :attr:`_pose_lock`, since the source id is written
+        both here and by `_push_pose` when it disarms itself.
+        """
         if self._pose_push_source_id is not None:
             return
         self._pose_push_source_id = GLib.timeout_add(
@@ -1821,17 +1858,24 @@ class GstMediaServer:
     def _push_pose(self) -> bool:
         """Broadcast the latest pose frame to every open pose channel.
 
-        Runs on the GLib main loop. Returns ``True`` to stay scheduled;
-        it's a cheap no-op while nobody is subscribed or no provider is set,
-        so we keep it alive for the media server's lifetime rather than
-        churning the timer as peers come and go.
+        Runs on the GLib main loop. Returns ``False`` - dropping the timer -
+        as soon as there is nothing to push, so an idle session costs no
+        periodic wakeup at all; `set_pose_subscription` re-arms it when a
+        peer subscribes again.
         """
-        if not self._pose_subscribers or self._pose_provider is None:
-            return True
-        message = self._pose_provider()
+        with self._pose_lock:
+            provider = self._pose_provider
+            if not self._pose_subscribers or provider is None:
+                self._pose_push_source_id = None
+                return False
+            subscribers = list(self._pose_subscribers)
+        # Building and sending the frame happens outside the lock: the
+        # provider walks the robot state and `send-string` hits SCTP, neither
+        # of which should block a peer subscribing on the other thread.
+        message = provider()
         if message is None:
             return True
-        for peer_id in list(self._pose_subscribers):
+        for peer_id in subscribers:
             channel = self._pose_channels.get(peer_id)
             if channel is None:
                 continue
@@ -1846,8 +1890,18 @@ class GstMediaServer:
 
     def _on_pose_channel_close(self, channel: Gst.Element, peer_id: str) -> None:
         self._logger.info(f"Pose channel closed for peer {peer_id}")
+        self._drop_pose_peer(peer_id)
+
+    def _drop_pose_peer(self, peer_id: str) -> None:
+        """Forget a peer's pose channel and subscription.
+
+        Called both on pose-channel close and on consumer removal: a peer can
+        vanish (ICE failure, killed tab) without `on-close` ever firing, and a
+        lingering subscriber would keep the push timer armed forever.
+        """
         self._pose_channels.pop(peer_id, None)
-        self._pose_subscribers.discard(peer_id)
+        with self._pose_lock:
+            self._pose_subscribers.discard(peer_id)
 
     def _on_data_channel_open(self, channel: Gst.Element, peer_id: str) -> None:
         self._logger.info(f"Data channel opened for peer {peer_id}")

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -232,6 +232,9 @@ class GstMediaServer:
         # `_push_pose`). Kept separate from `_data_channels` so a stale pose
         # frame is never head-of-line-blocking a reliable control message.
         self._pose_channels: dict[str, Gst.Element] = {}  # peer_id -> channel
+        # Each peer's `webrtcbin`, kept so the pose channel can be opened
+        # lazily on `subscribe_pose` rather than eagerly for every peer.
+        self._peer_webrtcbins: dict[str, Gst.Element] = {}  # peer_id -> bin
         # Peers that have opted into the pose stream via `subscribe_pose`. The
         # push timer only exists while this set is non-empty, so an idle
         # session (no 3D mirror on screen) costs nothing - not even a wakeup.
@@ -451,6 +454,7 @@ class GstMediaServer:
         self._logger.info(f"consumer removed: {peer_id}")
         self._cleanup_incoming_audio(peer_id)
         self._drop_pose_peer(peer_id)
+        self._peer_webrtcbins.pop(peer_id, None)
         # Cancel any outstanding watchdog for this peer; the consumer
         # is gone so there's nothing left to police.
         self._teardown_negotiation_watchdog(peer_id)
@@ -1782,11 +1786,14 @@ class GstMediaServer:
         else:
             self._logger.error(f"Failed to create data channel for peer {peer_id}")
 
-        # Second channel for the pushed pose stream. Created right after the
-        # control channel (before the SDP offer) so it rides the same SCTP
-        # association; additional data channels are negotiated in-band via
-        # DCEP, so this needs no separate renegotiation.
-        self._setup_pose_channel(peer_id, webrtcbin)
+        # The pose channel is deliberately NOT created here. Opening a second
+        # channel for every peer breaks any client that predates label-based
+        # routing: such a client keeps the *last* channel it is handed as its
+        # command channel, so its commands would end up on the pose channel,
+        # which carries no message handler. We keep the webrtcbin instead and
+        # open the channel on demand from `set_pose_subscription`; a client
+        # that never asks for pose therefore never sees a second channel.
+        self._peer_webrtcbins[peer_id] = webrtcbin
 
     def set_pose_provider(
         self, provider: Optional[Callable[[], Optional[str]]]
@@ -1811,8 +1818,10 @@ class GstMediaServer:
 
         Driven by the backend's `subscribe_pose`/`unsubscribe_pose` handling,
         so this runs on the backend's asyncio thread rather than the GLib main
-        loop. Idempotent. Subscribing arms the push timer; the timer disarms
-        itself once the last subscriber leaves.
+        loop. Idempotent. Subscribing opens the peer's pose channel if it has
+        none yet and arms the push timer; the timer disarms itself once the
+        last subscriber leaves. The channel is kept open for the rest of the
+        session: unsubscribing only stops the frames.
         """
         with self._pose_lock:
             if enabled:
@@ -1822,11 +1831,36 @@ class GstMediaServer:
             else:
                 self._pose_subscribers.discard(peer_id)
         if enabled:
+            # Touching the peer's webrtcbin has to happen on the GLib main
+            # loop, not on the caller's asyncio thread.
+            GLib.idle_add(self._open_pose_channel_if_needed, peer_id)
             self._logger.info(f"Pose stream subscribed by peer {peer_id}")
         else:
             self._logger.info(f"Pose stream unsubscribed by peer {peer_id}")
 
+    def _open_pose_channel_if_needed(self, peer_id: str) -> bool:
+        """Create the peer's pose channel on first subscribe.
+
+        Runs on the GLib main loop (scheduled by `set_pose_subscription`),
+        which also serialises the check-then-create against a second
+        subscribe. Returns ``False`` so the idle source fires once.
+        """
+        if peer_id in self._pose_channels:
+            return False
+        webrtcbin = self._peer_webrtcbins.get(peer_id)
+        if webrtcbin is None:
+            self._logger.warning(
+                f"No webrtcbin for peer {peer_id}, cannot open pose channel"
+            )
+            return False
+        self._setup_pose_channel(peer_id, webrtcbin)
+        return False
+
     def _setup_pose_channel(self, peer_id: str, webrtcbin: Gst.Element) -> None:
+        # Opened mid-session, after the SDP exchange: extra data channels are
+        # negotiated in-band via DCEP, so this needs no renegotiation and the
+        # client just sees another `ondatachannel`.
+        #
         # Unreliable + unordered: pose is a "latest value wins" stream, so we
         # never want a lost frame to be retransmitted (it'd already be stale)
         # nor to head-of-line-block the frames behind it.
@@ -1897,7 +1931,9 @@ class GstMediaServer:
 
         Called both on pose-channel close and on consumer removal: a peer can
         vanish (ICE failure, killed tab) without `on-close` ever firing, and a
-        lingering subscriber would keep the push timer armed forever.
+        lingering subscriber would keep the push timer armed forever. The
+        peer's webrtcbin outlives this (see `_consumer_removed`) so a peer
+        whose pose channel closed can still re-subscribe.
         """
         self._pose_channels.pop(peer_id, None)
         with self._pose_lock:

--- a/tests/unit_tests/test_media_server_pose.py
+++ b/tests/unit_tests/test_media_server_pose.py
@@ -1,0 +1,169 @@
+"""Unit tests for the pushed pose stream in ``GstMediaServer``.
+
+The daemon pushes the robot pose to subscribed peers over a dedicated
+unreliable/unordered ``pose`` data channel. These tests cover the pure
+Python logic - subscriber bookkeeping, the periodic ``_push_pose``
+broadcast, and channel cleanup - with the GStreamer / GLib edges mocked,
+mirroring the approach in ``test_media_server_watchdog``.
+
+Out of scope (would belong to an integration test): real
+``create-data-channel`` negotiation, GLib timer firing, and on-wire SCTP
+delivery.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini.media.media_server import GstMediaServer
+
+
+def _make_server() -> GstMediaServer:
+    """Build a minimal ``GstMediaServer`` with only the pose attrs wired up.
+
+    Bypasses ``__init__`` (which boots GStreamer) and initialises just the
+    attributes the pose code touches; same approach as
+    ``test_media_server_watchdog``.
+    """
+    server = cast(GstMediaServer, object.__new__(GstMediaServer))
+    server._logger = logging.getLogger("test_pose")
+    server._pose_channels = {}
+    server._pose_subscribers = set()
+    server._pose_provider = None
+    server._pose_push_source_id = None
+    # Stubs for `__del__` -> `close()`, which the destructor calls at GC time.
+    server._loop = MagicMock()
+    server._bus_sender = MagicMock()
+    return server
+
+
+def test_set_pose_subscription_add_and_remove_is_idempotent() -> None:
+    """Adding/removing a peer is a set op - safe to repeat."""
+    server = _make_server()
+
+    server.set_pose_subscription("peer-1", True)
+    assert server._pose_subscribers == {"peer-1"}
+    server.set_pose_subscription("peer-1", True)
+    assert server._pose_subscribers == {"peer-1"}
+
+    server.set_pose_subscription("peer-1", False)
+    assert server._pose_subscribers == set()
+    # Removing an unknown peer must not raise.
+    server.set_pose_subscription("peer-1", False)
+    assert server._pose_subscribers == set()
+
+
+def test_push_pose_noop_without_subscribers() -> None:
+    """No subscribers: the provider isn't even polled, timer stays alive."""
+    server = _make_server()
+    provider = MagicMock(return_value='{"state": {}, "seq": 1}')
+    server._pose_provider = provider
+
+    assert server._push_pose() is True
+    provider.assert_not_called()
+
+
+def test_push_pose_noop_without_provider() -> None:
+    """A subscriber but no provider: nothing to send, timer stays alive."""
+    server = _make_server()
+    channel = MagicMock()
+    server._pose_channels = {"peer-1": channel}
+    server._pose_subscribers = {"peer-1"}
+
+    assert server._push_pose() is True
+    channel.emit.assert_not_called()
+
+
+def test_push_pose_skips_tick_when_provider_returns_none() -> None:
+    """A ``None`` frame (state not ready) skips the tick without sending."""
+    server = _make_server()
+    channel = MagicMock()
+    server._pose_channels = {"peer-1": channel}
+    server._pose_subscribers = {"peer-1"}
+    server._pose_provider = MagicMock(return_value=None)
+
+    assert server._push_pose() is True
+    channel.emit.assert_not_called()
+
+
+def test_push_pose_broadcasts_to_subscribed_channels() -> None:
+    """Every subscribed peer with an open channel gets the frame."""
+    server = _make_server()
+    message = '{"state": {}, "seq": 7}'
+    server._pose_provider = MagicMock(return_value=message)
+    channel_a = MagicMock()
+    channel_b = MagicMock()
+    server._pose_channels = {"peer-a": channel_a, "peer-b": channel_b}
+    server._pose_subscribers = {"peer-a", "peer-b"}
+
+    assert server._push_pose() is True
+    channel_a.emit.assert_called_once_with("send-string", message)
+    channel_b.emit.assert_called_once_with("send-string", message)
+
+
+def test_push_pose_skips_subscriber_without_open_channel() -> None:
+    """A subscribed peer whose channel isn't open yet is skipped, not crashed."""
+    server = _make_server()
+    server._pose_provider = MagicMock(return_value='{"state": {}, "seq": 1}')
+    server._pose_subscribers = {"peer-no-channel"}
+    server._pose_channels = {}
+
+    assert server._push_pose() is True  # must not raise
+
+
+def test_push_pose_survives_a_failing_channel() -> None:
+    """One channel raising on send must not stop the broadcast to others."""
+    server = _make_server()
+    message = '{"state": {}, "seq": 3}'
+    server._pose_provider = MagicMock(return_value=message)
+    bad = MagicMock()
+    bad.emit.side_effect = RuntimeError("channel closed")
+    good = MagicMock()
+    server._pose_channels = {"bad": bad, "good": good}
+    server._pose_subscribers = {"bad", "good"}
+
+    assert server._push_pose() is True
+    good.emit.assert_called_once_with("send-string", message)
+
+
+def test_pose_channel_close_drops_channel_and_subscriber() -> None:
+    """Closing a pose channel frees both the channel ref and the subscription."""
+    server = _make_server()
+    channel = MagicMock()
+    server._pose_channels = {"peer-1": channel}
+    server._pose_subscribers = {"peer-1"}
+
+    server._on_pose_channel_close(channel, "peer-1")
+
+    assert "peer-1" not in server._pose_channels
+    assert "peer-1" not in server._pose_subscribers
+
+
+def test_ensure_pose_push_started_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The push timer is armed exactly once, even across repeated calls."""
+    added: List[Any] = []
+    from reachy_mini.media import media_server as ms
+
+    def fake_timeout_add(interval: int, fn: Any) -> int:
+        added.append((interval, fn))
+        return 4242
+
+    monkeypatch.setattr(ms.GLib, "timeout_add", fake_timeout_add)
+
+    server = _make_server()
+    server._ensure_pose_push_started()
+    server._ensure_pose_push_started()
+
+    assert len(added) == 1
+    assert added[0][0] == GstMediaServer.POSE_PUSH_INTERVAL_MS
+    assert server._pose_push_source_id == 4242
+
+    # Clear the fake source id so `__del__` -> `close()` doesn't try to remove
+    # a non-existent GLib source at GC time (noisy unraisable warning).
+    server._pose_push_source_id = None

--- a/tests/unit_tests/test_media_server_pose.py
+++ b/tests/unit_tests/test_media_server_pose.py
@@ -33,6 +33,7 @@ def _make_server() -> GstMediaServer:
     server = cast(GstMediaServer, object.__new__(GstMediaServer))
     server._logger = logging.getLogger("test_pose")
     server._pose_channels = {}
+    server._peer_webrtcbins = {}
     server._pose_subscribers = set()
     server._pose_provider = None
     server._pose_push_source_id = None
@@ -58,8 +59,31 @@ def _stub_timeout_add(
     return added
 
 
-def test_set_pose_subscription_add_and_remove_is_idempotent() -> None:
+def _stub_idle_add(monkeypatch: pytest.MonkeyPatch, run: bool = False) -> List[Any]:
+    """Record ``GLib.idle_add`` calls, optionally running them inline.
+
+    ``set_pose_subscription`` defers pose-channel creation to the GLib main
+    loop, which no test runs, so the scheduled callback has to be captured
+    (and invoked by hand when the test cares about the result).
+    """
+    scheduled: List[Any] = []
+    from reachy_mini.media import media_server as ms
+
+    def fake_idle_add(fn: Any, *args: Any) -> int:
+        scheduled.append((fn, args))
+        if run:
+            fn(*args)
+        return 1
+
+    monkeypatch.setattr(ms.GLib, "idle_add", fake_idle_add)
+    return scheduled
+
+
+def test_set_pose_subscription_add_and_remove_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Adding/removing a peer is a set op - safe to repeat."""
+    _stub_idle_add(monkeypatch)
     server = _make_server()
 
     server.set_pose_subscription("peer-1", True)
@@ -185,6 +209,7 @@ def test_arm_pose_push_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_subscribing_arms_the_push_timer(monkeypatch: pytest.MonkeyPatch) -> None:
     """A peer subscribing is what starts the 30 Hz push, not the connection."""
     added = _stub_timeout_add(monkeypatch)
+    _stub_idle_add(monkeypatch)
 
     server = _make_server()
     server._pose_provider = MagicMock(return_value='{"state": {}, "seq": 1}')
@@ -206,6 +231,7 @@ def test_subscribing_arms_the_push_timer(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_timer_rearms_after_disarming(monkeypatch: pytest.MonkeyPatch) -> None:
     """Once the last subscriber leaves, the next subscribe re-arms the timer."""
     added = _stub_timeout_add(monkeypatch)
+    _stub_idle_add(monkeypatch)
 
     server = _make_server()
     server._pose_provider = MagicMock(return_value='{"state": {}, "seq": 1}')
@@ -228,6 +254,7 @@ def test_set_pose_provider_arms_when_subscribers_already_waiting(
 ) -> None:
     """A late-wired provider picks up peers that subscribed before it."""
     added = _stub_timeout_add(monkeypatch)
+    _stub_idle_add(monkeypatch)
 
     server = _make_server()
     server.set_pose_subscription("peer-1", True)
@@ -275,3 +302,68 @@ def test_consumer_removal_drops_pose_state() -> None:
 
     assert server._pose_channels == {}
     assert server._pose_subscribers == set()
+
+
+def test_subscribing_opens_the_pose_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The pose channel is opened on subscribe, never for every peer.
+
+    A client predating label-based routing keeps the last channel it is
+    handed as its command channel, so handing it an unsolicited second one
+    would silently break its control path.
+    """
+    _stub_timeout_add(monkeypatch)
+    _stub_idle_add(monkeypatch, run=True)
+
+    server = _make_server()
+    server._pose_provider = MagicMock(return_value='{"state": {}, "seq": 1}')
+    webrtcbin = MagicMock()
+    server._peer_webrtcbins = {"peer-1": webrtcbin}
+
+    # Connected but not subscribed: no channel has been created.
+    assert webrtcbin.emit.call_count == 0
+
+    server.set_pose_subscription("peer-1", True)
+
+    labels = [c.args[1] for c in webrtcbin.emit.call_args_list]
+    assert labels == ["pose"]
+    assert "peer-1" in server._pose_channels
+
+    server._pose_push_source_id = None
+
+
+def test_pose_channel_is_opened_once_per_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-subscribing reuses the channel instead of opening another."""
+    _stub_timeout_add(monkeypatch)
+    _stub_idle_add(monkeypatch, run=True)
+
+    server = _make_server()
+    server._pose_provider = MagicMock(return_value='{"state": {}, "seq": 1}')
+    webrtcbin = MagicMock()
+    server._peer_webrtcbins = {"peer-1": webrtcbin}
+
+    server.set_pose_subscription("peer-1", True)
+    server.set_pose_subscription("peer-1", False)
+    server.set_pose_subscription("peer-1", True)
+
+    assert webrtcbin.emit.call_count == 1
+
+    server._pose_push_source_id = None
+
+
+def test_subscribe_without_a_known_peer_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A subscribe for a peer whose webrtcbin is gone is logged, not fatal."""
+    _stub_timeout_add(monkeypatch)
+    _stub_idle_add(monkeypatch, run=True)
+
+    server = _make_server()
+    server._pose_provider = MagicMock(return_value='{"state": {}, "seq": 1}')
+
+    server.set_pose_subscription("ghost-peer", True)
+
+    assert server._pose_channels == {}
+
+    server._pose_push_source_id = None

--- a/tests/unit_tests/test_media_server_pose.py
+++ b/tests/unit_tests/test_media_server_pose.py
@@ -14,6 +14,7 @@ delivery.
 from __future__ import annotations
 
 import logging
+from threading import Lock
 from typing import Any, List, cast
 from unittest.mock import MagicMock
 
@@ -35,10 +36,26 @@ def _make_server() -> GstMediaServer:
     server._pose_subscribers = set()
     server._pose_provider = None
     server._pose_push_source_id = None
+    server._pose_lock = Lock()
     # Stubs for `__del__` -> `close()`, which the destructor calls at GC time.
     server._loop = MagicMock()
     server._bus_sender = MagicMock()
     return server
+
+
+def _stub_timeout_add(
+    monkeypatch: pytest.MonkeyPatch, source_id: int = 4242
+) -> List[Any]:
+    """Record ``GLib.timeout_add`` calls instead of arming a real timer."""
+    added: List[Any] = []
+    from reachy_mini.media import media_server as ms
+
+    def fake_timeout_add(interval: int, fn: Any) -> int:
+        added.append((interval, fn))
+        return source_id
+
+    monkeypatch.setattr(ms.GLib, "timeout_add", fake_timeout_add)
+    return added
 
 
 def test_set_pose_subscription_add_and_remove_is_idempotent() -> None:
@@ -57,25 +74,29 @@ def test_set_pose_subscription_add_and_remove_is_idempotent() -> None:
     assert server._pose_subscribers == set()
 
 
-def test_push_pose_noop_without_subscribers() -> None:
-    """No subscribers: the provider isn't even polled, timer stays alive."""
+def test_push_pose_disarms_without_subscribers() -> None:
+    """No subscribers: the provider isn't polled and the timer is dropped."""
     server = _make_server()
     provider = MagicMock(return_value='{"state": {}, "seq": 1}')
     server._pose_provider = provider
+    server._pose_push_source_id = 4242
 
-    assert server._push_pose() is True
+    assert server._push_pose() is False
     provider.assert_not_called()
+    assert server._pose_push_source_id is None
 
 
-def test_push_pose_noop_without_provider() -> None:
-    """A subscriber but no provider: nothing to send, timer stays alive."""
+def test_push_pose_disarms_without_provider() -> None:
+    """A subscriber but no provider: nothing to push, so the timer is dropped."""
     server = _make_server()
     channel = MagicMock()
     server._pose_channels = {"peer-1": channel}
     server._pose_subscribers = {"peer-1"}
+    server._pose_push_source_id = 4242
 
-    assert server._push_pose() is True
+    assert server._push_pose() is False
     channel.emit.assert_not_called()
+    assert server._pose_push_source_id is None
 
 
 def test_push_pose_skips_tick_when_provider_returns_none() -> None:
@@ -143,22 +164,14 @@ def test_pose_channel_close_drops_channel_and_subscriber() -> None:
     assert "peer-1" not in server._pose_subscribers
 
 
-def test_ensure_pose_push_started_is_idempotent(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_arm_pose_push_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
     """The push timer is armed exactly once, even across repeated calls."""
-    added: List[Any] = []
-    from reachy_mini.media import media_server as ms
-
-    def fake_timeout_add(interval: int, fn: Any) -> int:
-        added.append((interval, fn))
-        return 4242
-
-    monkeypatch.setattr(ms.GLib, "timeout_add", fake_timeout_add)
+    added = _stub_timeout_add(monkeypatch)
 
     server = _make_server()
-    server._ensure_pose_push_started()
-    server._ensure_pose_push_started()
+    with server._pose_lock:
+        server._arm_pose_push_locked()
+        server._arm_pose_push_locked()
 
     assert len(added) == 1
     assert added[0][0] == GstMediaServer.POSE_PUSH_INTERVAL_MS
@@ -167,3 +180,98 @@ def test_ensure_pose_push_started_is_idempotent(
     # Clear the fake source id so `__del__` -> `close()` doesn't try to remove
     # a non-existent GLib source at GC time (noisy unraisable warning).
     server._pose_push_source_id = None
+
+
+def test_subscribing_arms_the_push_timer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A peer subscribing is what starts the 30 Hz push, not the connection."""
+    added = _stub_timeout_add(monkeypatch)
+
+    server = _make_server()
+    server._pose_provider = MagicMock(return_value='{"state": {}, "seq": 1}')
+
+    # A connected peer that never subscribes must not cost a periodic wakeup.
+    assert added == []
+
+    server.set_pose_subscription("peer-1", True)
+    assert len(added) == 1
+    assert server._pose_push_source_id == 4242
+
+    # A second subscriber shares the single timer.
+    server.set_pose_subscription("peer-2", True)
+    assert len(added) == 1
+
+    server._pose_push_source_id = None
+
+
+def test_timer_rearms_after_disarming(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Once the last subscriber leaves, the next subscribe re-arms the timer."""
+    added = _stub_timeout_add(monkeypatch)
+
+    server = _make_server()
+    server._pose_provider = MagicMock(return_value='{"state": {}, "seq": 1}')
+
+    server.set_pose_subscription("peer-1", True)
+    server.set_pose_subscription("peer-1", False)
+    # The timer only drops on its next tick, which finds nobody subscribed.
+    assert server._push_pose() is False
+    assert server._pose_push_source_id is None
+
+    server.set_pose_subscription("peer-1", True)
+    assert len(added) == 2
+    assert server._pose_push_source_id == 4242
+
+    server._pose_push_source_id = None
+
+
+def test_set_pose_provider_arms_when_subscribers_already_waiting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A late-wired provider picks up peers that subscribed before it."""
+    added = _stub_timeout_add(monkeypatch)
+
+    server = _make_server()
+    server.set_pose_subscription("peer-1", True)
+    # No provider yet, so nothing to push and nothing armed.
+    assert added == []
+
+    server.set_pose_provider(MagicMock(return_value='{"state": {}, "seq": 1}'))
+    assert len(added) == 1
+
+    server._pose_push_source_id = None
+
+
+def test_close_tolerates_a_half_built_server() -> None:
+    """`__del__` on an instance whose `__init__` raised must stay silent."""
+    server = cast(GstMediaServer, object.__new__(GstMediaServer))
+    server._logger = logging.getLogger("test_pose")
+
+    # No pose attrs, no main loop, no bus: must not raise.
+    server.close()
+
+
+def test_close_disarms_an_armed_push_timer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A live timer is removed from the main loop on shutdown."""
+    removed: List[Any] = []
+    from reachy_mini.media import media_server as ms
+
+    monkeypatch.setattr(ms.GLib, "source_remove", removed.append)
+
+    server = _make_server()
+    server._pose_push_source_id = 4242
+
+    server.close()
+
+    assert removed == [4242]
+    assert server._pose_push_source_id is None
+
+
+def test_consumer_removal_drops_pose_state() -> None:
+    """A peer vanishing without an `on-close` must not pin the timer on."""
+    server = _make_server()
+    server._pose_channels = {"peer-1": MagicMock()}
+    server._pose_subscribers = {"peer-1"}
+
+    server._drop_pose_peer("peer-1")
+
+    assert server._pose_channels == {}
+    assert server._pose_subscribers == set()

--- a/tests/unit_tests/test_media_server_pose.py
+++ b/tests/unit_tests/test_media_server_pose.py
@@ -352,10 +352,14 @@ def test_pose_channel_is_opened_once_per_peer(
     server._pose_push_source_id = None
 
 
-def test_subscribe_without_a_known_peer_does_not_raise(
+def test_subscribe_without_a_known_peer_drops_the_subscription(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A subscribe for a peer whose webrtcbin is gone is logged, not fatal."""
+    """A subscribe for a peer whose webrtcbin is gone is logged, not fatal.
+
+    The peer must not stay subscribed either, or the timer would keep
+    building a frame 30 times a second for a peer with no channel.
+    """
     _stub_timeout_add(monkeypatch)
     _stub_idle_add(monkeypatch, run=True)
 
@@ -365,5 +369,29 @@ def test_subscribe_without_a_known_peer_does_not_raise(
     server.set_pose_subscription("ghost-peer", True)
 
     assert server._pose_channels == {}
+    assert server._pose_subscribers == set()
+    # Nothing left to push, so the next tick drops the timer.
+    assert server._push_pose() is False
+
+    server._pose_push_source_id = None
+
+
+def test_failed_channel_creation_drops_the_subscription(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`create-data-channel` returning null must not leave a ghost subscriber."""
+    _stub_timeout_add(monkeypatch)
+    _stub_idle_add(monkeypatch, run=True)
+
+    server = _make_server()
+    server._pose_provider = MagicMock(return_value='{"state": {}, "seq": 1}')
+    webrtcbin = MagicMock()
+    webrtcbin.emit.return_value = None  # GStreamer refused the channel
+    server._peer_webrtcbins = {"peer-1": webrtcbin}
+
+    server.set_pose_subscription("peer-1", True)
+
+    assert server._pose_channels == {}
+    assert server._pose_subscribers == set()
 
     server._pose_push_source_id = None

--- a/tests/unit_tests/test_pose_stream.py
+++ b/tests/unit_tests/test_pose_stream.py
@@ -1,0 +1,103 @@
+"""Unit tests for the pose-stream command dispatch + state envelope.
+
+Covers the backend side of the live pose stream: ``subscribe_pose`` /
+``unsubscribe_pose`` dispatch through :meth:`process_command` (scoped by
+``peer_id`` and delegated to the media server), plus the
+``build_state_json`` envelope and its monotonic ``seq`` used by the push
+provider.
+
+The media-server transport is mocked here; ``GstMediaServer._push_pose``
+and friends are covered separately in ``test_media_server_pose.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+from reachy_mini.daemon.backend.mockup_sim.backend import MockupSimBackend
+from reachy_mini.io.protocol import SubscribePoseCmd, UnsubscribePoseCmd
+
+
+def _make_backend() -> MockupSimBackend:
+    """Build a lightweight backend with no audio, no kinematics warmup."""
+    return MockupSimBackend(use_audio=False)
+
+
+def test_subscribe_pose_delegates_to_media_server() -> None:
+    """``subscribe_pose`` scopes the subscription to the peer and acks."""
+    backend = _make_backend()
+    media = MagicMock()
+    backend._media_server = media
+
+    responses: list[dict[str, Any]] = []
+    backend.process_command(
+        SubscribePoseCmd(), send_response=responses.append, peer_id="peer-1"
+    )
+
+    media.set_pose_subscription.assert_called_once_with("peer-1", True)
+    assert responses == [{"status": "ok", "command": "subscribe_pose"}]
+
+
+def test_unsubscribe_pose_delegates_to_media_server() -> None:
+    """``unsubscribe_pose`` removes the peer's subscription and acks."""
+    backend = _make_backend()
+    media = MagicMock()
+    backend._media_server = media
+
+    responses: list[dict[str, Any]] = []
+    backend.process_command(
+        UnsubscribePoseCmd(), send_response=responses.append, peer_id="peer-1"
+    )
+
+    media.set_pose_subscription.assert_called_once_with("peer-1", False)
+    assert responses == [{"status": "ok", "command": "unsubscribe_pose"}]
+
+
+def test_subscribe_pose_without_peer_id_is_noop_but_acks() -> None:
+    """A transport with no peer identity (e.g. WS) can't scope a subscription.
+
+    The dispatch must not touch the media server, but still ack so a client
+    that blindly subscribes on every reconnect doesn't hang waiting.
+    """
+    backend = _make_backend()
+    media = MagicMock()
+    backend._media_server = media
+
+    responses: list[dict[str, Any]] = []
+    backend.process_command(
+        SubscribePoseCmd(), send_response=responses.append, peer_id=None
+    )
+
+    media.set_pose_subscription.assert_not_called()
+    assert responses == [{"status": "ok", "command": "subscribe_pose"}]
+
+
+def test_build_state_json_wraps_state_and_increments_seq() -> None:
+    """Each frame wraps the state dict and carries a strictly increasing seq."""
+    backend = _make_backend()
+    backend.build_state_dict = lambda: {"body_yaw": 0.0}  # type: ignore[assignment]
+
+    first = backend.build_state_json()
+    second = backend.build_state_json()
+    assert first is not None and second is not None
+
+    a = json.loads(first)
+    b = json.loads(second)
+    assert a["state"] == {"body_yaw": 0.0}
+    # Monotonic, strictly increasing so the client can drop stale/out-of-order
+    # frames on the unordered pose channel.
+    assert a["seq"] == 1
+    assert b["seq"] == 2
+
+
+def test_build_state_json_returns_none_on_build_error() -> None:
+    """A transient build failure skips the tick instead of crashing the push."""
+    backend = _make_backend()
+
+    def boom() -> dict[str, Any]:
+        raise RuntimeError("kinematics not ready")
+
+    backend.build_state_dict = boom  # type: ignore[assignment]
+    assert backend.build_state_json() is None

--- a/tests/unit_tests/test_pose_stream.py
+++ b/tests/unit_tests/test_pose_stream.py
@@ -17,7 +17,13 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from reachy_mini.daemon.backend.mockup_sim.backend import MockupSimBackend
-from reachy_mini.io.protocol import SubscribePoseCmd, UnsubscribePoseCmd
+from reachy_mini.io.protocol import (
+    FaceTarget,
+    MotorControlMode,
+    StateSnapshot,
+    SubscribePoseCmd,
+    UnsubscribePoseCmd,
+)
 
 
 def _make_backend() -> MockupSimBackend:
@@ -74,10 +80,20 @@ def test_subscribe_pose_without_peer_id_is_noop_but_acks() -> None:
     assert responses == [{"status": "ok", "command": "subscribe_pose"}]
 
 
+def _snapshot(body_yaw: float = 0.0) -> StateSnapshot:
+    return StateSnapshot(
+        body_yaw=body_yaw,
+        motor_mode=MotorControlMode.Enabled,
+        is_recording=False,
+        is_move_running=False,
+        face_target=FaceTarget(),
+    )
+
+
 def test_build_state_json_wraps_state_and_increments_seq() -> None:
-    """Each frame wraps the state dict and carries a strictly increasing seq."""
+    """Each frame wraps the state snapshot and carries a strictly increasing seq."""
     backend = _make_backend()
-    backend.build_state_dict = lambda: {"body_yaw": 0.0}  # type: ignore[assignment]
+    backend.build_state_snapshot = _snapshot  # type: ignore[assignment]
 
     first = backend.build_state_json()
     second = backend.build_state_json()
@@ -85,7 +101,9 @@ def test_build_state_json_wraps_state_and_increments_seq() -> None:
 
     a = json.loads(first)
     b = json.loads(second)
-    assert a["state"] == {"body_yaw": 0.0}
+    assert a["state"]["body_yaw"] == 0.0
+    # The enum must serialize to its wire value, not its Python repr.
+    assert a["state"]["motor_mode"] == "enabled"
     # Monotonic, strictly increasing so the client can drop stale/out-of-order
     # frames on the unordered pose channel.
     assert a["seq"] == 1
@@ -96,8 +114,20 @@ def test_build_state_json_returns_none_on_build_error() -> None:
     """A transient build failure skips the tick instead of crashing the push."""
     backend = _make_backend()
 
-    def boom() -> dict[str, Any]:
+    def boom() -> StateSnapshot:
         raise RuntimeError("kinematics not ready")
 
-    backend.build_state_dict = boom  # type: ignore[assignment]
+    backend.build_state_snapshot = boom  # type: ignore[assignment]
     assert backend.build_state_json() is None
+
+
+def test_state_dict_carries_no_duplicate_antenna_field() -> None:
+    """The per-motor antenna twin was dropped.
+
+    `antennas` already IS the two motor values (review nit on #1296).
+    """
+    backend = _make_backend()
+    state = backend.build_state_dict()
+    assert "antennas_joint_positions" not in state
+    assert "head_joint_positions" in state
+    assert state["motor_mode"] == "enabled"

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -150,6 +150,16 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
     private _state: 'disconnected' | 'connected' | 'streaming' = 'disconnected';
     private _robots: RobotInfo[] = [];
     private _robotState: RobotState = {};
+    // Highest `seq` seen on the unordered `pose` channel. Frames that arrive
+    // out of order (older seq) are dropped so a late packet can't rewind the
+    // live mirror. `null` until the first pose frame.
+    private _lastPoseSeq: number | null = null;
+    // Local refcount of pose-stream consumers (the 3D mirror, the wizard's
+    // move-end watcher, ...). The daemon's subscription is a per-peer boolean
+    // (not refcounted), so we only send `unsubscribe_pose` once the LAST local
+    // consumer releases - otherwise one consumer's cleanup would kill the
+    // stream for the others.
+    private _poseSubRefs = 0;
     private readonly _preselectedRobotId: string | null;
 
     // ─── Auth ────────────────────────────────────────────────────────────
@@ -687,7 +697,32 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
             };
 
             this._pc!.ondatachannel = (e) => {
-                this._dc = e.channel;
+                const ch = e.channel;
+                // The daemon opens a second, unreliable/unordered channel
+                // labelled "pose" that *pushes* the robot state at ~30 Hz
+                // (see media_server `_setup_pose_channel`). It carries the
+                // same `{state:{...}}` envelope as a get_state reply, so we
+                // route it through the same handler - but it must NOT gate
+                // session readiness (that's the reliable control channel's
+                // job) nor become `_dc` (commands must never ride the lossy
+                // channel).
+                if (ch.label === 'pose') {
+                    // Fresh channel (new session or daemon restart): the
+                    // daemon's seq counter may have reset, so forget the old
+                    // high-water mark or we'd drop every new frame.
+                    this._lastPoseSeq = null;
+                    ch.onmessage = (ev) => {
+                        const msg = JSON.parse(ev.data);
+                        // Drop stale/reordered frames (unordered channel).
+                        if (typeof msg.seq === 'number') {
+                            if (this._lastPoseSeq !== null && msg.seq <= this._lastPoseSeq) return;
+                            this._lastPoseSeq = msg.seq;
+                        }
+                        this._handleRobotMessage(msg);
+                    };
+                    return;
+                }
+                this._dc = ch;
                 this._dc.onopen = () => {
                     this._dcOpen = true;
                     this._checkSessionReady();
@@ -1419,6 +1454,30 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
         return this._sendCommand({ type: 'get_state' });
     }
 
+    /**
+     * Ask the daemon to *push* the robot state (~30 Hz) over the dedicated
+     * unreliable/unordered `pose` data channel instead of polling get_state.
+     * Fires `state` events as frames arrive. No-op against an older daemon (no
+     * pose channel) - fall back to `requestState()` polling there.
+     *
+     * Refcounted: pair every `subscribePose()` with exactly one
+     * `unsubscribePose()`. Multiple consumers share a single daemon-side
+     * subscription; the daemon only stops pushing once the last one releases.
+     * If the channel isn't open yet (or the session later reconnects), the
+     * subscription is (re-)asserted from `_checkSessionReady`.
+     */
+    subscribePose(): boolean {
+        this._poseSubRefs++;
+        return this._sendCommand({ type: 'subscribe_pose' });
+    }
+
+    /** Release one pose-stream consumer; sends `unsubscribe_pose` on the last. */
+    unsubscribePose(): boolean {
+        if (this._poseSubRefs > 0) this._poseSubRefs--;
+        if (this._poseSubRefs > 0) return true; // still wanted by another consumer
+        return this._sendCommand({ type: 'unsubscribe_pose' });
+    }
+
     // ─── Audio ───────────────────────────────────────────────────────────
 
     setAudioMuted(muted: boolean): void {
@@ -1860,6 +1919,11 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
         if (this._iceConnected && this._dcOpen && this._sessionResolve) {
             this._state = 'streaming';
             this.requestState();
+            // Re-assert a pose subscription that was requested before the data
+            // channel was open, or lost on reconnect (a fresh peer starts
+            // unsubscribed on the daemon). Sent raw so it doesn't touch the
+            // local refcount, which already reflects the live consumer count.
+            if (this._poseSubRefs > 0) this._sendCommand({ type: 'subscribe_pose' });
             this._stateRefreshInterval = setInterval(() => this.requestState(), 500);
             this._emit('streaming', { sessionId: this._sessionId!, robotId: this._selectedRobotId! });
             this._sessionResolve();

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -137,7 +137,9 @@ const ICE_FAILED_GRACE_MS = 1000;
 const MAX_VISIBILITY_DEFER_MS = 60_000;
 
 /**
- * How long a pushed pose frame keeps the periodic `get_state` poll on hold.
+ * How long a pushed pose frame keeps the periodic `get_state` poll on hold -
+ * both on the way out (no request is sent) and on the way back (a reply that
+ * arrives anyway doesn't touch the state mirror).
  *
  * Poll replies carry no `seq`, so they slip past the stale-frame guard: a
  * reply that crosses a fresher pushed frame would rewind the very mirror the
@@ -754,7 +756,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
                             this._lastPoseSeq = msg.seq;
                         }
                         this._lastPoseFrameAt = Date.now();
-                        this._handleRobotMessage(msg);
+                        this._handleRobotMessage(msg, true);
                     };
                     return;
                 }
@@ -2186,7 +2188,12 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
         }
     }
 
-    private _handleRobotMessage(data: Record<string, unknown>): void {
+    /**
+     * @param fromPoseStream Frame came from the pushed `pose` channel rather
+     *   than the reliable control channel. Only those may refresh the state
+     *   mirror while the stream is live (see the `data.state` branch).
+     */
+    private _handleRobotMessage(data: Record<string, unknown>, fromPoseStream = false): void {
         // JSON-RPC frames (app control surface) are handled separately from
         // the legacy {command|type} robot messages that share this channel.
         if (data.jsonrpc === '2.0') {
@@ -2322,7 +2329,18 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
             }
             return;
         }
-        if (data.state) {
+        // Only the stream may write the mirror while the stream is live. The
+        // poll stands down in that case (see POSE_STREAM_FRESH_MS), but it
+        // can't unsend a request already in flight: `get_state` rides the
+        // reliable channel, so its reply queues behind whatever else is on it
+        // - a `upload_move_*` burst, typically - and can land hundreds of ms
+        // after the snapshot it carries. Having no `seq`, it slips past the
+        // stale-frame guard and rewinds every consumer to a pose from before
+        // the upload, until the next pushed frame puts them back. That reads
+        // as a one-frame flick to the pre-move pose right as an animation
+        // starts. Nothing is lost by dropping it: pushed frames carry the same
+        // fields (daemon-side `build_state_dict` feeds both).
+        if (data.state && (fromPoseStream || Date.now() - this._lastPoseFrameAt >= POSE_STREAM_FRESH_MS)) {
             const s = data.state as {
                 head_pose?: number[][];
                 antennas?: [number, number];

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -136,6 +136,20 @@ const ICE_FAILED_GRACE_MS = 1000;
  */
 const MAX_VISIBILITY_DEFER_MS = 60_000;
 
+/**
+ * How long a pushed pose frame keeps the periodic `get_state` poll on hold.
+ *
+ * Poll replies carry no `seq`, so they slip past the stale-frame guard: a
+ * reply that crosses a fresher pushed frame would rewind the very mirror the
+ * stream exists to smooth. While frames flow at ~30 Hz there is nothing left
+ * for the poll to add, so it stands down. Keying that on frame arrival rather
+ * than on `_poseSubRefs` keeps the poll running against a daemon that doesn't
+ * know `subscribe_pose`, and brings it back on its own if the stream stalls.
+ * A little over one 500 ms poll period, so a couple of dropped frames don't
+ * flip it back and forth.
+ */
+const POSE_STREAM_FRESH_MS = 750;
+
 export class ReachyMini extends EventTarget implements ReachyMiniInstance {
 
     // ─── Config ──────────────────────────────────────────────────────────
@@ -154,6 +168,9 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
     // out of order (older seq) are dropped so a late packet can't rewind the
     // live mirror. `null` until the first pose frame.
     private _lastPoseSeq: number | null = null;
+    // When the last pushed pose frame was applied, used to park the periodic
+    // `get_state` poll while the stream is live (see POSE_STREAM_FRESH_MS).
+    private _lastPoseFrameAt = 0;
     // Local refcount of pose-stream consumers (the 3D mirror, the wizard's
     // move-end watcher, ...). The daemon's subscription is a per-peer boolean
     // (not refcounted), so we only send `unsubscribe_pose` once the LAST local
@@ -719,6 +736,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
                             if (this._lastPoseSeq !== null && msg.seq <= this._lastPoseSeq) return;
                             this._lastPoseSeq = msg.seq;
                         }
+                        this._lastPoseFrameAt = Date.now();
                         this._handleRobotMessage(msg);
                     };
                     return;
@@ -1925,7 +1943,15 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
             // unsubscribed on the daemon). Sent raw so it doesn't touch the
             // local refcount, which already reflects the live consumer count.
             if (this._poseSubRefs > 0) this._sendCommand({ type: 'subscribe_pose' });
-            this._stateRefreshInterval = setInterval(() => this.requestState(), 500);
+            // A fresh session has received no pose frame yet, so a timestamp
+            // left over from the previous one must not hold off the poll.
+            this._lastPoseFrameAt = 0;
+            this._stateRefreshInterval = setInterval(() => {
+                // Skip while the pose stream is already feeding state; see
+                // POSE_STREAM_FRESH_MS.
+                if (Date.now() - this._lastPoseFrameAt < POSE_STREAM_FRESH_MS) return;
+                this.requestState();
+            }, 500);
             this._emit('streaming', { sessionId: this._sessionId!, robotId: this._selectedRobotId! });
             this._sessionResolve();
             this._sessionResolve = null;

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -698,14 +698,15 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
 
             this._pc!.ondatachannel = (e) => {
                 const ch = e.channel;
-                // The daemon opens a second, unreliable/unordered channel
-                // labelled "pose" that *pushes* the robot state at ~30 Hz
-                // (see media_server `_setup_pose_channel`). It carries the
-                // same `{state:{...}}` envelope as a get_state reply, so we
-                // route it through the same handler - but it must NOT gate
-                // session readiness (that's the reliable control channel's
-                // job) nor become `_dc` (commands must never ride the lossy
-                // channel).
+                // On `subscribe_pose` the daemon opens a second,
+                // unreliable/unordered channel labelled "pose" that *pushes*
+                // the robot state at ~30 Hz (see media_server
+                // `_setup_pose_channel`), so this can fire mid-session. It
+                // carries the same `{state:{...}}` envelope as a get_state
+                // reply, so we route it through the same handler - but it
+                // must NOT gate session readiness (that's the reliable
+                // control channel's job) nor become `_dc` (commands must
+                // never ride the lossy channel).
                 if (ch.label === 'pose') {
                     // Fresh channel (new session or daemon restart): the
                     // daemon's seq counter may have reset, so forget the old


### PR DESCRIPTION
Extracted from #1286 as a standalone feature (part of splitting that PR into reviewable pieces). Depends on nothing else in #1286; the mobile first-wake-up wizard is the main consumer, but the pose stream benefits any live 3D mirror / head-tracking view.

## What

A push-based pose stream: the daemon *pushes* the robot's present state to subscribed WebRTC peers over a dedicated **unreliable/unordered `pose` data channel** at ~30 Hz, instead of the client polling `get_state` over the reliable-ordered control channel.

## Why

Polling `get_state` for a live mirror is at the mercy of Wi-Fi round-trip latency and head-of-line blocking on the control channel, so the 3D view jitters. Pushing on a separate lossy channel is immune to both: a dropped frame is simply superseded by the next one 33 ms later rather than stalling the stream.

## How

- **Protocol** (`protocol.py`): `subscribe_pose` / `unsubscribe_pose` data-channel commands.
- **Backend** (`abstract.py`): `build_state_dict` / `build_state_json` become the single source of truth for both the polled `get_state` reply and the pushed frames; each pushed frame carries a monotonic `seq` so the client can drop stale/out-of-order frames. `get_state` now delegates to `build_state_dict` (same envelope, incl. `face_target`, plus per-motor `head_joint_positions` / `antennas_joint_positions`).
- **Media server** (`media_server.py`): a second per-peer `pose` channel (`ordered=false, max-retransmits=0`) created alongside the control channel, per-peer subscriber tracking, and a ~30 Hz `_push_pose` timer that only builds+sends a frame while at least one peer is subscribed (idle sessions cost nothing).
- **JS SDK** (`reachy-mini.ts`): label-based routing so the `pose` channel never becomes `_dc` nor gates session readiness; a `seq` high-water-mark stale-frame guard; and refcounted `subscribePose()` / `unsubscribePose()` (multiple local consumers share one daemon-side subscription), re-asserted on reconnect.

Backward-compatible: `hasattr` guards mean an older media server without the pose hooks simply falls back to `get_state` polling.

## Tests

- `tests/unit_tests/test_pose_stream.py` — backend dispatch (peer-scoped subscribe/unsubscribe, delegated to the media server) and the `build_state_json` envelope + monotonic `seq`.
- `tests/unit_tests/test_media_server_pose.py` — subscriber bookkeeping, `_push_pose` gating/broadcast, channel-close cleanup, idempotent timer arming (GStreamer/GLib edges mocked, mirroring `test_media_server_watchdog`).
- Local run: pose tests 14 passed; `ruff`/`mypy` clean; SDK `tsc` passes.

## Note for reviewers

`GstMediaServer.close()` reads `self._pose_push_source_id` unconditionally, so a `GstMediaServer` whose `__init__` raises before that attribute is set will raise an unraisable `AttributeError` in `__del__` → `close()` (harmless warning, but new noise). Cheap fix would be `getattr(self, "_pose_push_source_id", None)`. Kept as-is to stay a faithful extraction — flagging so it's decided in review.

## Scope note

This branch intentionally excludes two things that were bundled into the same upstream commit but belong to the onboarding/wizard work: the onboarding-dataset preloading in `recorded_move.py` and the BLE cue sourcing in `bluetooth_service.py`. Those will land with the wizard PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
