### PR TITLE
feat(daemon): persisted robot rename with live no-restart apply

### DIFF
--- a/docs/source/API/openapi.json
+++ b/docs/source/API/openapi.json
@@ -717,7 +717,7 @@
     "/api/daemon/robot-name": {
       "get": {
         "summary": "Get Robot Display Name",
-        "description": "Return the persisted robot display name (``null`` when unset).",
+        "description": "Return the robot's current display name.\n\nReports the effective/advertised name: the persisted override when a\nclient has renamed the robot, otherwise the ``--robot-name`` default the\ndaemon is running with. A client can pre-fill a rename field from this\nwithout having to fall back to the daemon status for the default.",
         "operationId": "get_robot_display_name_api_daemon_robot_name_get",
         "responses": {
           "200": {
@@ -3709,7 +3709,7 @@
         },
         "type": "object",
         "title": "RobotNameResponse",
-        "description": "The persisted robot display name (``null`` when unset)."
+        "description": "The robot's current display name (``null`` only if none is resolvable)."
       },
       "SourceKind": {
         "type": "string",

--- a/docs/source/API/openapi.json
+++ b/docs/source/API/openapi.json
@@ -714,6 +714,62 @@
         }
       }
     },
+    "/api/daemon/robot-name": {
+      "get": {
+        "summary": "Get Robot Display Name",
+        "description": "Return the persisted robot display name (``null`` when unset).",
+        "operationId": "get_robot_display_name_api_daemon_robot_name_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RobotNameResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Set Robot Display Name",
+        "description": "Persist a new robot display name and apply it live (no restart).\n\nPersists the name to disk, then refreshes the advertised copies so the\nrename takes effect immediately: the daemon status + central relay (via\n``Daemon.apply_robot_name``) and the LAN mDNS record. This is the REST\nentry point used by the BLE setup service; the WebRTC ``set_robot_name``\ncommand goes through the same live-apply path on the backend.",
+        "operationId": "set_robot_display_name_api_daemon_robot_name_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RobotNameRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RobotNameResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/daemon/hardware-id": {
       "get": {
         "summary": "Get Robot Hardware Id",
@@ -3620,6 +3676,40 @@
         ],
         "title": "RobotBackendStatus",
         "description": "Status of the Robot Backend."
+      },
+      "RobotNameRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "RobotNameRequest",
+        "description": "Body for setting the robot display name."
+      },
+      "RobotNameResponse": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "title": "RobotNameResponse",
+        "description": "The persisted robot display name (``null`` when unset)."
       },
       "SourceKind": {
         "type": "string",

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -135,6 +135,9 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
             args.fastapi_port,
             wireless_version=args.wireless_version,
         )
+        # Exposed on app.state so the `/api/daemon/robot-name` route can
+        # re-advertise the LAN record live on a rename (BLE setup path).
+        app.state.mdns = mdns
 
         def preload_with_logging() -> None:
             """Download datasets with logging."""
@@ -225,6 +228,23 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
 
             # Register mDNS service only after the daemon is ready
             mdns.register()
+
+            # Wire the live rename hook now that both the daemon (relay +
+            # status) and the mDNS registration exist. A `set_robot_name`
+            # command then applies without a restart: daemon status + central
+            # relay (via apply_robot_name) and the LAN mDNS record (re-register).
+            daemon_instance = app.state.daemon
+            if daemon_instance.backend is not None:
+
+                def _apply_robot_name_live(
+                    name: str,
+                    _daemon: Daemon = daemon_instance,
+                    _mdns: MdnsServiceRegistration = mdns,
+                ) -> None:
+                    _daemon.apply_robot_name(name)
+                    _mdns.update_name(name)
+
+                daemon_instance.backend.set_robot_name_callback(_apply_robot_name_live)
 
             yield
         finally:

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -501,6 +501,19 @@ def run_app(args: Args) -> None:
     root_logger.handlers.clear()
     root_logger.addHandler(handler)
 
+    # Surface a persisted rename so an operator isn't puzzled when the
+    # advertised name differs from the --robot-name they passed. The override
+    # happens earlier in main() (before logging is configured), so we log it
+    # here — right after the stderr handler is installed — where it will show.
+    from reachy_mini.utils.robot_name import get_robot_name as _get_persisted_name
+
+    if _get_persisted_name():
+        logger.info(
+            "Robot name %r comes from a persisted rename and overrides the "
+            "--robot-name default.",
+            args.robot_name,
+        )
+
     # Explicitly configure the apps.manager logger to ensure propagation
     apps_logger = logging.getLogger("reachy_mini.apps.manager")
     apps_logger.setLevel(args.log_level)

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -502,9 +502,7 @@ def run_app(args: Args) -> None:
     root_logger.addHandler(handler)
 
     # Surface a persisted rename so an operator isn't puzzled when the
-    # advertised name differs from the --robot-name they passed. The override
-    # happens earlier in main() (before logging is configured), so we log it
-    # here — right after the stderr handler is installed — where it will show.
+    # advertised name differs from the --robot-name they passed.
     from reachy_mini.utils.robot_name import get_robot_name as _get_persisted_name
 
     if _get_persisted_name():

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -784,6 +784,15 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    # A name set by a client (e.g. the mobile app over the data channel) is
+    # persisted on the robot and wins over the CLI default so the rename
+    # survives reboots. Fail-safe: falls back to --robot-name on any error.
+    from reachy_mini.utils.robot_name import get_robot_name as get_persisted_robot_name
+
+    persisted_robot_name = get_persisted_robot_name()
+    if persisted_robot_name:
+        args.robot_name = persisted_robot_name
+
     if args.log_file:
         file_handler = logging.FileHandler(args.log_file, mode="a")
         file_handler.setFormatter(

--- a/src/reachy_mini/daemon/app/routers/daemon.py
+++ b/src/reachy_mini/daemon/app/routers/daemon.py
@@ -4,11 +4,13 @@ import logging
 import threading
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
 
 from reachy_mini.daemon.app import bg_job_register
 from reachy_mini.daemon.robot_app_lock import RobotAppLockStatus
 from reachy_mini.io.protocol import DaemonStatus
 from reachy_mini.utils.hardware_id import get_hardware_id
+from reachy_mini.utils.robot_name import get_robot_name, set_robot_name
 
 from ...daemon import Daemon
 from ..dependencies import get_daemon
@@ -83,6 +85,64 @@ async def restart_daemon(
 async def get_daemon_status(daemon: Daemon = Depends(get_daemon)) -> DaemonStatus:
     """Get the current status of the daemon."""
     return daemon.status()
+
+
+class RobotNameRequest(BaseModel):
+    """Body for setting the robot display name."""
+
+    name: str = Field(..., min_length=1, max_length=64)
+
+
+class RobotNameResponse(BaseModel):
+    """The persisted robot display name (``null`` when unset)."""
+
+    name: str | None = None
+
+
+@router.get("/robot-name")
+async def get_robot_display_name() -> RobotNameResponse:
+    """Return the persisted robot display name (``null`` when unset)."""
+    return RobotNameResponse(name=get_robot_name())
+
+
+@router.post("/robot-name")
+async def set_robot_display_name(
+    body: RobotNameRequest,
+    request: Request,
+    daemon: Daemon = Depends(get_daemon),
+) -> RobotNameResponse:
+    """Persist a new robot display name and apply it live (no restart).
+
+    Persists the name to disk, then refreshes the advertised copies so the
+    rename takes effect immediately: the daemon status + central relay (via
+    ``Daemon.apply_robot_name``) and the LAN mDNS record. This is the REST
+    entry point used by the BLE setup service; the WebRTC ``set_robot_name``
+    command goes through the same live-apply path on the backend.
+    """
+    stored = set_robot_name(body.name)
+    if stored is None:
+        raise HTTPException(status_code=422, detail="Invalid robot name")
+
+    # Live-apply: daemon status + central relay. Fail-safe so a wiring issue
+    # can't turn a successful persist into an HTTP error.
+    try:
+        daemon.apply_robot_name(stored)
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            "apply_robot_name failed after rename: %s", e
+        )
+
+    # Re-advertise the LAN mDNS record if the app lifespan wired it up.
+    mdns = getattr(request.app.state, "mdns", None)
+    if mdns is not None:
+        try:
+            mdns.update_name(stored)
+        except Exception as e:
+            logging.getLogger(__name__).warning(
+                "mDNS update_name failed after rename: %s", e
+            )
+
+    return RobotNameResponse(name=stored)
 
 
 @router.get("/hardware-id")

--- a/src/reachy_mini/daemon/app/routers/daemon.py
+++ b/src/reachy_mini/daemon/app/routers/daemon.py
@@ -94,15 +94,23 @@ class RobotNameRequest(BaseModel):
 
 
 class RobotNameResponse(BaseModel):
-    """The persisted robot display name (``null`` when unset)."""
+    """The robot's current display name (``null`` only if none is resolvable)."""
 
     name: str | None = None
 
 
 @router.get("/robot-name")
-async def get_robot_display_name() -> RobotNameResponse:
-    """Return the persisted robot display name (``null`` when unset)."""
-    return RobotNameResponse(name=get_robot_name())
+async def get_robot_display_name(
+    daemon: Daemon = Depends(get_daemon),
+) -> RobotNameResponse:
+    """Return the robot's current display name.
+
+    Reports the effective/advertised name: the persisted override when a
+    client has renamed the robot, otherwise the ``--robot-name`` default the
+    daemon is running with. A client can pre-fill a rename field from this
+    without having to fall back to the daemon status for the default.
+    """
+    return RobotNameResponse(name=get_robot_name() or daemon.robot_name)
 
 
 @router.post("/robot-name")

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -959,6 +959,15 @@ class BluetoothCommandService:
             ssid = command_str[len("WIFI_FORGET ") :]
             self._run_async(lambda: _wifi_forget(ssid))
             return "OK: working"
+        # Set the robot display name over BLE (end of the setup flow). Mutating,
+        # so it requires a live TTL session like the WiFi commands. The name can
+        # contain spaces, so everything after "SET_NAME " is the raw value.
+        elif upper.startswith("SET_NAME "):
+            if not self._is_authed():
+                return "ERROR: Not connected. Please authenticate first."
+            name = command_str[len("SET_NAME ") :].strip()
+            self._run_async(lambda: _set_robot_name(name))
+            return "OK: working"
 
         # else if command starts with "CMD_xxxxx" check if  commands directory contains the said named script command xxxx.sh and run its, show output or/and send to read
         elif command_str.startswith("CMD_"):
@@ -1475,6 +1484,30 @@ def _wifi_connect_sealed(blob: str) -> str:
         if e.code == 409:
             return "ERROR: Busy"
         return "ERROR: Connect request failed"
+    except urllib.error.URLError:
+        return "ERROR: Daemon unreachable"
+    except Exception as e:
+        return f"ERROR: {e}"
+
+
+def _set_robot_name(name: str) -> str:
+    """Persist + live-apply the robot display name (proxy to the daemon).
+
+    Relays to the daemon's ``/api/daemon/robot-name`` route, which persists
+    the name and applies it live (status + central relay + mDNS) so it takes
+    effect without a restart. Best-effort by design: naming is the last,
+    non-critical step of setup.
+    """
+    name = name.strip()
+    if not name:
+        return "ERROR: Missing name"
+    try:
+        _daemon_request("POST", "/api/daemon/robot-name", data={"name": name})
+        return f"OK: Named {name}"
+    except urllib.error.HTTPError as e:
+        if e.code == 422:
+            return "ERROR: Invalid name"
+        return "ERROR: Set name failed"
     except urllib.error.URLError:
         return "ERROR: Daemon unreachable"
     except Exception as e:

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -36,6 +36,7 @@ from reachy_mini.io.protocol import (
     GetHardwareIdCmd,
     GetMicrophoneVolumeCmd,
     GetMotorModeCmd,
+    GetRobotNameCmd,
     GetStateCmd,
     GetTrackedFaceCmd,
     GetVersionCmd,
@@ -63,6 +64,7 @@ from reachy_mini.io.protocol import (
     SetHeadTrackingCmd,
     SetMicrophoneVolumeCmd,
     SetMotorModeCmd,
+    SetRobotNameCmd,
     SetSpeechOffsetsCmd,
     SetTargetCmd,
     SetTorqueCmd,
@@ -1471,6 +1473,30 @@ class Backend:
             from reachy_mini.utils.hardware_id import get_hardware_id
 
             send_response({"hardware_id": get_hardware_id()})
+
+        elif isinstance(cmd, (GetRobotNameCmd, SetRobotNameCmd)):
+            # Robot display name is a persistent, robot-wide string stored on
+            # disk (same fail-safe helpers as the first-wake-up flag). A rename
+            # takes effect on the next daemon start, where the persisted value
+            # overrides the --robot-name default.
+            from reachy_mini.utils.robot_name import get_robot_name, set_robot_name
+
+            if isinstance(cmd, SetRobotNameCmd):
+                stored = set_robot_name(cmd.name)
+                send_response(
+                    {
+                        "command": "set_robot_name",
+                        "status": "ok" if stored is not None else "error",
+                        "name": stored if stored is not None else get_robot_name(),
+                    }
+                )
+            else:  # GetRobotNameCmd
+                send_response(
+                    {
+                        "command": "get_robot_name",
+                        "name": get_robot_name(),
+                    }
+                )
 
         elif isinstance(
             cmd,

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -382,6 +382,12 @@ class Backend:
         # wakes (however the wake was triggered: on-start, button, or REST).
         self._on_wake_up_callback: Optional[Callable[[], None]] = None
 
+        # Synchronous callback fired after a `set_robot_name` command persists
+        # a new name. Wired in by the app lifespan to apply the rename live
+        # (daemon status + central relay + mDNS) so it takes effect without a
+        # restart. Receives the stored (trimmed) name and must return promptly.
+        self._set_robot_name_callback: Optional[Callable[[str], None]] = None
+
     # Life cycle methods
     def wrapped_run(self) -> None:
         """Run the backend in a try-except block to store errors."""
@@ -1476,13 +1482,22 @@ class Backend:
 
         elif isinstance(cmd, (GetRobotNameCmd, SetRobotNameCmd)):
             # Robot display name is a persistent, robot-wide string stored on
-            # disk (same fail-safe helpers as the first-wake-up flag). A rename
-            # takes effect on the next daemon start, where the persisted value
-            # overrides the --robot-name default.
+            # disk. A rename is applied live below (status + central relay +
+            # mDNS) via the set-robot-name callback, so no daemon restart is
+            # needed; the persisted value also overrides the --robot-name
+            # default on the next start.
             from reachy_mini.utils.robot_name import get_robot_name, set_robot_name
 
             if isinstance(cmd, SetRobotNameCmd):
                 stored = set_robot_name(cmd.name)
+                # Apply the rename live (status + central relay + mDNS) so it
+                # takes effect without a daemon restart. Fail-safe: a wiring
+                # error here must not break the persisted rename or the ack.
+                if stored is not None and self._set_robot_name_callback is not None:
+                    try:
+                        self._set_robot_name_callback(stored)
+                    except Exception as e:  # noqa: BLE001 - never break the cmd loop
+                        self.logger.warning(f"set_robot_name live-apply failed: {e}")
                 send_response(
                     {
                         "command": "set_robot_name",
@@ -2391,6 +2406,17 @@ class Backend:
         any async work as a task).
         """
         self._on_wake_up_callback = callback
+
+    def set_robot_name_callback(self, callback: Callable[[str], None]) -> None:
+        """Wire the live-apply hook for the ``set_robot_name`` DataChannel cmd.
+
+        The app lifespan injects a callback that refreshes the advertised
+        name in place (daemon status + central relay + mDNS) so a rename
+        takes effect without a daemon restart. It receives the persisted
+        (trimmed) name and MUST return promptly (any slow work is
+        thread-offloaded on its side).
+        """
+        self._set_robot_name_callback = callback
 
     def setup_media_server(self, media_server: Any) -> None:
         """Connect the backend to the media server.

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -250,6 +250,33 @@ class Daemon:
         except Exception as e:
             self.logger.debug(f"Error stopping central signaling relay: {e}")
 
+    def apply_robot_name(self, name: str) -> None:
+        """Apply a new robot name to the live daemon without a restart.
+
+        Refreshes the in-memory name and the daemon status, then nudges the
+        central relay so its next heartbeat advertises the new label. The
+        persistent store (``utils/robot_name``) is written by the caller
+        (the ``set_robot_name`` command handler); this only updates the
+        live/advertised copies. mDNS re-registration is wired separately in
+        the app lifespan, which owns the ``MdnsServiceRegistration``.
+
+        Safe to call from the backend's command thread: it only mutates
+        attributes and calls the relay's thread-safe name setter.
+        """
+        new_name = (name or "").strip()
+        if not new_name:
+            return
+        self.robot_name = new_name
+        self._status.robot_name = new_name
+        try:
+            from reachy_mini.media.central_signaling_relay import (
+                notify_robot_name_change,
+            )
+
+            notify_robot_name_change(new_name)
+        except Exception as e:
+            self.logger.warning(f"Failed to update relay robot name: {e}")
+
     async def start(
         self,
         sim: bool = False,

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -8,6 +8,7 @@ Client->Server command types:
     set_motor_mode, set_torque, get_motor_mode,
     set_gravity_compensation, set_automatic_body_yaw,
     get_state, get_version, start_recording, stop_recording, append_record,
+    get_robot_name, set_robot_name,
     subscribe_logs, unsubscribe_logs, restart_daemon, start_update,
     upload_move_start, upload_move_chunk, upload_move_finish,
     upload_audio_start, upload_audio_chunk, upload_audio_finish,
@@ -292,6 +293,23 @@ class GetMicrophoneVolumeCmd(BaseModel):
     """Query the current input (microphone) volume."""
 
     type: Literal["get_microphone_volume"] = "get_microphone_volume"
+
+
+# Robot display name. A persistent, robot-wide string (not per-session):
+# advertised to the central relay / mDNS and shown in the apps' robot list.
+# Defaults to the daemon's --robot-name; a client rename is stored on the
+# robot and wins over the default at the next daemon start.
+class GetRobotNameCmd(BaseModel):
+    """Query the persisted robot display name (null if unset)."""
+
+    type: Literal["get_robot_name"] = "get_robot_name"
+
+
+class SetRobotNameCmd(BaseModel):
+    """Set and persist the robot display name."""
+
+    type: Literal["set_robot_name"] = "set_robot_name"
+    name: str = Field(..., min_length=1, max_length=64)
 
 
 class SetSpeechOffsetsCmd(BaseModel):
@@ -753,6 +771,8 @@ AnyCommand = Annotated[
     | GetVolumeCmd
     | SetMicrophoneVolumeCmd
     | GetMicrophoneVolumeCmd
+    | GetRobotNameCmd
+    | SetRobotNameCmd
     | SubscribeLogsCmd
     | UnsubscribeLogsCmd
     | RestartDaemonCmd

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -31,6 +31,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, TypeAdapter
 
 from reachy_mini.utils.interpolation import InterpolationTechnique
+from reachy_mini.utils.robot_name import MAX_ROBOT_NAME_LENGTH
 
 # ------------------------------------------------------------------
 # Shared enums
@@ -309,7 +310,7 @@ class SetRobotNameCmd(BaseModel):
     """Set and persist the robot display name."""
 
     type: Literal["set_robot_name"] = "set_robot_name"
-    name: str = Field(..., min_length=1, max_length=64)
+    name: str = Field(..., min_length=1, max_length=MAX_ROBOT_NAME_LENGTH)
 
 
 class SetSpeechOffsetsCmd(BaseModel):

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -1732,6 +1732,25 @@ async def notify_token_change(new_token: Optional[str] = None) -> None:
     await _relay_instance.update_token(new_token)
 
 
+def notify_robot_name_change(new_name: str) -> None:
+    """Update the producer name advertised to the central relay.
+
+    The name is read fresh from ``self.robot_name`` on every heartbeat
+    re-emit (see ``_heartbeat_loop`` / ``_producer_status_payload``), so
+    mutating it here is enough for central to pick up the new label at the
+    next heartbeat (a few seconds) with no reconnect. A plain attribute
+    write is atomic under the GIL, so this is safe to call from the
+    backend's command thread. No-op if no relay is running.
+    """
+    if _relay_instance is not None and new_name:
+        _relay_instance.robot_name = new_name
+        logger.info(
+            "[Central Relay] robot name updated to %r "
+            "(propagates to central on next heartbeat)",
+            new_name,
+        )
+
+
 async def notify_force_reconnect() -> bool:
     """Force the central signaling relay to drop and reconnect right now.
 

--- a/src/reachy_mini/utils/discovery.py
+++ b/src/reachy_mini/utils/discovery.py
@@ -103,6 +103,21 @@ class MdnsServiceRegistration:
         thread.start()
         thread.join(timeout=5.0)
 
+    def update_name(self, robot_name: str) -> None:
+        """Re-advertise the service under a new name.
+
+        Unregisters the current service (if any) then registers a fresh
+        one so a live rename shows up on the LAN without a daemon restart.
+        No-op when the name is unchanged; never raises (register /
+        unregister already swallow their own errors).
+        """
+        new_name = (robot_name or "").strip()
+        if not new_name or new_name == self._robot_name:
+            return
+        self.unregister()
+        self._robot_name = new_name
+        self.register()
+
     def _do_register(self) -> None:
         try:
             pkg_version = version("reachy_mini")

--- a/src/reachy_mini/utils/robot_name.py
+++ b/src/reachy_mini/utils/robot_name.py
@@ -1,0 +1,63 @@
+"""Persistence for the user-set robot name.
+
+The robot's display name (advertised to the central signaling relay, over
+mDNS, and shown in the apps' robot list) defaults to the daemon's
+``--robot-name`` CLI argument. When a client renames the robot (e.g. from
+the mobile app over the WebRTC data channel) the new name is stored here so
+it survives reboots and wins over the CLI default at the next daemon start.
+
+It lives as a tiny JSON file under the user's config dir, next to the
+first-wake-up flag. Every failure path is swallowed so a read/write error
+can never crash the daemon command loop.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_STATE_PATH = Path.home() / ".config" / "reachy_mini" / "robot_name.json"
+
+# Keep names short enough for mDNS / UI labels and free of surrounding
+# whitespace. Empty names are rejected (treated as "no override").
+_MAX_NAME_LENGTH = 64
+
+
+def get_robot_name() -> str | None:
+    """Return the persisted robot name, or None if none is stored.
+
+    Defaults to None (no override) on a missing file or any read / parse
+    error, so the caller falls back to the CLI default.
+    """
+    try:
+        data = json.loads(_STATE_PATH.read_text())
+        name = data.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        return None
+    except FileNotFoundError:
+        return None
+    except Exception as e:  # noqa: BLE001 - never crash the command loop
+        logger.warning("Could not read robot name: %s", e)
+        return None
+
+
+def set_robot_name(name: str) -> str | None:
+    """Persist a new robot name.
+
+    Returns the stored (trimmed, length-capped) name on success, or None on
+    empty/invalid input or a write error.
+    """
+    sanitized = name.strip()[:_MAX_NAME_LENGTH] if isinstance(name, str) else ""
+    if not sanitized:
+        return None
+    try:
+        _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _STATE_PATH.write_text(json.dumps({"name": sanitized}))
+        return sanitized
+    except Exception as e:  # noqa: BLE001 - never crash the command loop
+        logger.warning("Could not write robot name: %s", e)
+        return None

--- a/src/reachy_mini/utils/robot_name.py
+++ b/src/reachy_mini/utils/robot_name.py
@@ -22,8 +22,9 @@ logger = logging.getLogger(__name__)
 _STATE_PATH = Path.home() / ".config" / "reachy_mini" / "robot_name.json"
 
 # Keep names short enough for mDNS / UI labels and free of surrounding
-# whitespace. Empty names are rejected (treated as "no override").
-_MAX_NAME_LENGTH = 64
+# whitespace. Empty names are rejected (treated as "no override"). This is the
+# single source of truth for the cap; the SetRobotNameCmd schema imports it.
+MAX_ROBOT_NAME_LENGTH = 64
 
 
 def get_robot_name() -> str | None:
@@ -51,7 +52,7 @@ def set_robot_name(name: str) -> str | None:
     Returns the stored (trimmed, length-capped) name on success, or None on
     empty/invalid input or a write error.
     """
-    sanitized = name.strip()[:_MAX_NAME_LENGTH] if isinstance(name, str) else ""
+    sanitized = name.strip()[:MAX_ROBOT_NAME_LENGTH] if isinstance(name, str) else ""
     if not sanitized:
         return None
     try:

--- a/tests/unit_tests/test_robot_name.py
+++ b/tests/unit_tests/test_robot_name.py
@@ -44,8 +44,8 @@ def test_set_trims_surrounding_whitespace(state_path: Path):
 def test_set_caps_length_to_max(state_path: Path):
     long_name = "x" * 200
     stored = robot_name.set_robot_name(long_name)
-    assert stored == "x" * robot_name._MAX_NAME_LENGTH
-    assert robot_name.get_robot_name() == "x" * robot_name._MAX_NAME_LENGTH
+    assert stored == "x" * robot_name.MAX_ROBOT_NAME_LENGTH
+    assert robot_name.get_robot_name() == "x" * robot_name.MAX_ROBOT_NAME_LENGTH
 
 
 @pytest.mark.parametrize("value", ["", "   ", "\n\t"])

--- a/tests/unit_tests/test_robot_name.py
+++ b/tests/unit_tests/test_robot_name.py
@@ -1,0 +1,81 @@
+"""Unit tests for the persisted robot-name helpers.
+
+Exercise ``get_robot_name`` / ``set_robot_name`` against a tmp config path
+(monkeypatched ``_STATE_PATH``) so the real ``~/.config`` is never touched.
+The helpers are deliberately fail-safe: every error path returns ``None``
+instead of raising, so a storage problem can't break the daemon command loop.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from reachy_mini.utils import robot_name
+
+
+@pytest.fixture
+def state_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the module at a throwaway JSON file under a tmp config dir."""
+    path = tmp_path / ".config" / "reachy_mini" / "robot_name.json"
+    monkeypatch.setattr(robot_name, "_STATE_PATH", path)
+    return path
+
+
+def test_get_returns_none_when_unset(state_path: Path):
+    assert robot_name.get_robot_name() is None
+
+
+def test_set_then_get_round_trips(state_path: Path):
+    assert robot_name.set_robot_name("Wall-E") == "Wall-E"
+    assert robot_name.get_robot_name() == "Wall-E"
+
+
+def test_set_creates_parent_dirs(state_path: Path):
+    assert not state_path.parent.exists()
+    robot_name.set_robot_name("R2D2")
+    assert state_path.is_file()
+
+
+def test_set_trims_surrounding_whitespace(state_path: Path):
+    assert robot_name.set_robot_name("  Eve  ") == "Eve"
+    assert robot_name.get_robot_name() == "Eve"
+
+
+def test_set_caps_length_to_max(state_path: Path):
+    long_name = "x" * 200
+    stored = robot_name.set_robot_name(long_name)
+    assert stored == "x" * robot_name._MAX_NAME_LENGTH
+    assert robot_name.get_robot_name() == "x" * robot_name._MAX_NAME_LENGTH
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\n\t"])
+def test_set_rejects_empty_or_whitespace(state_path: Path, value: str):
+    assert robot_name.set_robot_name(value) is None
+    assert not state_path.exists()
+
+
+def test_set_rejects_non_string(state_path: Path):
+    assert robot_name.set_robot_name(123) is None  # type: ignore[arg-type]
+    assert not state_path.exists()
+
+
+def test_get_is_failsafe_on_corrupt_json(state_path: Path):
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("{ not valid json")
+    assert robot_name.get_robot_name() is None
+
+
+def test_get_ignores_non_string_name(state_path: Path):
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text('{"name": 42}')
+    assert robot_name.get_robot_name() is None
+
+
+def test_set_is_failsafe_on_write_error(
+    state_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    def boom(*a, **k):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(robot_name.Path, "write_text", boom)
+    assert robot_name.set_robot_name("Hal") is None

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -1359,8 +1359,10 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
 
     /**
      * Set and persist the robot display name on the robot. Resolves with the
-     * stored (trimmed) name, or `null` on error / channel-closed. Takes effect
-     * on the next daemon restart (the persisted name overrides --robot-name).
+     * stored (trimmed) name, or `null` on error / channel-closed. Applied live
+     * by the daemon (status + central relay + mDNS), so it takes effect right
+     * away without a restart; the persisted name also overrides --robot-name
+     * on the next start.
      */
     setRobotName(name: string): Promise<string | null> {
         return this._slotRoundtrip(

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -183,6 +183,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
     private _volumeResolve: ((v: number | null) => void) | null = null;
     private _micVolumeResolve: ((v: number | null) => void) | null = null;
     private _trackedFaceResolve: ((v: FaceTarget | null) => void) | null = null;
+    private _robotNameResolve: ((v: string | null) => void) | null = null;
     // applyAudioConfig() / readAudioParameter() share the same single-slot
     // pattern as the volume helpers. Separate slots so the two can be
     // in-flight concurrently without collision.
@@ -743,6 +744,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
         if (this._trackedFaceResolve) { this._trackedFaceResolve(null); this._trackedFaceResolve = null; }
         if (this._applyAudioConfigResolve) { this._applyAudioConfigResolve(false); this._applyAudioConfigResolve = null; }
         if (this._readAudioParameterResolve) { this._readAudioParameterResolve(null); this._readAudioParameterResolve = null; }
+        if (this._robotNameResolve) { this._robotNameResolve(null); this._robotNameResolve = null; }
         this._logSubscribers.clear();
         this._updateProgressSubscribers.clear();
         this._rejectPendingMotionCompletions(new Error('Session stopped'));
@@ -792,6 +794,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
         if (this._trackedFaceResolve) { this._trackedFaceResolve(null); this._trackedFaceResolve = null; }
         if (this._applyAudioConfigResolve) { this._applyAudioConfigResolve(false); this._applyAudioConfigResolve = null; }
         if (this._readAudioParameterResolve) { this._readAudioParameterResolve(null); this._readAudioParameterResolve = null; }
+        if (this._robotNameResolve) { this._robotNameResolve(null); this._robotNameResolve = null; }
         this._logSubscribers.clear();
         this._updateProgressSubscribers.clear();
         this._rejectPendingMotionCompletions(new Error('Disconnected'));
@@ -1338,6 +1341,32 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
             () => this._micVolumeResolve,
             (next) => { this._micVolumeResolve = next; },
             { type: 'set_microphone_volume', volume: clampVolume(volume) },
+        );
+    }
+
+    /**
+     * Query the persisted robot display name. Resolves the stored name,
+     * `null` when none is set / the channel isn't open / the daemon predates
+     * the `get_robot_name` command.
+     */
+    getRobotName(): Promise<string | null> {
+        return this._slotRoundtrip(
+            () => this._robotNameResolve,
+            (next) => { this._robotNameResolve = next; },
+            { type: 'get_robot_name' },
+        );
+    }
+
+    /**
+     * Set and persist the robot display name on the robot. Resolves with the
+     * stored (trimmed) name, or `null` on error / channel-closed. Takes effect
+     * on the next daemon restart (the persisted name overrides --robot-name).
+     */
+    setRobotName(name: string): Promise<string | null> {
+        return this._slotRoundtrip(
+            () => this._robotNameResolve,
+            (next) => { this._robotNameResolve = next; },
+            { type: 'set_robot_name', name },
         );
     }
 
@@ -2029,6 +2058,15 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
             if (this._micVolumeResolve) {
                 this._micVolumeResolve(data.status === 'error' ? null : (data.volume as number));
                 this._micVolumeResolve = null;
+            }
+            return;
+        }
+        if (data.command === 'get_robot_name' || data.command === 'set_robot_name') {
+            if (this._robotNameResolve) {
+                this._robotNameResolve(
+                    data.status === 'error' ? null : ((data.name as string | null) ?? null),
+                );
+                this._robotNameResolve = null;
             }
             return;
         }

--- a/ts/lib/types.ts
+++ b/ts/lib/types.ts
@@ -361,6 +361,17 @@ export interface ReachyMiniInstance extends EventTarget {
     setMicrophoneVolume(volume: number): Promise<number | null>;
 
     /**
+     * Query the persisted robot display name. `null` when none is set, the
+     * channel isn't open, or the daemon predates the `get_robot_name` command.
+     */
+    getRobotName(): Promise<string | null>;
+    /**
+     * Set and persist the robot display name (takes effect on the next daemon
+     * restart). Resolves with the stored name, or `null` on error.
+     */
+    setRobotName(name: string): Promise<string | null>;
+
+    /**
      * Apply a batch of XVF3800 audio-board parameters on the robot.
      * Mirrors the on-robot `AudioBase.apply_audio_config()` SDK call.
      * Resolves `true` when every parameter was written (and, when

--- a/ts/lib/types.ts
+++ b/ts/lib/types.ts
@@ -366,8 +366,9 @@ export interface ReachyMiniInstance extends EventTarget {
      */
     getRobotName(): Promise<string | null>;
     /**
-     * Set and persist the robot display name (takes effect on the next daemon
-     * restart). Resolves with the stored name, or `null` on error.
+     * Set and persist the robot display name. Applied live by the daemon
+     * (status + central relay + mDNS), so it takes effect right away without a
+     * restart. Resolves with the stored name, or `null` on error.
      */
     setRobotName(name: string): Promise<string | null>;
 


### PR DESCRIPTION
Extracted from #1286 — the last of the split. Self-contained robot-rename feature, incl. the no-restart live-apply path.

## What

A user-set robot **display name** that persists on the robot, wins over the `--robot-name` CLI default, and is applied **live** (no daemon restart) across every place the name is advertised.

## Why

The robot's name (shown in the apps' robot list, advertised over mDNS and to the central relay) was fixed at the `--robot-name` CLI value. Owners need to rename a robot from the app / BLE setup flow and see it take effect immediately.

## How

**Persistence** (`utils/robot_name.py`)
- Fail-safe JSON store under the config dir (never raises). `MAX_ROBOT_NAME_LENGTH` is the single source of truth, imported by the command schema.
- At startup, a persisted name overrides `args.robot_name` (`main.py`), so a rename survives reboots.

**Commands / API**
- Data channel: `get_robot_name` / `set_robot_name` (`protocol.py`, backend handler in `abstract.py`).
- REST: `GET` / `POST /api/daemon/robot-name` (`routers/daemon.py`, + regenerated OpenAPI spec) — the entry point used by the BLE setup service.
- BLE: `SET_NAME` command proxying the REST route (`bluetooth_service.py`).
- SDK: `getRobotName()` / `setRobotName()` (`reachy-mini.ts`, `types.ts`).

**Live-apply (no restart)**
- `Daemon.apply_robot_name` refreshes the in-memory name + daemon status and nudges the central relay, which re-advertises on its next heartbeat (a few seconds, no reconnect — `notify_robot_name_change`).
- `MdnsServiceRegistration.update_name` re-registers the LAN record.
- The backend exposes a `set_robot_name_callback`; the app lifespan wires it to `apply_robot_name` + mDNS `update_name` once both exist. Every write path (data channel, REST, BLE) converges on the same live-apply.

## Tests

`tests/unit_tests/test_robot_name.py` — persistence round-trip, trimming, length cap, whitespace/non-string rejection, corrupt-JSON fail-safe, write-error fail-safe. Local: `ruff`/`mypy` clean, SDK `tsc` passes, `generate_openapi.py` produces no drift.

## Scope notes

- Assembled from the rename-specific hunks of #1286's commits. **Excluded on purpose:** the unrelated recorded-move / joint-state changes and the drive-by formatting churn (`_broadcast` / `DiscoveredRobot.__repr__` / argparse reflows) that were bundled into the same upstream commit; and the BLE *advertised-name* experiment (`9b838fbec` / `f5c823b4b`), which is a separate broadcast-name concern that was mostly reverted.
- The middle commit's subject still reads "…+ add onboarding JS SDK methods" from the original; those `getFirstWakeUp`/`setFirstWakeUp` SDK methods were stripped here (they belong to the wizard feature). Commit lineage kept intact; this description is the accurate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
