### PR TITLE
fix(daemon): fix install hanging on "finalizing" (WS terminal status lost)

### DIFF
--- a/src/reachy_mini/daemon/app/bg_job_register.py
+++ b/src/reachy_mini/daemon/app/bg_job_register.py
@@ -58,6 +58,16 @@ def run_command(
 
     start_evt = threading.Event()
 
+    # The job runs in its own thread/event loop, but the WS waiters in
+    # ``new_log_evt`` live in the main daemon loop. ``asyncio.Event.set()`` is
+    # not thread-safe and won't wake that loop, so the terminal DONE/FAILED
+    # notification can be lost, leaving ``ws_poll_info`` parked forever. Hop
+    # back onto the main loop via ``call_soon_threadsafe`` to wake the waiters.
+    try:
+        main_loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
+    except RuntimeError:
+        main_loop = None
+
     async def wrapper() -> None:
         jh.info.status = JobStatus.IN_PROGRESS
 
@@ -65,7 +75,10 @@ def run_command(
             def emit(self, record: logging.LogRecord) -> None:
                 jh.info.logs.append(self.format(record))
                 for ws in jh.new_log_evt.values():
-                    ws.set()
+                    if main_loop is not None:
+                        main_loop.call_soon_threadsafe(ws.set)
+                    else:
+                        ws.set()
 
         logger = logging.getLogger(f"logs_job_{job_uuid}")
         logger.setLevel(logging.INFO)

--- a/tests/unit_tests/test_bg_job_register.py
+++ b/tests/unit_tests/test_bg_job_register.py
@@ -1,0 +1,52 @@
+"""Regression tests for background job log streaming over WebSocket."""
+
+import asyncio
+import json
+import threading
+
+import pytest
+
+from reachy_mini.daemon.app import bg_job_register
+from reachy_mini.daemon.app.bg_job_register import JobStatus
+
+
+class _FakeWebSocket:
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    async def send_text(self, text: str) -> None:
+        self.texts.append(text)
+
+    async def send_json(self, data: dict) -> None:  # pragma: no cover
+        self.texts.append(json.dumps(data))
+
+
+@pytest.mark.asyncio
+async def test_ws_poll_info_receives_terminal_status_from_worker_thread():
+    """A job finishing in its worker thread must wake the WS waiter in the main loop.
+
+    ``run_command`` runs the job in a separate thread with its own event loop, but
+    the ``new_log_evt`` waiters live in the daemon loop. ``asyncio.Event.set()`` is
+    not thread-safe, so without hopping back onto the daemon loop the terminal DONE
+    notification is lost and ``ws_poll_info`` hangs forever (the desktop app's
+    "finalizing" step never completes and the connection eventually drops).
+    """
+    proceed = threading.Event()
+
+    async def job(logger):
+        logger.info("working")
+        await asyncio.to_thread(proceed.wait)
+
+    job_id = bg_job_register.run_command("test", job)
+
+    ws = _FakeWebSocket()
+    task = asyncio.create_task(bg_job_register.ws_poll_info(ws, job_id))
+
+    await asyncio.sleep(0.1)  # let ws_poll_info register its waiter
+    proceed.set()
+
+    await asyncio.wait_for(task, timeout=10)
+
+    terminal = json.loads(ws.texts[-1])
+    assert terminal["status"] == JobStatus.DONE.value
+    assert any("completed successfully" in t for t in ws.texts)


### PR DESCRIPTION
## Summary

Installing an app from the desktop app hangs on the **"finalizing"** step until the connection drops, even though the daemon logs `Job 'install' completed successfully`.

**Root cause:** background jobs (`install`, `update`, `remove`, `daemon-*`) run in a **separate thread** with their own event loop (`run_command` → `threading.Thread(target=lambda: asyncio.run(wrapper()))`), but the WebSocket log waiters in `new_log_evt` live in the **main daemon loop**. `JobLogger.emit()` wakes them with `asyncio.Event.set()` **from the worker thread**, which is not thread-safe and doesn't wake the main loop's selector.

While the job produces a flood of logs, the main loop stays busy from other traffic and lines trickle through. But the terminal `... completed successfully` / `DONE` line is the *last* thing to happen — nothing is left to wake the main loop, so `ws_poll_info` stays parked in `await ...wait()`, never sends the terminal status, and the client hangs on "finalizing" until the socket drops.

**Fix:** capture the daemon loop in `run_command` and wake waiters with `loop.call_soon_threadsafe(ws.set)`, which writes to the loop's self-pipe and wakes it immediately. Applies to all background jobs.

## Test plan

- [x] New regression test `tests/unit_tests/test_bg_job_register.py` runs a real job in the worker thread and asserts `ws_poll_info` delivers the terminal `DONE` status.
  - With the fix: passes in ~0.15s.
  - Reverted to `ws.set()`: fails with `TimeoutError` after 10s (logs show "completed successfully" but the WS terminal status never arrives) — reproduces the reported hang.