### PR TITLE
fix: use main branch instead of develop for conversation template

### DIFF
--- a/src/reachy_mini/apps/fork_conversation.py
+++ b/src/reachy_mini/apps/fork_conversation.py
@@ -145,7 +145,7 @@ def _clone_repo(console: Console, target_path: Path) -> None:
                 "--depth",
                 "1",
                 "-b",
-                "develop",
+                "main",
                 CONVERSATION_APP_REPO,
                 str(tmp_clone),
             ],


### PR DESCRIPTION
### Context
I was following the tutorial and specifically the video from the documentation here: https://huggingface.co/docs/reachy_mini/SDK/readme. 
However, when I ran the command ` reachy-mini-app-assistant` create --template conversation my_app .` to create the app, it crashed and didn't work as shown in the video.

### The Issue
After investigating the error, I realized the CLI was trying to clone the `develop` branch of the template repository, which no longer exists. 

### The Fix
I updated the target branch in the `_clone_repo` function from `"develop"` to `"main"`. 

The command runs successfully now without crashing, and the repository is cloned. However, to be completely transparent, I don't have a definitive reference to compare my local files against, so I cannot be 100% certain that the final output is exactly what is expected. It would be great if your team could quickly double-check the resulting folder structure