### PR TITLE
test: fix flaky antenna watcher wake-from-baseline test on macos

### DIFF
--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -346,7 +346,10 @@ async def test_antenna_watcher_wakes_from_baseline_when_target_is_missing() -> N
     try:
         await asyncio.sleep(0.03)
         daemon.backend.present = [0.30, 0.0]
-        await asyncio.sleep(0.03)
+        for _ in range(50):
+            if mgr.started:
+                break
+            await asyncio.sleep(0.01)
 
         assert daemon.backend.wake_up_calls == 1
         assert mgr.started == ["foo"]


### PR DESCRIPTION
## Problem

`pytest` fails intermittently on `macos-latest` (and this is what tanks CI on #1294, where the ubuntu job only shows red because fail-fast cancels it after macos fails):

```
FAILED tests/unit_tests/test_autostart_app.py::test_antenna_watcher_wakes_from_baseline_when_target_is_missing
  AssertionError: assert [] == ['foo']
```

## Cause

The test flipped the antenna position, then waited a **fixed** `asyncio.sleep(0.03)` for the watcher coroutine to observe the change and call `mgr.start`, before asserting `mgr.started == ["foo"]`. On slower runners that fixed window isn't always long enough, so the watcher hasn't started the app yet and the assertion fails.

## Fix

Poll until `mgr.started` is populated (bounded to 50 × 0.01s) instead of sleeping a fixed amount — the same pattern already used by the sibling `test_antenna_watcher_starts_app_when_target_missing_and_antennas_move` test just above it. No production code changes.

Branched from `main` with only this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)