### PR TITLE
docs: point users to the JavaScript/Web app path by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ Reachy Mini comes with an app store powered by Hugging Face Spaces. You can inst
 ### User guides
 * **[Installation](https://huggingface.co/docs/reachy_mini/SDK/installation)**: 5 minutes to set up your computer
 * **[Quickstart Guide](https://huggingface.co/docs/reachy_mini/SDK/quickstart)**: Run your first behavior on Reachy Mini
-* **[Python SDK](https://huggingface.co/docs/reachy_mini/SDK/python-sdk)**: Learn to move, see, speak, and hear.
+* **[JavaScript SDK & Web Apps](https://huggingface.co/docs/reachy_mini/SDK/javascript-sdk)**: Build browser apps that drive the robot over WebRTC — **the recommended path for most apps**.
 * **[AI Integrations](https://huggingface.co/docs/reachy_mini/SDK/integration)**: Connect LLMs, build Apps, and publish to Hugging Face.
 * **[Core Concepts](https://huggingface.co/docs/reachy_mini/SDK/core-concept)**: Architecture, coordinate systems, and safety limits.
+* **[Python SDK](https://huggingface.co/docs/reachy_mini/SDK/python-sdk)**: Lower-level on-robot control from Python.
 * 🤗[**Share your app with the community**](https://huggingface.co/blog/pollen-robotics/make-and-publish-your-reachy-mini-apps)
 * 📂 [**Browse the Examples Folder**](examples)
 * 📓 [**Tutorial Notebooks**](docs/notebooks): Step-by-step Jupyter notebooks covering connection, movement, camera, and audio
@@ -57,7 +58,9 @@ Using an AI coding agent (Claude Code, Codex, Copilot, etc.)? You can start buil
 This [**AGENTS.md**](AGENTS.md) guide gives AI agents everything they need: SDK patterns, best practices, example apps, and step-by-step skills.
 
 ### Quick Look
-After [installing the SDK](https://huggingface.co/docs/reachy_mini/SDK/installation), once your robot is awake, you can control it in just **a few lines of code**:
+Most Reachy Mini apps are **web / JS apps**: a static page that drives the robot over WebRTC from any browser, with zero install for whoever uses it — this is the recommended path for new apps (see the [JavaScript SDK & Web Apps](https://huggingface.co/docs/reachy_mini/SDK/javascript-sdk) guide).
+
+Prefer to stay in Python for on-robot control loops? After [installing the SDK](https://huggingface.co/docs/reachy_mini/SDK/installation), once your robot is awake, you can control it in just **a few lines of code**:
 
 ```python
 from reachy_mini import ReachyMini

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Reachy Mini comes with an app store powered by Hugging Face Spaces. You can inst
 ### User guides
 * **[Installation](https://huggingface.co/docs/reachy_mini/SDK/installation)**: 5 minutes to set up your computer
 * **[Quickstart Guide](https://huggingface.co/docs/reachy_mini/SDK/quickstart)**: Run your first behavior on Reachy Mini
-* **[JavaScript SDK & Web Apps](https://huggingface.co/docs/reachy_mini/SDK/javascript-sdk)**: Build browser apps that drive the robot over WebRTC — **the recommended path for most apps**.
+* **[JavaScript SDK & Web Apps](https://huggingface.co/docs/reachy_mini/SDK/javascript-sdk)**: Build browser apps that drive the robot over WebRTC — **the easiest way to share your apps**.
 * **[AI Integrations](https://huggingface.co/docs/reachy_mini/SDK/integration)**: Connect LLMs, build Apps, and publish to Hugging Face.
 * **[Core Concepts](https://huggingface.co/docs/reachy_mini/SDK/core-concept)**: Architecture, coordinate systems, and safety limits.
-* **[Python SDK](https://huggingface.co/docs/reachy_mini/SDK/python-sdk)**: Lower-level on-robot control from Python.
+* **[Python SDK](https://huggingface.co/docs/reachy_mini/SDK/python-sdk)**: Full robot control from Python — scripts, control loops, and on-robot code.
 * 🤗[**Share your app with the community**](https://huggingface.co/blog/pollen-robotics/make-and-publish-your-reachy-mini-apps)
 * 📂 [**Browse the Examples Folder**](examples)
 * 📓 [**Tutorial Notebooks**](docs/notebooks): Step-by-step Jupyter notebooks covering connection, movement, camera, and audio

--- a/docs/source/SDK/apps.md
+++ b/docs/source/SDK/apps.md
@@ -289,23 +289,23 @@ Open the Reachy Mini dashboard and click **Install** on any community app. This 
 
 ### Via the REST API
 
+The daemon host is `localhost:8000` on Lite (daemon on your machine) and `reachy-mini.local:8000` (or the robot's IP) on Wireless — substitute it for `<HOST>` below.
+
 ```bash
 # Install from Hugging Face
-curl -X POST http://localhost:8000/api/apps/install \
+curl -X POST http://<HOST>/api/apps/install \
   -H "Content-Type: application/json" \
   -d '{"url": "https://huggingface.co/spaces/<user>/<app_name>"}'
 
 # Start an app
-curl -X POST http://localhost:8000/api/apps/start-app/<app_name>
+curl -X POST http://<HOST>/api/apps/start-app/<app_name>
 
 # Stop the current app
-curl -X POST http://localhost:8000/api/apps/stop-current-app
+curl -X POST http://<HOST>/api/apps/stop-current-app
 
 # List installed apps
-curl http://localhost:8000/api/apps/list
+curl http://<HOST>/api/apps/list
 ```
-
-Replace `localhost` with `reachy-mini.local` or the robot's IP address for the Wireless version.
 
 ### Offline / manual deployment for a Wireless unit
 
@@ -359,7 +359,7 @@ sudo journalctl -u reachy-mini-daemon --since '5 min ago' | grep -v "uvicorn\|GE
 
 | Problem | Solution |
 |---------|----------|
-| "An app is already running" | Stop the current app first: `curl -X POST http://localhost:8000/api/apps/stop-current-app` |
+| "An app is already running" | Stop the current app first: `curl -X POST http://<HOST>/api/apps/stop-current-app` (`<HOST>` is `localhost:8000` on Lite, `reachy-mini.local:8000` on Wireless) |
 | Daemon in a bad state | Restart it: `sudo systemctl restart reachy-mini-daemon` (wait ~30s before starting an app) |
 | App not picking up code changes | Restart the app. If you deployed manually, also clear bytecode: `rm -rf __pycache__` |
 

--- a/docs/source/SDK/core-concept.md
+++ b/docs/source/SDK/core-concept.md
@@ -9,7 +9,7 @@ Reachy Mini uses a **Client-Server** architecture:
 1.  **The Daemon (Server):** 
     * Runs on the computer connected to the robot (or the simulation).
     * Handles hardware I/O (USB/Serial), safety checks, and sensor reading.
-    * Exposes a REST API (`localhost:8000`) and WebSocket.
+    * Exposes a REST API and WebSocket at `http://<host>:8000` — the host is `localhost` on Lite (daemon on your machine) and `reachy-mini.local` (or the robot's IP) on Wireless.
     
 2.  **The SDK (Client):**
     * Your Python code (`reachy_mini` package).

--- a/docs/source/SDK/integration.md
+++ b/docs/source/SDK/integration.md
@@ -12,9 +12,11 @@ Want a zero-install, cross-platform app that runs in the browser? Check out the 
 ## HTTP & WebSocket API
 Building a dashboard or a non-Python controller? The Daemon exposes full control via REST.
 
-* **Docs:** `http://localhost:8000/docs`
+The daemon host is `localhost:8000` on Lite (daemon on your machine) and `reachy-mini.local:8000` (or the robot's IP) on Wireless — substitute it for `<HOST>` below.
+
+* **Docs:** `http://<HOST>/docs`
 * **Get State:** `GET /api/state/full`
-* **WebSocket:** `ws://localhost:8000/api/state/ws/full`
+* **WebSocket:** `ws://<HOST>/api/state/ws/full`
 
 ## AI Experimentation Tips
 

--- a/docs/source/SDK/javascript-sdk.md
+++ b/docs/source/SDK/javascript-sdk.md
@@ -67,7 +67,13 @@ you call directly if you opted out of the host shell.
 ```js
 new ReachyMini({
     signalingUrl: "https://pollen-robotics-reachy-mini-central.hf.space",  // default
-    enableMicrophone: true,  // default — request mic on startSession()
+    clientId: "my-app",              // optional — OAuth client / app id
+    appName: "My App",               // optional — label advertised to the robot
+    videoJitterBufferTargetMs: 0,    // optional — 0 = render ASAP (teleop); omit for default browser buffering
+    autoStartFromUrl: false,         // optional — auto startSession() when the URL carries a robot_peer_id hint
+    // NOTE: `enableMicrophone` is deprecated and ignored. The SDK never grabs
+    // the user's mic; it always wires a silent placeholder audio sender you
+    // can replaceTrack() with your own audio (TTS, files, or the user's mic).
 })
 ```
 
@@ -79,18 +85,27 @@ new ReachyMini({
      └─────────────────────────────┘
 ```
 
+> **One-shot bring-up.** `autoConnect(options?)` runs the whole
+> auth → `connect()` → robot pick → `startSession()` → `ensureAwake()`
+> chain and resolves to `{ robotId, robotName, isEmbedded }`. It
+> auto-picks when exactly one robot is free, otherwise calls your
+> `options.pickRobot(robots)` callback. This is the recommended entry
+> point when you're **not** using the host shell.
+
 ### Properties (read-only)
 
 | Property | Type | Description |
 | :--- | :--- | :--- |
 | `state` | `string` | `"disconnected"`, `"connected"`, or `"streaming"` |
 | `robots` | `Array` | Available robots: `[{ id, meta: { name } }]` |
-| `robotState` | `Object` | Latest `state` event detail — `{ head: number[16], antennas: [rRad, lRad], body_yaw, motor_mode, is_move_running }` (wire shape) |
+| `robotState` | `Object` | Latest `state` event detail — `{ head: number[16], antennas: [rRad, lRad], head_joint_positions: number[7], antennas_joint_positions: [rRad, lRad], body_yaw, motor_mode, is_move_running }` (wire shape). `head_joint_positions` is per-motor radians: body yaw at `[0]`, the 6 Stewart-platform neck motors at `[1..6]`; `antennas_joint_positions` is `[right, left]` in radians. Both fields appear only once the daemon emits them. |
 | `username` | `string\|null` | HF username after `authenticate()` |
 | `isAuthenticated` | `boolean` | True if a valid HF token is available |
 | `micSupported` | `boolean` | True if robot offers bidirectional audio |
 | `micMuted` | `boolean` | Your microphone mute state |
 | `audioMuted` | `boolean` | Robot speaker mute state (local only) |
+| `preselectedRobotId` | `string\|null` | Robot id read from `?robot_peer_id=` / `#robot_peer_id=` (set by the host iframe) |
+| `isEmbedded` | `boolean` | `true` iff `preselectedRobotId !== null` — UX branching helper (embed vs standalone) |
 
 ### Methods
 
@@ -99,26 +114,47 @@ new ReachyMini({
 | `authenticate()` | `Promise<boolean>` | Check for existing HF OAuth token |
 | `login()` | — | Redirect to HF login page |
 | `connect()` | `Promise` | Open SSE connection, receive robot list |
+| `autoConnect(opts?)` | `Promise<{robotId, robotName, isEmbedded}>` | One-shot bring-up: auth → connect → pick robot → session → wake. Auto-picks a single free robot, else calls `opts.pickRobot(robots)` |
 | `startSession(robotId)` | `Promise` | Negotiate WebRTC, resolves when video + data ready |
 | `stopSession()` | `Promise` | End session, back to `connected` |
 | `disconnect()` | — | Close signaling (keeps auth) |
 | `logout()` | — | Clear HF credentials |
 | `attachVideo(videoEl)` | `() => void` | Bind video stream to element; returns cleanup function |
 | `setTarget({ head?, antennas?, body_yaw? })` | `boolean` | Atomic raw-units update — `head` is `number[16]` (flat 4×4), `antennas` is `[rRad, lRad]`, `body_yaw` is radians |
+| `gotoTarget({ head?, antennas?, body_yaw?, duration })` | `boolean` | Smooth daemon-side interpolation to a target pose over `duration` seconds (same wire units as `setTarget`). Throws `TypeError` on invalid input |
 | `setHeadRpyDeg(roll, pitch, yaw)` | `boolean` | Set head orientation in degrees (wraps `setTarget`) |
 | `setAntennasDeg(right, left)` | `boolean` | Set antenna positions in degrees (wraps `setTarget`) |
 | `setBodyYawDeg(yaw)` | `boolean` | Set body yaw in degrees (wraps `setTarget`) |
+| `startHeadTracking(weight?)` / `stopHeadTracking()` | `boolean` | Enable / disable daemon-side visual head tracking. `weight` in `[0,1]` blends tracking with app motion (default `1.0`) |
+| `getTrackedFace()` | `Promise<FaceTarget\|null>` | Latest face seen by head tracking — `{ detected, x, y, roll }` |
+| `setMotorMode(mode)` | `boolean` | `"enabled"` (position control), `"disabled"` (limp), or `"gravity_compensation"` (float by hand) |
+| `setMotorTorque(on, ids?)` | `boolean` | Toggle torque; per-motor when `ids` is given, else global |
+| `wakeUp(opts?)` / `gotoSleep(opts?)` | `Promise<void>` | Play the wake-up / sleep trajectory; resolves on daemon completion (rejects after `opts.timeoutMs`, default 8000). `wakeUp` enables motors first |
+| `isAwake()` | `boolean` | Awake state derived from the cached `motor_mode` |
+| `ensureAwake(timeoutMs?)` | `Promise<boolean>` | Idempotent wake-up: no-op if already awake; does not await the trajectory |
 | `playSound(filename)` | `boolean` | Play a sound file on the robot |
 | `clearIncomingAudio()` | `boolean` | Drop audio queued for the robot speaker (barge-in) |
 | `sendRaw(data)` | `boolean` | Send arbitrary JSON via data channel |
 | `requestState()` | `boolean` | Request a state snapshot |
 | `setAudioMuted(muted)` | — | Mute/unmute robot speaker (local) |
 | `setMicMuted(muted)` | — | Mute/unmute your microphone |
+| `getVolume()` / `setVolume(v)` | `Promise<number\|null>` | Read / set speaker volume (integer `0..100`, clamped); resolves the applied value or `null` if unavailable |
+| `getMicrophoneVolume()` / `setMicrophoneVolume(v)` | `Promise<number\|null>` | Read / set microphone gain (integer `0..100`, clamped) |
+| `getVersion()` | `Promise<string\|null>` | Daemon version string |
+| `getHardwareId()` | `Promise<string\|null>` | Hardware ID (USB serial); `null` on developer machines |
+| `applyAudioConfig(config, opts?)` | `Promise<boolean>` | Write a batch of XVF3800 audio-board parameters (`[{ name, values }]`); `opts.verify` reads them back (default `true`). Wireless only |
+| `readAudioParameter(name)` | `Promise<number[]\|null>` | Read one XVF3800 parameter by name |
+| `subscribeLogs({ onLine, onError? })` | `() => void` | Stream the daemon's `journalctl` logs over the data channel; returns an unsubscribe fn |
+| `playRecordedMove(name, opts?)` | `boolean` | Play a named move (motion + bundled sound) from a HF dataset, daemon-side. Fire-and-forget (resolves on send, not on playback end). `opts.dataset` defaults to the pre-downloaded emotions library; `opts.initialGotoDuration` sets the lead-in goto |
 | `playMove(motion, opts?)` | `Promise<{finished?, cancelled?, error?, has_audio?}>` | Upload + play a recorded move (optionally with audio) on the daemon's local clock; resolves when playback ends — see [Daemon-side recorded-move playback](#daemon-side-recorded-move-playback) |
 | `cancelMove()` | `boolean` | Cancel an in-flight `playMove` |
 | `uploadAudio(blob, opts?)` | `Promise<string>` | Upload a standalone audio slot, returns `uploadId` — pair with `playUploadedAudio` for record-time sync |
 | `playUploadedAudio(uploadId, opts?)` | `Promise<{started: true, ...}>` | Trigger daemon-side standalone audio playback; resolves on the daemon's `started` broadcast (use as a sync anchor) |
 | `cancelAudio()` | `boolean` | Cancel an in-flight `playUploadedAudio` |
+| `subscribePose()` / `unsubscribePose()` | `boolean` | Opt into a ~30 Hz daemon-pushed pose stream (unreliable/unordered data channel) that fires `state` events, instead of the 500 ms `requestState` poll. Refcounted — pair each subscribe with one unsubscribe. No-op on daemons without the pose channel |
+| `getFirstWakeUp()` / `setFirstWakeUp(done)` | `Promise<boolean\|null>` | Read / persist the robot-wide "first wake-up wizard completed" flag. `null` = channel closed or daemon predates the command (fail-open: skip the wizard) |
+| `getRobotName()` / `setRobotName(name)` | `Promise<string\|null>` | Read / persist the robot display name. Applied live by the daemon (status + central relay + mDNS), no restart needed. Resolves the stored name, or `null` on error / unsupported |
+| `signOut()` | `Promise<boolean\|null>` | Sign the robot out of Hugging Face (daemon deletes its stored HF token, de-registering it from central). Reaches the robot remotely over the data channel. The session may drop right after the ack — expected |
 
 > **`setTarget` head-vs-body coupling.** The `head` matrix is in the
 > world frame. Sending `setTarget({ body_yaw })` alone rotates the
@@ -146,6 +182,10 @@ Use `robot.addEventListener(name, handler)` — the SDK extends `EventTarget`.
 | `videoTrack` | `{ track, stream }` | Video track available |
 | `micSupported` | `{ supported }` | Bidirectional audio availability |
 | `error` | `{ source, error }` | Error from `signaling`, `webrtc`, or `robot` |
+| `sessionRejected` | `{ reason, activeApp }` | The robot refused the session (e.g. busy with another app) |
+| `iceStateChange` | `{ state }` | Granular ICE transition (`RTCIceConnectionState`); a transient `disconnected` is debounced before it escalates to `error` |
+| `networkOnline` / `networkOffline` | `{}` | Browser connectivity regained / lost |
+| `networkChange` | `{ effectiveType?, downlink?, rtt?, saveData? }` | Transport swap (Wi-Fi ↔ cellular) via the NetworkInformation API; best-effort, Chromium-only |
 
 ### Math Utilities
 
@@ -155,6 +195,14 @@ import { rpyToMatrix, matrixToRpy, degToRad, radToDeg } from "@pollen-robotics/r
 rpyToMatrix(roll, pitch, yaw)  // degrees → 4×4 rotation matrix (ZYX)
 matrixToRpy(matrix)            // 4×4 matrix → { roll, pitch, yaw } in degrees
 ```
+
+### Advanced: JSON-RPC & daemon admin
+
+Beyond the typed surface above, the runtime object exposes lower-level hooks (not part of the host-shell typed handle — reach for these only when you need them):
+
+- `rpcCall(method, params?, { timeoutMs? })` — send a JSON-RPC request over the data channel and await the correlated result (e.g. app-defined methods).
+- `onNotification(method, cb)` — subscribe to one-way JSON-RPC notifications pushed by the robot/app (e.g. `conversation.turn`); returns an unsubscribe fn.
+- `startDaemonUpdate({ preRelease?, onProgress? })` — trigger a PyPI update of the daemon. It restarts on success (which tears the session down), so treat a successful reconnect as the "done" signal; `onProgress` fires with `status: "failed"` if the install errors first.
 
 ## Daemon-side recorded-move playback
 
@@ -215,6 +263,56 @@ Audio must be canonical **16 kHz mono 16-bit PCM WAV**. Apps are responsible for
 ### Backpressure & cancellation
 
 `playMove` and `uploadAudio` pace chunk sends on the data channel's `bufferedAmount` so multi-megabyte uploads (a 3-min song's WAV is ~6 MB base64) don't degrade other channels on the same peer connection. There's no separate `pause` — to stop a long upload mid-way, close the session.
+
+## Live pose stream (30 Hz)
+
+By default the SDK refreshes `robotState` by polling `requestState()` every
+500 ms. For anything that mirrors the robot in real time (a 3D view, a
+"wait for the move to finish" watcher), opt into the daemon's **pose
+stream** instead: it *pushes* the state at ~30 Hz over a dedicated
+unreliable/unordered data channel, firing the same `state` events.
+
+```js
+robot.subscribePose();               // start the push stream
+robot.addEventListener("state", (e) => {
+    // e.detail.head_joint_positions → per-motor radians (body yaw + 6 neck)
+    render(e.detail);
+});
+
+// Later, when this consumer no longer needs the stream:
+robot.unsubscribePose();
+```
+
+The subscription is **refcounted**: multiple consumers share one daemon-side
+stream, so pair every `subscribePose()` with exactly one `unsubscribePose()`
+— the daemon only stops pushing once the last consumer releases. Frames that
+arrive out of order are dropped (the channel is unordered). Against an older
+daemon that has no pose channel this is a no-op; fall back to `requestState()`
+polling there.
+
+## Robot onboarding & management
+
+These daemon-side commands power first-run setup and remote administration.
+Each resolves `null` when the data channel isn't open or the daemon predates
+the command, so **fail-open**: treat `null` as "unsupported" and skip the
+gated UI.
+
+```js
+// First wake-up wizard (robot-wide, persisted on the robot).
+if ((await robot.getFirstWakeUp()) === false) {
+    await runWakeUpWizard();
+    await robot.setFirstWakeUp(true);
+}
+
+// Robot display name — applied live (status + central relay + mDNS), no restart.
+const name = await robot.getRobotName();
+await robot.setRobotName("Marvin");
+
+// Sign the robot out of Hugging Face (deletes its stored token; the robot
+// disappears from its owner's list until set up again). The session may
+// tear down right after the ack — that's expected.
+await robot.signOut();
+```
 
 ## Security
 

--- a/docs/source/SDK/javascript-sdk.md
+++ b/docs/source/SDK/javascript-sdk.md
@@ -178,7 +178,7 @@ Use `robot.addEventListener(name, handler)` — the SDK extends `EventTarget`.
 | `robotsChanged` | `{ robots }` | Robot list updated |
 | `streaming` | `{ sessionId, robotId }` | WebRTC session active |
 | `sessionStopped` | `{ reason }` | Session ended |
-| `state` | `{ head, antennas, body_yaw, motor_mode, is_move_running }` | Robot state update (~500ms; wire shape — see "Receive robot state" above) |
+| `state` | Same shape as the `robotState` property (see above) | Robot state update (~500 ms polled, or ~30 Hz when subscribed via `subscribePose()`; wire shape) |
 | `videoTrack` | `{ track, stream }` | Video track available |
 | `micSupported` | `{ supported }` | Bidirectional audio availability |
 | `error` | `{ source, error }` | Error from `signaling`, `webrtc`, or `robot` |

--- a/docs/source/SDK/python-sdk.md
+++ b/docs/source/SDK/python-sdk.md
@@ -1,6 +1,6 @@
 # Python SDK Reference
 
-> **Heads up:** For building and shipping apps, the recommended path is now **[JavaScript & Web Apps](javascript-sdk.md)**. The Python SDK is kept here as a reference for lower-level on-robot control, but is no longer actively developed.
+> **Heads up:** The Python and **[JavaScript](javascript-sdk.md)** SDKs both give you full control of the robot — they simply target different audiences. If you want to build apps that are easy to share (zero-install, open a link in a browser), the JavaScript/Web path is usually the better fit. The Python SDK shines for scripting, control loops, and code running directly on the robot.
 
 > **💡 Reminder:** The SDK now auto-detects whether it should connect over USB/localhost or over the network, so `ReachyMini()` works out of the box. You can still force a mode with `ReachyMini(connection_mode="localhost_only" | "network")` if needed.
 

--- a/docs/source/SDK/python-sdk.md
+++ b/docs/source/SDK/python-sdk.md
@@ -1,5 +1,7 @@
 # Python SDK Reference
 
+> **Heads up:** For building and shipping apps, the recommended path is now **[JavaScript & Web Apps](javascript-sdk.md)**. The Python SDK is kept here as a reference for lower-level on-robot control, but is no longer actively developed.
+
 > **💡 Reminder:** The SDK now auto-detects whether it should connect over USB/localhost or over the network, so `ReachyMini()` works out of the box. You can still force a mode with `ReachyMini(connection_mode="localhost_only" | "network")` if needed.
 
 ## Movement

--- a/docs/source/SDK/quickstart.md
+++ b/docs/source/SDK/quickstart.md
@@ -77,7 +77,7 @@ The **Daemon** is a background service that handles the low-level communication 
       >
       > If you get a segmentation fault from `libgstpython`, see the [simulation troubleshooting](../platforms/simulation/get_started.md#-troubleshooting) section.
 
-✅ **Verification:** Open [http://localhost:8000/docs](http://localhost:8000/docs) in your browser. If you see the Reachy SDK API documentation, you are ready!
+✅ **Verification:** Open the daemon's API docs in your browser — [http://localhost:8000/docs](http://localhost:8000/docs) on Lite/Simulation (daemon on your machine), or [http://reachy-mini.local:8000/docs](http://reachy-mini.local:8000/docs) on Wireless (daemon on the robot). If you see the Reachy SDK API documentation, you are ready!
 
 ## 3. Your First Script
 

--- a/docs/source/SDK/readme.md
+++ b/docs/source/SDK/readme.md
@@ -26,10 +26,11 @@ with ReachyMini() as mini:
 ## 🚀 Get Started
 * **[Installation](installation.md)**: 5 minutes to set up your computer
 * **[Quickstart Guide](quickstart.md)**: Run your first behavior on Reachy Mini
-* **[Python SDK](python-sdk.md)**: Learn to move, see, speak, and hear.
-* **[AI Integrations](integration.md)**: Connect LLMs, build Apps, and publish to Hugging Face.
+* **[JavaScript SDK & Web Apps](javascript-sdk.md)**: Build browser apps that drive the robot over WebRTC — the recommended path for most apps.
 * **[Building & Publishing Apps](apps.md)**: Create, test, publish, and debug Reachy Mini apps.
+* **[AI Integrations](integration.md)**: Connect LLMs, build Apps, and publish to Hugging Face.
 * **[Core Concepts](core-concept.md)**: Architecture, coordinate systems, and safety limits.
+* **[Python SDK](python-sdk.md)**: Lower-level on-robot control from Python.
 
 ## 📂 Code Examples
 

--- a/docs/source/SDK/readme.md
+++ b/docs/source/SDK/readme.md
@@ -26,11 +26,11 @@ with ReachyMini() as mini:
 ## 🚀 Get Started
 * **[Installation](installation.md)**: 5 minutes to set up your computer
 * **[Quickstart Guide](quickstart.md)**: Run your first behavior on Reachy Mini
-* **[JavaScript SDK & Web Apps](javascript-sdk.md)**: Build browser apps that drive the robot over WebRTC — the recommended path for most apps.
+* **[JavaScript SDK & Web Apps](javascript-sdk.md)**: Build browser apps that drive the robot over WebRTC — the easiest way to share your apps.
 * **[Building & Publishing Apps](apps.md)**: Create, test, publish, and debug Reachy Mini apps.
 * **[AI Integrations](integration.md)**: Connect LLMs, build Apps, and publish to Hugging Face.
 * **[Core Concepts](core-concept.md)**: Architecture, coordinate systems, and safety limits.
-* **[Python SDK](python-sdk.md)**: Lower-level on-robot control from Python.
+* **[Python SDK](python-sdk.md)**: Full robot control from Python — scripts, control loops, and on-robot code.
 
 ## 📂 Code Examples
 

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -49,16 +49,16 @@
       title: Core Concepts
     - local: SDK/quickstart
       title: Quickstart Guide
-    - local: SDK/python-sdk
-      title: Python SDK
-    - local: SDK/integration
-      title: AI Integrations
-    - local: SDK/apps
-      title: Building & Publishing Apps
-    - local: API/rest-api
-      title: REST API
     - local: SDK/javascript-sdk
       title: JavaScript SDK & Web Apps
+    - local: SDK/apps
+      title: Building & Publishing Apps
+    - local: SDK/integration
+      title: AI Integrations
+    - local: SDK/python-sdk
+      title: Python SDK
+    - local: API/rest-api
+      title: REST API
     - local: SDK/media-architecture
       title: Media Architecture
     - local: SDK/gstreamer-installation

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -41,7 +41,11 @@ Reachy Mini comes with an app store powered by Hugging Face Spaces. You can inst
 />
 
 ### Quick Look
-Control your robot in just **a few lines of code**:
+Most Reachy Mini apps are **web / JS apps**: a static page that drives the robot over WebRTC from any browser, with zero install for whoever uses it. This is the recommended path for new apps. The fastest way is to describe your idea to an AI coding agent:
+
+> *I'd like to build a Reachy Mini web app that **[waves when I say hello]**. Read https://github.com/pollen-robotics/reachy_mini/blob/main/AGENTS.md first — it has everything you need.*
+
+Prefer to stay in Python for on-robot control loops? The Python SDK is still available:
 
 ```python
 from reachy_mini import ReachyMini
@@ -58,10 +62,11 @@ with ReachyMini() as mini:
 ### User guides
 * **[Installation](./SDK/installation.md)**: 5 minutes to set up your computer
 * **[Quickstart Guide](./SDK/quickstart.md)**: Run your first behavior on Reachy Mini
-* **[Python SDK](./SDK/python-sdk.md)**: Learn to move, see, speak, and hear.
-* **[AI Integrations](./SDK/integration.md)**: Connect LLMs, build Apps, and publish to Hugging Face.
+* **[JavaScript SDK & Web Apps](./SDK/javascript-sdk.md)**: Build browser apps that drive the robot over WebRTC — **the recommended path for most apps**.
 * **[Building & Publishing Apps](./SDK/apps.md)**: Create, test, publish, and debug Reachy Mini apps.
+* **[AI Integrations](./SDK/integration.md)**: Connect LLMs, build Apps, and publish to Hugging Face.
 * **[Core Concepts](./SDK/core-concept.md)**: Architecture, coordinate systems, and safety limits.
+* **[Python SDK](./SDK/python-sdk.md)**: Lower-level on-robot control from Python.
 * **[Tutorials](./sdk-tutorials.md)**: Hands-on Jupyter notebooks to learn the SDK step by step.
 * 📂 [**Browse the Examples Folder**](https://github.com/pollen-robotics/reachy_mini/tree/main/examples)
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -62,11 +62,11 @@ with ReachyMini() as mini:
 ### User guides
 * **[Installation](./SDK/installation.md)**: 5 minutes to set up your computer
 * **[Quickstart Guide](./SDK/quickstart.md)**: Run your first behavior on Reachy Mini
-* **[JavaScript SDK & Web Apps](./SDK/javascript-sdk.md)**: Build browser apps that drive the robot over WebRTC — **the recommended path for most apps**.
+* **[JavaScript SDK & Web Apps](./SDK/javascript-sdk.md)**: Build browser apps that drive the robot over WebRTC — **the easiest way to share your apps**.
 * **[Building & Publishing Apps](./SDK/apps.md)**: Create, test, publish, and debug Reachy Mini apps.
 * **[AI Integrations](./SDK/integration.md)**: Connect LLMs, build Apps, and publish to Hugging Face.
 * **[Core Concepts](./SDK/core-concept.md)**: Architecture, coordinate systems, and safety limits.
-* **[Python SDK](./SDK/python-sdk.md)**: Lower-level on-robot control from Python.
+* **[Python SDK](./SDK/python-sdk.md)**: Full robot control from Python — scripts, control loops, and on-robot code.
 * **[Tutorials](./sdk-tutorials.md)**: Hands-on Jupyter notebooks to learn the SDK step by step.
 * 📂 [**Browse the Examples Folder**](https://github.com/pollen-robotics/reachy_mini/tree/main/examples)
 

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -291,8 +291,8 @@ If you need to reset the robot's Wi-Fi hotspot (for example, if you can't connec
 <details>
 <summary><strong>Does the robot have a Web API?</strong></summary>
 
-Yes. The daemon provides a REST API (FastAPI) and WebSocket support.
-* **Docs:** `http://localhost:8000/docs` (available when daemon is running).
+Yes. The daemon provides a REST API (FastAPI) and WebSocket support. The daemon host is `localhost:8000` on Lite (daemon on your machine) and `reachy-mini.local:8000` (or the robot's IP) on Wireless.
+* **Docs:** `http://<host>:8000/docs` (available when daemon is running).
 * **Features:** Get state, Move joints, Control daemon.
 
 You can use the API to control the robot and get its state and even control the daemon itself. The API is implemented using [FastAPI](https://fastapi.tiangolo.com/) and [pydantic](https://docs.pydantic.dev/latest/) models.
@@ -302,7 +302,7 @@ It should provide you all the necessary endpoints to interact with the robot, in
 - Getting the state of the robot (joints positions, motor status, etc.)
 - Moving the robot's joints or setting specific poses
 
-The API is documented using OpenAPI, and you can access all available routes and test them at http://localhost:8000/docs when the daemon is running. You can also access the raw OpenAPI schema at http://localhost:8000/openapi.json.
+The API is documented using OpenAPI, and you can access all available routes and test them at `http://<host>:8000/docs` (`localhost` on Lite, `reachy-mini.local` or the robot's IP on Wireless) when the daemon is running. You can also access the raw OpenAPI schema at `http://<host>:8000/openapi.json`.
 
 This can be useful if you want to generate client code for your preferred programming language or framework, connect it to your AI application, or even to create your MCP server.
 
@@ -311,7 +311,9 @@ This can be useful if you want to generate client code for your preferred progra
 The API also supports WebSocket connections for real-time updates. For instance, you can subscribe to joint state updates:
 
 ```
-let ws = new WebSocket(`ws://127.0.0.1:8000/api/state/ws/full`);
+// Daemon host: "localhost:8000" on Lite, "reachy-mini.local:8000" on Wireless.
+const HOST = "localhost:8000";
+let ws = new WebSocket(`ws://${HOST}/api/state/ws/full`);
 
 ws.onmessage = (event) => {
     const data = JSON.parse(event.data);


### PR DESCRIPTION
## Summary

Reorients the documentation entry points so the **JavaScript SDK & Web Apps** guide becomes the default, recommended path for building Reachy Mini apps, instead of Python.

The Python SDK content is left in place (kept as a reference for lower-level on-robot control), just deprioritized in the navigation and framed as no longer actively developed.

Changes:
- `docs/source/index.mdx` - "Quick Look" now leads with the web/JS app path (agent workflow + `AGENTS.md`); the Python snippet stays below as the on-robot option. The user-guides list surfaces the JS SDK (previously not linked here at all) and moves Python down.
- `docs/source/SDK/readme.md` - same reordering in the "Get Started" list.
- `README.md` (repo landing) - same reorientation for the GitHub-facing page.
- `docs/source/_toctree.yml` - "Software guide" nav order updated: Quickstart -> JavaScript SDK & Web Apps -> Building & Publishing Apps -> AI Integrations -> Python SDK.
- `docs/source/SDK/python-sdk.md` - discrete note at the top pointing to the JS/Web path and stating the Python SDK is kept as reference but no longer actively developed.

No Python SDK content was removed.

## Test plan

- [ ] Doc builds / renders without broken links
- [ ] Sidebar nav order reflects JS-first ordering
- [ ] Wording review on the Python "no longer actively developed" note

Made with [Cursor](https://cursor.com)