### PR TITLE
docs(design): conversation service design breakdown

### DIFF
--- a/docs/design/conversation-service/01-conversation-engine.md
+++ b/docs/design/conversation-service/01-conversation-engine.md
@@ -1,0 +1,95 @@
+# 01 - Conversation engine
+
+Status: draft / design proposal.
+
+The engine is the in-process component that runs one speech-to-speech (S2S)
+session at a time. It owns the cloud realtime connection, its audio I/O, and its
+public `conversation.*` control surface. It is glue: it dispatches tool calls and
+drives the body through `motion.*`, but never touches motors directly.
+
+This doc covers the engine, the protocol it exposes, and its audio path - the
+three faces of the same block.
+
+## Public interface
+
+### `conversation.*` (JSON-RPC 2.0 over the WebRTC DataChannel)
+
+Rides the existing relay (#1266); no bespoke transport. Requests are dispatched
+by direct in-process calls to the controller.
+
+| method | params | blocking | resolves with |
+|---|---|---|---|
+| `conversation.start` | `config` | yes, until `running` or `start_timeout` | phase snapshot |
+| `conversation.stop` | `session_id?` | no | phase snapshot (`idle`) |
+| `conversation.restart` | `config`, `session_id?` | yes | phase snapshot (fresh `session_id`) |
+| `conversation.status` | - | no | phase snapshot |
+| `conversation.say` | `text`, `session_id?` | no (on accept) | result |
+| `conversation.interrupt` | `session_id?` | yes, until playback stops | result |
+
+### Events (one-way notifications, broadcast to every connected transport)
+
+- `conversation.phase` - `{ session_id, phase, reason, origin{by}, config }`. Source of truth, also returned by `status`.
+- `conversation.turn` - `{ state: listening|thinking|speaking, reason? }`.
+- `conversation.transcript` - `{ role, text, final }`.
+- `conversation.level` - `{ rms }` (~10 Hz).
+
+### Error `reason` codes (stable, UI branches on them)
+
+`robot_busy`, `missing_credentials`, `already_running`, `not_running`,
+`start_timeout`.
+
+### Consumes
+
+- `motion.*` ([`02-motion-service.md`](./02-motion-service.md)) for embodiment.
+- Tools ([`04-tools.md`](./04-tools.md)) on model tool-calls.
+- The daemon's mic/speaker hardware for audio I/O.
+
+## Lifecycle (controller FSM)
+
+```
+idle -> starting -> running -> stopping -> idle
+                 \-> error (transient) -> idle
+```
+
+- `start` resolves config, takes the robot lock, wakes the robot if asleep, opens
+  the S2S session, goes `running`.
+- `stop` tears down, sleeps the robot, releases the lock. Idempotent.
+- `restart` = stop + start (v1 may be non-atomic).
+- `say` injects an assistant turn; `interrupt` is barge-in (cancel response, flush
+  playback, back to `listening`).
+
+Wake/sleep and the lock are owned by the supervisor
+([`07-lifecycle-and-supervision.md`](./07-lifecycle-and-supervision.md)).
+
+## Audio
+
+- Mic capture + speaker playback happen in-process (GStreamer), low latency, no
+  WebRTC renegotiation.
+- The mic/speaker hardware has a **single owner** at a time; the engine
+  coordinates acquire/release with the daemon media server.
+- Barge-in flushes the player queue on user speech.
+- Audio never rides the control DataChannel. v1 keeps mic + speaker on the robot
+  (`local`); remote audio routes use dedicated WebRTC media tracks (later).
+
+## Key decisions
+
+- **In-process, warm, dormant.** Runs as a supervised asyncio task, deps ready at
+  boot, no session until a trigger. Not a subprocess (see README rationale).
+- **Reuse the relay, not a new transport.** `conversation.*` registers on #1266.
+- **Ported concurrency core, dropped debt.** Keep the serialized `response.create`
+  sender, `active_response` retry, debounced partial transcripts, barge-in flush,
+  tool plumbing, and the `ConversationHandler` ABC as the real contract. Drop the
+  `LocalStream` god-object, the multi-backend duck-typing, and the REST + SSE
+  surface.
+- **Stateless protocol.** No persistent server state; the full `config` is supplied
+  on every `start` and echoed on `phase`. A late-joining transport resyncs via
+  `status` (no replay buffer).
+- **Optional heavy deps.** HF realtime deps are an optional extra, lazy-imported,
+  so the daemon core stays lean.
+
+## PR1 scope
+
+Full FSM + `start/stop/status/say/interrupt`; ported S2S loop producing real
+audio + transcripts + tool calls; `conversation.*` on the relay with `phase` /
+`turn` / `transcript` / `level` broadcast and the five error codes; in-process
+audio with clean hardware ownership and barge-in. `restart` may be non-atomic.

--- a/docs/design/conversation-service/02-motion-service.md
+++ b/docs/design/conversation-service/02-motion-service.md
@@ -1,0 +1,79 @@
+# 02 - Motion service (embodiment)
+
+Status: draft / design proposal.
+
+The embodiment layer is a **standalone daemon capability**, not something buried
+inside the conversation. It is exposed over WebRTC as `motion.*` so **any client
+or JS-SDK app can drive the robot's body without a conversation session**. The
+conversation engine is just one consumer.
+
+## Public interface
+
+### `motion.*` (over the relay)
+
+Proposed v1 surface (minimal, extend later without breaking):
+
+| RPC | Params | Effect |
+|---|---|---|
+| `motion.play` | `{ name }` | Play a recorded move, interrupt breathing, return to base |
+| `motion.stop` | - | Stop the current move, resume idle |
+| `motion.look_at` | `{ yaw, pitch } \| null` | Aim gaze (smoothed/held); `null` releases |
+| `motion.set_listening` | `{ enabled }` | Freeze / blend-back the antennas |
+| `motion.set_idle` | `{ enabled }` | Turn idle life on/off |
+| `motion.status` | - | Current move, listening, loop stats |
+
+Later (roadmap): raw `motion.set_target` / `goto`, `motion.set_offsets`,
+`wake_up` / `goto_sleep`.
+
+### Consumed by
+
+- The conversation engine ([`01-conversation-engine.md`](./01-conversation-engine.md)):
+  enqueues emotion/dance moves, toggles `set_listening` on speech events.
+- The motion tools ([`04-tools.md`](./04-tools.md)): `play_emotion` / `dance` /
+  `move_head` resolve to `motion.*` calls.
+
+## Behavior model
+
+Four layers fused in a single control loop, summed on top of each other and
+clamped to the reachable envelope:
+
+- **Primary**: sequential recorded moves (emotions, dances, gotos) + the idle
+  breathing floor. The only layer that moves the antennas.
+- **Gaze** (additive): aim from face tracking.
+- **Offsets** (additive): speech-reactive wobble.
+
+Invariants: a move wins over breathing; gaze coexists with breathing but yields to
+expressive moves; direct poses pause idle and auto-resume; `set_listening` freezes
+then blends the antennas back.
+
+## Key decisions
+
+- **Standalone and over WebRTC.** "Alive" is a property of the robot, not of an
+  app. Every app gets the same breathing, never-frozen Reachy by sending
+  intentions ("play this emotion", "look here"), never a 30 Hz keep-alive from the
+  network.
+- **Lazy, under the lock.** Not always-on: started on the first `motion.*` call or
+  when a conversation starts, dormant otherwise. Runs under the current
+  `robot_app_lock` holder; never fights a store app for the motors. See
+  [`07-lifecycle-and-supervision.md`](./07-lifecycle-and-supervision.md).
+- **Not a general arbitration engine (explicit non-goal).** We ship the constrained
+  slice games have run for 20 years - a fixed layer set, trivial arbitration
+  (fixed priority + last-writer-wins), clamp as safety only, additive fusion in one
+  RT loop. No runtime-arbitrary blend graph, no "smart" command fusion. Tractable
+  because Reachy Mini is low-DoF, position-controlled, no balance, no contact.
+
+## Notes (implementation)
+
+- **Port** the primary layer + idle breathing + listening freeze in-process,
+  calling the backend motion API directly.
+- **Reuse** the daemon-side gaze from the existing vision stack
+  ([`03-vision.md`](./03-vision.md)) and the speech wobble already tapped in the
+  media server. Do not reimplement head tracking.
+- **New**: the fusion point (sum primary + gaze + offsets, clamp) and the `motion.*`
+  RPC binding on the relay.
+
+## PR1 scope
+
+Primary layer + idle breathing + listening freeze ported in-process; fusion with
+existing gaze and wobble; `motion.play` / `stop` / `set_listening` / `status` on
+the relay; drivable standalone with no conversation session.

--- a/docs/design/conversation-service/03-vision.md
+++ b/docs/design/conversation-service/03-vision.md
@@ -1,0 +1,79 @@
+# 03 - Vision
+
+Status: **already implemented in the daemon** (this doc describes the existing
+surface; the conversation service reuses it, it does not rebuild it).
+
+Vision is a daemon capability, not part of the conversation service. Two things
+matter to us: **camera frames** (a read-only fan-out any consumer can read) and
+**face/head tracking** (a daemon-side worker that feeds the gaze layer). Scene
+understanding ("what does the robot see?") is **cloud**, via the realtime model,
+not a local VLM.
+
+## Public interface (what already exists)
+
+### Camera frames
+
+One `GstMediaServer` owns the camera and fans it out over two channels from a
+single pipeline: a **WebRTC video track** (remote clients) and a **local IPC
+branch** (Unix socket `/tmp/reachymini_camera_socket`, Windows named pipe). BGR,
+paced at ~10 fps on the local feed.
+
+| Entry point | Where | Notes |
+|---|---|---|
+| `reachy.media.get_frame()` / `get_frame_jpeg()` | `media/media_manager.py` | The public "give me a frame" API (LOCAL IPC or WEBRTC, auto-selected) |
+| Unix socket / Win pipe | `daemon/utils.py` (`CAMERA_SOCKET_PATH` / `CAMERA_PIPE_NAME`) | Raw frame fan-out; multiple readers OK |
+| `GET /camera/specs` | `daemon/app/routers/camera.py` | Name, resolutions, intrinsics `K`, distortion `D`. No raw-frame HTTP endpoint. |
+
+The camera is a **read-only fan-out**: face tracking, the `camera` tool and remote
+WebRTC video all consume it concurrently. No exclusive lock (unlike audio).
+
+### Face / head tracking
+
+A `FaceTracker` daemon thread reads the same IPC socket, detects the largest/nearest
+face, smooths it, and exposes an aim the motion layer eases toward.
+
+| Surface | Method / route / command |
+|---|---|
+| SDK | `start_head_tracking(weight=1.0)`, `stop_head_tracking()`, `get_tracked_face()`, `look_at_image(...)`, `look_at_world(...)` |
+| HTTP | `POST /media/tracking/enable` (`{weight}`), `POST /media/tracking/disable`, `GET /media/tracking/face` |
+| Data-channel RPC | `set_head_tracking` (`{enabled, weight}`), `get_tracked_face` |
+| Status | `DaemonStatus.face_target` = `{ detected, x, y, roll, ts }` |
+
+`weight` in `[0, 1]` blends the gaze aim; `weight=0` pauses the worker without
+tearing it down. Tracking output (normalized center + roll) is what the motion
+service consumes as its **gaze layer**.
+
+### Detector
+
+- **YuNet on ONNX Runtime**, CPU, single-thread. Model pulled from HF Hub
+  (`pollen-robotics/face_detection_yunet_2026may`) on first tracking start.
+- Not YOLO, not MediaPipe (those only ever existed in an app-side experiment).
+
+## How the conversation service uses it
+
+- **Gaze**: the motion service ([`02-motion-service.md`](./02-motion-service.md))
+  consumes the tracker's aim as its additive gaze layer. It does not run detection
+  itself.
+- **`look` / `camera` tool** ([`04-tools.md`](./04-tools.md)): grabs one frame via
+  `media.get_frame()`, JPEG-encodes it, and hands it to the **cloud realtime model**
+  with the user's question. The picture is understood in the cloud, not on-device.
+
+## Key facts / decisions
+
+- **Reuse, don't rebuild.** Camera fan-out, YuNet tracking and look-at geometry are
+  already daemon-side and battle-tested. The conversation service wires into them.
+- **No local VLM in the daemon.** Scene understanding is cloud. A local SmolVLM2 was
+  prototyped in an app branch but is not part of the daemon and is out of scope
+  here.
+- **Read-only fan-out.** The camera has no single-owner constraint, so vision never
+  contends with the conversation the way audio does
+  ([`01-conversation-engine.md`](./01-conversation-engine.md)).
+- **Tracking is opt-in.** The worker is lazily created on the first
+  `enable`/`start_head_tracking` call and runs at lowest CPU priority.
+
+## Not in scope for this design
+
+Vision is pre-existing daemon infrastructure. There is no PR1 work item here beyond
+**wiring** the gaze layer and the `camera`/`look` tool to the surfaces above. Any
+on-device VLM, alternative detectors, or richer perception is a separate daemon
+effort, not part of the conversation service.

--- a/docs/design/conversation-service/04-tools.md
+++ b/docs/design/conversation-service/04-tools.md
@@ -1,0 +1,61 @@
+# 03 - Tools
+
+Status: draft / design proposal.
+
+Tools are the verbs the model may call. The runtime routes every call, bounds it,
+returns recoverable failures to the model, and cancels in-flight calls on
+`interrupt` / `stop`. The client only observes (informational `conversation.tool`
+events, later).
+
+## Public interface
+
+### Built-in set (v1)
+
+| Tool | Effect | Resolves to |
+|---|---|---|
+| `move_head` | Aim the head | `motion.*` |
+| `play_emotion` | Play an emotion clip | `motion.*` |
+| `dance` | Play a dance | `motion.*` |
+| `look` | Gaze / camera (when gaze is wired) | `motion.*` |
+
+Memory tools (`save_memory` / `recall_memory`) are always-on system tools,
+documented in [`05-memory.md`](./05-memory.md).
+
+### Selection
+
+- `config.tools` picks which built-ins are enabled for a session; unknown names
+  degrade (skipped + reported), never fail `start`.
+- `config.animations` scopes which clips the motion verbs may reach (AND with
+  `tools`). See [`06-personas-and-config.md`](./06-personas-and-config.md).
+
+### Execution contract
+
+- Each call is bounded by a timeout; on error/timeout the runtime returns a failure
+  the model can recover from.
+- `interrupt` / `stop` cancel in-flight calls; a result landing after cancellation
+  is dropped silently.
+- Tools that opt out of a spoken follow-up keep that behavior.
+
+## Consumed by / consumes
+
+- Called by the engine ([`01-conversation-engine.md`](./01-conversation-engine.md))
+  when the model emits a tool call.
+- Motion tools call into [`02-motion-service.md`](./02-motion-service.md).
+- The `camera` / `look` tools read a frame from the existing vision stack
+  ([`03-vision.md`](./03-vision.md)); scene understanding is done by the cloud model.
+
+## Key decisions
+
+- **Fixed built-in registry for v1.** No per-profile Python file loading, no
+  external dir scan, no remote MCP resolution at startup - that was a
+  startup-latency source. Keep the `BackgroundToolManager` (async execution,
+  cancel, timeout, cleanup); it is well built and tested - port close to as-is.
+- **Degrade, never fail.** Unknown tool/animation names are dropped and reported,
+  not fatal.
+- **MCP tool-spaces are the later extension path**, re-wired behind the same
+  `config.tools` shape.
+
+## PR1 scope
+
+`BackgroundToolManager` + `move_head` / `play_emotion` / `dance` wired to
+`motion.*`, fixed built-in registry, timeout + cancel-on-interrupt.

--- a/docs/design/conversation-service/05-memory.md
+++ b/docs/design/conversation-service/05-memory.md
@@ -1,0 +1,66 @@
+# 04 - Memory
+
+Status: draft / design proposal (V1 already implemented in the current app,
+see PR #360 line).
+
+Memory lets the robot recall facts across sessions, so the second interaction is
+not a blank slate. It is a **capability the engine drives**, exposed to the model
+as two always-on tools plus two automatic behaviors (logging + prompt injection).
+
+## Public interface
+
+### Model-facing tools (always-on system tools)
+
+Registered like `task_status` / `task_cancel`: auto-loaded for every persona, not
+listed in any `config.tools`.
+
+| Tool | Params | Returns | Effect |
+|---|---|---|---|
+| `save_memory` | `fact` (string) | `{ status: "saved", fact }` | Append a concise fact to active memory (prompt-injected next session). |
+| `recall_memory` | `log_ref` (string, or empty) | `{ log_ref, content }` \| `{ available_logs }` \| `{ error }` | Read a past session log; empty `log_ref` lists available logs. |
+
+### Automatic behaviors (no client/model action)
+
+- **Conversation logging.** Every user/assistant transcript and completed tool call
+  is appended to a per-session log. Fire-and-forget; failures never crash the audio
+  pipeline.
+- **Prompt injection.** Non-empty active memory is appended to the system prompt on
+  every session start and persona switch, so newly saved facts show up next time.
+
+### Configuration
+
+| Key | Default | Effect |
+|---|---|---|
+| `memory.enabled` | `true` | Turn the whole memory system on/off. |
+| data directory | `~/.reachy_mini/data/` | Root for logs + active memory (outside the repo). |
+
+Fits the session `config` object as an optional `memory` field
+([`06-personas-and-config.md`](./06-personas-and-config.md)); absent = defaults.
+
+## Two-tier model
+
+1. **Active memory** - a small curated file of facts, injected into the prompt.
+   Grows unbounded; a soft warning fires around ~1,500 tokens (comfortable headroom
+   under the realtime model's instruction budget).
+2. **Conversation logs** - full per-session transcripts, kept indefinitely, read on
+   demand via `recall_memory`. Each active-memory fact carries the log filename it
+   came from, so the model can pull the detailed conversation.
+
+## Key decisions
+
+- **Flat files, no vector DB (V1).** File-based grep/read matches the Letta
+  Filesystem benchmark (~74% LoCoMo, beating vector approaches) and is sufficient
+  below ~150 conversations. Vector search can slot in behind `recall_memory` later
+  with no interface change.
+- **LLM-driven save.** The model decides what to remember via `save_memory`, rather
+  than automatic extraction - more selective, less noise.
+- **Graceful degradation.** Enabled by default, disableable; any memory failure is
+  logged, never fatal to the conversation.
+- **Global, not per-persona.** One robot = one memory. Multi-user scoping is a
+  future extension (namespace the data dir by user id).
+
+## PR1 scope
+
+`save_memory` / `recall_memory` as always-on tools, per-session transcript logging,
+active-memory prompt injection, and the `memory.enabled` switch. Sleep-time
+compute, summarization, vector recall and a `forget_memory` tool are later.

--- a/docs/design/conversation-service/06-personas-and-config.md
+++ b/docs/design/conversation-service/06-personas-and-config.md
@@ -1,0 +1,76 @@
+# 05 - Personas and config
+
+Status: draft / design proposal.
+
+`config` is the single source of truth for a session, handed to
+`conversation.start`. A **persona** is a named preset that resolves into config
+fields (prompt / voice / tools). They belong together: config is the contract,
+personas are the convenience layer over it.
+
+## Public interface
+
+### `config` object (v1 fields)
+
+```jsonc
+{
+  "prompt": "You are a friendly desk robot...",
+  "voice": "...",
+  "language": "en",                 // soft hint, biases transcription
+  "tools": ["move_head", "play_emotion", "dance"],
+  "animations": { "emotions": ["happy", "curious"], "dances": ["wiggle", "spin"] }
+}
+```
+
+Every field optional; absent fields fill from robot defaults. Deferred (documented
+so they slot in without a protocol change): `memory`, `assets`, `sounds`,
+`wobble`, `vision.gaze`, `vad`, `inactivity_timeout_ms`, `audio` route.
+
+### `personalities.*` / `voices.*` (over the relay)
+
+Discovery:
+
+- `personalities.list` - choices + current + startup + lock state.
+- `personalities.all` - every persona with full config + `avatar_id` (no inline SVG).
+- `personalities.load` - one persona's instructions / greeting / tools / voice.
+- `personalities.avatar` - SVG markup for a persona (lazy, cached by `avatar_id`).
+- `voices.list` / `voices.current`.
+
+CRUD and apply:
+
+- `personalities.save` - create/update a user persona (persisted on the robot).
+- `personalities.delete` - delete a user persona (never a built-in or the active/startup one).
+- `personalities.apply` - apply now, optionally persist as the startup choice.
+- `voices.apply` - change voice live.
+
+## Config resolution (fill + degrade)
+
+On `start` the runtime produces an **effective config** deterministically:
+
+1. drop unknown fields, fill unset ones from robot defaults;
+2. resolve references, dropping ones that degrade (unknown `tools` / `animations` /
+   `voice` entry is removed, never fatal);
+3. normalise to canonical form (scalars by value, reference lists as sets).
+
+The effective config is echoed back on `conversation.phase`. Unknown field or
+reference degrades + is reported, never fails `start` - this is what keeps a newer
+client compatible with an older robot.
+
+## Key decisions
+
+- **Stateless protocol, config as resolver.** The full config is supplied on every
+  `start`; the protocol holds no persistent state. A thin client may send just a
+  persona name and let the robot resolve it, or send an inline config. Discovery of
+  names is out-of-band (`personalities.*` / `voices.*`), never enumerated by
+  `conversation.*`.
+- **Works standalone.** Default personas are embedded on the robot and the startup
+  persona is persisted, so the robot is usable with no client and no catalog.
+- **Port personas as-is.** `PersonalityOps` is already transport-agnostic; port it
+  and register on the relay. Avatar SVGs live on the robot (profile-local, built-in
+  map, default fallback, stable `avatar_id` for client caching).
+
+## PR1 scope
+
+The five v1 config fields with fill-defaults + degrade-unknown resolution and
+effective config echoed on `phase`; `personalities.*` / `voices.*` registered on
+the relay with default personas + persisted startup; a persona resolves into
+config.

--- a/docs/design/conversation-service/07-lifecycle-and-supervision.md
+++ b/docs/design/conversation-service/07-lifecycle-and-supervision.md
@@ -1,0 +1,106 @@
+# 06 - Lifecycle and supervision
+
+Status: draft / design proposal.
+
+The cross-cutting rules that govern both the conversation engine and the motion
+service: how they are kept warm and supervised, how they arbitrate robot
+ownership, how power state and failures are handled. These are settled decisions,
+not notes.
+
+## Public-facing behaviors
+
+- **Ownership errors** surface as `robot_busy` on `conversation.start`.
+- **Auth errors** surface as `missing_credentials`.
+- **Crashes** surface as `conversation.error { fatal: true }` + `phase: error`,
+  then settle back to `idle` (a retry is just another `start`).
+- **Inactivity** stops a session unless a control transport is connected.
+
+Everything below is how those behaviors are produced; it has no separate client
+surface.
+
+## Warm supervision
+
+A `ConversationSupervisor`:
+
+- Keeps code/deps **warm** at daemon boot but the **runtime dormant**: no session,
+  no motion loop until a trigger (`conversation.start`, or NFC/wake-word later).
+  The motion service is lazy (started on first `motion.*` or on conversation
+  start). No kiosk auto-start in v1.
+- Runs the engine as a supervised asyncio task; on unhandled exception it logs and
+  restarts the task gracefully without bouncing the daemon.
+- Runs a **memory watchdog**: polls RSS below the OOM point and recycles the
+  session before the kernel intervenes (workload has no sudden large allocation -
+  vision is cloud).
+- Keeps all queues **bounded**.
+
+Rule: a **heavy local model** (future on-device vision) gets its own process,
+OOM-scored. The engine does not; it stays in-process.
+
+## Robot ownership: the app lock arbitrates
+
+`robot_app_lock` is the single arbiter. Binary by design (conversation OR store app
+OR remote session, never two), so no hardware conflict and no extra feature flag
+for safety.
+
+- **Extension required**: a **conversation holder not bound to the triggering
+  transport**. `REMOTE_SESSION` dies with the WebRTC session and `LOCAL_APP` is a
+  subprocess; a conversation survives client disconnect, so it needs its own holder
+  identity/state, reusing the existing acquire / release / evict / `on_became_free`
+  machinery.
+- `conversation.start` while a store app holds the lock -> `robot_busy`; a store app
+  starting while a conversation holds it -> eviction or `robot_busy` per policy.
+- The lazy motion service operates under the current lock holder.
+- The lock already prevents the old store conversation app and the new in-daemon
+  service from running together, so hiding the old app behind a flag is optional
+  cosmetics, not a safety requirement.
+
+## Power state: wake / sleep owned by the daemon
+
+- `conversation.start`: if asleep, **wake first** (enable motors + wake-up
+  trajectory), then open the session.
+- `conversation.stop`, fatal error, inactivity stop: **`goto_sleep`** + release /
+  disable motors.
+- Motors enabled on demand, released when idle, never held awake across sessions.
+
+## Failure surfacing
+
+The **supervisor** (not the dead task) owns failure -> client surfacing:
+
+1. broadcast `conversation.error { fatal: true }` + `phase: error`;
+2. tear down the session (release lock, sleep/release motors, stop audio);
+3. settle to `idle`;
+4. re-arm the warm engine.
+
+`error` stays transient: every transport sees it via broadcast.
+
+## Inactivity auto-stop
+
+A prolonged inactivity window stops the session, **except when a control transport
+is connected** (e.g. the mobile app observing keeps it alive indefinitely). Any
+user/assistant turn or `say` resets the window.
+
+## Auth (HF credentials)
+
+`conversation.start` needs the HF token; absent -> `missing_credentials`. The
+daemon already owns OAuth device-code login + token refresh + sign-out. The engine
+just consumes the daemon-managed token; no new auth flow.
+
+## Starting animation (latency mask)
+
+Opening the S2S session takes a couple of seconds. During `starting` the controller
+plays a wake-up animation via `motion.*` so the robot feels responsive. Session
+pre-warm/pool is optional, only if the animation is not enough.
+
+## Camera sharing (non-issue)
+
+The camera is served by the daemon over IPC (unixfd socket), a read-only fan-out.
+Face tracking, the `look`/camera tool and remote WebRTC video all consume
+concurrently. No exclusive lock like audio.
+
+## PR1 scope
+
+Supervisor with warm-code/dormant-runtime, lazy motion, graceful task restart +
+memory watchdog + bounded queues; lifespan/teardown wiring; transport-independent
+conversation lock holder; wake-on-start / sleep-on-stop; crash -> error -> idle
+surfacing; inactivity stop gated by a connected transport; consume the daemon HF
+token; `starting` animation hook.

--- a/docs/design/conversation-service/08-testing.md
+++ b/docs/design/conversation-service/08-testing.md
@@ -1,0 +1,54 @@
+# 07 - Testing
+
+Status: draft / design proposal.
+
+Method: the public contract is precise enough to become a conformance suite first,
+then the implementation is written to green (docs -> tests -> agent).
+
+## Control plane: conformance tests (PR1)
+
+The control plane (RPC / events / config) is deterministic and mockable - unit
+testable with a mocked S2S backend and a mocked backend/motion layer:
+
+- **RPC subset**: `start` / `stop` / `status` / `say` / `interrupt` request-response
+  shapes and blocking semantics.
+- **Lifecycle**: `idle -> starting -> running -> stopping -> idle`, and `error` as a
+  transient that settles back to `idle`.
+- **Events**: `conversation.phase` (source of truth) and `conversation.turn`
+  sub-states emitted on the right transitions and broadcast to all transports.
+- **Config resolution**: fill-defaults, degrade-unknown-field,
+  degrade-unknown-reference; effective config echoed on `phase`.
+- **Error codes**: `robot_busy`, `not_running`, `missing_credentials`,
+  `already_running`, `start_timeout`.
+- **Observe-without-starting**: a second transport `status` mid-session sees
+  `running` + `origin.by`.
+
+Ported components keep their existing tests where they move over
+(`BackgroundToolManager`, personality ops, memory manager, motion primary layer).
+
+## Motion service
+
+- **Unit**: fusion clamps to the reachable envelope; move-wins-over-breathing;
+  `set_listening` freeze/blend; gaze yields to expressive moves.
+- **Standalone**: `motion.*` drivable with no conversation session.
+
+## End-to-end: full WebRTC (PR1)
+
+PR1 is driven **entirely over WebRTC** (relay #1266 + JS SDK), no REST/SSE
+fallback. The deliverable includes a **minimal WebRTC SDK harness** (a script or a
+tiny page) that runs `start` -> observes `phase` / `turn` / `transcript` -> `say`
+-> `interrupt` -> `stop`, and drives `motion.*` standalone. This harness is the
+actual driver for on-robot manual validation until the reference thin client lands.
+
+## Not unit-testable (human-in-the-loop)
+
+The embodied, real-time feel - turn-taking, voice, S2S latency, motion feel - needs
+HITL iteration on hardware. Validate on the robot over SSH
+(`journalctl -u reachy_mini`), and land latency `metrics` early to measure
+`first_audio_ms` / turn latency rather than guess.
+
+## PR1 scope
+
+The control-plane conformance suite for the v1 RPC/event/config/error subset, the
+motion-service unit tests (green against mocked backends), and the minimal WebRTC
+SDK harness for end-to-end validation.

--- a/docs/design/conversation-service/README.md
+++ b/docs/design/conversation-service/README.md
@@ -1,0 +1,163 @@
+# Conversation service - design breakdown
+
+Status: draft / design proposal.
+
+This folder is the **shared discussion base** for the on-robot conversation
+service and its embodiment layer. It is organised around the **public interface**
+of each block (the `conversation.*` / `motion.*` / `personalities.*` surfaces, the
+`config` schema, the model-facing tools), so the docs describe WHAT each block
+exposes and the decisions that frame it, not the internal wiring.
+
+A separate set of client-contract docs (overview / public API / design) defines
+the exact wire contract; when it lands it will be linked from here.
+
+## Goal
+
+Turn the conversation from a store app (separate subprocess, cold start, REST +
+SSE) into a **first-class in-process service of the daemon**, kept warm, exposed
+through the stable `conversation.*` protocol. Port the solid parts of the current
+app, drop the debt. The embodiment (`MovementManager`) becomes a **standalone
+daemon capability** exposed over WebRTC so any client or JS-SDK app can drive the
+robot's body, with the conversation as just one consumer.
+
+## Core architecture decision: in-process
+
+The engine runs **in-process** in the daemon (a supervised asyncio task), not in
+a separate subprocess. Rationale:
+
+- Once the `MovementManager` moves to the daemon, the engine is glue (cloud WS +
+  audio + motion calls + tools). Nothing safety-critical drives motors from it.
+- The only native crash source is GStreamer, which the daemon already hosts.
+- No large sudden allocation in scope (vision is cloud, no local model), so a
+  memory watchdog plus bounded queues covers gradual leaks.
+- A separate process would pay its cost where it hurts (two-owner audio hardware
+  coordination, cross-process `set_listening` latency) for a theoretical gain.
+- Recent precedent: #1268 removed the face tracker's process boundary and runs it
+  as a niced daemon thread ([`../../../src/reachy_mini/vision/face_tracking.py`](../../../src/reachy_mini/vision/face_tracking.py)).
+
+Rule: a **heavy local model** (future on-device vision) gets its own process. The
+conversation engine does not.
+
+Two more settled behaviors (full detail in [`07-lifecycle-and-supervision.md`](./07-lifecycle-and-supervision.md)):
+
+- **Dormant until a trigger.** Nothing runs by default; a session (and the lazy
+  motion service) starts only on a client trigger (`conversation.start`) or a robot
+  trigger (NFC/wake-word, later). `start` wakes the robot, `stop` sleeps it.
+- **One owner, arbitrated by `robot_app_lock`.** Conversation OR store app OR
+  remote session, never two. The conversation takes a transport-independent holder
+  so it survives client disconnect.
+
+## Components (one doc per block)
+
+Each doc is scoped to the **public interface** of its block (the RPC / events /
+config / tools it exposes and consumes), plus the few decisions that frame it.
+Implementation notes, PR1 scope and open questions are kept short and local.
+
+| Block | Doc | Public interface |
+|---|---|---|
+| Conversation engine | [`01-conversation-engine.md`](./01-conversation-engine.md) | `conversation.*` (RPC + events), the controller FSM, and the audio I/O path |
+| Motion service | [`02-motion-service.md`](./02-motion-service.md) | `motion.*` - standalone embodiment over WebRTC |
+| Vision | [`03-vision.md`](./03-vision.md) | Camera fan-out + face/head tracking - **already in the daemon**, we reuse it |
+| Tools | [`04-tools.md`](./04-tools.md) | The model-facing verbs + execution contract |
+| Memory | [`05-memory.md`](./05-memory.md) | `save_memory` / `recall_memory`, logging + prompt injection |
+| Personas & config | [`06-personas-and-config.md`](./06-personas-and-config.md) | `personalities.*` / `voices.*` + the `config` schema they resolve into |
+| Lifecycle & supervision | [`07-lifecycle-and-supervision.md`](./07-lifecycle-and-supervision.md) | Warm supervision, robot lock, wake/sleep, auth, crash surfacing, inactivity |
+| Testing | [`08-testing.md`](./08-testing.md) | Contract/conformance tests + the WebRTC harness |
+
+## A note on levels ("service" vs "engine")
+
+Two things share the word but sit at different levels:
+
+- **The conversation service** is this whole thing - the umbrella capability the
+  daemon hosts (engine + tools + memory + personas/config + lifecycle).
+- The **conversation engine** ([`01-conversation-engine.md`](./01-conversation-engine.md))
+  is its runtime **core** (the controller FSM + S2S handler), not the whole service.
+- The **motion service** ([`02-motion-service.md`](./02-motion-service.md)) is a
+  **standalone** capability that lives *beside* the engine and is usable with no
+  conversation at all.
+
+So over the relay `conversation.*` and `motion.*` look like two peer namespaces,
+but internally the engine is the heart of the conversation service while motion is
+a reusable capability it happens to consume.
+
+## Namespaces exposed over WebRTC
+
+All ride the existing JSON-RPC-2.0-over-WebRTC relay (#1266, "Expose the apps
+control API over WebRTC"), never a bespoke transport:
+
+- `conversation.*` - session lifecycle and control.
+- `motion.*` - standalone embodiment (usable without any conversation session).
+- `personalities.*` / `voices.*` - discovery and CRUD.
+
+Events (`conversation.phase` / `turn` / `transcript` / `level`) fan out to every
+connected transport via `broadcast_to_all_clients`.
+
+## System view
+
+```mermaid
+flowchart TB
+  subgraph clients [Thin clients / JS-SDK apps]
+    app[app or orb]
+  end
+  subgraph daemon [Daemon reachy_mini - single process]
+    relay[WebRTC JSON-RPC relay #1266]
+    subgraph engine [Conversation engine - in-process supervised task]
+      ctrl[Controller FSM]
+      s2s[S2S handler]
+      tools[Tools]
+    end
+    subgraph motion [Motion service - in-process, standalone]
+      prim[Moves + idle breathing]
+      gaze[Gaze - vision/]
+      off[Offsets - wobble]
+    end
+    personas[PersonalityOps + avatars]
+    sup[Supervisor + watchdog]
+    backend[Backend motors + media hardware]
+  end
+  app <-->|"conversation.* / motion.* / personalities.*"| relay
+  relay --> ctrl
+  relay --> motion
+  relay --> personas
+  sup --> ctrl
+  ctrl --> s2s
+  ctrl -->|moves + set_listening| motion
+  ctrl --> tools
+  motion -->|set_target fused| backend
+  s2s -->|audio| backend
+```
+
+## PR1 - tracer bullet v1
+
+Minimal but real: `conversation.start` makes the robot talk, move and call a
+tool; `stop` / `say` / `interrupt` work; `motion.*` is drivable standalone
+(no session). See each block doc for its PR1 scope.
+
+## Roadmap (after PR1)
+
+1. Pure in-process media (single GStreamer pipeline, PCM tap).
+2. Full `motion.*` surface (raw target/goto, gaze tuning) + third-party apps.
+3. (Optional) S2S session pre-warm/pool, only if the `starting` animation is not enough.
+4. Full `config` + atomic `restart` + effective-config idempotence.
+5. `tool` / `metrics` / `error` events + error taxonomy.
+6. MCP tool-spaces, asset manifest, NFC/wake-word triggers, offline degraded mode.
+7. Memory extensions (vector recall, sleep-time compute, `forget_memory`) - see [`05-memory.md`](./05-memory.md).
+8. Reference JS thin client + removal of the REST + SSE / :7860 transport.
+
+## Open questions
+
+Collected from the block docs so discussion stays in one place:
+
+- **Motion**: exact minimal `motion.*` surface vs what the JS SDK already exposes;
+  concurrency policy when a client drives `motion.*` during an active conversation
+  (v1: last writer wins).
+- **Engine**: whether `restart` must be atomic in v1; how much of the app's
+  weighted `idle_policy` to keep vs defer.
+- **Lifecycle**: the exact `robot_app_lock` extension shape for the
+  transport-independent conversation holder; watchdog thresholds on the target CM4
+  RAM size.
+- **Audio**: whether to invest early in the single-pipeline PCM tap if the
+  two-owner handshake proves fragile on hardware.
+- **Config**: how strict canonicalization / idempotence needs to be in PR1.
+- **Personas**: where an eventual backend catalog (moderation buffer for
+  third-party content) fits vs on-robot personas.


### PR DESCRIPTION
## Summary

Adds a shared **design-discussion base** for the on-robot conversation service,
under `docs/design/conversation-service/`. Each doc is scoped to the **public
interface** of its block (the `conversation.*` / `motion.*` / `personalities.*`
surfaces, the `config` schema, the model-facing tools) plus the few decisions that
frame it - not internal wiring.

The core proposal: turn the conversation from a store app (separate subprocess,
cold start, REST + SSE) into a **first-class in-process service of the daemon**,
kept warm and exposed through a stable `conversation.*` protocol over the existing
WebRTC relay, with the embodiment (`MovementManager`) extracted as a **standalone
`motion.*` capability** any client or JS-SDK app can drive.

## Contents

| Doc | Public interface |
|---|---|
| `README.md` | Overview, the in-process architecture decision, roadmap, open questions |
| `01-conversation-engine.md` | `conversation.*` (RPC + events), the controller FSM, audio I/O |
| `02-motion-service.md` | `motion.*` - standalone embodiment over WebRTC |
| `03-vision.md` | Camera fan-out + face/head tracking - documents the **existing** daemon capability we reuse |
| `04-tools.md` | Model-facing verbs + execution contract |
| `05-memory.md` | `save_memory` / `recall_memory`, logging + prompt injection |
| `06-personas-and-config.md` | `personalities.*` / `voices.*` + the `config` schema they resolve into |
| `07-lifecycle-and-supervision.md` | Warm supervision, robot lock, wake/sleep, auth, crash surfacing, inactivity |
| `08-testing.md` | Contract/conformance tests + the WebRTC harness |

## Notes

- Docs only, no code changes. Status is "draft / design proposal" (except vision,
  which documents the already-implemented daemon surface).
- Meant as a common base to discuss and refine the breakdown before implementation.

Made with [Cursor](https://cursor.com)