### PR TITLE
docs(troubleshooting): explain why a robot with torque off silently ignores commands

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -726,6 +726,36 @@ If the period is much higher than 20ms, it means the control loop is not running
 
 </details>
 
+<details>
+<summary><strong>My robot doesn't move and no error is reported</strong></summary>
+
+If motion commands are accepted but nothing happens, the motors are most likely disabled. With torque off the daemon still accepts every command, reports success, and keeps its control loop running at 50Hz with no errors, so nothing indicates that the robot is not moving.
+
+Two common situations leave the motors disabled:
+- The robot is asleep and limp after an app has stopped, or after the daemon has just started.
+- `wake_up()` was called on its own. It plays the wake up pose, emote and sound, but it does not enable torque.
+
+Check the current mode:
+- via the SDK
+```python
+mini = ReachyMini()
+print(mini.client.get_status().backend_status.motor_control_mode)
+```
+- via the REST API, in the `backend_status` field of the `/api/daemon/status` endpoint
+
+If it reads `MotorControlMode.Disabled`, enable the motors before moving the robot:
+
+```python
+mini.enable_motors()
+mini.wake_up()
+```
+
+Note that a limp robot keeps its head down in the sleep position, close to the body. The camera then faces the inside of the shell and returns a dark, almost uniform image with exposure and gain at their maximum, which is easy to mistake for a broken camera. Check that the head is really up before investigating the camera.
+
+The **Why are the motors "limp" or "stiff"? (Compliancy)** entry above describes the different motor modes.
+
+</details>
+
 
 
 ## 👁️ Vision & Audio


### PR DESCRIPTION
Adds one troubleshooting entry for a failure mode that gives no signal at all: when the motors are disabled, the daemon accepts motion commands, reports success, and keeps the control loop at 50Hz with `nb_error: 0`, while the robot does not move.

This is expected behaviour rather than a bug, since the robot is deliberately left asleep and limp after an app stops, and `wake_up()` only plays the wake up pose, emote and sound. It is just hard to discover, because every signal a user would normally check looks healthy. Reproduced on a freshly restarted daemon (v1.9.0, Wireless):

| Step | `motor_control_mode` | Head pitch | Control loop |
|---|---|---|---|
| fresh daemon start | `disabled` | 26.2° (sleep) | 49.5Hz, 0 errors |
| after `wake_up()` | `disabled` | 26.2°, unchanged | 49.6Hz, 0 errors |
| after `enable_motors()` + `wake_up()` | `enabled` | 1.9° | 49.7Hz, 0 errors |

The entry also covers the downstream symptom that cost me the most time: a limp robot keeps its head in the sleep position, so the camera faces the inside of the shell and returns a dark, near-uniform image with exposure and gain maxed out. That looks exactly like a broken camera, and I spent a while diagnosing one that turned out to be fine.

Notes:

- One entry appended to `## 🕹️ Moving the Robot`, no new files, so `_toctree.yml` is unchanged.
- Both snippets were run against a real Wireless robot.
- I ran `doc-builder build reachy_mini docs/source/` locally and confirmed the entry converts to MDX intact. The CI doc build is currently sitting at `action_required`, since this is my first PR here and the workflow needs a maintainer to approve the run.

@FabienDanieau if you have a moment for a look, thanks.
