### PR TITLE
feat(daemon): idle-reset handoff grace + wake stand-down

### DIFF
--- a/src/reachy_mini/daemon/app/startup_app.py
+++ b/src/reachy_mini/daemon/app/startup_app.py
@@ -178,11 +178,6 @@ async def start_startup_app_if_idle(
         return False
 
 
-async def play_awake_startup_cue(backend: Any) -> None:
-    """Play the wake sound without running the full wake-up pose."""
-    backend.play_sound("wake_up.wav")
-
-
 async def wake_or_start_startup_app_if_idle(
     app_manager: AppManager,
     daemon: "Daemon",
@@ -197,18 +192,23 @@ async def wake_or_start_startup_app_if_idle(
         return False
 
     try:
-        if backend.get_motor_control_mode() == MotorControlMode.Disabled:
+        # Decide before touching the motors: enabling them first would flip
+        # the awake predicate and turn the wake below into a silent no-op.
+        if backend.is_awake_at_init_pose():
+            # Already up: just ack the touch with the wake sound.
+            backend.play_sound("wake_up.wav")
+        else:
             logger.info(f"Waking up from antenna touch before starting app: {name}")
             backend.set_motor_control_mode(MotorControlMode.Enabled)
-            await backend.wake_up()
+            # force: the predicate above already ruled a wake is due, and the
+            # set_motor_control_mode may have satisfied wake_up's own check.
+            await backend.wake_up(force=True)
             # wake_up() may fire the daemon-level startup-app callback, which
             # schedules the same app start as a task. Yield once so that task
             # can acquire the app slot before this antenna path checks it.
             await asyncio.sleep(0)
             if not _startup_app_slot_is_free(app_manager, daemon):
                 return True
-        else:
-            await play_awake_startup_cue(backend)
 
         return await start_startup_app_if_idle(app_manager, daemon, name)
     except Exception as e:

--- a/src/reachy_mini/daemon/app/startup_app.py
+++ b/src/reachy_mini/daemon/app/startup_app.py
@@ -192,7 +192,8 @@ async def wake_or_start_startup_app_if_idle(
         return False
 
     try:
-        # Decide before touching the motors: enabling them first would flip
+        # Decide before touching the motors: enabling them pins the targets
+        # to the measured pose, which for a robot resting at init could flip
         # the awake predicate and turn the wake below into a silent no-op.
         if backend.is_awake_at_init_pose():
             # Already up: just ack the touch with the wake sound.

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -1154,12 +1154,31 @@ class Backend:
     )
 
     async def wake_up(self) -> None:
-        """Wake up the robot - go to the initial head position and play the wake up emote and sound."""
+        """Wake up the robot - go to the initial head position and play the wake up emote and sound.
+
+        Skips the emote (and its "toudoum") when the robot is already awake and
+        standing at the init pose: clients routinely send ``wake_up`` on
+        session start, and now that a handoff keeps the robot awake between
+        sessions (see ``request_idle_reset``'s handoff grace), replaying the
+        animation on an already-awake robot reads as a glitch, not a wake.
+        Mirrors ``goto_sleep``, which likewise stands down near its target
+        pose. The wake-completed callback still fires so the "start app after
+        wake" hook keeps its semantics: the robot IS awake.
+        """
         await asyncio.sleep(0.1)
 
         _, _, magic_distance = distance_between_poses(
             self.get_current_head_pose(), self.INIT_HEAD_POSE
         )
+
+        # Same empirical "close enough" threshold as goto_sleep's.
+        if (
+            self.get_motor_control_mode() == MotorControlMode.Enabled
+            and magic_distance < 10
+        ):
+            if self._on_wake_up_callback is not None:
+                self._on_wake_up_callback()
+            return
 
         await self.goto_target(
             self.INIT_HEAD_POSE,

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -1170,11 +1170,25 @@ class Backend:
         _, _, magic_distance = distance_between_poses(
             self.get_current_head_pose(), self.INIT_HEAD_POSE
         )
+        # The goto below is also what re-homes the antennas, so the
+        # stand-down must check them too: head at init but antennas left
+        # askew by the previous app would otherwise stay askew all session.
+        antenna_offset = float(
+            np.max(
+                np.abs(
+                    self.get_present_antenna_joint_positions()
+                    - self.INIT_ANTENNAS_JOINT_POSITIONS
+                )
+            )
+        )
 
-        # Same empirical "close enough" threshold as goto_sleep's.
+        # Head: same empirical "close enough" threshold as goto_sleep's.
+        # Antennas: ~17° of slack absorbs sag/jitter while still catching a
+        # genuinely misplaced antenna (sleep parks them ~165° away).
         if (
             self.get_motor_control_mode() == MotorControlMode.Enabled
             and magic_distance < 10
+            and antenna_offset < 0.3
         ):
             if self._on_wake_up_callback is not None:
                 self._on_wake_up_callback()
@@ -2713,11 +2727,7 @@ class Backend:
             if self.get_motor_control_mode() == MotorControlMode.Disabled:
                 return
             self._cancel_idle_reset()
-            self._idle_reset_task = asyncio.create_task(
-                self._async_idle_reset(
-                    self.IDLE_RESET_DEBOUNCE_S if grace_s is None else grace_s
-                )
-            )
+            self._idle_reset_task = asyncio.create_task(self._async_idle_reset(grace_s))
         except Exception:
             self.logger.warning("Idle reset scheduling failed", exc_info=True)
 

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -2610,7 +2610,18 @@ class Backend:
     # an intermediate pose.
     IDLE_RESET_DEBOUNCE_S: float = 1.5
 
-    def request_idle_reset(self) -> None:
+    # Longer grace used when the previous owner released the slot on purpose so
+    # another session could take over (see ``RobotAppLock.release_remote``).
+    # The canonical case is the mobile app dropping its own session to hand the
+    # robot to an app's iframe: the daemon only sees an empty slot, but a new
+    # session *is* coming - it just has to cold-start a Space (page load, auth,
+    # bundle, WebRTC handshake), which takes far longer than the debounce
+    # above. Sleeping in that window is exactly what the user doesn't want:
+    # they tapped an app, not "go to sleep". Long enough to cover a slow Space,
+    # short enough that a hand-off that never lands still parks the robot.
+    IDLE_RESET_HANDOFF_GRACE_S: float = 30.0
+
+    def request_idle_reset(self, *, expect_handoff: bool = False) -> None:
         """Return the robot to a clean idle state when no managed app owns it.
 
         Called by the daemon when the shared ``RobotAppLock`` transitions to
@@ -2627,11 +2638,22 @@ class Backend:
         one that also handles data-channel commands) and returns immediately.
         No-op when that loop isn't up yet (e.g. ``--no-media`` daemons, which
         have no remote sessions anyway).
+
+        Args:
+            expect_handoff: True when the slot was released on purpose for a
+                successor session, which earns the longer
+                ``IDLE_RESET_HANDOFF_GRACE_S`` instead of the default debounce.
+
         """
         loop = getattr(self, "_log_loop", None)
         if loop is None:
             return
-        loop.call_soon_threadsafe(self._maybe_start_idle_reset)
+        grace_s = (
+            self.IDLE_RESET_HANDOFF_GRACE_S
+            if expect_handoff
+            else self.IDLE_RESET_DEBOUNCE_S
+        )
+        loop.call_soon_threadsafe(self._maybe_start_idle_reset, grace_s)
 
     def cancel_idle_reset(self) -> None:
         """Cancel a pending/in-flight idle reset from any thread.
@@ -2654,7 +2676,7 @@ class Backend:
             task.cancel()
         self._idle_reset_task = None
 
-    def _maybe_start_idle_reset(self) -> None:
+    def _maybe_start_idle_reset(self, grace_s: float) -> None:
         """Kick off a goto_sleep if the robot is still awake. Runs on the loop."""
         try:
             if not self.ready.is_set() or self.is_shutting_down:
@@ -2665,17 +2687,21 @@ class Backend:
             if self.get_motor_control_mode() == MotorControlMode.Disabled:
                 return
             self._cancel_idle_reset()
-            self._idle_reset_task = asyncio.create_task(self._async_idle_reset())
+            self._idle_reset_task = asyncio.create_task(
+                self._async_idle_reset(
+                    self.IDLE_RESET_DEBOUNCE_S if grace_s is None else grace_s
+                )
+            )
         except Exception:
             self.logger.warning("Idle reset scheduling failed", exc_info=True)
 
-    async def _async_idle_reset(self) -> None:
+    async def _async_idle_reset(self, grace_s: float) -> None:
         """Graceful return to the sleep pose, which ends with motors disabled.
 
-        Starts with a short debounce (``IDLE_RESET_DEBOUNCE_S``): a fast
-        reconnect or a local app grabbing the robot cancels the task during that
-        window, so no motion happens at all on transient drops. Only if the slot
-        stays free past the grace period do we actually goto_sleep.
+        Starts with a debounce (``grace_s``): a fast reconnect or a local app
+        grabbing the robot cancels the task during that window, so no motion
+        happens at all on transient drops. Only if the slot stays free past the
+        grace period do we actually goto_sleep.
 
         Mirrors the reference leave behaviour clients already run by hand
         (gotoSleep -> motors off). ``goto_sleep()`` finishes with
@@ -2684,7 +2710,7 @@ class Backend:
         correctly triggers a fresh wake.
         """
         try:
-            await asyncio.sleep(self.IDLE_RESET_DEBOUNCE_S)
+            await asyncio.sleep(grace_s)
             # Conditions may have changed during the grace period (shutdown
             # started, or the robot was already put to sleep by whoever briefly
             # held the slot). Re-check before committing to the trajectory.

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -2638,7 +2638,14 @@ class Backend:
     # above. Sleeping in that window is exactly what the user doesn't want:
     # they tapped an app, not "go to sleep". Long enough to cover a slow Space,
     # short enough that a hand-off that never lands still parks the robot.
-    IDLE_RESET_HANDOFF_GRACE_S: float = 30.0
+    #
+    # Sized down from an initial 30 s after hardware testing: real handoffs
+    # re-acquire the slot within 1-4 s, and abrupt client deaths (tab kill)
+    # ride the same local endSession path as deliberate hang-ups - the relay
+    # cannot tell them apart - so this grace is also how long a crashed
+    # client keeps the robot needlessly awake. A Space colder than this just
+    # gets a legitimate wake animation when it finally connects.
+    IDLE_RESET_HANDOFF_GRACE_S: float = 15.0
 
     def request_idle_reset(self, *, expect_handoff: bool = False) -> None:
         """Return the robot to a clean idle state when no managed app owns it.

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -1153,26 +1153,34 @@ class Backend:
         ]
     )
 
-    # Init-pose proximity in magic-mm (mm + deg), same empirical threshold as
-    # goto_sleep's stand-down (see SLEEP_POSE_MAGIC_DISTANCE, apps/manager.py).
-    INIT_POSE_MAGIC_DISTANCE: float = 10.0
-    # ~17° of antenna slack: absorbs sag/jitter while still catching a
-    # genuinely misplaced antenna (sleep parks them ~165° away).
-    INIT_ANTENNAS_TOLERANCE_RAD: float = 0.3
+    # Bounds the goto interpolation tail, not the hardware: play_move never
+    # evaluates a move at exactly t=duration, so the last written target sits
+    # a (velocity-eased) tick short of the commanded endpoint.
+    INIT_TARGET_ATOL: float = 1e-2
 
     def is_awake_at_init_pose(self) -> bool:
-        """Motors on and head + antennas already home: nothing to wake."""
-        _, _, head_offset = distance_between_poses(
-            self.get_current_head_pose(), self.INIT_HEAD_POSE
-        )
+        """Motors on and init is the pose the controller is actively holding.
+
+        Compares the commanded targets, not the measured pose: a head sagging
+        a few mm under its own weight while commanded to init IS standing at
+        init, and per-unit calibration residual must not flip the answer.
+        """
+        if self.target_head_pose is None or self.target_antenna_joint_positions is None:
+            return False
         return (
             self.get_motor_control_mode() == MotorControlMode.Enabled
-            and head_offset < self.INIT_POSE_MAGIC_DISTANCE
             and bool(
                 np.allclose(
-                    self.get_present_antenna_joint_positions(),
+                    self.target_head_pose,
+                    self.INIT_HEAD_POSE,
+                    atol=self.INIT_TARGET_ATOL,
+                )
+            )
+            and bool(
+                np.allclose(
+                    self.target_antenna_joint_positions,
                     self.INIT_ANTENNAS_JOINT_POSITIONS,
-                    atol=self.INIT_ANTENNAS_TOLERANCE_RAD,
+                    atol=self.INIT_TARGET_ATOL,
                 )
             )
         )

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -1153,47 +1153,50 @@ class Backend:
         ]
     )
 
-    async def wake_up(self) -> None:
-        """Wake up the robot - go to the initial head position and play the wake up emote and sound.
+    # Init-pose proximity in magic-mm (mm + deg), same empirical threshold as
+    # goto_sleep's stand-down (see SLEEP_POSE_MAGIC_DISTANCE, apps/manager.py).
+    INIT_POSE_MAGIC_DISTANCE: float = 10.0
+    # ~17° of antenna slack: absorbs sag/jitter while still catching a
+    # genuinely misplaced antenna (sleep parks them ~165° away).
+    INIT_ANTENNAS_TOLERANCE_RAD: float = 0.3
 
-        Skips the emote (and its "toudoum") when the robot is already awake and
-        standing at the init pose: clients routinely send ``wake_up`` on
-        session start, and now that a handoff keeps the robot awake between
-        sessions (see ``request_idle_reset``'s handoff grace), replaying the
-        animation on an already-awake robot reads as a glitch, not a wake.
-        Mirrors ``goto_sleep``, which likewise stands down near its target
-        pose. The wake-completed callback still fires so the "start app after
-        wake" hook keeps its semantics: the robot IS awake.
-        """
-        await asyncio.sleep(0.1)
-
-        _, _, magic_distance = distance_between_poses(
+    def is_awake_at_init_pose(self) -> bool:
+        """Motors on and head + antennas already home: nothing to wake."""
+        _, _, head_offset = distance_between_poses(
             self.get_current_head_pose(), self.INIT_HEAD_POSE
         )
-        # The goto below is also what re-homes the antennas, so the
-        # stand-down must check them too: head at init but antennas left
-        # askew by the previous app would otherwise stay askew all session.
-        antenna_offset = float(
-            np.max(
-                np.abs(
-                    self.get_present_antenna_joint_positions()
-                    - self.INIT_ANTENNAS_JOINT_POSITIONS
+        return (
+            self.get_motor_control_mode() == MotorControlMode.Enabled
+            and head_offset < self.INIT_POSE_MAGIC_DISTANCE
+            and bool(
+                np.allclose(
+                    self.get_present_antenna_joint_positions(),
+                    self.INIT_ANTENNAS_JOINT_POSITIONS,
+                    atol=self.INIT_ANTENNAS_TOLERANCE_RAD,
                 )
             )
         )
 
-        # Head: same empirical "close enough" threshold as goto_sleep's.
-        # Antennas: ~17° of slack absorbs sag/jitter while still catching a
-        # genuinely misplaced antenna (sleep parks them ~165° away).
-        if (
-            self.get_motor_control_mode() == MotorControlMode.Enabled
-            and magic_distance < 10
-            and antenna_offset < 0.3
-        ):
+    async def wake_up(self, *, force: bool = False) -> None:
+        """Wake up the robot - go to the initial head position and play the wake up emote and sound.
+
+        Stands down (silently - no motion, no sound) when the robot is already
+        awake at the init pose, so a boot-time ``wake_up`` after a session
+        handoff doesn't replay the emote. The wake-completed callback still
+        fires either way: the robot IS awake. ``force=True`` bypasses the
+        stand-down, e.g. for a deliberate replay or a caller that just
+        enabled the motors itself and knows a real wake is due.
+        """
+        await asyncio.sleep(0.1)
+
+        if not force and self.is_awake_at_init_pose():
             if self._on_wake_up_callback is not None:
                 self._on_wake_up_callback()
             return
 
+        _, _, magic_distance = distance_between_poses(
+            self.get_current_head_pose(), self.INIT_HEAD_POSE
+        )
         await self.goto_target(
             self.INIT_HEAD_POSE,
             antennas=self.INIT_ANTENNAS_JOINT_POSITIONS,
@@ -2643,22 +2646,9 @@ class Backend:
     # an intermediate pose.
     IDLE_RESET_DEBOUNCE_S: float = 1.5
 
-    # Longer grace used when the previous owner released the slot on purpose so
-    # another session could take over (see ``RobotAppLock.release_remote``).
-    # The canonical case is the mobile app dropping its own session to hand the
-    # robot to an app's iframe: the daemon only sees an empty slot, but a new
-    # session *is* coming - it just has to cold-start a Space (page load, auth,
-    # bundle, WebRTC handshake), which takes far longer than the debounce
-    # above. Sleeping in that window is exactly what the user doesn't want:
-    # they tapped an app, not "go to sleep". Long enough to cover a slow Space,
-    # short enough that a hand-off that never lands still parks the robot.
-    #
-    # Sized down from an initial 30 s after hardware testing: real handoffs
-    # re-acquire the slot within 1-4 s, and abrupt client deaths (tab kill)
-    # ride the same local endSession path as deliberate hang-ups - the relay
-    # cannot tell them apart - so this grace is also how long a crashed
-    # client keeps the robot needlessly awake. A Space colder than this just
-    # gets a legitimate wake animation when it finally connects.
+    # Longer grace used when the slot was released on purpose for a successor
+    # (covers a Space cold-start). Also bounds how long a client that died on
+    # the endSession path keeps the robot needlessly awake.
     IDLE_RESET_HANDOFF_GRACE_S: float = 15.0
 
     def request_idle_reset(self, *, expect_handoff: bool = False) -> None:

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -250,7 +250,7 @@ class Daemon:
         except Exception as e:
             self.logger.debug(f"Error stopping central signaling relay: {e}")
 
-    def _on_robot_slot_free(self) -> None:
+    def _on_robot_slot_free(self, expect_handoff: bool = False) -> None:
         """Return the robot to a clean idle state when the app slot frees.
 
         Wired into ``robot_app_lock`` so that when a remote session ends/drops
@@ -260,14 +260,21 @@ class Daemon:
         threadsafely on the backend's loop. Fires on both graceful and abnormal
         teardown (crash, killed tab, lost Wi-Fi), which is the whole point:
         those paths run no client-side cleanup.
+
+        Args:
+            expect_handoff: True when the session ended on purpose to let a
+                successor take the slot, which buys the incoming session a much
+                longer grace period before the robot is put back to sleep.
+
         """
         backend = self.backend
         if backend is None:
             return
         try:
-            backend.request_idle_reset()
+            backend.request_idle_reset(expect_handoff=expect_handoff)
         except Exception as e:
             self.logger.warning(f"Idle reset request failed: {e}")
+
     def apply_robot_name(self, name: str) -> None:
         """Apply a new robot name to the live daemon without a restart.
 

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -275,6 +275,23 @@ class Daemon:
         except Exception as e:
             self.logger.warning(f"Idle reset request failed: {e}")
 
+    def _on_robot_slot_acquired(self) -> None:
+        """Cancel any pending idle reset when a remote session takes the slot.
+
+        Counterpart of ``_on_robot_slot_free``: the successor now owns the
+        robot, so the previous session's grace timer must not fire under it.
+        Without this, only the successor's first data-channel command cancels
+        the timer - a WebRTC handshake slower than the handoff grace would
+        let the daemon goto_sleep mid-session.
+        """
+        backend = self.backend
+        if backend is None:
+            return
+        try:
+            backend.cancel_idle_reset()
+        except Exception as e:
+            self.logger.warning(f"Idle reset cancel failed: {e}")
+
     def apply_robot_name(self, name: str) -> None:
         """Apply a new robot name to the live daemon without a restart.
 
@@ -437,6 +454,13 @@ class Daemon:
             # after the backend loop is up (setup_media_server) so
             # `request_idle_reset()` has a loop to hop onto.
             self.robot_app_lock.set_on_became_free_handler(self._on_robot_slot_free)
+            # Counterpart: a remote successor taking the slot cancels any
+            # pending idle reset right away, instead of relying on its first
+            # data-channel command to do it - a handshake slower than the
+            # handoff grace would otherwise take a goto_sleep mid-session.
+            self.robot_app_lock.set_on_remote_acquired_handler(
+                self._on_robot_slot_acquired
+            )
 
             # Wire the wake-up hook before any wake can fire (on-start below, or
             # later via button/REST on the wireless unit, which boots asleep).
@@ -508,11 +532,12 @@ class Daemon:
             self.backend.is_shutting_down = True
             self._thread_event_publish_status.set()
 
-            # Unwire the idle-reset hook before tearing down the relay: stopping
+            # Unwire the idle-reset hooks before tearing down the relay: stopping
             # the relay releases the remote hold on `robot_app_lock`, which would
             # otherwise fire `_on_robot_slot_free` and race the explicit
             # goto_sleep below with a second one.
             self.robot_app_lock.set_on_became_free_handler(None)
+            self.robot_app_lock.set_on_remote_acquired_handler(None)
 
             # Close the JSON-RPC app relay (drops the app /rpc connection and
             # fails any in-flight calls) before tearing the backend down.

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -250,7 +250,7 @@ class Daemon:
         except Exception as e:
             self.logger.debug(f"Error stopping central signaling relay: {e}")
 
-    def _on_robot_slot_free(self, expect_handoff: bool = False) -> None:
+    def _on_robot_slot_free(self, expect_handoff: bool) -> None:
         """Return the robot to a clean idle state when the app slot frees.
 
         Wired into ``robot_app_lock`` so that when a remote session ends/drops
@@ -439,20 +439,12 @@ class Daemon:
                     self.backend.set_start_update_callback(self._spawn_webrtc_update)
                 self._media_server.start()
 
-            # Wire the JSON-RPC app relay now that the backend + broadcast
-            # paths exist. Runs on this (the main) loop; the DataChannel
-            # transport schedules frames onto it.
-            if self.backend is not None and self.app_manager is not None:
-                self._setup_jsonrpc_relay(self.backend, self.app_manager)
-
-                # Start central signaling relay for remote WebRTC access
-                await self._start_central_signaling_relay()
-
             # Reset the robot to a clean idle state whenever the managed app
             # slot becomes free (remote session end/drop or local app exit), so
             # no client can leave it parked awake across sessions. Registered
             # after the backend loop is up (setup_media_server) so
-            # `request_idle_reset()` has a loop to hop onto.
+            # `request_idle_reset()` has a loop to hop onto, and *before* the
+            # relay starts so no remote session can slip through unwired.
             self.robot_app_lock.set_on_became_free_handler(self._on_robot_slot_free)
             # Counterpart: a remote successor taking the slot cancels any
             # pending idle reset right away, instead of relying on its first
@@ -461,6 +453,15 @@ class Daemon:
             self.robot_app_lock.set_on_remote_acquired_handler(
                 self._on_robot_slot_acquired
             )
+
+            # Wire the JSON-RPC app relay now that the backend + broadcast
+            # paths exist. Runs on this (the main) loop; the DataChannel
+            # transport schedules frames onto it.
+            if self.backend is not None and self.app_manager is not None:
+                self._setup_jsonrpc_relay(self.backend, self.app_manager)
+
+                # Start central signaling relay for remote WebRTC access
+                await self._start_central_signaling_relay()
 
             # Wire the wake-up hook before any wake can fire (on-start below, or
             # later via button/REST on the wireless unit, which boots asleep).

--- a/src/reachy_mini/daemon/robot_app_lock.py
+++ b/src/reachy_mini/daemon/robot_app_lock.py
@@ -90,7 +90,7 @@ class RobotAppLock:
         # no app leaves it parked awake (enabled / gravity_compensation) across
         # sessions. Called *outside* the mutex, must return promptly and MUST
         # NOT re-enter the lock (would deadlock).
-        self._on_became_free: Optional[Callable[[], None]] = None
+        self._on_became_free: Optional[Callable[[bool], None]] = None
 
     # ------------------------------------------------------------------
     # Registration
@@ -107,23 +107,27 @@ class RobotAppLock:
         """
         self._on_remote_evicted = handler
 
-    def set_on_became_free_handler(self, handler: Optional[Callable[[], None]]) -> None:
+    def set_on_became_free_handler(
+        self, handler: Optional[Callable[[bool], None]]
+    ) -> None:
         """Register (or clear) the callback fired when the slot becomes FREE.
 
         Fired once per FREE transition, from either ``release_local`` or
         ``release_remote``, *after* the internal mutex is released. The handler
-        must return promptly and must not call back into this lock. Pass
-        ``None`` to clear.
+        receives ``expect_handoff``: True when the previous owner released the
+        slot on purpose for someone else to pick it up (see
+        ``release_remote``). It must return promptly and must not call back
+        into this lock. Pass ``None`` to clear.
         """
         self._on_became_free = handler
 
-    def _fire_became_free(self) -> None:
+    def _fire_became_free(self, expect_handoff: bool = False) -> None:
         """Invoke the FREE-transition handler outside the mutex. Best-effort."""
         handler = self._on_became_free
         if handler is None:
             return
         try:
-            handler()
+            handler(expect_handoff)
         except Exception:
             logger.warning("RobotAppLock: on_became_free handler raised", exc_info=True)
 
@@ -296,8 +300,19 @@ class RobotAppLock:
             logger.info("RobotAppLock: acquired by remote session %r", app_name)
             return True
 
-    def release_remote(self) -> None:
-        """Release a remote-session hold. Idempotent."""
+    def release_remote(self, *, expect_handoff: bool = False) -> None:
+        """Release a remote-session hold. Idempotent.
+
+        Args:
+            expect_handoff: True when the client ended its session on purpose
+                (a relayed ``endSession``) rather than vanishing. The two read
+                very differently downstream: a deliberate release usually means
+                another session is on its way in - the mobile app dropping its
+                own session so an app's iframe can take the slot - whereas a
+                drop means nobody is coming back. Passed to the FREE handler so
+                the daemon can wait longer before reclaiming the robot.
+
+        """
         with self._mutex:
             if self._state != RobotAppLockState.REMOTE_SESSION:
                 logger.debug(
@@ -308,6 +323,10 @@ class RobotAppLock:
             released_name = self._holder_name
             self._state = RobotAppLockState.FREE
             self._holder_name = None
-            logger.info("RobotAppLock: released by remote session %r", released_name)
+            logger.info(
+                "RobotAppLock: released by remote session %r (expect_handoff=%s)",
+                released_name,
+                expect_handoff,
+            )
 
-        self._fire_became_free()
+        self._fire_became_free(expect_handoff)

--- a/src/reachy_mini/daemon/robot_app_lock.py
+++ b/src/reachy_mini/daemon/robot_app_lock.py
@@ -92,6 +92,15 @@ class RobotAppLock:
         # NOT re-enter the lock (would deadlock).
         self._on_became_free: Optional[Callable[[bool], None]] = None
 
+        # Synchronous callback invoked when a REMOTE session acquires the
+        # slot. Counterpart of the free-transition handler above: the daemon
+        # registers it to cancel a pending idle reset, so a successor whose
+        # WebRTC handshake outlives the handoff grace doesn't take a
+        # goto_sleep mid-session. (Local-app acquisition already cancels via
+        # ``AppManager.start_app``.) Same contract: called outside the mutex,
+        # must return promptly, must not re-enter the lock.
+        self._on_remote_acquired: Optional[Callable[[], None]] = None
+
     # ------------------------------------------------------------------
     # Registration
     # ------------------------------------------------------------------
@@ -121,6 +130,17 @@ class RobotAppLock:
         """
         self._on_became_free = handler
 
+    def set_on_remote_acquired_handler(
+        self, handler: Optional[Callable[[], None]]
+    ) -> None:
+        """Register (or clear) the callback fired when a remote session acquires the slot.
+
+        Fired from ``try_acquire_remote`` after a successful acquisition,
+        *after* the internal mutex is released. It must return promptly and
+        must not call back into this lock. Pass ``None`` to clear.
+        """
+        self._on_remote_acquired = handler
+
     def _fire_became_free(self, expect_handoff: bool = False) -> None:
         """Invoke the FREE-transition handler outside the mutex. Best-effort."""
         handler = self._on_became_free
@@ -130,6 +150,18 @@ class RobotAppLock:
             handler(expect_handoff)
         except Exception:
             logger.warning("RobotAppLock: on_became_free handler raised", exc_info=True)
+
+    def _fire_remote_acquired(self) -> None:
+        """Invoke the remote-acquired handler outside the mutex. Best-effort."""
+        handler = self._on_remote_acquired
+        if handler is None:
+            return
+        try:
+            handler()
+        except Exception:
+            logger.warning(
+                "RobotAppLock: on_remote_acquired handler raised", exc_info=True
+            )
 
     # ------------------------------------------------------------------
     # Introspection
@@ -298,7 +330,9 @@ class RobotAppLock:
             self._state = RobotAppLockState.REMOTE_SESSION
             self._holder_name = app_name
             logger.info("RobotAppLock: acquired by remote session %r", app_name)
-            return True
+
+        self._fire_remote_acquired()
+        return True
 
     def release_remote(self, *, expect_handoff: bool = False) -> None:
         """Release a remote-session hold. Idempotent.

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -705,7 +705,11 @@ class CentralSignalingRelay:
                             f"Connection failed after {self._connection_attempts} attempts: {e}",
                         )
 
-                if self._running and not had_exception and self._state == RelayState.ERROR:
+                if (
+                    self._running
+                    and not had_exception
+                    and self._state == RelayState.ERROR
+                ):
                     # Clean return but ERROR (e.g. 401) - back off like a failure.
                     had_exception = True
                     self._connection_attempts += 1
@@ -1471,13 +1475,16 @@ class CentralSignalingRelay:
                 logger.info(
                     f"[Central Relay] After cleanup - pending: {len(self._pending_central_sessions)}, active: {len(self._central_to_local_session)}"
                 )
-                # If no sessions remain, release the robot lock.
+                # If no sessions remain, release the robot lock. This is the
+                # client hanging up on purpose, so flag it as a hand-off: it may
+                # well be making room for a successor session (mobile app ->
+                # app iframe) rather than walking away from the robot.
                 if (
                     self._robot_app_lock is not None
                     and not self._central_to_local_session
                     and not self._pending_central_sessions
                 ):
-                    self._robot_app_lock.release_remote()
+                    self._robot_app_lock.release_remote(expect_handoff=True)
 
         elif msg_type == "peerStatusChanged":
             # Another peer changed status - ignore for producers
@@ -1604,13 +1611,14 @@ class CentralSignalingRelay:
                 logger.info(
                     f"[Central Relay] After cleanup - pending: {len(self._pending_central_sessions)}, active: {len(self._central_to_local_session)}"
                 )
-                # If no sessions remain, release the robot lock.
+                # If no sessions remain, release the robot lock. Deliberate
+                # hang-up, so same hand-off treatment as the central-side path.
                 if (
                     self._robot_app_lock is not None
                     and not self._central_to_local_session
                     and not self._pending_central_sessions
                 ):
-                    self._robot_app_lock.release_remote()
+                    self._robot_app_lock.release_remote(expect_handoff=True)
 
 
 # Singleton instance for integration

--- a/tests/unit_tests/test_autostart_app.py
+++ b/tests/unit_tests/test_autostart_app.py
@@ -16,7 +16,6 @@ from reachy_mini.daemon.app.startup_app import (
     _antennas_in_commanded_motion,
     ensure_startup_app_installed,
     make_startup_app_launcher,
-    play_awake_startup_cue,
     rearm_startup_app_watcher,
     start_startup_app,
     start_startup_app_if_idle,
@@ -72,7 +71,9 @@ class StubBackend:
         self.present = [0.0, 0.0]
         self.target_antenna_joint_positions: list[float] | None = [0.0, 0.0]
         self.motor_control_mode = MotorControlMode.Enabled
+        self.at_init_pose = True
         self.wake_up_calls = 0
+        self.wake_up_forces: list[bool] = []
         self.played_sounds: list[str] = []
         self.goto_target_calls = 0
         self.on_wake_up_callback: Callable[[], None] | None = None
@@ -86,11 +87,15 @@ class StubBackend:
     def set_motor_control_mode(self, mode: MotorControlMode) -> None:
         self.motor_control_mode = mode
 
+    def is_awake_at_init_pose(self) -> bool:
+        return self.motor_control_mode == MotorControlMode.Enabled and self.at_init_pose
+
     def set_on_wake_up_callback(self, callback: Callable[[], None]) -> None:
         self.on_wake_up_callback = callback
 
-    async def wake_up(self) -> None:
+    async def wake_up(self, *, force: bool = False) -> None:
         self.wake_up_calls += 1
+        self.wake_up_forces.append(force)
         if self.on_wake_up_callback is not None:
             self.on_wake_up_callback()
 
@@ -211,6 +216,10 @@ async def test_antenna_touch_wakes_sleeping_robot_before_starting_app() -> None:
 
     assert daemon.backend.motor_control_mode == MotorControlMode.Enabled
     assert daemon.backend.wake_up_calls == 1
+    # force=True: the touch path enables the motors right before waking, which
+    # would otherwise satisfy wake_up's own stand-down and swallow the emote.
+    # Note the stub rests at the init pose, so this is the exact trap case.
+    assert daemon.backend.wake_up_forces == [True]
     assert daemon.backend.played_sounds == []
     assert daemon.backend.goto_target_calls == 0
     assert mgr.started == ["foo"]
@@ -250,13 +259,23 @@ async def test_antenna_touch_plays_awake_sound_before_starting_app() -> None:
 
 
 @pytest.mark.asyncio
-async def test_awake_startup_cue_only_plays_sound() -> None:
-    backend = StubBackend()
+async def test_antenna_touch_full_wake_when_enabled_but_off_pose() -> None:
+    """Motors on but parked off init (e.g. crashed app): full wake, not cue.
 
-    await play_awake_startup_cue(backend)
+    Locks the behavior change that came with routing this path through
+    ``is_awake_at_init_pose``: the old ``motor_mode == Disabled`` branch would
+    have played the cue and left the robot askew for the whole session.
+    """
+    mgr = StubAppManager(installed=["foo"], catalog=[])
+    daemon = StubDaemon()
+    daemon.backend.at_init_pose = False
 
-    assert backend.played_sounds == ["wake_up.wav"]
-    assert backend.goto_target_calls == 0
+    assert await wake_or_start_startup_app_if_idle(mgr, daemon, "foo") is True  # type: ignore[arg-type]
+
+    assert daemon.backend.wake_up_calls == 1
+    assert daemon.backend.wake_up_forces == [True]
+    assert daemon.backend.played_sounds == []
+    assert mgr.started == ["foo"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_backend_idle_reset.py
+++ b/tests/unit_tests/test_backend_idle_reset.py
@@ -16,6 +16,8 @@ import pytest
 from reachy_mini.daemon.backend.abstract import Backend
 from reachy_mini.io.protocol import MotorControlMode
 
+GRACE_S = 0.02
+
 
 def _fake_backend(
     *,
@@ -23,7 +25,8 @@ def _fake_backend(
     shutting_down: bool = False,
 ) -> SimpleNamespace:
     return SimpleNamespace(
-        IDLE_RESET_DEBOUNCE_S=0.02,
+        IDLE_RESET_DEBOUNCE_S=GRACE_S,
+        IDLE_RESET_HANDOFF_GRACE_S=GRACE_S * 10,
         is_shutting_down=shutting_down,
         get_motor_control_mode=lambda: motor_mode,
         goto_sleep=AsyncMock(),
@@ -36,7 +39,7 @@ def _fake_backend(
 async def test_idle_reset_sleeps_after_debounce() -> None:
     """When the slot stays free past the grace period, goto_sleep runs."""
     fake = _fake_backend()
-    task = asyncio.ensure_future(Backend._async_idle_reset(fake))
+    task = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))
     fake._idle_reset_task = task
     await task
     fake.goto_sleep.assert_awaited_once()
@@ -47,7 +50,7 @@ async def test_idle_reset_sleeps_after_debounce() -> None:
 async def test_cancel_during_debounce_skips_motion() -> None:
     """A reconnect within the grace period cancels the reset before any motion."""
     fake = _fake_backend()
-    task = asyncio.ensure_future(Backend._async_idle_reset(fake))
+    task = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))
     fake._idle_reset_task = task
     await asyncio.sleep(0)  # let the task reach the debounce sleep
     task.cancel()
@@ -60,7 +63,7 @@ async def test_cancel_during_debounce_skips_motion() -> None:
 async def test_idle_reset_skips_when_already_disabled() -> None:
     """Re-check after the grace period: skip goto_sleep if already limp."""
     fake = _fake_backend(motor_mode=MotorControlMode.Disabled)
-    task = asyncio.ensure_future(Backend._async_idle_reset(fake))
+    task = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))
     fake._idle_reset_task = task
     await task
     fake.goto_sleep.assert_not_awaited()
@@ -70,10 +73,32 @@ async def test_idle_reset_skips_when_already_disabled() -> None:
 async def test_idle_reset_skips_when_shutting_down() -> None:
     """Re-check after the grace period: skip goto_sleep if shutdown started."""
     fake = _fake_backend(shutting_down=True)
-    task = asyncio.ensure_future(Backend._async_idle_reset(fake))
+    task = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))
     fake._idle_reset_task = task
     await task
     fake.goto_sleep.assert_not_awaited()
+
+
+def test_handoff_release_gets_the_long_grace() -> None:
+    """A hand-off release must schedule with the long grace, not the debounce.
+
+    Regression guard for the mobile app dropping its session so an app iframe
+    can take the slot: the short debounce expires long before a Space has
+    finished cold-starting, and the robot would fall asleep in that gap.
+    """
+    scheduled: list[tuple] = []
+    fake = _fake_backend()
+    fake._maybe_start_idle_reset = lambda *args: None
+    fake._log_loop = SimpleNamespace(
+        call_soon_threadsafe=lambda fn, *args: scheduled.append(args)
+    )
+
+    Backend.request_idle_reset(fake, expect_handoff=True)
+    assert scheduled == [(fake.IDLE_RESET_HANDOFF_GRACE_S,)]
+
+    scheduled.clear()
+    Backend.request_idle_reset(fake, expect_handoff=False)
+    assert scheduled == [(fake.IDLE_RESET_DEBOUNCE_S,)]
 
 
 @pytest.mark.asyncio
@@ -85,7 +110,7 @@ async def test_finally_does_not_clobber_newer_task() -> None:
     ``_cancel_idle_reset`` would miss the newer in-flight goto_sleep.
     """
     fake = _fake_backend()
-    task_a = asyncio.ensure_future(Backend._async_idle_reset(fake))
+    task_a = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))
     fake._idle_reset_task = task_a
     await asyncio.sleep(0)  # let task_a reach the debounce sleep
 

--- a/tests/unit_tests/test_backend_idle_reset.py
+++ b/tests/unit_tests/test_backend_idle_reset.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from reachy_mini.daemon.backend.abstract import Backend
+from reachy_mini.daemon.robot_app_lock import RobotAppLock
 from reachy_mini.io.protocol import MotorControlMode
 
 GRACE_S = 0.02
@@ -90,15 +91,85 @@ def test_handoff_release_gets_the_long_grace() -> None:
     fake = _fake_backend()
     fake._maybe_start_idle_reset = lambda *args: None
     fake._log_loop = SimpleNamespace(
-        call_soon_threadsafe=lambda fn, *args: scheduled.append(args)
+        call_soon_threadsafe=lambda fn, *args: scheduled.append((fn, args))
     )
 
     Backend.request_idle_reset(fake, expect_handoff=True)
-    assert scheduled == [(fake.IDLE_RESET_HANDOFF_GRACE_S,)]
+    assert scheduled == [
+        (fake._maybe_start_idle_reset, (fake.IDLE_RESET_HANDOFF_GRACE_S,))
+    ]
 
     scheduled.clear()
     Backend.request_idle_reset(fake, expect_handoff=False)
-    assert scheduled == [(fake.IDLE_RESET_DEBOUNCE_S,)]
+    assert scheduled == [(fake._maybe_start_idle_reset, (fake.IDLE_RESET_DEBOUNCE_S,))]
+
+
+def _wire_lock_to_backend(fake: SimpleNamespace) -> RobotAppLock:
+    """Wire a real RobotAppLock to the fake backend the way the daemon does.
+
+    Free transition -> ``request_idle_reset(expect_handoff=...)``; remote
+    acquire -> ``cancel_idle_reset()``. The fake gets the real scheduling
+    machinery bound so an actual asyncio task carries the grace period.
+    """
+    fake.ready = SimpleNamespace(is_set=lambda: True)
+    fake._log_loop = asyncio.get_running_loop()
+    fake._maybe_start_idle_reset = lambda grace_s: Backend._maybe_start_idle_reset(
+        fake, grace_s
+    )
+    fake._cancel_idle_reset = lambda: Backend._cancel_idle_reset(fake)
+    fake._async_idle_reset = lambda grace_s: Backend._async_idle_reset(fake, grace_s)
+
+    lock = RobotAppLock()
+    lock.set_on_became_free_handler(
+        lambda expect_handoff: Backend.request_idle_reset(
+            fake, expect_handoff=expect_handoff
+        )
+    )
+    lock.set_on_remote_acquired_handler(lambda: Backend.cancel_idle_reset(fake))
+    return lock
+
+
+@pytest.mark.asyncio
+async def test_remote_acquire_cancels_pending_handoff_grace_reset() -> None:
+    """A successor taking the slot must cancel the pending handoff-grace reset.
+
+    This is the daemon seam end to end: release-for-handoff schedules a real
+    reset task with the long grace, and the successor's ``try_acquire_remote``
+    - not its first data-channel command - cancels it before any motion.
+    """
+    fake = _fake_backend()
+    lock = _wire_lock_to_backend(fake)
+
+    assert lock.try_acquire_remote("predecessor") is True
+    lock.release_remote(expect_handoff=True)
+    await asyncio.sleep(0)  # run the posted _maybe_start_idle_reset
+    assert fake._idle_reset_task is not None  # the grace timer is really armed
+
+    assert lock.try_acquire_remote("successor") is True
+    await asyncio.sleep(0)  # run the posted _cancel_idle_reset
+
+    # Wait well past the handoff grace: the cancelled reset must never fire.
+    await asyncio.sleep(fake.IDLE_RESET_HANDOFF_GRACE_S * 1.5)
+    fake.goto_sleep.assert_not_awaited()
+    assert fake._idle_reset_task is None
+
+
+@pytest.mark.asyncio
+async def test_handoff_grace_reset_fires_when_no_successor_arrives() -> None:
+    """Positive control for the seam: no successor, the robot goes to sleep.
+
+    Proves the wiring in the test above would have slept the robot - so the
+    assert_not_awaited there is the acquire's doing, not a broken setup.
+    """
+    fake = _fake_backend()
+    lock = _wire_lock_to_backend(fake)
+
+    assert lock.try_acquire_remote("predecessor") is True
+    lock.release_remote(expect_handoff=True)
+    await asyncio.sleep(0)
+
+    await asyncio.sleep(fake.IDLE_RESET_HANDOFF_GRACE_S * 1.5)
+    fake.goto_sleep.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_backend_wake_up.py
+++ b/tests/unit_tests/test_backend_wake_up.py
@@ -1,0 +1,83 @@
+"""Backend.wake_up stand-down on an already-awake robot.
+
+Clients routinely send ``wake_up`` on session start. Since the idle-reset
+handoff grace keeps the robot awake between sessions, that boot-time wake
+would replay the emote (goto + "toudoum" + roll) on a robot that never
+slept. ``wake_up`` must stand down when the motors are enabled and the head
+is already at the init pose - and still run in full from any other state.
+
+Same lightweight-fake approach as ``test_backend_idle_reset``: the method
+only touches a handful of ``self`` attributes, so it is exercised unbound.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+
+from reachy_mini.daemon.backend.abstract import Backend
+from reachy_mini.io.protocol import MotorControlMode
+
+
+def _fake_backend(
+    *,
+    motor_mode: MotorControlMode,
+    head_pose: np.ndarray,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        INIT_HEAD_POSE=Backend.INIT_HEAD_POSE,
+        INIT_ANTENNAS_JOINT_POSITIONS=Backend.INIT_ANTENNAS_JOINT_POSITIONS,
+        get_current_head_pose=lambda: head_pose,
+        get_motor_control_mode=lambda: motor_mode,
+        goto_target=AsyncMock(),
+        play_sound=MagicMock(),
+        _on_wake_up_callback=MagicMock(),
+    )
+
+
+def _far_pose() -> np.ndarray:
+    """Build a pose ~50 magic-mm away from init - well past the 10 threshold."""
+    pose = Backend.INIT_HEAD_POSE.copy()
+    pose[0, 3] += 0.05  # +50 mm along x
+    return pose
+
+
+@pytest.mark.asyncio
+async def test_wake_up_stands_down_when_already_awake_at_init() -> None:
+    """Enabled motors + head at init pose: no motion, no sound."""
+    fake = _fake_backend(
+        motor_mode=MotorControlMode.Enabled,
+        head_pose=Backend.INIT_HEAD_POSE.copy(),
+    )
+    await Backend.wake_up(fake)
+    fake.goto_target.assert_not_awaited()
+    fake.play_sound.assert_not_called()
+    # The "robot is awake" hook keeps firing so a configured startup app
+    # still launches whatever path the wake took.
+    fake._on_wake_up_callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wake_up_runs_in_full_when_asleep() -> None:
+    """Disabled motors (fresh boot / post-sleep): the full emote plays."""
+    fake = _fake_backend(
+        motor_mode=MotorControlMode.Disabled,
+        head_pose=Backend.SLEEP_HEAD_POSE.copy(),
+    )
+    await Backend.wake_up(fake)
+    assert fake.goto_target.await_count >= 1
+    fake.play_sound.assert_called_once_with("wake_up.wav")
+    fake._on_wake_up_callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wake_up_runs_when_enabled_but_off_pose() -> None:
+    """Enabled but parked far from init (e.g. crashed app): still wakes."""
+    fake = _fake_backend(
+        motor_mode=MotorControlMode.Enabled,
+        head_pose=_far_pose(),
+    )
+    await Backend.wake_up(fake)
+    assert fake.goto_target.await_count >= 1
+    fake.play_sound.assert_called_once_with("wake_up.wav")

--- a/tests/unit_tests/test_backend_wake_up.py
+++ b/tests/unit_tests/test_backend_wake_up.py
@@ -28,9 +28,11 @@ def _fake_backend(
 ) -> SimpleNamespace:
     if antennas is None:
         antennas = Backend.INIT_ANTENNAS_JOINT_POSITIONS.copy()
-    return SimpleNamespace(
+    fake = SimpleNamespace(
         INIT_HEAD_POSE=Backend.INIT_HEAD_POSE,
         INIT_ANTENNAS_JOINT_POSITIONS=Backend.INIT_ANTENNAS_JOINT_POSITIONS,
+        INIT_POSE_MAGIC_DISTANCE=Backend.INIT_POSE_MAGIC_DISTANCE,
+        INIT_ANTENNAS_TOLERANCE_RAD=Backend.INIT_ANTENNAS_TOLERANCE_RAD,
         get_current_head_pose=lambda: head_pose,
         get_present_antenna_joint_positions=lambda: antennas,
         get_motor_control_mode=lambda: motor_mode,
@@ -38,6 +40,9 @@ def _fake_backend(
         play_sound=MagicMock(),
         _on_wake_up_callback=MagicMock(),
     )
+    # Bind the real predicate so these tests exercise it, not a stub.
+    fake.is_awake_at_init_pose = lambda: Backend.is_awake_at_init_pose(fake)
+    return fake
 
 
 def _far_pose() -> np.ndarray:
@@ -99,6 +104,24 @@ async def test_wake_up_runs_when_disabled_even_at_init_pose() -> None:
         head_pose=Backend.INIT_HEAD_POSE.copy(),
     )
     await Backend.wake_up(fake)
+    assert fake.goto_target.await_count >= 1
+    fake.play_sound.assert_called_once_with("wake_up.wav")
+    fake._on_wake_up_callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wake_up_force_replays_even_when_awake_at_init() -> None:
+    """force=True bypasses the stand-down: full emote on an awake robot.
+
+    Used by callers that enable the motors themselves right before waking
+    (antenna touch on a sleeping robot): enabling first would otherwise
+    satisfy the stand-down and swallow the wake they just decided on.
+    """
+    fake = _fake_backend(
+        motor_mode=MotorControlMode.Enabled,
+        head_pose=Backend.INIT_HEAD_POSE.copy(),
+    )
+    await Backend.wake_up(fake, force=True)
     assert fake.goto_target.await_count >= 1
     fake.play_sound.assert_called_once_with("wake_up.wav")
     fake._on_wake_up_callback.assert_called_once()

--- a/tests/unit_tests/test_backend_wake_up.py
+++ b/tests/unit_tests/test_backend_wake_up.py
@@ -3,8 +3,11 @@
 Clients routinely send ``wake_up`` on session start. Since the idle-reset
 handoff grace keeps the robot awake between sessions, that boot-time wake
 would replay the emote (goto + "toudoum" + roll) on a robot that never
-slept. ``wake_up`` must stand down when the motors are enabled and the head
-is already at the init pose - and still run in full from any other state.
+slept. ``wake_up`` must stand down when the motors are enabled and the
+controller is actively holding the init pose - and still run in full from
+any other state. The predicate reads the commanded targets, not the
+measured pose, so per-unit calibration residual can't flip the answer
+(hardware-verified in #1311 review).
 
 Same lightweight-fake approach as ``test_backend_idle_reset``: the method
 only touches a handful of ``self`` attributes, so it is exercised unbound.
@@ -23,18 +26,22 @@ from reachy_mini.io.protocol import MotorControlMode
 def _fake_backend(
     *,
     motor_mode: MotorControlMode,
-    head_pose: np.ndarray,
+    head_pose: np.ndarray | None,
     antennas: np.ndarray | None = None,
 ) -> SimpleNamespace:
-    if antennas is None:
+    if antennas is None and head_pose is not None:
         antennas = Backend.INIT_ANTENNAS_JOINT_POSITIONS.copy()
     fake = SimpleNamespace(
         INIT_HEAD_POSE=Backend.INIT_HEAD_POSE,
         INIT_ANTENNAS_JOINT_POSITIONS=Backend.INIT_ANTENNAS_JOINT_POSITIONS,
-        INIT_POSE_MAGIC_DISTANCE=Backend.INIT_POSE_MAGIC_DISTANCE,
-        INIT_ANTENNAS_TOLERANCE_RAD=Backend.INIT_ANTENNAS_TOLERANCE_RAD,
-        get_current_head_pose=lambda: head_pose,
-        get_present_antenna_joint_positions=lambda: antennas,
+        INIT_TARGET_ATOL=Backend.INIT_TARGET_ATOL,
+        # The predicate reads the commanded targets; the full wake path still
+        # measures the present pose to size its goto duration.
+        target_head_pose=head_pose,
+        target_antenna_joint_positions=antennas,
+        get_current_head_pose=lambda: (
+            head_pose if head_pose is not None else Backend.SLEEP_HEAD_POSE.copy()
+        ),
         get_motor_control_mode=lambda: motor_mode,
         goto_target=AsyncMock(),
         play_sound=MagicMock(),
@@ -46,7 +53,7 @@ def _fake_backend(
 
 
 def _far_pose() -> np.ndarray:
-    """Build a pose ~50 magic-mm away from init - well past the 10 threshold."""
+    """Build a pose 50 mm away from init - well past the target atol."""
     pose = Backend.INIT_HEAD_POSE.copy()
     pose[0, 3] += 0.05  # +50 mm along x
     return pose
@@ -54,7 +61,7 @@ def _far_pose() -> np.ndarray:
 
 @pytest.mark.asyncio
 async def test_wake_up_stands_down_when_already_awake_at_init() -> None:
-    """Enabled motors + head at init pose: no motion, no sound."""
+    """Enabled motors + init is the commanded target: no motion, no sound."""
     fake = _fake_backend(
         motor_mode=MotorControlMode.Enabled,
         head_pose=Backend.INIT_HEAD_POSE.copy(),
@@ -64,6 +71,44 @@ async def test_wake_up_stands_down_when_already_awake_at_init() -> None:
     fake.play_sound.assert_not_called()
     # The "robot is awake" hook keeps firing so a configured startup app
     # still launches whatever path the wake took.
+    fake._on_wake_up_callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wake_up_stands_down_despite_calibration_residual() -> None:
+    """A goto's interpolation tail (< atol) must not defeat the stand-down.
+
+    The predicate compares commanded targets exactly so hardware residual is
+    out of the picture, but the target itself lands one eased tick short of
+    the endpoint (play_move never evaluates at t=duration). That tail must
+    stay inside INIT_TARGET_ATOL.
+    """
+    near_init = Backend.INIT_HEAD_POSE.copy()
+    near_init[0, 3] += 0.005  # half the atol
+    fake = _fake_backend(
+        motor_mode=MotorControlMode.Enabled,
+        head_pose=near_init,
+    )
+    await Backend.wake_up(fake)
+    fake.goto_target.assert_not_awaited()
+    fake.play_sound.assert_not_called()
+    fake._on_wake_up_callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wake_up_runs_when_no_target_commanded_yet() -> None:
+    """Enabled motors but no target ever commanded (fresh boot): full wake.
+
+    Also covers --sim, where the mujoco backend hardcodes motor mode to
+    Enabled: the None guard keeps wake_up_on_start audible there.
+    """
+    fake = _fake_backend(
+        motor_mode=MotorControlMode.Enabled,
+        head_pose=None,
+    )
+    await Backend.wake_up(fake)
+    assert fake.goto_target.await_count >= 1
+    fake.play_sound.assert_called_once_with("wake_up.wav")
     fake._on_wake_up_callback.assert_called_once()
 
 
@@ -94,10 +139,10 @@ async def test_wake_up_runs_when_enabled_but_off_pose() -> None:
 
 @pytest.mark.asyncio
 async def test_wake_up_runs_when_disabled_even_at_init_pose() -> None:
-    """Disabled motors + head at init: must still wake in full.
+    """Disabled motors + init target still in place: must wake in full.
 
-    Locks the `and` in the stand-down condition: a limp robot that happens
-    to rest at the init pose is asleep, not awake.
+    Locks the `and` in the stand-down condition: a limp robot whose last
+    commanded target was init is asleep, not awake.
     """
     fake = _fake_backend(
         motor_mode=MotorControlMode.Disabled,
@@ -129,7 +174,7 @@ async def test_wake_up_force_replays_even_when_awake_at_init() -> None:
 
 @pytest.mark.asyncio
 async def test_wake_up_runs_when_antennas_off_init() -> None:
-    """Enabled + head at init but antennas askew: the wake must run.
+    """Enabled + head target at init but antennas targeted askew: must run.
 
     The wake's goto is what re-homes the antennas; standing down here
     would leave them wherever the previous app parked them.

--- a/tests/unit_tests/test_backend_wake_up.py
+++ b/tests/unit_tests/test_backend_wake_up.py
@@ -24,11 +24,15 @@ def _fake_backend(
     *,
     motor_mode: MotorControlMode,
     head_pose: np.ndarray,
+    antennas: np.ndarray | None = None,
 ) -> SimpleNamespace:
+    if antennas is None:
+        antennas = Backend.INIT_ANTENNAS_JOINT_POSITIONS.copy()
     return SimpleNamespace(
         INIT_HEAD_POSE=Backend.INIT_HEAD_POSE,
         INIT_ANTENNAS_JOINT_POSITIONS=Backend.INIT_ANTENNAS_JOINT_POSITIONS,
         get_current_head_pose=lambda: head_pose,
+        get_present_antenna_joint_positions=lambda: antennas,
         get_motor_control_mode=lambda: motor_mode,
         goto_target=AsyncMock(),
         play_sound=MagicMock(),
@@ -81,3 +85,38 @@ async def test_wake_up_runs_when_enabled_but_off_pose() -> None:
     await Backend.wake_up(fake)
     assert fake.goto_target.await_count >= 1
     fake.play_sound.assert_called_once_with("wake_up.wav")
+
+
+@pytest.mark.asyncio
+async def test_wake_up_runs_when_disabled_even_at_init_pose() -> None:
+    """Disabled motors + head at init: must still wake in full.
+
+    Locks the `and` in the stand-down condition: a limp robot that happens
+    to rest at the init pose is asleep, not awake.
+    """
+    fake = _fake_backend(
+        motor_mode=MotorControlMode.Disabled,
+        head_pose=Backend.INIT_HEAD_POSE.copy(),
+    )
+    await Backend.wake_up(fake)
+    assert fake.goto_target.await_count >= 1
+    fake.play_sound.assert_called_once_with("wake_up.wav")
+    fake._on_wake_up_callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wake_up_runs_when_antennas_off_init() -> None:
+    """Enabled + head at init but antennas askew: the wake must run.
+
+    The wake's goto is what re-homes the antennas; standing down here
+    would leave them wherever the previous app parked them.
+    """
+    fake = _fake_backend(
+        motor_mode=MotorControlMode.Enabled,
+        head_pose=Backend.INIT_HEAD_POSE.copy(),
+        antennas=Backend.SLEEP_ANTENNAS_JOINT_POSITIONS.copy(),
+    )
+    await Backend.wake_up(fake)
+    assert fake.goto_target.await_count >= 1
+    fake.play_sound.assert_called_once_with("wake_up.wav")
+    fake._on_wake_up_callback.assert_called_once()

--- a/tests/unit_tests/test_central_signaling_relay.py
+++ b/tests/unit_tests/test_central_signaling_relay.py
@@ -630,13 +630,16 @@ class _FakeLock:
         self._acquire = acquire
         self.acquired = 0
         self.released = 0
+        self.handoff_releases = 0
 
     def try_acquire_remote(self, app_name: str) -> bool:
         self.acquired += 1
         return self._acquire
 
-    def release_remote(self) -> None:
+    def release_remote(self, *, expect_handoff: bool = False) -> None:
         self.released += 1
+        if expect_handoff:
+            self.handoff_releases += 1
 
 
 def _make_relay_with_journals(
@@ -756,6 +759,9 @@ def test_central_end_session_cleans_up_and_releases_lock() -> None:
     assert relay._session_to_local_peer == {}
     assert local.sent == [{"type": "endSession", "sessionId": "ls1"}]
     assert lock.released == 1
+    # A deliberate hang-up: flagged as a hand-off so the daemon gives a
+    # successor session time to arrive before sleeping the robot.
+    assert lock.handoff_releases == 1
 
 
 # ---- local -> central direction ----
@@ -832,6 +838,7 @@ def test_local_end_session_forwards_to_central_and_releases_lock() -> None:
     assert relay._central_to_local_session == {}
     assert central.sent == [{"type": "endSession", "sessionId": "cs1"}]
     assert lock.released == 1
+    assert lock.handoff_releases == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_robot_app_lock.py
+++ b/tests/unit_tests/test_robot_app_lock.py
@@ -310,7 +310,7 @@ def test_became_free_handler_fires_on_remote_release() -> None:
     """Releasing a remote session fires the FREE-transition handler once."""
     lock = RobotAppLock()
     calls: list[str] = []
-    lock.set_on_became_free_handler(lambda: calls.append("free"))
+    lock.set_on_became_free_handler(lambda _handoff: calls.append("free"))
 
     assert lock.try_acquire_remote("client1") is True
     assert calls == []  # acquiring must not fire it
@@ -322,18 +322,42 @@ def test_became_free_handler_fires_on_local_release() -> None:
     """Releasing a local app fires the FREE-transition handler once."""
     lock = RobotAppLock()
     calls: list[str] = []
-    lock.set_on_became_free_handler(lambda: calls.append("free"))
+    lock.set_on_became_free_handler(lambda _handoff: calls.append("free"))
 
     assert lock.try_acquire_local("app_a") is True
     lock.release_local("app_a")
     assert calls == ["free"]
 
 
+def test_became_free_handler_reports_handoff_intent() -> None:
+    """The FREE handler must be able to tell a hand-off from a plain drop.
+
+    A deliberate ``endSession`` usually means a successor session is on its way
+    in, so the daemon waits much longer before reclaiming the robot; a drop
+    gets the short debounce. Local exits are never hand-offs.
+    """
+    lock = RobotAppLock()
+    seen: list[bool] = []
+    lock.set_on_became_free_handler(seen.append)
+
+    lock.try_acquire_remote("client1")
+    lock.release_remote(expect_handoff=True)
+    assert seen == [True]
+
+    lock.try_acquire_remote("client2")
+    lock.release_remote()
+    assert seen == [True, False]
+
+    lock.try_acquire_local("app_a")
+    lock.release_local("app_a")
+    assert seen == [True, False, False]
+
+
 def test_became_free_handler_sees_free_state() -> None:
     """When the handler runs, the lock is already FREE (post-transition)."""
     lock = RobotAppLock()
     seen: list[RobotAppLockState] = []
-    lock.set_on_became_free_handler(lambda: seen.append(lock.status().state))
+    lock.set_on_became_free_handler(lambda _handoff: seen.append(lock.status().state))
 
     lock.try_acquire_remote("client1")
     lock.release_remote()
@@ -344,7 +368,7 @@ def test_became_free_handler_not_fired_on_noop_release() -> None:
     """A release that doesn't actually free the slot must not fire the handler."""
     lock = RobotAppLock()
     calls: list[str] = []
-    lock.set_on_became_free_handler(lambda: calls.append("free"))
+    lock.set_on_became_free_handler(lambda _handoff: calls.append("free"))
 
     # No hold at all: release is a no-op.
     lock.release_remote()
@@ -362,7 +386,7 @@ async def test_became_free_handler_not_fired_on_eviction() -> None:
     """Evicting a remote for a local app goes REMOTE→LOCAL, never through FREE."""
     lock = RobotAppLock()
     calls: list[str] = []
-    lock.set_on_became_free_handler(lambda: calls.append("free"))
+    lock.set_on_became_free_handler(lambda _handoff: calls.append("free"))
 
     assert lock.try_acquire_remote("client1") is True
     await lock.acquire_local_evicting_remote("app_a")
@@ -373,7 +397,7 @@ def test_became_free_handler_exception_is_swallowed() -> None:
     """A raising FREE handler must not break the release path."""
     lock = RobotAppLock()
 
-    def handler() -> None:
+    def handler(expect_handoff: bool) -> None:
         raise RuntimeError("boom")
 
     lock.set_on_became_free_handler(handler)
@@ -386,7 +410,7 @@ def test_clearing_became_free_handler_disables_it() -> None:
     """Passing ``None`` clears the FREE-transition handler."""
     lock = RobotAppLock()
     calls: list[str] = []
-    lock.set_on_became_free_handler(lambda: calls.append("free"))
+    lock.set_on_became_free_handler(lambda _handoff: calls.append("free"))
     lock.set_on_became_free_handler(None)
 
     lock.try_acquire_remote("client1")

--- a/tests/unit_tests/test_robot_app_lock.py
+++ b/tests/unit_tests/test_robot_app_lock.py
@@ -416,3 +416,61 @@ def test_clearing_became_free_handler_disables_it() -> None:
     lock.try_acquire_remote("client1")
     lock.release_remote()
     assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Remote-acquired handler: daemon-side idle-reset cancellation
+# ---------------------------------------------------------------------------
+
+
+def test_remote_acquired_handler_fires_on_successful_acquire() -> None:
+    """A successful remote acquire fires the handler once, post-transition.
+
+    This is what cancels a pending handoff-grace idle reset the moment a
+    successor takes the slot, instead of waiting for its first data-channel
+    command.
+    """
+    lock = RobotAppLock()
+    seen: list[RobotAppLockState] = []
+    lock.set_on_remote_acquired_handler(lambda: seen.append(lock.status().state))
+
+    assert lock.try_acquire_remote("client1") is True
+    assert seen == [RobotAppLockState.REMOTE_SESSION]
+
+
+def test_remote_acquired_handler_not_fired_on_refused_acquire() -> None:
+    """A refused acquire (slot already held) must not fire the handler."""
+    lock = RobotAppLock()
+    assert lock.try_acquire_remote("client1") is True
+
+    calls: list[str] = []
+    lock.set_on_remote_acquired_handler(lambda: calls.append("acquired"))
+
+    assert lock.try_acquire_remote("client2") is False
+    assert calls == []
+
+
+def test_remote_acquired_handler_not_fired_on_local_acquire() -> None:
+    """Local-app acquisition must not fire the remote-acquired hook.
+
+    It has its own cancel path (``AppManager.start_app`` calls
+    ``backend.cancel_idle_reset()`` directly).
+    """
+    lock = RobotAppLock()
+    calls: list[str] = []
+    lock.set_on_remote_acquired_handler(lambda: calls.append("acquired"))
+
+    assert lock.try_acquire_local("app_a") is True
+    assert calls == []
+
+
+def test_remote_acquired_handler_exception_is_swallowed() -> None:
+    """A raising handler must not break (or undo) the acquire."""
+    lock = RobotAppLock()
+
+    def handler() -> None:
+        raise RuntimeError("boom")
+
+    lock.set_on_remote_acquired_handler(handler)
+    assert lock.try_acquire_remote("client1") is True
+    assert lock.status().state == RobotAppLockState.REMOTE_SESSION


### PR DESCRIPTION
Split out of #1304 (see the split plan there).

A client ending its session deliberately is often making room for a successor (e.g. the mobile app dropping its session so an app's iframe can take the slot), and a Space cold-start outlives the 1.5 s idle-reset debounce - the robot fell asleep mid-handoff.

- An `expect_handoff` flag travels from the relay's `endSession` paths through `RobotAppLock.release_remote` into `Backend.request_idle_reset`, which waits 15 s (tuned down from 30 after hardware testing) instead of the debounce.
- The grace is cancelled immediately when a remote session acquires the slot (`RobotAppLock.set_on_remote_acquired_handler` wired to `backend.cancel_idle_reset()` in the daemon), so a successful handoff never leaves a stale sleep timer behind.
- Companion fix: `wake_up` stand-down - see the behavior change section below, it is observable outside the handoff flow.

## Behavior change: `wake_up` stands down on an already-awake robot

This is a deliberate, observable change for the daemon-side `wake_up` callers: REST `/move/play_wake_up`, the WebRTC data-channel command, and the daemon's own boot/antenna wake paths.

> **Not covered: the Python SDK.** `ReachyMini.wake_up()` reimplements the emote client-side (goto + sound + roll) and never reaches `Backend.wake_up`, so Python apps still replay it on an awake robot. Fixing that needs a wake-up task request in the protocol to keep the method blocking - follow-up PR.

- **Before**: `wake_up` always replayed the full emote + "toudoum", even when the robot was already awake and standing at the init pose.
- **After**: when `Backend.is_awake_at_init_pose()` holds - motors enabled and init is the commanded target the controller is actively holding - `wake_up` is a silent no-op. The wake-completed callback still fires, so "start app after wake" semantics are preserved: the robot IS awake.
- `wake_up(force=True)` bypasses the stand-down for callers that need the emote unconditionally.

Rationale: clients routinely send `wake_up` on session start, and now that a handoff keeps the robot awake between sessions, replaying the animation on an already-awake robot reads as a glitch, not a wake. (Unlike `goto_sleep`'s stand-down, which still plays its cue, this one is deliberately silent - the sound on session start is the whole point.)

The "already awake" decision is a single predicate, `Backend.is_awake_at_init_pose()`, shared by `wake_up` and the antenna-touch startup path. **It compares the commanded targets, not the measured pose**: the first hardware pass (review below) showed a measured-pose comparison against the ideal init never fires - per-unit calibration residual ate the whole threshold, silently, on every wake. "Standing at init" now means "init is what the controller is holding": a head sagging a few mm under its own weight while commanded to init IS at init; a head an app parked elsewhere isn't. Both per-unit magic thresholds are gone; the remaining `atol` bounds the goto interpolation tail (a `play_move` loop never evaluates at exactly `t=duration`), a property of the trajectory, not of the robot.

Two knock-ons on the antenna path:

- It used to enable the motors before calling `wake_up()`, which could satisfy the stand-down it had just decided to bypass (`enable_motors` pins the targets to the measured pose); it now decides first and wakes with `force=True`.
- "Motors enabled but robot parked off init" (e.g. crashed app) used to get the cue-only branch and never re-home; it now runs the full wake.

## Known limitation

Any client death on the `endSession` path - tab kill, ICE failure, network drop - is indistinguishable from a deliberate hang-up, so those crashes get the same 15 s grace. The worst case is bounded: a client that "promised" a handoff and never came back leaves the robot awake for 15 s, then the normal idle reset runs. (Tightening this would need an explicit intent/reason field on the relayed `endSession`.)

Under `--sim`, the mujoco backend hardcodes `get_motor_control_mode() -> Enabled`, so the stand-down rests on the target check there. A fresh boot has no commanded target yet (the predicate's `None` guard), so `wake_up_on_start` still plays the full wake in simulation.

Pre-existing bug found during hardware review, not fixed here: `play_move`'s loop never evaluates a move at exactly `t=duration`, so every goto leaves the robot holding a target one eased tick short of the commanded endpoint. Core motion code, every move affected - follow-up PR.

## Behavioural pairing

Fail-open, any merge order: the JS block's sleep-on-leave pairs with this - without the grace the daemon may replay its own `goto_sleep` after a handoff.

## Tests

`test_robot_app_lock.py`, `test_backend_idle_reset.py`, `test_central_signaling_relay.py`, `test_backend_wake_up.py`, `test_autostart_app.py` (148 passed locally), including seam tests proving a pending handoff-grace reset task is cancelled by the successor's acquire. Handoff flows validated on hardware (mobile-to-app and web-host-to-app); the target-based stand-down was verified on hardware in review: 0.1 s no-op task, 0.001 rad peak roll, vs a 1.0 s / 0.216 rad replay before.

Made with [Cursor](https://cursor.com)
