### PR TITLE
fix(update): fail the update job on a non-zero install exit code

### DIFF
--- a/src/reachy_mini/utils/wireless_version/update.py
+++ b/src/reachy_mini/utils/wireless_version/update.py
@@ -57,10 +57,14 @@ async def update_reachy_mini(
     else:
         logger.info("apps_venv not found, skipping")
 
-    # Restart daemon to apply updates. --no-block: a blocking restart SIGTERMs
-    # our own cgroup (the systemctl child included), so it can exit 143 on a
-    # SUCCESSFUL update; --no-block returns once the job is queued, so a
-    # non-zero exit is a real failure.
+    # Restart daemon to apply updates. Two constraints, both load-bearing:
+    # - the argv must match /etc/sudoers.d/010-pollen-reachy exactly (any extra
+    #   flag, --no-block included, makes sudo demand a password and fail);
+    # - systemd SIGTERMs our own cgroup, killing this systemctl child, so
+    #   143/-15 means "the restart we asked for is happening", not a failure.
+    # Everything else (unknown unit, sudo refusal) still raises.
     await call_logger_wrapper(
-        "sudo systemctl --no-block restart reachy-mini-daemon", logger
+        "sudo systemctl restart reachy-mini-daemon",
+        logger,
+        ok_returncodes=(0, -15, 143),
     )

--- a/src/reachy_mini/utils/wireless_version/update.py
+++ b/src/reachy_mini/utils/wireless_version/update.py
@@ -18,13 +18,22 @@ async def update_reachy_mini(
         pre_release: If True, install pre-release from PyPI (ignored if git_ref set).
         git_ref: If set, install from this GitHub tag/branch instead of PyPI.
 
+    Raises:
+        RuntimeError: If the daemon venv install (or the final restart
+            command) fails. The daemon is then NOT restarted, nothing has
+            been applied, and the job is reported as failed - a retry stays
+            possible. An apps_venv failure is deliberately non-fatal (see
+            below).
+
     """
-    # Update daemon venv
+    # Update daemon venv. A failure here aborts the whole update BEFORE the
+    # restart: the running daemon is untouched and the failed install left
+    # the venv on the previous version, so a retry works.
     logger.info("Updating daemon venv...")
     cmd, extra_env = build_install_command(
         extras="wireless-version",
-        git_ref=git_ref, 
-        pre_release=pre_release, 
+        git_ref=git_ref,
+        pre_release=pre_release,
         upgrade=True,
     )
     await call_logger_wrapper(cmd, logger, env=extra_env or None)
@@ -33,15 +42,26 @@ async def update_reachy_mini(
     apps_venv_python = Path("/venvs/apps_venv/bin/python")
     if apps_venv_python.exists():
         logger.info("Updating apps_venv SDK...")
-        cmd, extra_env = build_install_command( 
+        cmd, extra_env = build_install_command(
             extras="",
-            git_ref=git_ref, 
+            git_ref=git_ref,
             pre_release=pre_release,
-            python=apps_venv_python, 
+            python=apps_venv_python,
             upgrade=True,
         )
-        await call_logger_wrapper(cmd, logger, env=extra_env or None)
-        logger.info("Apps venv SDK updated successfully")
+        try:
+            await call_logger_wrapper(cmd, logger, env=extra_env or None)
+            logger.info("Apps venv SDK updated successfully")
+        except RuntimeError as e:
+            # Non-fatal by design. The daemon venv is already on the new
+            # version at this point: aborting without restarting would leave
+            # it installed-but-not-running, and a retry would be refused as
+            # "no update available" (the availability check reads installed
+            # metadata). Restart anyway; `check_and_sync_apps_venv_sdk`
+            # re-syncs apps_venv to the daemon's version on every boot.
+            logger.error(
+                f"apps_venv SDK update failed (will re-sync on next boot): {e}"
+            )
     else:
         logger.info("apps_venv not found, skipping")
 

--- a/src/reachy_mini/utils/wireless_version/update.py
+++ b/src/reachy_mini/utils/wireless_version/update.py
@@ -19,16 +19,12 @@ async def update_reachy_mini(
         git_ref: If set, install from this GitHub tag/branch instead of PyPI.
 
     Raises:
-        RuntimeError: If the daemon venv install (or the final restart
-            command) fails. The daemon is then NOT restarted, nothing has
-            been applied, and the job is reported as failed - a retry stays
-            possible. An apps_venv failure is deliberately non-fatal (see
-            below).
+        RuntimeError: If the daemon venv install or the restart command
+            fails. An apps_venv failure is deliberately non-fatal.
 
     """
-    # Update daemon venv. A failure here aborts the whole update BEFORE the
-    # restart: the running daemon is untouched and the failed install left
-    # the venv on the previous version, so a retry works.
+    # Update daemon venv. Fatal: abort before the restart. On the PyPI path
+    # the venv is left on the previous version, so a retry works.
     logger.info("Updating daemon venv...")
     cmd, extra_env = build_install_command(
         extras="wireless-version",
@@ -52,18 +48,19 @@ async def update_reachy_mini(
         try:
             await call_logger_wrapper(cmd, logger, env=extra_env or None)
             logger.info("Apps venv SDK updated successfully")
-        except RuntimeError as e:
-            # Non-fatal by design. The daemon venv is already on the new
-            # version at this point: aborting without restarting would leave
-            # it installed-but-not-running, and a retry would be refused as
-            # "no update available" (the availability check reads installed
-            # metadata). Restart anyway; `check_and_sync_apps_venv_sdk`
-            # re-syncs apps_venv to the daemon's version on every boot.
+        except Exception as e:
+            # Non-fatal: the daemon venv is already on the new version, and
+            # check_and_sync_apps_venv_sdk re-syncs apps_venv on the next boot.
             logger.error(
                 f"apps_venv SDK update failed (will re-sync on next boot): {e}"
             )
     else:
         logger.info("apps_venv not found, skipping")
 
-    # Restart daemon to apply updates
-    await call_logger_wrapper("sudo systemctl restart reachy-mini-daemon", logger)
+    # Restart daemon to apply updates. --no-block: a blocking restart SIGTERMs
+    # our own cgroup (the systemctl child included), so it can exit 143 on a
+    # SUCCESSFUL update; --no-block returns once the job is queued, so a
+    # non-zero exit is a real failure.
+    await call_logger_wrapper(
+        "sudo systemctl --no-block restart reachy-mini-daemon", logger
+    )

--- a/src/reachy_mini/utils/wireless_version/utils.py
+++ b/src/reachy_mini/utils/wireless_version/utils.py
@@ -90,10 +90,7 @@ def build_install_command(
         if not _check_uv_available():
             step3_args += ["--upgrade-strategy", "only-if-needed"]
         step3 = shlex.join(step3_args)
-        # Group steps 2-3 explicitly: with the bare `step1 && step2 || step3`
-        # shell precedence, a FAILED step1 would run step3 (a plain PyPI
-        # upgrade), silently replacing the requested git ref with the latest
-        # wheel and masking the failure behind step3's exit code.
+        # Grouped: a failed step1 must not fall through to step3.
         cmd = f"{step1} && ( {step2} || {step3} )"
         logger.info(f"Git ref install: {cmd}")
         extra_env: dict[str, str] = {"GIT_LFS_SKIP_SMUDGE": "1"}
@@ -130,10 +127,7 @@ async def call_logger_wrapper(
         env: Optional environment variables dict. If None, inherits current environment.
 
     Raises:
-        RuntimeError: If the command exits with a non-zero code, so callers
-            (the update flow) can surface a real failure instead of carrying
-            on - e.g. restarting the daemon after a failed install and
-            reporting the job as done.
+        RuntimeError: If the command exits with a non-zero code.
 
     """
     logger.info(f"Running: {command}")
@@ -164,6 +158,4 @@ async def call_logger_wrapper(
     await asyncio.gather(*tasks)
     returncode = await process.wait()
     if returncode != 0:
-        message = f"Command failed with exit code {returncode}: {command}"
-        logger.error(message)
-        raise RuntimeError(message)
+        raise RuntimeError(f"Command failed with exit code {returncode}: {command}")

--- a/src/reachy_mini/utils/wireless_version/utils.py
+++ b/src/reachy_mini/utils/wireless_version/utils.py
@@ -118,6 +118,7 @@ async def call_logger_wrapper(
     command: str,
     logger: logging.Logger,
     env: dict[str, str] | None = None,
+    ok_returncodes: tuple[int, ...] = (0,),
 ) -> None:
     """Run a shell command asynchronously, streaming stdout and stderr to logger in real time.
 
@@ -125,9 +126,11 @@ async def call_logger_wrapper(
         command: Shell command string.
         logger: logger object with .info and .error methods
         env: Optional environment variables dict. If None, inherits current environment.
+        ok_returncodes: Exit codes treated as success. Only the daemon restart
+            needs more than ``(0,)`` - see ``update_reachy_mini``.
 
     Raises:
-        RuntimeError: If the command exits with a non-zero code.
+        RuntimeError: If the command exits with a code outside *ok_returncodes*.
 
     """
     logger.info(f"Running: {command}")
@@ -157,5 +160,5 @@ async def call_logger_wrapper(
 
     await asyncio.gather(*tasks)
     returncode = await process.wait()
-    if returncode != 0:
+    if returncode not in ok_returncodes:
         raise RuntimeError(f"Command failed with exit code {returncode}: {command}")

--- a/src/reachy_mini/utils/wireless_version/utils.py
+++ b/src/reachy_mini/utils/wireless_version/utils.py
@@ -79,7 +79,9 @@ def build_install_command(
         git_url = f"git+https://github.com/{GITHUB_REPO}.git@{git_ref}"
         git_package = f"reachy-mini[{extras}] @ {git_url}"
         # Step 1: force reinstall the package without the dependencies
-        step1 = shlex.join(base + [git_package, "--force-reinstall", "--no-deps", "--no-cache-dir"])
+        step1 = shlex.join(
+            base + [git_package, "--force-reinstall", "--no-deps", "--no-cache-dir"]
+        )
         # Step 2: check if dependencies need to be updated
         check_base = [arg if arg != "install" else "check" for arg in base]
         step2 = shlex.join(check_base)
@@ -88,12 +90,18 @@ def build_install_command(
         if not _check_uv_available():
             step3_args += ["--upgrade-strategy", "only-if-needed"]
         step3 = shlex.join(step3_args)
-        cmd = f"{step1} && {step2} || {step3}"
+        # Group steps 2-3 explicitly: with the bare `step1 && step2 || step3`
+        # shell precedence, a FAILED step1 would run step3 (a plain PyPI
+        # upgrade), silently replacing the requested git ref with the latest
+        # wheel and masking the failure behind step3's exit code.
+        cmd = f"{step1} && ( {step2} || {step3} )"
         logger.info(f"Git ref install: {cmd}")
         extra_env: dict[str, str] = {"GIT_LFS_SKIP_SMUDGE": "1"}
         return cmd, extra_env
 
-    logger.info(f"Installing from PyPI: {version if version else 'latest pre-release' if pre_release else 'latest stable'}")
+    logger.info(
+        f"Installing from PyPI: {version if version else 'latest pre-release' if pre_release else 'latest stable'}"
+    )
     package = f"reachy-mini[{extras}]"
     if version:
         package = f"{package}=={version}"
@@ -120,6 +128,12 @@ async def call_logger_wrapper(
         command: Shell command string.
         logger: logger object with .info and .error methods
         env: Optional environment variables dict. If None, inherits current environment.
+
+    Raises:
+        RuntimeError: If the command exits with a non-zero code, so callers
+            (the update flow) can surface a real failure instead of carrying
+            on - e.g. restarting the daemon after a failed install and
+            reporting the job as done.
 
     """
     logger.info(f"Running: {command}")
@@ -148,4 +162,8 @@ async def call_logger_wrapper(
         tasks.append(asyncio.create_task(stream_output(process.stderr, logger.error)))
 
     await asyncio.gather(*tasks)
-    await process.wait()
+    returncode = await process.wait()
+    if returncode != 0:
+        message = f"Command failed with exit code {returncode}: {command}"
+        logger.error(message)
+        raise RuntimeError(message)

--- a/tests/unit_tests/test_wireless_version.py
+++ b/tests/unit_tests/test_wireless_version.py
@@ -122,6 +122,29 @@ async def test_call_logger_wrapper_nonzero_raises():
         await utils.call_logger_wrapper("exit 7", logging.getLogger("test"))
 
 
+@pytest.mark.asyncio
+async def test_call_logger_wrapper_tolerated_returncode():
+    """A code listed in ok_returncodes does not raise (the restart's 143/-15)."""
+    # 143 = exit status relayed by the shell.
+    await utils.call_logger_wrapper("exit 143", logging.getLogger("test"), ok_returncodes=(0, -15, 143))
+    # -15 = process killed by SIGTERM (asyncio reports the negated signal), the
+    # real self-inflicted signal seen inside the daemon's cgroup.
+    await utils.call_logger_wrapper("kill -TERM $$", logging.getLogger("test"), ok_returncodes=(0, -15, 143))
+    # A code outside the list still raises.
+    with pytest.raises(RuntimeError, match="exit code 5"):
+        await utils.call_logger_wrapper("exit 5", logging.getLogger("test"), ok_returncodes=(0, -15, 143))
+
+
+def test_restart_argv_matches_sudoers_whitelist():
+    """The restart argv is whitelisted verbatim in /etc/sudoers.d/010-pollen-reachy.
+
+    Any extra flag (e.g. --no-block) stops sudo matching the NOPASSWD rule, so the
+    restart fails with "a password is required" and the update never applies.
+    """
+    src = Path(update.__file__).read_text()
+    assert '"sudo systemctl restart reachy-mini-daemon"' in src
+
+
 # --- _semver_version ---
 
 
@@ -317,7 +340,7 @@ async def test_update_with_apps_venv(monkeypatch):
     await update.update_reachy_mini(logging.getLogger("test"))
 
     assert calls.call_count == 3
-    assert calls.await_args_list[-1].args[0] == "sudo systemctl --no-block restart reachy-mini-daemon"
+    assert calls.await_args_list[-1].args[0] == "sudo systemctl restart reachy-mini-daemon"
 
 
 @pytest.mark.asyncio
@@ -330,7 +353,7 @@ async def test_update_without_apps_venv(monkeypatch):
     await update.update_reachy_mini(logging.getLogger("test"), pre_release=True)
 
     assert calls.call_count == 2
-    assert calls.await_args_list[-1].args[0] == "sudo systemctl --no-block restart reachy-mini-daemon"
+    assert calls.await_args_list[-1].args[0] == "sudo systemctl restart reachy-mini-daemon"
 
 
 @pytest.mark.asyncio
@@ -352,7 +375,7 @@ async def test_update_apps_venv_failure_still_restarts(monkeypatch):
     """An apps_venv failure is non-fatal: the restart still applies the update."""
     commands: list[str] = []
 
-    async def fake_call(cmd, logger, env=None):
+    async def fake_call(cmd, logger, env=None, ok_returncodes=(0,)):
         commands.append(cmd)
         if len(commands) == 2:  # second call = apps_venv install
             raise RuntimeError("apps_venv install failed")
@@ -363,7 +386,7 @@ async def test_update_apps_venv_failure_still_restarts(monkeypatch):
     await update.update_reachy_mini(logging.getLogger("test"))
 
     assert len(commands) == 3
-    assert commands[-1] == "sudo systemctl --no-block restart reachy-mini-daemon"
+    assert commands[-1] == "sudo systemctl restart reachy-mini-daemon"
 
 
 @pytest.mark.asyncio
@@ -371,7 +394,7 @@ async def test_update_restart_failure_propagates(monkeypatch):
     """A failed restart command surfaces as a failed job, not a silent pass."""
     commands: list[str] = []
 
-    async def fake_call(cmd, logger, env=None):
+    async def fake_call(cmd, logger, env=None, ok_returncodes=(0,)):
         commands.append(cmd)
         if cmd.startswith("sudo systemctl"):
             raise RuntimeError("systemctl failed")

--- a/tests/unit_tests/test_wireless_version.py
+++ b/tests/unit_tests/test_wireless_version.py
@@ -61,14 +61,21 @@ def test_build_external_venv_pip_fallback(monkeypatch):
     assert tokens[:2] == [str(py.parent / "pip"), "install"]
 
 
+def _split_git_ref_cmd(cmd):
+    """Split `step1 && ( step2 || step3 )` into its three steps."""
+    step1, rest = cmd.split(" && ", 1)
+    assert rest.startswith("( ") and rest.endswith(" )")
+    step2, step3 = rest[2:-2].split(" || ", 1)
+    return step1, step2, step3
+
+
 def test_build_git_ref_uv(monkeypatch):
     """Git ref install chains three steps and sets the LFS env var (uv)."""
     monkeypatch.setattr(utils, "_check_uv_available", lambda: True)
     cmd, env = utils.build_install_command("wireless-version", git_ref="main")
     assert env == {"GIT_LFS_SKIP_SMUDGE": "1"}
 
-    step1, rest = cmd.split(" && ", 1)
-    step2, step3 = rest.split(" || ", 1)
+    step1, step2, step3 = _split_git_ref_cmd(cmd)
 
     t1 = shlex.split(step1)
     assert "--force-reinstall" in t1 and "--no-deps" in t1 and "--no-cache-dir" in t1
@@ -85,11 +92,49 @@ def test_build_git_ref_pip_fallback(monkeypatch):
     """Git ref via pip appends the only-if-needed upgrade strategy."""
     monkeypatch.setattr(utils, "_check_uv_available", lambda: False)
     cmd, _ = utils.build_install_command("wireless-version", git_ref="dev")
-    _, rest = cmd.split(" && ", 1)
-    step2, step3 = rest.split(" || ", 1)
+    _, step2, step3 = _split_git_ref_cmd(cmd)
     assert shlex.split(step2) == ["pip", "check"]
     t3 = shlex.split(step3)
     assert "--upgrade-strategy" in t3 and "only-if-needed" in t3
+
+
+def test_build_git_ref_step1_failure_not_masked(monkeypatch):
+    """Regression: a failed step1 must fail the WHOLE chain.
+
+    With the bare `step1 && step2 || step3` shell precedence, a failed
+    step1 ran step3 (a plain PyPI upgrade): the latest wheel silently
+    replaced the requested git ref AND its exit code masked the failure.
+    The grouped form `step1 && ( step2 || step3 )` short-circuits instead.
+    """
+    monkeypatch.setattr(utils, "_check_uv_available", lambda: True)
+    cmd, _ = utils.build_install_command("wireless-version", git_ref="main")
+    step1, _, _ = _split_git_ref_cmd(cmd)
+    assert cmd.startswith(f"{step1} && ( ")
+
+
+# --- call_logger_wrapper ---
+
+
+@pytest.mark.asyncio
+async def test_call_logger_wrapper_success():
+    """A zero exit code returns without raising."""
+    import logging
+
+    await utils.call_logger_wrapper("true", logging.getLogger("test"))
+
+
+@pytest.mark.asyncio
+async def test_call_logger_wrapper_nonzero_raises():
+    """Regression: a non-zero exit code must raise, not pass silently.
+
+    Before this check, a failed `pip install` sailed through and
+    `update_reachy_mini` restarted the daemon on the OLD version while
+    every route (REST job, BLE screen, WebRTC broadcast) reported success.
+    """
+    import logging
+
+    with pytest.raises(RuntimeError, match="exit code 7"):
+        await utils.call_logger_wrapper("exit 7", logging.getLogger("test"))
 
 
 # --- _semver_version ---
@@ -305,3 +350,65 @@ async def test_update_without_apps_venv(monkeypatch):
 
     assert calls.call_count == 2
     assert calls.await_args_list[-1].args[0] == "sudo systemctl restart reachy-mini-daemon"
+
+
+@pytest.mark.asyncio
+async def test_update_daemon_install_failure_aborts_before_restart(monkeypatch):
+    """A failed daemon venv install propagates and never restarts the daemon."""
+    calls = AsyncMock(side_effect=RuntimeError("pip install failed"))
+    monkeypatch.setattr(update, "call_logger_wrapper", calls)
+    monkeypatch.setattr(update.Path, "exists", lambda self: True)
+
+    import logging
+
+    with pytest.raises(RuntimeError, match="pip install failed"):
+        await update.update_reachy_mini(logging.getLogger("test"))
+
+    # Only the daemon venv install ran: no apps_venv step, no restart.
+    assert calls.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_update_apps_venv_failure_still_restarts(monkeypatch):
+    """An apps_venv failure is non-fatal: the restart still applies the update.
+
+    The daemon venv is already on the new version when apps_venv fails;
+    skipping the restart would leave it installed-but-not-running with
+    retries refused as "no update available". The startup check re-syncs
+    apps_venv on the next boot instead.
+    """
+    commands: list[str] = []
+
+    async def fake_call(cmd, logger, env=None):
+        commands.append(cmd)
+        if len(commands) == 2:  # second call = apps_venv install
+            raise RuntimeError("apps_venv install failed")
+
+    monkeypatch.setattr(update, "call_logger_wrapper", fake_call)
+    monkeypatch.setattr(update.Path, "exists", lambda self: True)
+
+    import logging
+
+    await update.update_reachy_mini(logging.getLogger("test"))
+
+    assert len(commands) == 3
+    assert commands[-1] == "sudo systemctl restart reachy-mini-daemon"
+
+
+@pytest.mark.asyncio
+async def test_update_restart_failure_propagates(monkeypatch):
+    """A failed restart command surfaces as a failed job, not a silent pass."""
+    commands: list[str] = []
+
+    async def fake_call(cmd, logger, env=None):
+        commands.append(cmd)
+        if cmd.startswith("sudo systemctl restart"):
+            raise RuntimeError("systemctl failed")
+
+    monkeypatch.setattr(update, "call_logger_wrapper", fake_call)
+    monkeypatch.setattr(update.Path, "exists", lambda self: False)
+
+    import logging
+
+    with pytest.raises(RuntimeError, match="systemctl failed"):
+        await update.update_reachy_mini(logging.getLogger("test"))

--- a/tests/unit_tests/test_wireless_version.py
+++ b/tests/unit_tests/test_wireless_version.py
@@ -1,6 +1,8 @@
 """Unit tests for the wireless_version update helpers."""
 
+import logging
 import shlex
+import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -98,18 +100,10 @@ def test_build_git_ref_pip_fallback(monkeypatch):
     assert "--upgrade-strategy" in t3 and "only-if-needed" in t3
 
 
-def test_build_git_ref_step1_failure_not_masked(monkeypatch):
-    """Regression: a failed step1 must fail the WHOLE chain.
-
-    With the bare `step1 && step2 || step3` shell precedence, a failed
-    step1 ran step3 (a plain PyPI upgrade): the latest wheel silently
-    replaced the requested git ref AND its exit code masked the failure.
-    The grouped form `step1 && ( step2 || step3 )` short-circuits instead.
-    """
-    monkeypatch.setattr(utils, "_check_uv_available", lambda: True)
-    cmd, _ = utils.build_install_command("wireless-version", git_ref="main")
-    step1, _, _ = _split_git_ref_cmd(cmd)
-    assert cmd.startswith(f"{step1} && ( ")
+def test_git_ref_grouping_shell_precedence():
+    """Regression: with the grouped form, a failed step1 fails the whole chain."""
+    assert subprocess.run("false && true || true", shell=True).returncode == 0  # old form, masked
+    assert subprocess.run("false && ( true || true )", shell=True).returncode != 0  # grouped, honest
 
 
 # --- call_logger_wrapper ---
@@ -118,21 +112,12 @@ def test_build_git_ref_step1_failure_not_masked(monkeypatch):
 @pytest.mark.asyncio
 async def test_call_logger_wrapper_success():
     """A zero exit code returns without raising."""
-    import logging
-
     await utils.call_logger_wrapper("true", logging.getLogger("test"))
 
 
 @pytest.mark.asyncio
 async def test_call_logger_wrapper_nonzero_raises():
-    """Regression: a non-zero exit code must raise, not pass silently.
-
-    Before this check, a failed `pip install` sailed through and
-    `update_reachy_mini` restarted the daemon on the OLD version while
-    every route (REST job, BLE screen, WebRTC broadcast) reported success.
-    """
-    import logging
-
+    """Regression: a non-zero exit code must raise, not pass silently."""
     with pytest.raises(RuntimeError, match="exit code 7"):
         await utils.call_logger_wrapper("exit 7", logging.getLogger("test"))
 
@@ -329,12 +314,10 @@ async def test_update_with_apps_venv(monkeypatch):
     monkeypatch.setattr(update, "call_logger_wrapper", calls)
     monkeypatch.setattr(update.Path, "exists", lambda self: True)
 
-    import logging
-
     await update.update_reachy_mini(logging.getLogger("test"))
 
     assert calls.call_count == 3
-    assert calls.await_args_list[-1].args[0] == "sudo systemctl restart reachy-mini-daemon"
+    assert calls.await_args_list[-1].args[0] == "sudo systemctl --no-block restart reachy-mini-daemon"
 
 
 @pytest.mark.asyncio
@@ -344,12 +327,10 @@ async def test_update_without_apps_venv(monkeypatch):
     monkeypatch.setattr(update, "call_logger_wrapper", calls)
     monkeypatch.setattr(update.Path, "exists", lambda self: False)
 
-    import logging
-
     await update.update_reachy_mini(logging.getLogger("test"), pre_release=True)
 
     assert calls.call_count == 2
-    assert calls.await_args_list[-1].args[0] == "sudo systemctl restart reachy-mini-daemon"
+    assert calls.await_args_list[-1].args[0] == "sudo systemctl --no-block restart reachy-mini-daemon"
 
 
 @pytest.mark.asyncio
@@ -358,8 +339,6 @@ async def test_update_daemon_install_failure_aborts_before_restart(monkeypatch):
     calls = AsyncMock(side_effect=RuntimeError("pip install failed"))
     monkeypatch.setattr(update, "call_logger_wrapper", calls)
     monkeypatch.setattr(update.Path, "exists", lambda self: True)
-
-    import logging
 
     with pytest.raises(RuntimeError, match="pip install failed"):
         await update.update_reachy_mini(logging.getLogger("test"))
@@ -370,13 +349,7 @@ async def test_update_daemon_install_failure_aborts_before_restart(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_update_apps_venv_failure_still_restarts(monkeypatch):
-    """An apps_venv failure is non-fatal: the restart still applies the update.
-
-    The daemon venv is already on the new version when apps_venv fails;
-    skipping the restart would leave it installed-but-not-running with
-    retries refused as "no update available". The startup check re-syncs
-    apps_venv on the next boot instead.
-    """
+    """An apps_venv failure is non-fatal: the restart still applies the update."""
     commands: list[str] = []
 
     async def fake_call(cmd, logger, env=None):
@@ -387,12 +360,10 @@ async def test_update_apps_venv_failure_still_restarts(monkeypatch):
     monkeypatch.setattr(update, "call_logger_wrapper", fake_call)
     monkeypatch.setattr(update.Path, "exists", lambda self: True)
 
-    import logging
-
     await update.update_reachy_mini(logging.getLogger("test"))
 
     assert len(commands) == 3
-    assert commands[-1] == "sudo systemctl restart reachy-mini-daemon"
+    assert commands[-1] == "sudo systemctl --no-block restart reachy-mini-daemon"
 
 
 @pytest.mark.asyncio
@@ -402,13 +373,11 @@ async def test_update_restart_failure_propagates(monkeypatch):
 
     async def fake_call(cmd, logger, env=None):
         commands.append(cmd)
-        if cmd.startswith("sudo systemctl restart"):
+        if cmd.startswith("sudo systemctl"):
             raise RuntimeError("systemctl failed")
 
     monkeypatch.setattr(update, "call_logger_wrapper", fake_call)
     monkeypatch.setattr(update.Path, "exists", lambda self: False)
-
-    import logging
 
     with pytest.raises(RuntimeError, match="systemctl failed"):
         await update.update_reachy_mini(logging.getLogger("test"))


### PR DESCRIPTION
Split out of #1304 (see the split plan there).

`call_logger_wrapper` streamed the install output but never checked the exit code, so a failed `pip install` sailed through: the daemon restarted on the OLD version while every route reported success.

- Now raises on a non-zero exit, with a per-step failure policy: daemon venv install is fatal before restart, `apps_venv` is non-fatal, restart is fatal.
- The restart keeps the exact whitelisted argv `sudo systemctl restart reachy-mini-daemon` and tolerates `(0, -15, 143)`. It has to stay verbatim: `/etc/sudoers.d/010-pollen-reachy` matches the argv literally, so any extra flag (`--no-block` included) makes `sudo` demand a password and the restart never runs. And since restarting our own cgroup SIGTERMs this `systemctl` child, `-15`/`143` is the normal outcome of a *successful* restart, not a failure; anything else (unknown unit, sudo refusal) still raises. `call_logger_wrapper` gained an `ok_returncodes` param (default `(0,)`), so every other call site stays strict. Verified on a real robot from inside the daemon's cgroup.
- Also fixes the `step1 && step2 || step3` precedence bug in the git-ref install chain. Bonus: this same chain is built by `check_and_sync_apps_venv_sdk` (`startup_check.py`), which gates on `returncode` - it used to log "Successfully synced" after quietly installing the latest PyPI wheel instead of the requested ref.

Failure archaeology (kept out of the code comments on purpose):

- daemon venv install failure aborts BEFORE the restart. On the PyPI path nothing was applied, so a retry works. On the git-ref path step1 (`--force-reinstall --no-deps`) can succeed while the dep sync fails, leaving the venv on the new version with the daemon on the old one; `/update/start-from-ref` has no availability guard so a retry still works there.
- apps_venv failure is non-fatal by design: the daemon venv is already on the new version at that point, so skipping the restart would leave it installed-but-not-running with retries refused as "no update available"; `check_and_sync_apps_venv_sdk` re-syncs on the next boot. Catches `Exception`, not just `RuntimeError`, so an `OSError` out of `create_subprocess_shell` doesn't skip the restart either.

Behavioural pairing (fail-open, any merge order): the JS block's daemon-update gate pairs with this - it's what makes the gate's failure path honest instead of looping on a silently-failed install.

Tests: `test_wireless_version.py` (33 passed locally, requires the `wireless-version` extra).

Made with [Cursor](https://cursor.com)
