### PR TITLE
feat(daemon): expose the IMU reading over the data channel (get_imu)

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -35,6 +35,7 @@ from reachy_mini.io.protocol import (
     DeleteHfTokenCmd,
     FaceTarget,
     GetHardwareIdCmd,
+    GetImuCmd,
     GetMicrophoneVolumeCmd,
     GetMotorModeCmd,
     GetRobotNameCmd,
@@ -44,6 +45,7 @@ from reachy_mini.io.protocol import (
     GetVolumeCmd,
     GotoSleepCmd,
     GotoTargetCmd,
+    ImuDataMsg,
     LogLineMsg,
     LogStreamErrorMsg,
     MockupSimBackendStatus,
@@ -489,6 +491,15 @@ class Backend:
 
         """
         self.imu_publisher = publisher
+
+    def get_imu_data(self) -> ImuDataMsg | None:
+        """Get the current IMU reading, or None when the backend has no IMU.
+
+        Overridden by the real-robot backend (BMI088 on the wireless
+        version); the default covers simulation backends and the Lite
+        version so `get_imu` can answer uniformly on every transport.
+        """
+        return None
 
     def update_target_head_joints_from_ik(
         self,
@@ -1541,6 +1552,19 @@ class Backend:
             from reachy_mini.utils.hardware_id import get_hardware_id
 
             send_response({"hardware_id": get_hardware_id()})
+
+        elif isinstance(cmd, GetImuCmd):
+            # `imu` is None on IMU-less hardware (Lite, simulation) so
+            # clients can tell "no IMU" from "no reply" (old daemon).
+            imu = self.get_imu_data()
+            send_response(
+                {
+                    "command": "get_imu",
+                    "imu": imu.model_dump(exclude={"type"})
+                    if imu is not None
+                    else None,
+                }
+            )
 
         elif isinstance(cmd, (GetRobotNameCmd, SetRobotNameCmd)):
             # Robot display name is a persistent, robot-wide string stored on

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -493,12 +493,7 @@ class Backend:
         self.imu_publisher = publisher
 
     def get_imu_data(self) -> ImuDataMsg | None:
-        """Get the current IMU reading, or None when the backend has no IMU.
-
-        Overridden by the real-robot backend (BMI088 on the wireless
-        version); the default covers simulation backends and the Lite
-        version so `get_imu` can answer uniformly on every transport.
-        """
+        """Latest IMU reading; None on backends without an IMU."""
         return None
 
     def update_target_head_joints_from_ik(
@@ -1557,14 +1552,8 @@ class Backend:
             # `imu` is None on IMU-less hardware (Lite, simulation) so
             # clients can tell "no IMU" from "no reply" (old daemon).
             imu = self.get_imu_data()
-            send_response(
-                {
-                    "command": "get_imu",
-                    "imu": imu.model_dump(exclude={"type"})
-                    if imu is not None
-                    else None,
-                }
-            )
+            payload = imu.model_dump(exclude={"type"}) if imu is not None else None
+            send_response({"command": "get_imu", "imu": payload})
 
         elif isinstance(cmd, (GetRobotNameCmd, SetRobotNameCmd)):
             # Robot display name is a persistent, robot-wide string stored on

--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -135,6 +135,20 @@ class RobotBackend(Backend):
         else:
             self.bmi088 = None
 
+        # Latest IMU reading, refreshed by the control loop each tick and
+        # served to on-demand readers (`get_imu_data`). The loop is the only
+        # code that talks to the BMI088: its `get_quat(dt)` call integrates
+        # the orientation filter with a fixed loop period, so an on-demand
+        # read would both race the i2c conversation and inject a spurious
+        # integration step. Stored as (msg, monotonic ts) so a reader can
+        # judge freshness in one atomic reference grab.
+        self._last_imu: tuple[ImuDataMsg, float] | None = None
+
+    # A cached reading older than this is treated as absent: the control
+    # loop refreshes at 50 Hz, so anything past a few periods means the
+    # loop is stalled and the data no longer describes the present.
+    IMU_CACHE_FRESH_S = 0.5
+
     def run(self) -> None:
         """Run the control loop for the robot backend.
 
@@ -257,10 +271,12 @@ class RobotBackend(Backend):
                         )
                     )
 
-                    if self.imu_publisher is not None and self.bmi088 is not None:
-                        imu_msg = self.get_imu_data()
+                    if self.bmi088 is not None:
+                        imu_msg = self._read_imu()
                         if imu_msg is not None:
-                            self.imu_publisher.put(imu_msg)
+                            self._last_imu = (imu_msg, time.monotonic())
+                            if self.imu_publisher is not None:
+                                self.imu_publisher.put(imu_msg)
 
                 self.last_alive = time.time()
 
@@ -495,7 +511,27 @@ class RobotBackend(Backend):
         return np.array(self.get_all_joint_positions()[1])
 
     def get_imu_data(self) -> ImuDataMsg | None:
-        """Get current IMU data (accelerometer, gyroscope, quaternion, temperature).
+        """Return the latest IMU reading cached by the control loop.
+
+        On-demand readers (the `get_imu` data-channel command) must not
+        touch the BMI088 themselves - see the `_last_imu` comment. A cache
+        entry older than ``IMU_CACHE_FRESH_S`` reads as absent so a stalled
+        loop can't keep serving a stale orientation.
+
+        Returns:
+            An ImuDataMsg, or None if the IMU is missing or the cache is stale.
+
+        """
+        cached = self._last_imu
+        if cached is None:
+            return None
+        msg, ts = cached
+        if time.monotonic() - ts > self.IMU_CACHE_FRESH_S:
+            return None
+        return msg
+
+    def _read_imu(self) -> ImuDataMsg | None:
+        """Read the BMI088 directly. Control-loop only (see `_last_imu`).
 
         Returns:
             An ImuDataMsg, or None if IMU is not available.
@@ -696,5 +732,3 @@ class RobotBackend(Backend):
 
         result: bytes = bytes(self.c.write_raw_packet(packet))
         return result
-
-

--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -135,18 +135,14 @@ class RobotBackend(Backend):
         else:
             self.bmi088 = None
 
-        # Latest IMU reading, refreshed by the control loop each tick and
-        # served to on-demand readers (`get_imu_data`). The loop is the only
-        # code that talks to the BMI088: its `get_quat(dt)` call integrates
-        # the orientation filter with a fixed loop period, so an on-demand
-        # read would both race the i2c conversation and inject a spurious
-        # integration step. Stored as (msg, monotonic ts) so a reader can
-        # judge freshness in one atomic reference grab.
+        # Latest IMU reading as (msg, monotonic ts), refreshed by the control
+        # loop and served by `get_imu_data`. Only `_read_imu` (see its
+        # docstring) may touch the BMI088.
         self._last_imu: tuple[ImuDataMsg, float] | None = None
 
-    # A cached reading older than this is treated as absent: the control
-    # loop refreshes at 50 Hz, so anything past a few periods means the
-    # loop is stalled and the data no longer describes the present.
+    # A cached reading older than this is treated as absent: 0.5 s is 25
+    # control-loop periods at 50 Hz, so the loop is stalled (e.g. died on a
+    # motor error) and the data no longer describes the present.
     IMU_CACHE_FRESH_S = 0.5
 
     def run(self) -> None:
@@ -271,6 +267,10 @@ class RobotBackend(Backend):
                         )
                     )
 
+                    # Note: this block inherits the joint/pose publisher
+                    # guards above, so the IMU cache is only refreshed once
+                    # `WSServer.start()` has wired the publishers (it sets
+                    # all four together).
                     if self.bmi088 is not None:
                         imu_msg = self._read_imu()
                         if imu_msg is not None:
@@ -513,13 +513,9 @@ class RobotBackend(Backend):
     def get_imu_data(self) -> ImuDataMsg | None:
         """Return the latest IMU reading cached by the control loop.
 
-        On-demand readers (the `get_imu` data-channel command) must not
-        touch the BMI088 themselves - see the `_last_imu` comment. A cache
-        entry older than ``IMU_CACHE_FRESH_S`` reads as absent so a stalled
-        loop can't keep serving a stale orientation.
-
         Returns:
-            An ImuDataMsg, or None if the IMU is missing or the cache is stale.
+            An ImuDataMsg, or None if the IMU is missing or the cache is
+            older than ``IMU_CACHE_FRESH_S``.
 
         """
         cached = self._last_imu
@@ -531,7 +527,13 @@ class RobotBackend(Backend):
         return msg
 
     def _read_imu(self) -> ImuDataMsg | None:
-        """Read the BMI088 directly. Control-loop only (see `_last_imu`).
+        """Read the BMI088 directly. Control-loop only.
+
+        The loop must stay the sensor's only reader: `get_quat(dt)`
+        integrates the orientation filter with a fixed loop period, so an
+        on-demand read would both race the i2c conversation and inject a
+        spurious integration step. Everyone else reads the `_last_imu`
+        cache through `get_imu_data`.
 
         Returns:
             An ImuDataMsg, or None if IMU is not available.

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -7,7 +7,7 @@ Client->Server command types:
     goto_target, wake_up, goto_sleep, play_sound,
     set_motor_mode, set_torque, get_motor_mode,
     set_gravity_compensation, set_automatic_body_yaw,
-    get_state, get_version, start_recording, stop_recording, append_record,
+    get_state, get_version, get_imu, start_recording, stop_recording, append_record,
     get_robot_name, set_robot_name, delete_hf_token,
     subscribe_logs, unsubscribe_logs, subscribe_pose, unsubscribe_pose,
     restart_daemon, start_update,
@@ -282,6 +282,17 @@ class GetHardwareIdCmd(BaseModel):
     """Query the robot's unique hardware ID (Pollen audio device serial)."""
 
     type: Literal["get_hardware_id"] = "get_hardware_id"
+
+
+class GetImuCmd(BaseModel):
+    """Query the current IMU reading (BMI088, wireless version only).
+
+    The response carries ``imu``: the `ImuDataMsg` payload
+    (accelerometer, gyroscope, quaternion, temperature) or ``None``
+    when the robot has no IMU (Lite version, simulation).
+    """
+
+    type: Literal["get_imu"] = "get_imu"
 
 
 class StartRecordingCmd(BaseModel):
@@ -832,6 +843,7 @@ AnyCommand = Annotated[
     | GetStateCmd
     | GetVersionCmd
     | GetHardwareIdCmd
+    | GetImuCmd
     | StartRecordingCmd
     | StopRecordingCmd
     | AppendRecordCmd

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -19,6 +19,7 @@ Client->Server command types:
     set_speech_offsets, set_wobbling, set_head_tracking, get_tracked_face
 
 Server->Client message types:
+    welcome (pushed once when the data channel opens),
     joint_positions, head_pose, imu_data, recorded_data,
     daemon_status, task_progress, log_line, log_stream_error,
     update_progress

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -286,12 +286,7 @@ class GetHardwareIdCmd(BaseModel):
 
 
 class GetImuCmd(BaseModel):
-    """Query the current IMU reading (BMI088, wireless version only).
-
-    The response carries ``imu``: the `ImuDataMsg` payload
-    (accelerometer, gyroscope, quaternion, temperature) or ``None``
-    when the robot has no IMU (Lite version, simulation).
-    """
+    """Query the current IMU reading (`ImuDataMsg`; null on IMU-less robots)."""
 
     type: Literal["get_imu"] = "get_imu"
 

--- a/tests/unit_tests/test_backend_process_command.py
+++ b/tests/unit_tests/test_backend_process_command.py
@@ -24,6 +24,7 @@ from reachy_mini.io.protocol import (
     ClearIncomingAudioCmd,
     DeleteHfTokenCmd,
     GetHardwareIdCmd,
+    GetImuCmd,
     GetMicrophoneVolumeCmd,
     GetMotorModeCmd,
     GetStateCmd,
@@ -31,6 +32,7 @@ from reachy_mini.io.protocol import (
     GetVersionCmd,
     GetVolumeCmd,
     GotoSleepCmd,
+    ImuDataMsg,
     PlaySoundCmd,
     ReadAudioParameterCmd,
     RestartDaemonCmd,
@@ -369,6 +371,40 @@ def test_get_hardware_id(sim_backend: Any, monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(hw, "get_hardware_id", lambda: "HW-1234")
     responses = _dispatch(sim_backend, GetHardwareIdCmd())
     assert responses == [{"hardware_id": "HW-1234"}]
+
+
+def test_get_imu_without_imu(sim_backend: Any) -> None:
+    """GetImuCmd on an IMU-less backend answers imu None (not silence).
+
+    The explicit None is what lets a client tell "no IMU" apart from
+    "old daemon that never replies".
+    """
+    responses = _dispatch(sim_backend, GetImuCmd())
+    assert responses == [{"command": "get_imu", "imu": None}]
+
+
+def test_get_imu_with_reading(sim_backend: Any) -> None:
+    """GetImuCmd serializes the backend's reading without the type envelope."""
+    sim_backend.get_imu_data = Mock(
+        return_value=ImuDataMsg(
+            accelerometer=[0.01, -0.02, 9.81],
+            gyroscope=[0.001, 0.002, -0.003],
+            quaternion=[1.0, 0.0, 0.0, 0.0],
+            temperature=31.5,
+        )
+    )
+    responses = _dispatch(sim_backend, GetImuCmd())
+    assert responses == [
+        {
+            "command": "get_imu",
+            "imu": {
+                "accelerometer": [0.01, -0.02, 9.81],
+                "gyroscope": [0.001, 0.002, -0.003],
+                "quaternion": [1.0, 0.0, 0.0, 0.0],
+                "temperature": 31.5,
+            },
+        }
+    ]
 
 
 # ------------------------------------------------------------------

--- a/tests/unit_tests/test_backend_process_command.py
+++ b/tests/unit_tests/test_backend_process_command.py
@@ -407,6 +407,35 @@ def test_get_imu_with_reading(sim_backend: Any) -> None:
     ]
 
 
+def test_get_imu_data_cache_freshness() -> None:
+    """The robot backend serves the cache while fresh, absent once stale.
+
+    Stale means older than ``IMU_CACHE_FRESH_S``: the 50 Hz control loop
+    (the cache's only writer) has stalled, so the reading no longer
+    describes the present.
+    """
+    import time
+
+    from reachy_mini.daemon.backend.robot.backend import RobotBackend
+
+    b = RobotBackend.__new__(RobotBackend)
+    msg = ImuDataMsg(
+        accelerometer=[0.0, 0.0, 9.81],
+        gyroscope=[0.0, 0.0, 0.0],
+        quaternion=[1.0, 0.0, 0.0, 0.0],
+        temperature=30.0,
+    )
+
+    b._last_imu = None
+    assert RobotBackend.get_imu_data(b) is None
+
+    b._last_imu = (msg, time.monotonic())
+    assert RobotBackend.get_imu_data(b) is msg
+
+    b._last_imu = (msg, time.monotonic() - RobotBackend.IMU_CACHE_FRESH_S - 0.1)
+    assert RobotBackend.get_imu_data(b) is None
+
+
 # ------------------------------------------------------------------
 # Hugging Face sign-out
 # ------------------------------------------------------------------


### PR DESCRIPTION
Split out of #1304 (see the split plan there).

New `get_imu` command on the transport-agnostic dispatcher: replies with the BMI088 reading (accelerometer, gyroscope, quaternion, temperature) or an explicit `imu: null` on IMU-less hardware (Lite version, simulation), so clients can tell "no IMU" from "old daemon that never replies".

- The reading already existed backend-side (published at 50 Hz on the local WebSocket); this exposes it to WebRTC clients too.
- `get_imu` is served from a cache refreshed by the 50 Hz control loop, not a direct BMI088 read: two concurrent readers on the sensor would interleave I2C transactions and inject spurious quaternion integration steps.
- Drive-by docs fix: the protocol docstring now also lists the `welcome` push in the server-to-client message inventory.

Behavioural pairing (fail-open, any merge order): the JS block's `getImu()` resolves `null` against older daemons.

Tests: `test_backend_process_command.py` (56 passed locally, incl. the two `get_imu` dispatcher tests). Validated on hardware (wireless robot).

Made with [Cursor](https://cursor.com)