### PR TITLE
feat(media): camera-only release, and release the camera while asleep

### DIFF
--- a/docs/source/API/openapi.json
+++ b/docs/source/API/openapi.json
@@ -1501,6 +1501,52 @@
         }
       }
     },
+    "/api/media/camera/release": {
+      "post": {
+        "summary": "Release Camera",
+        "description": "Release the camera only, keeping the microphone and speaker running.",
+        "operationId": "release_camera_api_media_camera_release_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Release Camera Api Media Camera Release Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/media/camera/acquire": {
+      "post": {
+        "summary": "Acquire Camera",
+        "description": "Re-acquire the camera after a camera-only release.",
+        "operationId": "acquire_camera_api_media_camera_acquire_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Acquire Camera Api Media Camera Acquire Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/media/status": {
       "get": {
         "summary": "Media Status",
@@ -2986,6 +3032,11 @@
           "media_released": {
             "type": "boolean",
             "title": "Media Released",
+            "default": false
+          },
+          "camera_released": {
+            "type": "boolean",
+            "title": "Camera Released",
             "default": false
           },
           "camera_specs_name": {

--- a/docs/source/SDK/media-architecture.md
+++ b/docs/source/SDK/media-architecture.md
@@ -91,6 +91,36 @@ frame = mini.media.get_frame()
 
 For a complete example with both OpenCV and sounddevice, see [Custom Media Manager](../examples/custom_media_manager.md).
 
+## Releasing the Camera Only
+
+An app that only needs audio — a voice assistant, a conversation app — still pays for the camera.
+The capture branch is driven by a live source, so it produces frames at the sensor's rate whether or
+not anything reads them; on a Wireless unit that is a continuous CPU cost with an audible fan.
+
+`release_camera()` drops the video branch and leaves the microphone, the speaker and the WebRTC
+signalling untouched:
+
+```python
+with ReachyMini() as mini:
+    mini.release_camera()
+    # Microphone and speaker keep working; media.get_frame() returns nothing.
+
+    mini.acquire_camera()
+    frame = mini.media.get_frame()
+```
+
+The same switch is available over REST, which is handy for a quick check on a Wireless robot:
+
+```bash
+curl -X POST http://<robot>:8000/api/media/camera/release
+curl -X POST http://<robot>:8000/api/media/camera/acquire
+curl http://<robot>:8000/api/media/status   # reports camera_released
+```
+
+> **⚠️ Note:** Toggling the camera rebuilds the GStreamer pipeline. Audio is interrupted for the
+> duration of the rebuild and WebRTC consumers have to reconnect, exactly as with
+> `release_media()` — so switch between activities, not mid-sentence. Both methods are idempotent.
+
 ## Advanced Controls
 
 Please refer to the dedicated pages to fine-tune camera and microphone parameters for [Reachy Mini](../platforms/reachy_mini/media_advanced_controls.md) and [Reachy Mini Lite](../platforms/reachy_mini_lite/media_advanced_controls.md).

--- a/docs/source/SDK/media-architecture.md
+++ b/docs/source/SDK/media-architecture.md
@@ -121,6 +121,9 @@ curl http://<robot>:8000/api/media/status   # reports camera_released
 > duration of the rebuild and WebRTC consumers have to reconnect, exactly as with
 > `release_media()` — so switch between activities, not mid-sentence. Both methods are idempotent.
 
+The daemon also does this on its own: the robot releases the camera when it goes to sleep and
+re-acquires it on wake-up, so an idle robot does not run its camera.
+
 ## Advanced Controls
 
 Please refer to the dedicated pages to fine-tune camera and microphone parameters for [Reachy Mini](../platforms/reachy_mini/media_advanced_controls.md) and [Reachy Mini Lite](../platforms/reachy_mini_lite/media_advanced_controls.md).

--- a/src/reachy_mini/daemon/app/routers/media.py
+++ b/src/reachy_mini/daemon/app/routers/media.py
@@ -2,6 +2,9 @@
 
 Allows clients to tell the daemon to release camera and audio hardware
 for direct access (e.g. OpenCV, sounddevice), then re-acquire when done.
+The camera can also be released on its own, which keeps the microphone
+and speaker running — useful for audio-only apps, where an idle capture
+branch is pure CPU cost.
 
 Also provides endpoints for remote sound playback and file management
 so that WebRTC clients can upload, play, list and delete sound files on
@@ -52,12 +55,27 @@ async def acquire_media(daemon: Daemon = Depends(get_daemon)) -> dict[str, str]:
     return {"status": "ok"}
 
 
+@router.post("/camera/release")
+async def release_camera(daemon: Daemon = Depends(get_daemon)) -> dict[str, str]:
+    """Release the camera only, keeping the microphone and speaker running."""
+    daemon.release_camera()
+    return {"status": "ok"}
+
+
+@router.post("/camera/acquire")
+async def acquire_camera(daemon: Daemon = Depends(get_daemon)) -> dict[str, str]:
+    """Re-acquire the camera after a camera-only release."""
+    daemon.acquire_camera()
+    return {"status": "ok"}
+
+
 @router.get("/status")
 async def media_status(daemon: Daemon = Depends(get_daemon)) -> dict[str, bool]:
     """Get the current media status."""
     return {
         "available": not daemon.media_released and daemon._media_server is not None,
         "released": daemon.media_released,
+        "camera_released": daemon.camera_released,
         "no_media": daemon.no_media,
     }
 

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -1155,6 +1155,11 @@ class Backend:
 
     async def wake_up(self) -> None:
         """Wake up the robot - go to the initial head position and play the wake up emote and sound."""
+        # Restore the camera first: the rebuild interrupts audio, so it has to
+        # happen before the wake-up sound rather than during it.
+        if self._media_server is not None:
+            self._media_server.enable_camera()
+
         await asyncio.sleep(0.1)
 
         _, _, magic_distance = distance_between_poses(
@@ -1236,6 +1241,13 @@ class Backend:
 
         # Rest limp at the sleep pose, like a fresh boot.
         self.set_motor_control_mode(MotorControlMode.Disabled)
+
+        # Drop the camera last: a sleeping robot has no use for frames, and the
+        # capture branch costs CPU (and audible fan) even with no consumer.
+        # Done after the sound and the motion because it rebuilds the pipeline,
+        # which briefly interrupts audio. `wake_up` brings it back.
+        if self._media_server is not None:
+            self._media_server.disable_camera()
 
     # Motor control modes
     @abstractmethod

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -168,6 +168,40 @@ class Daemon:
         self._status.media_released = False
         self.logger.info("Media hardware re-acquired.")
 
+    @property
+    def camera_released(self) -> bool:
+        """Whether the camera alone has been released, audio still running.
+
+        Derived from the media server rather than stored, so the flag stays
+        correct no matter who toggled the camera — REST, the SDK, or the
+        backend's own sleep handling.
+        """
+        return self._media_server is not None and not self._media_server.camera_enabled
+
+    def release_camera(self) -> None:
+        """Release the camera while keeping the microphone and speaker.
+
+        Unlike `release_media`, the audio branch, the WebRTC signalling and the
+        central relay all keep running: only the capture branch goes away.
+        Idempotent: no-op if already released or no media server.
+        """
+        if self._media_server is None:
+            return
+
+        self.logger.info("Releasing the camera, keeping audio...")
+        self._media_server.disable_camera()
+
+    def acquire_camera(self) -> None:
+        """Re-acquire the camera after a camera-only release.
+
+        Idempotent: no-op if the camera is not currently released.
+        """
+        if self._media_server is None:
+            return
+
+        self.logger.info("Re-acquiring the camera...")
+        self._media_server.enable_camera()
+
     def _setup_jsonrpc_relay(
         self, backend: "Backend", app_manager: "AppManager"
     ) -> None:
@@ -775,6 +809,8 @@ class Daemon:
 
     def status(self) -> "DaemonStatus":
         """Get the current status of the Reachy Mini daemon."""
+        self._status.camera_released = self.camera_released
+
         if self.backend is not None:
             self._status.backend_status = self.backend.get_status()
             self._status.face_target = self.backend.get_tracked_face()

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -144,6 +144,7 @@ class DaemonStatus(BaseModel):
     mockup_sim_enabled: Optional[bool]
     no_media: bool = False
     media_released: bool = False
+    camera_released: bool = False
     camera_specs_name: str = ""
     backend_status: Optional[
         RobotBackendStatus | MujocoBackendStatus | MockupSimBackendStatus

--- a/src/reachy_mini/io/ws_client.py
+++ b/src/reachy_mini/io/ws_client.py
@@ -316,6 +316,24 @@ class WSClient(AbstractClient):
         """
         return self._media_request("/api/media/acquire")
 
+    def release_camera(self) -> bool:
+        """Ask the daemon to release the camera, keeping audio running.
+
+        Returns:
+            True on success, False on failure.
+
+        """
+        return self._media_request("/api/media/camera/release")
+
+    def acquire_camera(self) -> bool:
+        """Ask the daemon to re-acquire the camera.
+
+        Returns:
+            True on success, False on failure.
+
+        """
+        return self._media_request("/api/media/camera/acquire")
+
     def _media_request(self, path: str) -> bool:
         """POST to a daemon media endpoint.
 

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -224,6 +224,13 @@ class GstMediaServer:
             raise RuntimeError("Failed to get default camera resolution.")
 
         self._cam_path = cam_path
+        # When False, `_build_pipeline` omits the whole video branch and the
+        # camera is never opened, while audio keeps running. Toggled by
+        # `disable_camera` / `enable_camera`.
+        self._camera_enabled = True
+        # Whether `start()` has run without a matching `stop()`. Toggling the
+        # camera only rebuilds a pipeline that is actually playing.
+        self._pipeline_running = False
 
         self._data_channels: dict[str, Gst.Element] = {}  # peer_id -> channel
         self._on_data_message: Optional[Callable[[str, str], None]] = None
@@ -291,7 +298,10 @@ class GstMediaServer:
 
         webrtcsink = self._configure_webrtc(self._pipeline_sender)
 
-        self._configure_video(self._cam_path, self._pipeline_sender, webrtcsink)
+        if self._camera_enabled:
+            self._configure_video(self._cam_path, self._pipeline_sender, webrtcsink)
+        else:
+            self._logger.info("Camera disabled: building an audio-only pipeline.")
         self._configure_audio(self._pipeline_sender, webrtcsink)
 
         self._logger.debug("Pipeline built")
@@ -1251,12 +1261,55 @@ class GstMediaServer:
         self._logger.debug("Starting WebRTC (rebuilding pipeline)")
         self._build_pipeline()
         self._pipeline_sender.set_state(Gst.State.PLAYING)
+        self._pipeline_running = True
         GLib.timeout_add_seconds(5, self._dump_latency)
 
     def stop(self) -> None:
         """Stop the pipeline and release all hardware (camera, audio)."""
         self._logger.debug("Stopping WebRTC")
         self._pipeline_sender.set_state(Gst.State.NULL)
+        self._pipeline_running = False
+
+    @property
+    def camera_enabled(self) -> bool:
+        """Whether the video branch is part of the pipeline."""
+        return self._camera_enabled
+
+    def disable_camera(self) -> None:
+        """Rebuild the pipeline without the video branch, keeping audio.
+
+        The camera source is a live source: it produces frames at the sensor's
+        rate whether or not anything consumes them, so an idle capture branch
+        still costs CPU. Dropping it leaves the microphone and speaker running.
+
+        Idempotent. When the pipeline is running, audio is interrupted for the
+        duration of the rebuild and WebRTC consumers must reconnect, as with
+        `stop()` / `start()`.
+        """
+        self._set_camera_enabled(False)
+
+    def enable_camera(self) -> None:
+        """Rebuild the pipeline with the video branch restored.
+
+        Idempotent; same rebuild caveats as `disable_camera`.
+        """
+        self._set_camera_enabled(True)
+
+    def _set_camera_enabled(self, enabled: bool) -> None:
+        if self._camera_enabled == enabled:
+            return
+
+        self._logger.info("%s camera branch", "Enabling" if enabled else "Disabling")
+        self._camera_enabled = enabled
+
+        # A stopped pipeline (media released, or not started yet) must stay
+        # stopped, so rebuild it in place rather than through start(): building
+        # only creates elements, it does not open any device.
+        if self._pipeline_running:
+            self.stop()
+            self.start()
+        else:
+            self._build_pipeline()
 
     def play_sound(self, sound_file: str) -> None:
         """Play a sound file on the robot's speaker.

--- a/src/reachy_mini/reachy_mini.py
+++ b/src/reachy_mini/reachy_mini.py
@@ -239,6 +239,33 @@ class ReachyMini:
         self._media_released = False
         self.logger.info("Media re-acquired by daemon.")
 
+    def release_camera(self) -> None:
+        """Tell the daemon to release the camera, keeping the microphone.
+
+        For an app that only needs audio, the camera is pure cost: the capture
+        branch runs at the sensor's framerate whether or not anyone reads it.
+        Audio, playback and the media backend are unaffected — only
+        ``media.get_frame()`` stops returning frames until ``acquire_camera()``.
+
+        Idempotent: safe to call multiple times.
+        """
+        if not self.client.release_camera():
+            self.logger.error("Failed to release the camera on daemon.")
+            return
+
+        self.logger.info("Camera released — audio still running.")
+
+    def acquire_camera(self) -> None:
+        """Tell the daemon to re-acquire the camera after `release_camera()`.
+
+        Idempotent: safe to call multiple times.
+        """
+        if not self.client.acquire_camera():
+            self.logger.error("Failed to re-acquire the camera on daemon.")
+            return
+
+        self.logger.info("Camera re-acquired by daemon.")
+
     def enable_wobbling(self) -> None:
         """Enable audio-reactive head wobbling.
 

--- a/tests/unit_tests/test_media_server_webrtc.py
+++ b/tests/unit_tests/test_media_server_webrtc.py
@@ -26,3 +26,77 @@ def test_media_server_constructs_in_mujoco_sim() -> None:
         assert server._resolution is not None
     finally:
         server.close()
+
+
+def _has(server: GstMediaServer, element_name: str) -> bool:
+    """Whether the sender pipeline currently holds a named element."""
+    return server._pipeline_sender.get_by_name(element_name) is not None
+
+
+def test_disable_camera_builds_an_audio_only_pipeline() -> None:
+    """Dropping the camera removes both video branches and keeps audio."""
+    server = GstMediaServer(sim_mode=SimulationMode.MUJOCO)
+    try:
+        assert server.camera_enabled
+        assert _has(server, "queue_webrtc")
+        assert _has(server, "queue_ipc")
+        had_audio = _has(server, "queue_audiosrc")
+
+        server.disable_camera()
+
+        assert not server.camera_enabled
+        assert not _has(server, "queue_webrtc")
+        assert not _has(server, "queue_ipc")
+        # Audio is untouched: present afterwards exactly when it was before
+        # (a machine with no audio device has no audio branch to begin with).
+        assert _has(server, "queue_audiosrc") == had_audio
+    finally:
+        server.close()
+
+
+def test_enable_camera_restores_the_video_branches() -> None:
+    """Re-enabling rebuilds the pipeline with video back in place."""
+    server = GstMediaServer(sim_mode=SimulationMode.MUJOCO)
+    try:
+        server.disable_camera()
+        server.enable_camera()
+
+        assert server.camera_enabled
+        assert _has(server, "queue_webrtc")
+        assert _has(server, "queue_ipc")
+    finally:
+        server.close()
+
+
+def test_camera_toggles_are_idempotent() -> None:
+    """Repeating a toggle is a no-op rather than a second rebuild."""
+    server = GstMediaServer(sim_mode=SimulationMode.MUJOCO)
+    try:
+        server.disable_camera()
+        server.disable_camera()
+        assert not server.camera_enabled
+
+        server.enable_camera()
+        server.enable_camera()
+        assert server.camera_enabled
+    finally:
+        server.close()
+
+
+def test_toggling_the_camera_leaves_a_stopped_pipeline_stopped() -> None:
+    """A toggle must not start a pipeline that was never started.
+
+    `release_media()` stops the pipeline; a camera toggle arriving while media
+    is released has to stay a flag change, or the daemon would silently
+    re-acquire the hardware it just handed over.
+    """
+    server = GstMediaServer(sim_mode=SimulationMode.MUJOCO)
+    try:
+        assert not server._pipeline_running
+
+        server.disable_camera()
+
+        assert not server.camera_enabled
+        assert not server._pipeline_running
+    finally:
+        server.close()


### PR DESCRIPTION
Refs #1277.

## Why

The camera source is live: `libcamerasrc` produces frames at the sensor's rate whether or not anything consumes them. On a Wireless unit that means the capture branch runs continuously — no IPC reader, no WebRTC consumer, robot asleep — and it is enough to spin the fan up audibly. #1277 profiles it on a CM4: ~40% of a core in `libcamerasrc` + `CameraManager` + `IPAProxyRPi`, all consumer-independent, while the hardware `v4l2h264enc` costs 1.7% and only runs with a viewer attached.

Today there is no way out for an audio-only app: `release_media()` drops the microphone and speaker along with the camera. This is request 2 from that issue.

## What

Two commits, deliberately separable.

**1. `feat(media): allow releasing the camera without the microphone`** — the mechanism, additive, no behaviour change by default.

`GstMediaServer` gains a `_camera_enabled` flag that `_build_pipeline` honours by skipping the video branch, reusing the path that already exists for "no camera detected". On top of it, idempotent `disable_camera()` / `enable_camera()`; `Daemon.release_camera()` / `acquire_camera()`, which unlike `release_media()` leave the audio branch, the WebRTC signalling and the central relay untouched; `POST /api/media/camera/{release,acquire}`; a `camera_released` field on `DaemonStatus`; and `ReachyMini.release_camera()` / `acquire_camera()`.

**2. `feat(daemon): release the camera while the robot sleeps`** — the policy, which does change default behaviour.

`goto_sleep` drops the camera at the very end and `wake_up` restores it at the very start. The placement matters in both directions: the toggle rebuilds the pipeline and briefly interrupts audio, so it has to land after `go_sleep.wav` has played and before `wake_up.wav` starts.

If you want the mechanism but not the policy, the second commit can be dropped on its own.

## Trade-offs, stated plainly

- **Toggling rebuilds the pipeline.** Audio is interrupted for the duration and WebRTC consumers reconnect — exactly as with today's `release_media()`. This is a switch between activities, not something to do mid-sentence. Surgically detaching branches from a live `tee` would avoid it, but that seemed like the wrong trade for a first pass; happy to go that way if you prefer.
- **With commit 2, a sleeping robot no longer serves video.** The dashboard shows no picture until wake-up.
- **`camera_released` is derived, not stored.** `Daemon.camera_released` reads the media server's flag rather than keeping its own copy, so it stays correct no matter who toggled the camera — REST, SDK, or the backend's own sleep handling.
- **A toggle while the pipeline is stopped rebuilds it in place rather than starting it**, so releasing media and then toggling the camera cannot silently re-acquire hardware the daemon just handed over. There is a regression test for this.

## Testing

- Four new tests in `tests/unit_tests/test_media_server_webrtc.py` (marker `webrtc`, MUJOCO sim, no hardware): audio-only pipeline has neither `queue_webrtc` nor `queue_ipc` while audio is untouched; re-enabling restores both; toggles are idempotent; a stopped pipeline stays stopped. 5/5 pass locally.
- `ruff check` clean, `mypy --strict` clean over 144 files.
- `docs/source/API/openapi.json` regenerated; the diff is additions only.

What I have **not** been able to verify, stated so you can weigh it:

- **Not tested on Wireless hardware.** I have one robot in daily use and did not want to flash a branch onto it, especially given #1251. Behaviour on a real CM4 — in particular whether dropping the capture branch actually reclaims the ~40% of a core — is the one claim I cannot make first-hand. What I did confirm on my own unit is the premise: `POST /api/media/release` silences the fan within a couple of minutes and `/api/media/acquire` brings it back, which is what motivated this shape.
- **The local full suite is not a clean signal on my machine.** `test_app.py` and `test_daemon.py` fail or hang here because they bind port 8000, which was occupied by an unrelated simulation daemon I had running. That is environmental, not related to this branch, but it means I cannot show you a green local run of the whole suite — CI is the authority here.

## Two unrelated things I hit while working on this

Both pre-exist this branch, both reproduce on a clean `main`, neither is touched here — flagging in case they are news:

1. `ruff check` fails on the repo's own `.gitignore`: `E902 ... line 235: error parsing glob 'Icon[]': unclosed character class`. That is the macOS `Icon\r` artefact; ruff 0.12.0 (the pinned CI version) refuses it. Locally it needs `--no-respect-gitignore` to run at all.
2. `scripts/generate_openapi.py` hangs indefinitely on macOS. Its docstring says `create_app(Args())` "never touches motors, serial ports, or audio devices", but `Daemon.__init__` constructs a `GstMediaServer`, which calls `Gst.init()` and stalls in plugin scanning. Stack:

   ```
   Gst.py:1267 in init
   media_server.py:198 in __init__
   daemon.py:116 in __init__
   main.py:298 in create_app
   ```

   I regenerated the spec by building the app with `no_media=True` instead; routers are registered independently of that flag (only `wireless_version` gates any of them), and the resulting diff confirms it — additions only, nothing dropped.
