### PR TITLE
Warn when motion is requested with motors disabled

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -132,6 +132,18 @@ class _PlaybackCancelToken:
         self.cancelled = False
 
 
+_MOTION_COMMAND_TYPES = (
+    SetTargetCmd,
+    SetHeadJointsCmd,
+    SetBodyYawCmd,
+    SetAntennasCmd,
+    SetFullTargetCmd,
+    GotoTargetCmd,
+    WakeUpCmd,
+    PlayUploadedMoveCmd,
+)
+
+
 class Backend:
     """Base class for robot backends, simulated or real."""
 
@@ -167,6 +179,7 @@ class Backend:
 
         self.should_stop = threading.Event()
         self.ready = threading.Event()
+        self._disabled_motion_warning_emitted = False
 
         self.check_collision = (
             check_collision  # Flag to enable/disable collision checking
@@ -470,6 +483,19 @@ class Backend:
         """Return True if a move is currently executing."""
         return self._active_move_depth > 0
 
+    def _warn_if_motors_disabled(self) -> None:
+        """Log once when motion is requested while motor torque is disabled."""
+        if self.get_motor_control_mode() != MotorControlMode.Disabled:
+            self._disabled_motion_warning_emitted = False
+            return
+        if self._disabled_motion_warning_emitted:
+            return
+        self.logger.warning(
+            "Motion command received while motors are disabled; "
+            "call enable_motors() first."
+        )
+        self._disabled_motion_warning_emitted = True
+
     def _try_start_move(self) -> bool:
         """Attempt to acquire the move guard, returning False if another client already owns it."""
         if not self._play_move_lock.acquire(blocking=False):
@@ -630,6 +656,7 @@ class Backend:
         body_yaw: float | None = None,  # Body yaw angle in radians
     ) -> None:
         """Set the target head pose and/or antenna positions and/or body_yaw."""
+        self._warn_if_motors_disabled()
         if head is not None:
             self.set_target_head_pose(head)
 
@@ -821,6 +848,7 @@ class Backend:
             cancel_token (_PlaybackCancelToken, optional): If provided, the inner loop polls ``cancel_token.cancelled`` every tick and exits when flipped. Used by ``_async_play_uploaded_move`` to wire ``cancel_move`` to a specific upload_id; direct callers (goto_target, etc.) pass None and stay non-cancellable.
 
         """
+        self._warn_if_motors_disabled()
         if not self._try_start_move():
             self.logger.warning("Ignoring play_move request: another move is running.")
             return
@@ -922,6 +950,7 @@ class Backend:
             ValueError: If neither head nor antennas are provided, or if duration is not positive.
 
         """
+        self._warn_if_motors_disabled()
         return await self.play_move(
             move=GotoMove(
                 start_head_pose=self.get_present_head_pose(),
@@ -1231,6 +1260,7 @@ class Backend:
         stand-down, e.g. for a deliberate replay or a caller that just
         enabled the motors itself and knows a real wake is due.
         """
+        self._warn_if_motors_disabled()
         await asyncio.sleep(0.1)
 
         if not force and self.is_awake_at_init_pose():
@@ -1551,6 +1581,9 @@ class Backend:
                 no-ops without one.
 
         """
+        if isinstance(cmd, _MOTION_COMMAND_TYPES):
+            self._warn_if_motors_disabled()
+
         block_targets = self.is_move_running
 
         def _maybe_ignore(field: str) -> bool:
@@ -1668,6 +1701,7 @@ class Backend:
 
         elif isinstance(cmd, SetMotorModeCmd):
             self.set_motor_control_mode(MotorControlMode(cmd.mode))
+            self._disabled_motion_warning_emitted = False
             send_response({"motor_mode": cmd.mode, "status": "ok"})
 
         elif isinstance(cmd, SetTorqueCmd):
@@ -1675,8 +1709,10 @@ class Backend:
                 self.set_motor_torque_ids(cmd.ids, cmd.on)
             elif cmd.on:
                 self.set_motor_control_mode(MotorControlMode.Enabled)
+                self._disabled_motion_warning_emitted = False
             else:
                 self.set_motor_control_mode(MotorControlMode.Disabled)
+                self._disabled_motion_warning_emitted = False
             send_response({"status": "ok", "command": "set_torque"})
 
         elif isinstance(cmd, GetMotorModeCmd):
@@ -1688,6 +1724,7 @@ class Backend:
                     self.set_motor_control_mode(MotorControlMode.GravityCompensation)
                 else:
                     self.set_motor_control_mode(MotorControlMode.Enabled)
+                self._disabled_motion_warning_emitted = False
             except ValueError as e:
                 send_response({"error": str(e), "command": "set_gravity_compensation"})
                 return

--- a/tests/unit_tests/test_backend_process_command.py
+++ b/tests/unit_tests/test_backend_process_command.py
@@ -11,6 +11,7 @@ and hardware-id seams are patched with in-memory stubs.
 """
 
 import asyncio
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -33,6 +34,7 @@ from reachy_mini.io.protocol import (
     GetVolumeCmd,
     GotoSleepCmd,
     ImuDataMsg,
+    MotorControlMode,
     PlaySoundCmd,
     ReadAudioParameterCmd,
     RestartDaemonCmd,
@@ -64,6 +66,16 @@ def _dispatch(backend: Any, cmd: Any, peer_id: str | None = None) -> list[dict]:
     responses: list[dict] = []
     backend.process_command(cmd, send_response=responses.append, peer_id=peer_id)
     return responses
+
+
+def _disabled_motor_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return only the diagnostics emitted for ignored disabled-motor motion."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if "motion command received while motors are disabled"
+        in record.getMessage().lower()
+    ]
 
 
 # ------------------------------------------------------------------
@@ -139,6 +151,48 @@ def test_set_target_ignored_when_move_running(sim_backend: Any) -> None:
     responses = _dispatch(sim_backend, SetTargetCmd(head=np.eye(4).flatten().tolist()))
     assert responses == [{"status": "ok", "command": "set_target"}]
     assert sim_backend.target_head_pose is None  # target left unchanged
+
+
+def test_motion_while_motors_disabled_warns_once(
+    sim_backend: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A high-rate target stream emits one actionable warning, not log spam."""
+    sim_backend.set_motor_control_mode(MotorControlMode.Disabled)
+
+    with caplog.at_level(logging.WARNING):
+        _dispatch(sim_backend, SetTargetCmd(head=np.eye(4).flatten().tolist()))
+        _dispatch(sim_backend, SetTargetCmd(head=np.eye(4).flatten().tolist()))
+
+    assert _disabled_motor_warnings(caplog) == [
+        "Motion command received while motors are disabled; call enable_motors() first."
+    ]
+
+
+def test_direct_motion_entry_point_warns_when_motors_disabled(
+    sim_backend: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """REST-style direct backend calls receive the same diagnostic."""
+    sim_backend.set_motor_control_mode(MotorControlMode.Disabled)
+
+    with caplog.at_level(logging.WARNING):
+        sim_backend.set_target(head=np.eye(4))
+
+    assert len(_disabled_motor_warnings(caplog)) == 1
+
+
+def test_disabled_motor_warning_resets_after_mode_change(
+    sim_backend: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A later disabled-motor episode receives its own first-command warning."""
+    sim_backend.set_motor_control_mode(MotorControlMode.Disabled)
+
+    with caplog.at_level(logging.WARNING):
+        _dispatch(sim_backend, SetTargetCmd(head=np.eye(4).flatten().tolist()))
+        _dispatch(sim_backend, SetMotorModeCmd(mode="enabled"))
+        _dispatch(sim_backend, SetMotorModeCmd(mode="disabled"))
+        _dispatch(sim_backend, SetTargetCmd(head=np.eye(4).flatten().tolist()))
+
+    assert len(_disabled_motor_warnings(caplog)) == 2
 
 
 # ------------------------------------------------------------------
@@ -441,9 +495,7 @@ def test_get_imu_data_cache_freshness() -> None:
 # ------------------------------------------------------------------
 
 
-def test_delete_hf_token_ok(
-    sim_backend: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_delete_hf_token_ok(sim_backend: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     """A successful delete_hf_token acks status ok."""
     import reachy_mini.apps.sources.hf_auth as hf_auth
 
@@ -562,7 +614,9 @@ def test_apply_audio_config_ok(
         config=[AudioParamPair(name="AGCGAIN", values=[1.0])], verify=False
     )
     responses = _dispatch(sim_backend, cmd)
-    respeaker.apply_audio_config.assert_called_once_with([("AGCGAIN", [1.0])], verify=False)
+    respeaker.apply_audio_config.assert_called_once_with(
+        [("AGCGAIN", [1.0])], verify=False
+    )
     respeaker.close.assert_called_once()
     assert responses == [
         {"status": "ok", "command": "apply_audio_config", "applied": True}


### PR DESCRIPTION
## Summary

- emit an actionable daemon warning when motion is first requested while `motor_control_mode` is `disabled`
- suppress repeated warnings from high-rate target streams
- reset the diagnostic after a motor-mode change so a later disabled episode is reported again
- cover both transport-dispatched commands and direct backend entry points used by the REST move routes

The command behavior is unchanged: requests are still accepted, but the logs now explain why the physical robot remains still and how to enable torque.

Fixes #1306.

## Validation

- `test_backend_process_command.py`, `test_backend_motion.py`, and `test_process_command.py`: 84 passed
- new regression cases cover first warning, stream de-duplication, REST-style direct calls, and reset after a mode change
- `ruff check .`: passed
- `mypy src/reachy_mini/daemon/backend/abstract.py`: passed
