### PR TITLE
Preserve Unicode SSIDs in WiFi scans

### DIFF
--- a/src/reachy_mini/daemon/app/routers/wifi_config.py
+++ b/src/reachy_mini/daemon/app/routers/wifi_config.py
@@ -24,6 +24,15 @@ from reachy_mini.utils.hardware_id import get_pin
 
 HOTSPOT_SSID = "reachy-mini-ap"
 HOTSPOT_PASSWORD = "reachy-mini"
+NMCLI_LOCALE = "C.UTF-8"
+
+
+def _configure_nmcli_locale() -> None:
+    """Keep nmcli output in English without replacing non-ASCII SSIDs."""
+    nmcli.set_lang(NMCLI_LOCALE)
+
+
+_configure_nmcli_locale()
 
 
 router = APIRouter(

--- a/tests/unit_tests/test_wifi_connect_retry.py
+++ b/tests/unit_tests/test_wifi_connect_retry.py
@@ -11,6 +11,7 @@ module also kicks off ``ensure_wifi_on_startup()`` on a real thread that shells
 out to ``sudo nmcli``; we neutralise ``threading.Thread`` during import so the
 test never touches WiFi hardware.
 """
+
 import importlib.util
 import sys
 import threading
@@ -63,6 +64,16 @@ def _import_wifi_config():
 # Imported once at module scope; only runs on Linux thanks to the guard.
 if sys.platform == "linux":
     wifi = _import_wifi_config()
+
+
+def test_nmcli_locale_preserves_non_ascii_ssids(monkeypatch):
+    """Nmcli must keep English output without degrading Unicode network names."""
+    set_lang = MagicMock()
+    monkeypatch.setattr(wifi.nmcli, "set_lang", set_lang)
+
+    wifi._configure_nmcli_locale()
+
+    set_lang.assert_called_once_with("C.UTF-8")
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #624

## Summary
- run nmcli with the C.UTF-8 locale instead of the ASCII-oriented C locale
- retain stable English nmcli output while preserving non-ASCII SSIDs end to end
- add regression coverage for the locale configuration

The scan and connect API already passes SSIDs as Unicode strings. The corruption happened earlier because the nmcli wrapper defaults subprocesses to LANG=C, which can render characters such as ó and ł as question marks before the dashboard receives them.

## Validation
- mocked nmcli locale configuration test passed
- Ruff 0.12.0 check passed
- Ruff 0.12.0 format check passed
- Python compileall passed
- git diff --check passed

No physical Reachy Mini Wireless hardware test was performed.