### PR TITLE
Parse custom app URLs from Python syntax

### DIFF
--- a/src/reachy_mini/apps/sources/local_common_venv.py
+++ b/src/reachy_mini/apps/sources/local_common_venv.py
@@ -1,10 +1,10 @@
 """Utilities for local common venv apps source."""
 
+import ast
 import asyncio
 import logging
 import os
 import platform
-import re
 import shutil
 import subprocess
 import sys
@@ -202,6 +202,38 @@ def _find_app_main_file(
     return None
 
 
+def _find_static_custom_app_url(scope: ast.Module | ast.ClassDef) -> str | None:
+    """Find the first literal custom_app_url assignment in source order."""
+    for statement in scope.body:
+        value_node: ast.expr | None = None
+        if isinstance(statement, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "custom_app_url"
+            for target in statement.targets
+        ):
+            value_node = statement.value
+        elif (
+            isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == "custom_app_url"
+        ):
+            value_node = statement.value
+
+        if value_node is not None:
+            try:
+                value = ast.literal_eval(value_node)
+            except (ValueError, TypeError):
+                pass
+            else:
+                if isinstance(value, str):
+                    return value
+
+        if isinstance(statement, ast.ClassDef):
+            value = _find_static_custom_app_url(statement)
+            if value is not None:
+                return value
+    return None
+
+
 def _get_custom_app_url_from_file(
     app_name: str,
     wireless_version: bool = False,
@@ -210,7 +242,7 @@ def _get_custom_app_url_from_file(
     """Get custom_app_url by reading it from the app's main.py file.
 
     This is much faster than subprocess and avoids sys.path pollution.
-    Looks for patterns like: custom_app_url: str | None = "http://..."
+    Looks for a statically assigned string on a module or class attribute.
     """
     main_file = _find_app_main_file(app_name, wireless_version, desktop_app_daemon)
     if main_file is None:
@@ -218,17 +250,8 @@ def _get_custom_app_url_from_file(
 
     try:
         content = main_file.read_text(encoding="utf-8")
-
-        # Match patterns like:
-        # custom_app_url: str | None = "http://..."
-        # custom_app_url = "http://..."
-        # custom_app_url: str = "http://..."
-        pattern = r'custom_app_url\s*(?::\s*[^=]+)?\s*=\s*["\']([^"\']+)["\']'
-        match = re.search(pattern, content)
-
-        if match:
-            return match.group(1)
-        return None
+        module = ast.parse(content, filename=str(main_file))
+        return _find_static_custom_app_url(module)
     except Exception as e:
         logging.getLogger("reachy_mini.apps").warning(
             f"Could not read custom_app_url from '{app_name}/main.py': {e}"

--- a/tests/unit_tests/test_custom_app_url.py
+++ b/tests/unit_tests/test_custom_app_url.py
@@ -70,3 +70,42 @@ def test_missing_everywhere_returns_none(monkeypatch, tmp_path):
         lambda *a, **k: SimpleNamespace(stdout="\n", returncode=0),
     )
     assert lcv._get_custom_app_url_from_file("nope_app") is None
+
+
+def test_ignores_custom_app_url_mentioned_in_class_docstring(monkeypatch, tmp_path):
+    """A documented attribute must not be mistaken for its assignment."""
+    pkg = _write_app(tmp_path, "some_app")
+    (pkg / "main.py").write_text(
+        '''class SomeApp:
+    """An app.
+
+    Attributes:
+        custom_app_url: URL where the app's web interface is served.
+        description: A human-readable description.
+    """
+
+    description = "An example Reachy Mini app"
+    custom_app_url: str | None = "http://0.0.0.0:7861/"
+''',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(lcv, "_get_app_site_packages", lambda *a, **k: tmp_path)
+
+    assert lcv._get_custom_app_url_from_file("some_app") == "http://0.0.0.0:7861/"
+
+
+def test_ignores_comments_and_non_literal_assignments(monkeypatch, tmp_path):
+    """Only a literal module or class attribute is safe to read statically."""
+    pkg = _write_app(tmp_path, "some_app")
+    (pkg / "main.py").write_text(
+        """# custom_app_url = "http://wrong.example/"
+base_url = "http://0.0.0.0:7862/"
+
+class SomeApp:
+    custom_app_url = base_url
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(lcv, "_get_app_site_packages", lambda *a, **k: tmp_path)
+
+    assert lcv._get_custom_app_url_from_file("some_app") is None


### PR DESCRIPTION
Fixes #1126.

## What changed

- replace the unanchored regular expression with Python AST parsing
- read only literal `custom_app_url` assignments at module or class scope
- preserve source order while ignoring docstrings, comments, and dynamic expressions
- add regression coverage for the reported class-docstring failure

## Why

The previous regex could start matching at `custom_app_url:` inside a class docstring and continue until the next assignment. In that case it returned another attribute's value as the app URL, which downstream consumers treated as an unreachable URL and could stop the running app.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.12 pytest -q --noconftest -p no:cacheprovider tests/unit_tests/test_custom_app_url.py` (5 passed)
- `uv run --python 3.12 ruff check src/reachy_mini/apps/sources/local_common_venv.py tests/unit_tests/test_custom_app_url.py`
- `uv run --python 3.12 ruff format --check src/reachy_mini/apps/sources/local_common_venv.py tests/unit_tests/test_custom_app_url.py`
- `git diff --check`
