### PR TITLE
fix: keep volume changes side-effect free

### DIFF
--- a/docs/source/API/openapi.json
+++ b/docs/source/API/openapi.json
@@ -2520,7 +2520,7 @@
     "/api/volume/set": {
       "post": {
         "summary": "Set Volume",
-        "description": "Set the output volume level and play a test sound.",
+        "description": "Set the output volume level without starting audio playback.",
         "operationId": "set_volume_api_volume_set_post",
         "requestBody": {
           "content": {

--- a/src/reachy_mini/daemon/app/routers/volume.py
+++ b/src/reachy_mini/daemon/app/routers/volume.py
@@ -10,7 +10,7 @@ This exposes:
 import logging
 from collections.abc import Callable
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from reachy_mini.daemon.app.dependencies import get_backend
@@ -87,29 +87,16 @@ async def get_volume() -> VolumeResponse:
 
 
 @router.post("/set")
-async def set_volume(
-    volume_req: VolumeRequest,
-    request: Request,
-) -> VolumeResponse:
-    """Set the output volume level and play a test sound."""
+async def set_volume(volume_req: VolumeRequest) -> VolumeResponse:
+    """Set the output volume level without starting audio playback."""
     vc = _get_volume_control()
-    response = _write_volume(
+    return _write_volume(
         vc.set_output_volume,
         volume_req.volume,
         vc,
         vc.output_device.name,
         "Failed to set volume",
     )
-
-    daemon = getattr(request.app.state, "daemon", None)
-    backend: Backend | None = daemon.backend if daemon is not None else None
-    if backend is not None and backend.ready.is_set():
-        try:
-            backend.play_sound("impatient1.wav")
-        except Exception as e:
-            logger.warning("Failed to play test sound: %s", e)
-
-    return response
 
 
 @router.post("/test-sound")

--- a/tests/unit_tests/test_router_volume.py
+++ b/tests/unit_tests/test_router_volume.py
@@ -104,8 +104,8 @@ def test_set_output_volume_success(monkeypatch, router_app):
     assert resp.json() == {"volume": 55, "platform": "TestOS", "device": "Speaker"}
 
 
-def test_set_output_volume_plays_test_sound(monkeypatch, router_app):
-    """A ready backend on app.state triggers a test sound after the set."""
+def test_set_output_volume_does_not_play_test_sound(monkeypatch, router_app):
+    """Changing the output volume must not interrupt active audio playback."""
     _patch_vc(monkeypatch, _StubVolumeControl(set_ok=True))
     daemon = MagicMock()
     daemon.backend.ready.is_set.return_value = True
@@ -114,20 +114,7 @@ def test_set_output_volume_plays_test_sound(monkeypatch, router_app):
     resp = client.post("/volume/set", json={"volume": 55})
 
     assert resp.status_code == 200
-    daemon.backend.play_sound.assert_called_once_with("impatient1.wav")
-
-
-def test_set_output_volume_test_sound_failure_ignored(monkeypatch, router_app):
-    """A failing test sound is swallowed — the set still returns 200."""
-    _patch_vc(monkeypatch, _StubVolumeControl(set_ok=True))
-    daemon = MagicMock()
-    daemon.backend.ready.is_set.return_value = True
-    daemon.backend.play_sound.side_effect = RuntimeError("boom")
-    client = router_app(volume.router, daemon=daemon)
-
-    resp = client.post("/volume/set", json={"volume": 55})
-
-    assert resp.status_code == 200
+    daemon.backend.play_sound.assert_not_called()
 
 
 def test_set_output_volume_failure(monkeypatch, router_app):


### PR DESCRIPTION
## What changed

- keep `POST /api/volume/set` limited to changing the mixer volume
- stop it from implicitly starting `impatient1.wav` through the media backend
- preserve the explicit `POST /api/volume/test-sound` endpoint for callers that want audible feedback
- update the router regression test and generated OpenAPI description

## Why

The volume setter currently performs two unrelated operations: it writes the volume and then opens daemon-side playback for a test sound. During a live app audio session, that hidden playback side effect can leave subsequent app playback silent until the daemon restarts. Separating the operations keeps volume changes safe for active sessions while retaining an explicit way to test the speaker.

Closes #1319.

## Validation

- `pytest tests/unit_tests/test_router_volume.py tests/unit_tests/test_backend_process_command.py -q` — 74 passed
- `ruff check` on the changed Python files
- `ruff format --check` on the changed Python files
- regenerated `docs/source/API/openapi.json`

Hardware reproduction was not available locally; the regression test verifies that even a ready daemon backend is not asked to play audio when the volume endpoint is called.
