### PR TITLE
fix(camera): give read_jpeg a longer sample timeout

### DIFF
--- a/src/reachy_mini/media/camera_base.py
+++ b/src/reachy_mini/media/camera_base.py
@@ -191,7 +191,10 @@ class CameraBase(ABC):
             self._build_jpeg_encoder(width, height)
         self._jpeg_pipeline.set_state(Gst.State.PLAYING)
         self._jpeg_appsrc.push_buffer(Gst.Buffer.new_wrapped(frame.tobytes()))
-        jpeg = get_sample(self._jpeg_appsink, self.logger)
+        # One-shot encode: unlike video-rate pulling, we must wait for the
+        # pipeline to preroll and emit the encoded buffer. The default 20 ms is
+        # too tight on a loaded CI runner and returns None there.
+        jpeg = get_sample(self._jpeg_appsink, self.logger, timeout_ns=Gst.SECOND)
         self._jpeg_pipeline.set_state(Gst.State.PAUSED)
         return jpeg
 

--- a/src/reachy_mini/media/gstreamer_utils.py
+++ b/src/reachy_mini/media/gstreamer_utils.py
@@ -53,18 +53,26 @@ def handle_default_bus_message(
     return True
 
 
-def get_sample(appsink: GstApp.AppSink, logger: logging.Logger) -> Optional[bytes]:
-    """Pull a sample from a GStreamer AppSink with a 20 ms timeout.
+def get_sample(
+    appsink: GstApp.AppSink,
+    logger: logging.Logger,
+    timeout_ns: int = 20_000_000,
+) -> Optional[bytes]:
+    """Pull a sample from a GStreamer AppSink with a bounded timeout.
 
     Args:
         appsink: The GStreamer AppSink element to pull from.
         logger: Logger for warnings.
+        timeout_ns: How long to wait for a sample, in nanoseconds. Defaults to
+            20 ms, which suits video-rate pulling where a missed frame is fine.
+            One-shot encoders (e.g. ``read_jpeg``) need a larger value so the
+            pipeline has time to preroll on a loaded machine.
 
     Returns:
         Raw bytes of the buffer, or ``None`` if no sample was available.
 
     """
-    sample = appsink.try_pull_sample(20_000_000)
+    sample = appsink.try_pull_sample(timeout_ns)
     if sample is None:
         return None
     data = None


### PR DESCRIPTION
`read_jpeg` pushes a frame into the one-shot JPEG encoder and then pulls with `get_sample`'s default 20 ms timeout. That is fine for video-rate pulling (a missed frame is fine) but too tight for a one-shot encode: on a loaded CI runner the pipeline has not prerolled and emitted the encoded buffer yet, so `try_pull_sample` returns None and `read_jpeg` returns None. It surfaces as a flaky `test_read_jpeg_encodes_bgr_frame` failing with `assert None is not None`.

This is a pre-existing flake (the test and code are already on `main`), split out of #1312 where it was turning CI red on an otherwise-unrelated change.

- `get_sample` gains an optional `timeout_ns` (default 20 ms), so the three video-rate call sites are untouched.
- `read_jpeg` opts into a 1 s timeout. Its only caller, `media_manager.get_frame_jpeg`, has no callers today, so the blast radius is nil.

Tested: `test_video.py::test_read_jpeg_encodes_bgr_frame` passes with `--extra opencv` (skipped by default via `importorskip("cv2")`), on both aarch64 and macOS.

Made with [Cursor](https://cursor.com)
