### PR TITLE
ci(docs): point doc build back at upstream doc-builder

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    uses: pollen-robotics/doc-builder/.github/workflows/build_main_documentation.yml@add-python-version-input
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main
     with:
       repo_owner: pollen-robotics
       commit_sha: ${{ github.sha }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    uses: pollen-robotics/doc-builder/.github/workflows/build_pr_documentation.yml@add-python-version-input
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@main
     with:
       repo_owner: pollen-robotics
       commit_sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Follow-up of #1261 and #1265.

#1265 needed `python_version: "3.11"` on the doc build (the runner default is 3.10, `reachy_mini` requires >=3.11). The input did not exist in the HF doc-builder workflows yet, so we added it in [huggingface/doc-builder#808](https://github.com/huggingface/doc-builder/pull/808) and, in the meantime, pointed both workflows at our fork branch `pollen-robotics/doc-builder@add-python-version-input`.

That PR is now merged upstream, so we go back to the classic HF pipeline: both `uses:` point at `huggingface/doc-builder/...@main` again, with `python_version: "3.11"` unchanged. The fork branch held nothing else of ours, and upstream `main` has moved on since (the version list is read from the doc bucket instead of the legacy dataset), so this also picks up those fixes.

Note: `build_pr_documentation` only triggers on `docs/**`, so it will not run on this PR — verify by dispatching `Build HF documentation` after merge, or on the next docs PR.