### PR TITLE
fix(media): tear down the play_sound playbin on EOS/error

### DIFF
--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -500,8 +500,7 @@ class GStreamerAudio(AudioBase):
         self._appsrc_pts = -1
         self._pipeline.set_state(Gst.State.NULL)
         if self._playbin is not None:
-            self._playbin.set_state(Gst.State.NULL)
-            self._playbin = None
+            self._teardown_playbin(self._playbin)
 
     def clear_player(self) -> None:
         """Flush the player's appsrc to drop any queued audio immediately."""
@@ -544,7 +543,7 @@ class GStreamerAudio(AudioBase):
             file_path = sound_file
 
         if self._playbin is not None:
-            self._playbin.set_state(Gst.State.NULL)
+            self._teardown_playbin(self._playbin)
 
         playbin = Gst.ElementFactory.make("playbin", "player")
         if not playbin:
@@ -569,7 +568,46 @@ class GStreamerAudio(AudioBase):
             self._head_wobbler.start()
 
         self._playbin = playbin
+
+        # Tear the playbin down once playback finishes.  Without this it
+        # idles in PLAYING with the file loaded indefinitely: its pipeline
+        # threads are never released, and the idle pipeline can spontaneously
+        # replay the loaded file with no log trace.
+        bus = playbin.get_bus()
+        bus.add_signal_watch()
+        bus.connect("message", self._on_playbin_message, playbin)
+
         playbin.set_state(Gst.State.PLAYING)
+
+    def _on_playbin_message(
+        self, _bus: Gst.Bus, msg: Gst.Message, playbin: Gst.Element
+    ) -> None:
+        """Tear down *playbin* once it reaches EOS or fails with an error.
+
+        Args:
+            _bus: The playbin's bus (provided by the signal, unused).
+            msg: The bus message being dispatched.
+            playbin: The playbin this watch was installed for.
+
+        """
+        if msg.type not in (Gst.MessageType.EOS, Gst.MessageType.ERROR):
+            return
+        if msg.type == Gst.MessageType.ERROR:
+            err, dbg = msg.parse_error()
+            self.logger.error(f"play_sound playbin error: {err} ({dbg})")
+        self._teardown_playbin(playbin)
+
+    def _teardown_playbin(self, playbin: Gst.Element) -> None:
+        """Stop *playbin*, drop its bus watch, and release its threads.
+
+        Args:
+            playbin: The playbin to tear down.
+
+        """
+        playbin.get_bus().remove_signal_watch()
+        playbin.set_state(Gst.State.NULL)
+        if self._playbin is playbin:
+            self._playbin = None
 
     def upload_sound(self, sound_file: str) -> str:
         """No-op for the local backend — the file is already accessible.

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -1281,7 +1281,7 @@ class GstMediaServer:
             file_path = sound_file
 
         if self._playbin is not None:
-            self._playbin.set_state(Gst.State.NULL)
+            self._teardown_playbin(self._playbin)
 
         playbin = Gst.ElementFactory.make("playbin", "player")
         if not playbin:
@@ -1306,6 +1306,15 @@ class GstMediaServer:
             self._head_wobbler.start()
 
         self._playbin = playbin
+
+        # Tear the playbin down once playback finishes.  Without this it
+        # idles in PLAYING with the file loaded indefinitely: its pipeline
+        # threads are never released, and the idle pipeline can spontaneously
+        # replay the loaded file with no log trace.
+        bus = playbin.get_bus()
+        bus.add_signal_watch()
+        bus.connect("message", self._on_playbin_message, playbin)
+
         playbin.set_state(Gst.State.PLAYING)
 
     def stop_sound(self) -> None:
@@ -1314,7 +1323,36 @@ class GstMediaServer:
         If no sound is currently playing this is a no-op.
         """
         if self._playbin is not None:
-            self._playbin.set_state(Gst.State.NULL)
+            self._teardown_playbin(self._playbin)
+
+    def _on_playbin_message(
+        self, _bus: Gst.Bus, msg: Gst.Message, playbin: Gst.Element
+    ) -> None:
+        """Tear down *playbin* once it reaches EOS or fails with an error.
+
+        Args:
+            _bus: The playbin's bus (provided by the signal, unused).
+            msg: The bus message being dispatched.
+            playbin: The playbin this watch was installed for.
+
+        """
+        if msg.type not in (Gst.MessageType.EOS, Gst.MessageType.ERROR):
+            return
+        if msg.type == Gst.MessageType.ERROR:
+            err, dbg = msg.parse_error()
+            self._logger.error(f"play_sound playbin error: {err} ({dbg})")
+        self._teardown_playbin(playbin)
+
+    def _teardown_playbin(self, playbin: Gst.Element) -> None:
+        """Stop *playbin*, drop its bus watch, and release its threads.
+
+        Args:
+            playbin: The playbin to tear down.
+
+        """
+        playbin.get_bus().remove_signal_watch()
+        playbin.set_state(Gst.State.NULL)
+        if self._playbin is playbin:
             self._playbin = None
 
     def _build_audiosink_element(self) -> Optional[Gst.Element]:

--- a/tests/unit_tests/test_playbin_teardown.py
+++ b/tests/unit_tests/test_playbin_teardown.py
@@ -1,0 +1,131 @@
+"""Unit tests for ``play_sound()`` playbin teardown on EOS/error."""
+
+import logging
+from types import SimpleNamespace
+from typing import cast
+
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst  # noqa: E402
+
+from reachy_mini.media.audio_gstreamer import GStreamerAudio  # noqa: E402
+
+Gst.init([])
+
+
+class _FakeBus:
+    """Stand-in for ``Gst.Bus`` recording signal-watch removal."""
+
+    def __init__(self) -> None:
+        self.watch_removed = False
+
+    def remove_signal_watch(self) -> None:
+        self.watch_removed = True
+
+
+class _FakePlaybin:
+    """Stand-in for a playbin ``Gst.Element`` recording state changes."""
+
+    def __init__(self) -> None:
+        self.bus = _FakeBus()
+        self.state: Gst.State | None = None
+
+    def get_bus(self) -> _FakeBus:
+        return self.bus
+
+    def set_state(self, state: Gst.State) -> None:
+        self.state = state
+
+
+def _fake_self(playbin: _FakePlaybin | None) -> GStreamerAudio:
+    """Return a stand-in carrying just the attrs the helpers touch."""
+    return cast(
+        GStreamerAudio,
+        SimpleNamespace(
+            _playbin=playbin,
+            logger=logging.getLogger("test_playbin_teardown"),
+            _teardown_playbin=lambda pb: None,
+        ),
+    )
+
+
+def test_teardown_stops_playbin_and_drops_watch() -> None:
+    """Teardown NULLs the playbin, removes its bus watch, clears the ref."""
+    playbin = _FakePlaybin()
+    fake = _fake_self(playbin)
+
+    GStreamerAudio._teardown_playbin(fake, cast(Gst.Element, playbin))
+
+    assert playbin.state == Gst.State.NULL
+    assert playbin.bus.watch_removed
+    assert fake._playbin is None
+
+
+def test_teardown_of_stale_playbin_keeps_current_ref() -> None:
+    """Tearing down a superseded playbin leaves the newer one in place."""
+    stale, current = _FakePlaybin(), _FakePlaybin()
+    fake = _fake_self(current)
+
+    GStreamerAudio._teardown_playbin(fake, cast(Gst.Element, stale))
+
+    assert stale.state == Gst.State.NULL
+    assert stale.bus.watch_removed
+    assert fake._playbin is cast(Gst.Element, current)
+
+
+def test_eos_message_triggers_teardown() -> None:
+    """An EOS bus message tears down the playbin that produced it."""
+    playbin = _FakePlaybin()
+    fake = _fake_self(playbin)
+    torn_down = []
+    fake._teardown_playbin = torn_down.append  # type: ignore[method-assign]
+    msg = SimpleNamespace(type=Gst.MessageType.EOS)
+
+    GStreamerAudio._on_playbin_message(
+        fake,
+        cast(Gst.Bus, playbin.bus),
+        cast(Gst.Message, msg),
+        cast(Gst.Element, playbin),
+    )
+
+    assert torn_down == [playbin]
+
+
+def test_error_message_triggers_teardown() -> None:
+    """An ERROR bus message is logged and tears down the playbin."""
+    playbin = _FakePlaybin()
+    fake = _fake_self(playbin)
+    torn_down = []
+    fake._teardown_playbin = torn_down.append  # type: ignore[method-assign]
+    gerror = SimpleNamespace(message="boom")
+    msg = SimpleNamespace(
+        type=Gst.MessageType.ERROR, parse_error=lambda: (gerror, "debug info")
+    )
+
+    GStreamerAudio._on_playbin_message(
+        fake,
+        cast(Gst.Bus, playbin.bus),
+        cast(Gst.Message, msg),
+        cast(Gst.Element, playbin),
+    )
+
+    assert torn_down == [playbin]
+
+
+def test_other_messages_are_ignored() -> None:
+    """Non-EOS/ERROR messages (e.g. STATE_CHANGED) do not tear down."""
+    playbin = _FakePlaybin()
+    fake = _fake_self(playbin)
+    torn_down = []
+    fake._teardown_playbin = torn_down.append  # type: ignore[method-assign]
+    msg = SimpleNamespace(type=Gst.MessageType.STATE_CHANGED)
+
+    GStreamerAudio._on_playbin_message(
+        fake,
+        cast(Gst.Bus, playbin.bus),
+        cast(Gst.Message, msg),
+        cast(Gst.Element, playbin),
+    )
+
+    assert torn_down == []

--- a/tests/unit_tests/test_playbin_teardown.py
+++ b/tests/unit_tests/test_playbin_teardown.py
@@ -1,17 +1,31 @@
-"""Unit tests for ``play_sound()`` playbin teardown on EOS/error."""
+"""Unit tests for ``play_sound()`` playbin teardown on EOS/error.
+
+Covers both ``play_sound`` implementations: ``GStreamerAudio``
+(``media/audio_gstreamer.py``, SDK/media-manager path) and
+``GstMediaServer`` (``media/media_server.py``, the daemon-side path used
+for wake-up/sleep and ``/api/media/play_sound``).
+"""
 
 import logging
 from types import SimpleNamespace
 from typing import cast
 
 import gi
+import pytest
 
 gi.require_version("Gst", "1.0")
 from gi.repository import Gst  # noqa: E402
 
 from reachy_mini.media.audio_gstreamer import GStreamerAudio  # noqa: E402
+from reachy_mini.media.media_server import GstMediaServer  # noqa: E402
 
 Gst.init([])
+
+# (class under test, name of its logger attribute)
+IMPLEMENTATIONS = [
+    pytest.param(GStreamerAudio, "logger", id="GStreamerAudio"),
+    pytest.param(GstMediaServer, "_logger", id="GstMediaServer"),
+]
 
 
 class _FakeBus:
@@ -38,51 +52,51 @@ class _FakePlaybin:
         self.state = state
 
 
-def _fake_self(playbin: _FakePlaybin | None) -> GStreamerAudio:
+def _fake_self(playbin: _FakePlaybin | None, logger_attr: str) -> SimpleNamespace:
     """Return a stand-in carrying just the attrs the helpers touch."""
-    return cast(
-        GStreamerAudio,
-        SimpleNamespace(
-            _playbin=playbin,
-            logger=logging.getLogger("test_playbin_teardown"),
-            _teardown_playbin=lambda pb: None,
-        ),
+    return SimpleNamespace(
+        _playbin=playbin,
+        **{logger_attr: logging.getLogger("test_playbin_teardown")},
+        _teardown_playbin=lambda pb: None,
     )
 
 
-def test_teardown_stops_playbin_and_drops_watch() -> None:
+@pytest.mark.parametrize("cls,logger_attr", IMPLEMENTATIONS)
+def test_teardown_stops_playbin_and_drops_watch(cls, logger_attr) -> None:
     """Teardown NULLs the playbin, removes its bus watch, clears the ref."""
     playbin = _FakePlaybin()
-    fake = _fake_self(playbin)
+    fake = _fake_self(playbin, logger_attr)
 
-    GStreamerAudio._teardown_playbin(fake, cast(Gst.Element, playbin))
+    cls._teardown_playbin(fake, cast(Gst.Element, playbin))
 
     assert playbin.state == Gst.State.NULL
     assert playbin.bus.watch_removed
     assert fake._playbin is None
 
 
-def test_teardown_of_stale_playbin_keeps_current_ref() -> None:
+@pytest.mark.parametrize("cls,logger_attr", IMPLEMENTATIONS)
+def test_teardown_of_stale_playbin_keeps_current_ref(cls, logger_attr) -> None:
     """Tearing down a superseded playbin leaves the newer one in place."""
     stale, current = _FakePlaybin(), _FakePlaybin()
-    fake = _fake_self(current)
+    fake = _fake_self(current, logger_attr)
 
-    GStreamerAudio._teardown_playbin(fake, cast(Gst.Element, stale))
+    cls._teardown_playbin(fake, cast(Gst.Element, stale))
 
     assert stale.state == Gst.State.NULL
     assert stale.bus.watch_removed
     assert fake._playbin is cast(Gst.Element, current)
 
 
-def test_eos_message_triggers_teardown() -> None:
+@pytest.mark.parametrize("cls,logger_attr", IMPLEMENTATIONS)
+def test_eos_message_triggers_teardown(cls, logger_attr) -> None:
     """An EOS bus message tears down the playbin that produced it."""
     playbin = _FakePlaybin()
-    fake = _fake_self(playbin)
+    fake = _fake_self(playbin, logger_attr)
     torn_down = []
-    fake._teardown_playbin = torn_down.append  # type: ignore[method-assign]
+    fake._teardown_playbin = torn_down.append
     msg = SimpleNamespace(type=Gst.MessageType.EOS)
 
-    GStreamerAudio._on_playbin_message(
+    cls._on_playbin_message(
         fake,
         cast(Gst.Bus, playbin.bus),
         cast(Gst.Message, msg),
@@ -92,18 +106,19 @@ def test_eos_message_triggers_teardown() -> None:
     assert torn_down == [playbin]
 
 
-def test_error_message_triggers_teardown() -> None:
+@pytest.mark.parametrize("cls,logger_attr", IMPLEMENTATIONS)
+def test_error_message_triggers_teardown(cls, logger_attr) -> None:
     """An ERROR bus message is logged and tears down the playbin."""
     playbin = _FakePlaybin()
-    fake = _fake_self(playbin)
+    fake = _fake_self(playbin, logger_attr)
     torn_down = []
-    fake._teardown_playbin = torn_down.append  # type: ignore[method-assign]
+    fake._teardown_playbin = torn_down.append
     gerror = SimpleNamespace(message="boom")
     msg = SimpleNamespace(
         type=Gst.MessageType.ERROR, parse_error=lambda: (gerror, "debug info")
     )
 
-    GStreamerAudio._on_playbin_message(
+    cls._on_playbin_message(
         fake,
         cast(Gst.Bus, playbin.bus),
         cast(Gst.Message, msg),
@@ -113,15 +128,16 @@ def test_error_message_triggers_teardown() -> None:
     assert torn_down == [playbin]
 
 
-def test_other_messages_are_ignored() -> None:
+@pytest.mark.parametrize("cls,logger_attr", IMPLEMENTATIONS)
+def test_other_messages_are_ignored(cls, logger_attr) -> None:
     """Non-EOS/ERROR messages (e.g. STATE_CHANGED) do not tear down."""
     playbin = _FakePlaybin()
-    fake = _fake_self(playbin)
+    fake = _fake_self(playbin, logger_attr)
     torn_down = []
-    fake._teardown_playbin = torn_down.append  # type: ignore[method-assign]
+    fake._teardown_playbin = torn_down.append
     msg = SimpleNamespace(type=Gst.MessageType.STATE_CHANGED)
 
-    GStreamerAudio._on_playbin_message(
+    cls._on_playbin_message(
         fake,
         cast(Gst.Bus, playbin.bus),
         cast(Gst.Message, msg),


### PR DESCRIPTION
## Summary

`play_sound()` creates a `playbin`, sets it to `PLAYING`, and never watches its bus. After playback finishes, the last playbin idles in `PLAYING` with the file loaded indefinitely — until the *next* `play_sound()` call, which may never come.

This bug exists in **both** `play_sound` implementations, and this PR fixes both:

- `GStreamerAudio.play_sound()` (`media/audio_gstreamer.py`) — first commit
- `GstMediaServer.play_sound()` (`media/media_server.py`) — second commit; this is the implementation the daemon actually uses for wake-up/sleep sounds and `POST /api/media/play_sound` (at least on Reachy Mini Lite, daemon 1.9.0)

This is the remaining half of #840 (closed for inactivity, but still present on `main`). #915 fixed the accumulation between plays by storing the playbin and tearing down the *previous* one, but nothing tears down the *last* one, so its pipeline threads are never released and the pipeline stays live.

## The surprising symptom: spontaneous replay

Beyond the thread leak documented in #840, an idle `PLAYING` playbin **spontaneously replays its loaded file every 12,198 s (3 h 23 m 18 s)**. Observed on a Reachy Mini Lite, daemon 1.9.0 (Linux host, PipeWire), over a two-day tap of the speaker sink:

- **11 replay events recorded**, intervals of exactly 12,198 s (±1 s); five events predicted in advance to the second.
- The replayed content **tracks the most recently played file**: after `wake_up.wav` plays, the replay is the wake sound; we then played `dance1.wav` and predicted (in advance) that the next phantom would be the dance jingle instead — it was, to the second, matching `dance1.wav` at r = 0.999. Each `play_sound()` tears down the previous playbin (the #915 behavior), which also cancels its pending replay — single-slot semantics that match `self._playbin` exactly.
- **Zero log traces at every event**: daemon journal empty, no new PipeWire playback stream (audio emerges from the idle playbin's still-open stream — same node, same `object.serial`), no API clients, no SSH sessions, no other audio processes.
- Replays are deterministic: replay-vs-replay comparison gives max sample diff 0.0. Curiously they are *not* bit-identical to the first (live) pass of the same sound (small diff, ≈4 % of peak worst-case) — the idle pipeline appears to deterministically re-render from its loaded media rather than re-emit captured output. May help whoever hunts the root cause inside GStreamer.
- Open questions we could not resolve: what inside GStreamer/PipeWire counts exactly 12,198 s (it is not a 2^29-sample counter at 44.1 kHz — that would be 12,173 s), and one anomalous first interval (~4,146 s) observed on the first day.

Audio captures of the sink, waveform correlation analysis, and the event timeline are available on request.

## Why both files matter

We initially shipped only the `GStreamerAudio` fix to the affected robot — **and the replays continued unchanged**, because the daemon-side path goes through `GstMediaServer.play_sound()`, which has the identical bug. Only after patching `media_server.py` did the replays stop. A fix to one twin without the other does not cure a deployed robot.

## Fix

Add a bus signal watch to each playbin created by `play_sound()`. On `EOS` or `ERROR` the playbin is set to `NULL`, the watch removed, and the stored reference cleared (guarded by identity, so a late message from a superseded playbin cannot tear down a newer one). The superseded-playbin path in `play_sound()`, `stop_playing()` (`GStreamerAudio`) and `stop_sound()` (`GstMediaServer`) share the same teardown helper, so their bus watches are removed as well.

After the fix (verified on the same robot, both patches applied):

- `play_sound()` behavior unchanged audibly; sounds play normally (wake/sleep chimes, API plays).
- After EOS the playbin reaches `NULL` (logged) and its PipeWire stream closes; the robot idles with **zero** open playback streams (pre-fix: the zombie stream persisted indefinitely).
- The next 12,198 s replay window passed in silence, with the sink tap still armed; no spontaneous replay since (pre-fix: every 12,198 s without exception).
- Thread count returns to baseline after playback (matches the "after fix" numbers in #840).

## Tests

`tests/unit_tests/test_playbin_teardown.py`, in the same fake-`self` style as `test_audio_gstreamer.py`, now parametrized over both implementations (`GStreamerAudio`, `GstMediaServer`):

- teardown NULLs the playbin, removes its bus watch, clears `_playbin`
- tearing down a superseded playbin leaves the newer `_playbin` reference intact
- `EOS` and `ERROR` bus messages trigger teardown (`ERROR` also logs)
- other bus messages are ignored

`ruff check` / `ruff format` clean on the touched files (ruff 0.12.0 as pinned); `mypy --strict` error delta zero vs `main`.
