### PR TITLE
feat(media): preroll move-paired sounds to remove playbin warmup skew

### DIFF
--- a/scripts/measure_playbin_warmup.py
+++ b/scripts/measure_playbin_warmup.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Measure GStreamer playbin start latency on the robot: cold vs prerolled.
+
+Context
+-------
+The daemon plays move-paired sounds through a playbin whose PLAYING
+transition does lazy work (open the ALSA sink, decode, fill the ring
+buffer). `audio_lead_ms` was historically used to paper over that warmup.
+The daemon now prerolls (PAUSED first, then flips to PLAYING). This script
+quantifies both paths in isolation, on the exact same pipeline shape as
+`GstMediaServer._make_playbin_for`:
+
+    playbin -> [tee -> queue -> audioconvert -> audioresample -> alsasink]
+                    -> queue -> audioconvert -> audioresample -> appsink(sync=true)
+
+The appsink branch mirrors the daemon's head-wobbler tap: with sync=True its
+`new-sample` callback fires at the buffer's PTS on the pipeline clock, i.e.
+the same instant the audiosink renders that audio. First `new-sample` after
+the PLAYING transition == first audible sample (minus constant DAC latency,
+identical in both scenarios).
+
+Measured per run:
+  cold_ms      wall time from set_state(PLAYING) (from NULL) to first sample
+  preroll_ms   wall time spent in set_state(PAUSED) + get_state() (the warmup,
+               paid ahead of the motion clock)
+  primed_ms    wall time from set_state(PLAYING) (from prerolled PAUSED) to
+               first sample  -> this is what the move actually waits for
+
+Usage (on the robot, daemon MUST be stopped first - it owns the ALSA device):
+    sudo systemctl stop reachy_mini
+    python3 measure_playbin_warmup.py --runs 10
+    python3 measure_playbin_warmup.py --file /path/to/other.wav --runs 5
+    sudo systemctl start reachy_mini
+
+No reachy_mini import needed; only pygobject + GStreamer (both ship with the
+robot image).
+"""
+
+import argparse
+import os
+import statistics
+import subprocess
+import sys
+import threading
+import time
+
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst  # noqa: E402
+
+DEFAULT_ASSETS = "/venvs/system_apps/lib/python3.11/site-packages/reachy_mini/assets"
+PREROLL_TIMEOUT_NS = 2 * Gst.SECOND  # same budget as GstMediaServer
+PLAY_TAIL_S = 0.25  # let the sound run briefly after first sample, then stop
+
+
+def find_asset(name: str) -> str:
+    """Resolve a sound name against known assets locations."""
+    if os.path.exists(name):
+        return os.path.abspath(name)
+    for root in (DEFAULT_ASSETS, os.path.expanduser("~/reachy_mini/assets")):
+        candidate = os.path.join(root, name)
+        if os.path.exists(candidate):
+            return candidate
+    # Last resort: ask python where reachy_mini lives.
+    try:
+        import reachy_mini  # type: ignore
+
+        candidate = os.path.join(os.path.dirname(reachy_mini.__file__), "assets", name)
+        if os.path.exists(candidate):
+            return candidate
+    except ImportError:
+        pass
+    sys.exit(f"error: sound file not found: {name}")
+
+
+def build_audiosink() -> Gst.Element:
+    """Mirror GstMediaServer._build_audiosink_element (robot branch).
+
+    Wireless CM4 defines the `reachymini_audio_sink` ALSA alias in ~/.asoundrc;
+    fall back to autoaudiosink elsewhere (e.g. dry-running on a laptop).
+    """
+    asoundrc = os.path.expanduser("~/.asoundrc")
+    if os.path.exists(asoundrc):
+        with open(asoundrc) as f:
+            if "reachymini_audio_sink" in f.read():
+                sink = Gst.ElementFactory.make("alsasink")
+                sink.set_property("device", "reachymini_audio_sink")
+                return sink
+    return Gst.ElementFactory.make("autoaudiosink")
+
+
+class ProbeBin:
+    """The daemon's tee bin, with the wobbler appsink used as a render probe."""
+
+    def __init__(self) -> None:
+        """Build the tee bin and wire the appsink probe."""
+        self.first_sample_t: float | None = None
+        self._bin = Gst.Bin.new("probe_audio_bin")
+
+        tee = Gst.ElementFactory.make("tee")
+        q_spk = Gst.ElementFactory.make("queue")
+        ac_spk = Gst.ElementFactory.make("audioconvert")
+        ar_spk = Gst.ElementFactory.make("audioresample")
+        sink = build_audiosink()
+        q_probe = Gst.ElementFactory.make("queue")
+        ac_probe = Gst.ElementFactory.make("audioconvert")
+        ar_probe = Gst.ElementFactory.make("audioresample")
+        appsink = Gst.ElementFactory.make("appsink")
+        appsink.set_property("emit-signals", True)
+        appsink.set_property("sync", True)  # deliver at render time, like the wobbler
+        appsink.set_property("max-buffers", 4)
+        appsink.set_property("drop", True)
+        appsink.connect("new-sample", self._on_sample)
+
+        for el in (
+            tee,
+            q_spk,
+            ac_spk,
+            ar_spk,
+            sink,
+            q_probe,
+            ac_probe,
+            ar_probe,
+            appsink,
+        ):
+            self._bin.add(el)
+        tee.link(q_spk)
+        q_spk.link(ac_spk)
+        ac_spk.link(ar_spk)
+        ar_spk.link(sink)
+        tee.link(q_probe)
+        q_probe.link(ac_probe)
+        ac_probe.link(ar_probe)
+        ar_probe.link(appsink)
+
+        ghost = Gst.GhostPad.new("sink", tee.get_static_pad("sink"))
+        self._bin.add_pad(ghost)
+
+    def _on_sample(self, appsink: Gst.Element) -> Gst.FlowReturn:
+        if self.first_sample_t is None:
+            self.first_sample_t = time.monotonic()
+        # Must pull, otherwise the streaming thread stalls.
+        appsink.emit("pull-sample")
+        return Gst.FlowReturn.OK
+
+    @property
+    def element(self) -> Gst.Bin:
+        """The bin to install as the playbin audio-sink."""
+        return self._bin
+
+
+def make_playbin(file_path: str) -> tuple[Gst.Element, ProbeBin]:
+    """Build a playbin wired to the probe bin, like the daemon does."""
+    playbin = Gst.ElementFactory.make("playbin", "player")
+    if playbin is None:
+        sys.exit("error: failed to create playbin (GStreamer install issue)")
+    playbin.set_property("uri", f"file://{file_path}")
+    probe = ProbeBin()
+    playbin.set_property("audio-sink", probe.element)
+    return playbin, probe
+
+
+def wait_first_sample(probe: ProbeBin, timeout_s: float = 5.0) -> float | None:
+    """Busy-wait until the probe sees the first rendered sample."""
+    deadline = time.monotonic() + timeout_s
+    while probe.first_sample_t is None and time.monotonic() < deadline:
+        time.sleep(0.001)
+    return probe.first_sample_t
+
+
+def run_cold(file_path: str) -> float:
+    """NULL -> PLAYING in one go: the legacy play_sound path."""
+    playbin, probe = make_playbin(file_path)
+    t0 = time.monotonic()
+    playbin.set_state(Gst.State.PLAYING)
+    t_first = wait_first_sample(probe)
+    latency = (t_first - t0) * 1000 if t_first is not None else float("nan")
+    time.sleep(PLAY_TAIL_S)
+    playbin.set_state(Gst.State.NULL)
+    return latency
+
+
+def run_prerolled(file_path: str) -> tuple[float, float]:
+    """PAUSED + get_state (preroll), then PLAYING: the new prepare/start path."""
+    playbin, probe = make_playbin(file_path)
+    t0 = time.monotonic()
+    playbin.set_state(Gst.State.PAUSED)
+    ret, _, _ = playbin.get_state(PREROLL_TIMEOUT_NS)
+    preroll_ms = (time.monotonic() - t0) * 1000
+    if ret not in (Gst.StateChangeReturn.SUCCESS, Gst.StateChangeReturn.NO_PREROLL):
+        playbin.set_state(Gst.State.NULL)
+        return preroll_ms, float("nan")
+
+    t1 = time.monotonic()
+    playbin.set_state(Gst.State.PLAYING)
+    t_first = wait_first_sample(probe)
+    primed_ms = (t_first - t1) * 1000 if t_first is not None else float("nan")
+    time.sleep(PLAY_TAIL_S)
+    playbin.set_state(Gst.State.NULL)
+    return preroll_ms, primed_ms
+
+
+def stats(label: str, values: list[float]) -> None:
+    """Print summary statistics for one measurement series."""
+    clean = [v for v in values if v == v]  # drop NaNs
+    if not clean:
+        print(f"  {label:<12} all runs failed")
+        return
+    print(
+        f"  {label:<12} n={len(clean):<3} "
+        f"median={statistics.median(clean):7.1f} ms  "
+        f"mean={statistics.fmean(clean):7.1f} ms  "
+        f"min={min(clean):7.1f} ms  "
+        f"max={max(clean):7.1f} ms"
+        + (f"  stdev={statistics.stdev(clean):6.1f} ms" if len(clean) > 1 else "")
+    )
+
+
+def check_daemon() -> None:
+    """Warn when the reachy_mini daemon holds the audio device."""
+    try:
+        out = subprocess.run(
+            ["systemctl", "is-active", "reachy_mini"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if out == "active":
+            print(
+                "WARNING: the reachy_mini daemon is running and owns the audio "
+                "device.\n         Results will be wrong or the sink will fail "
+                "to open.\n         Run: sudo systemctl stop reachy_mini\n"
+            )
+    except FileNotFoundError:
+        pass  # not on the robot (dry run on a dev machine)
+
+
+def main() -> None:
+    """Run the cold vs prerolled measurement campaign."""
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--file",
+        action="append",
+        default=None,
+        help="sound file(s) to test; name resolved against the assets dir "
+        "(default: wake_up.wav and go_sleep.wav)",
+    )
+    parser.add_argument(
+        "--runs", type=int, default=10, help="runs per file (default 10)"
+    )
+    parser.add_argument("--mute", action="store_true", help="volume 0 (silent test)")
+    args = parser.parse_args()
+
+    Gst.init(None)
+    check_daemon()
+
+    files = args.file or ["wake_up.wav", "go_sleep.wav"]
+    for name in files:
+        path = find_asset(name)
+        print(f"\n=== {path} ===")
+        cold: list[float] = []
+        preroll: list[float] = []
+        primed: list[float] = []
+        for i in range(args.runs):
+            c = run_cold(path)
+            pre, pri = run_prerolled(path)
+            cold.append(c)
+            preroll.append(pre)
+            primed.append(pri)
+            print(
+                f"  run {i + 1:>2}: cold={c:7.1f} ms   "
+                f"preroll={pre:7.1f} ms   primed={pri:7.1f} ms"
+            )
+            time.sleep(0.2)
+        print()
+        stats("cold", cold)
+        stats("preroll", preroll)
+        stats("primed", primed)
+        clean_cold = [v for v in cold if v == v]
+        clean_primed = [v for v in primed if v == v]
+        if clean_cold and clean_primed:
+            gain = statistics.median(clean_cold) - statistics.median(clean_primed)
+            print(f"\n  -> preroll removes {gain:.1f} ms of start latency (median)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -817,7 +817,7 @@ class Backend:
             move (Move): The Move object to be played.
             play_frequency (float): The frequency at which to evaluate the move (in Hz).
             initial_goto_duration (float): Duration for an initial goto to the move's starting position. If 0.0, no initial goto is performed.
-            audio_lead_s (float): How many seconds the audio (if any) starts BEFORE the motion. Positive values compensate for the constant GStreamer playbin latency on the robot so the audio reaches the speaker at the same moment the actuator starts moving. Negative values delay audio relative to motion. No-op when the move has no sound_path. Default 0.
+            audio_lead_s (float): How many seconds the audio (if any) starts BEFORE the motion. The sound is prerolled (PAUSED) before the motion clock starts, so 0 means audio and motion start together with no GStreamer warmup skew. Positive values start the audio ahead of the motion, negative values delay it. No-op when the move has no sound_path. Default 0.
             cancel_token (_PlaybackCancelToken, optional): If provided, the inner loop polls ``cancel_token.cancelled`` every tick and exits when flipped. Used by ``_async_play_uploaded_move`` to wire ``cancel_move`` to a specific upload_id; direct callers (goto_target, etc.) pass None and stay non-cancellable.
 
         """
@@ -838,27 +838,46 @@ class Backend:
                 )
             sleep_period = 1.0 / play_frequency
 
-            # Sound handoff.  audio_lead_s shifts the audio start
-            # relative to the motion loop:
+            # Sound handoff. We PREROLL the playbin first (drive it to PAUSED
+            # and block until GStreamer has opened the sink + filled its ring
+            # buffer), so flipping it to PLAYING makes the first sample hit the
+            # speaker essentially immediately. This removes the variable
+            # playbin warmup that used to make the motion visibly lead the
+            # audio. audio_lead_s then shifts a *prerolled* start around the
+            # motion clock, with a clean, warmup-free meaning:
             #   > 0: audio starts first, motion follows after the wait
             #   < 0: motion starts first, audio follows
-            #   = 0: kick off audio just before entering the loop (legacy behaviour)
-            if move.sound_path is not None and audio_lead_s > 0:
-                self.play_sound(str(move.sound_path))
+            #   = 0: both start together (now genuinely in sync)
+            #
+            # Preroll blocks for the warmup duration, so run it off the event
+            # loop to avoid stalling the daemon while GStreamer wakes up.
+            sound_ready = False
+            if move.sound_path is not None:
+                loop = asyncio.get_running_loop()
+                sound_ready = await loop.run_in_executor(
+                    None, self.prepare_sound, str(move.sound_path)
+                )
+                if not sound_ready:
+                    # Preroll failed / no media: fall back to the old
+                    # fire-and-forget start so the move isn't silent
+                    # (accepts the legacy warmup latency).
+                    self.play_sound(str(move.sound_path))
+
+            if sound_ready and audio_lead_s > 0:
+                self.start_prepared_sound()
                 await asyncio.sleep(audio_lead_s)
-            elif move.sound_path is not None and audio_lead_s == 0:
-                self.play_sound(str(move.sound_path))
+            elif sound_ready and audio_lead_s == 0:
+                self.start_prepared_sound()
 
             t0 = time.time()
-            # Negative audio_lead_s: schedule sound to fire mid-loop,
-            # |audio_lead_s| seconds after t0. We hold a reference to
-            # the background task so the finally block can cancel it
-            # if the motion loop exits before the sleep elapses (short
-            # move + big negative lead would otherwise leak a task that
-            # plays audio after the move has ended).
+            # Negative audio_lead_s: start the (already prerolled) sound
+            # mid-loop, |audio_lead_s| seconds after t0. We hold a reference
+            # to the background task so the finally block can cancel it if the
+            # motion loop exits before the sleep elapses (short move + big
+            # negative lead would otherwise leak a task that plays audio after
+            # the move has ended).
             delayed_sound_task: Optional["asyncio.Task[None]"] = None
-            if move.sound_path is not None and audio_lead_s < 0:
-                sound_path_str = str(move.sound_path)
+            if sound_ready and audio_lead_s < 0:
 
                 async def _delayed_sound() -> None:
                     try:
@@ -867,7 +886,7 @@ class Backend:
                         return
                     if cancel_token is not None and cancel_token.cancelled:
                         return
-                    self.play_sound(sound_path_str)
+                    self.start_prepared_sound()
 
                 delayed_sound_task = asyncio.create_task(_delayed_sound())
             try:
@@ -894,9 +913,15 @@ class Backend:
                 # Don't leak the delayed-sound task past the loop. Two
                 # cases this matters: the move duration was shorter
                 # than |audio_lead_s|, or the loop was cancelled before
-                # the sleep elapsed.
+                # the sleep elapsed. Because the sound is prerolled (playbin
+                # sitting in PAUSED with the audio sink claimed), if the
+                # scheduled start never fired we must also release it via
+                # stop_sound, otherwise the device stays held until the next
+                # play. The task runs on this same loop, so "not done()" here
+                # reliably means the sound was never started.
                 if delayed_sound_task is not None and not delayed_sound_task.done():
                     delayed_sound_task.cancel()
+                    self.stop_sound()
         finally:
             self._end_move()
 
@@ -1144,6 +1169,33 @@ class Backend:
         """
         if self._media_server is not None:
             self._media_server.play_sound(sound_file)
+
+    def prepare_sound(self, sound_file: str) -> bool:
+        """Preroll a sound for a warmup-free start_prepared_sound().
+
+        Delegates to the media server.  Returns False if the server is not
+        available (no_media mode) or the preroll failed, in which case the
+        caller should fall back to play_sound.
+
+        Args:
+            sound_file (str): The name of the sound file to prepare.
+
+        Returns:
+            bool: True when the sound is prerolled and ready to start.
+
+        """
+        if self._media_server is None:
+            return False
+        return self._media_server.prepare_sound(sound_file)
+
+    def start_prepared_sound(self) -> None:
+        """Start a sound previously prerolled via prepare_sound().
+
+        Delegates to the media server.  No-op if the server is not
+        available (no_media mode) or nothing was prepared.
+        """
+        if self._media_server is not None:
+            self._media_server.start_prepared_sound()
 
     def stop_sound(self) -> None:
         """Stop the currently playing sound file.

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -1258,16 +1258,16 @@ class GstMediaServer:
         self._logger.debug("Stopping WebRTC")
         self._pipeline_sender.set_state(Gst.State.NULL)
 
-    def play_sound(self, sound_file: str) -> None:
-        """Play a sound file on the robot's speaker.
+    # Max time we let the playbin sit in PAUSED waiting for preroll before
+    # giving up and falling back to a plain (warm-up-latency) play.
+    _PREROLL_TIMEOUT_NS = 2 * Gst.SECOND
 
-        Uses GStreamer's playbin element with a platform-aware audio sink.
-        This is used for daemon-side sounds (wake-up, sleep, etc.).
+    def _make_playbin_for(self, sound_file: str) -> Optional[Gst.Element]:
+        """Resolve ``sound_file`` and build a fresh playbin + audio sink.
 
-        Args:
-            sound_file: Path to the sound file to play. If the file is not
-                found at the given path, it is looked up in the assets directory.
-
+        Returns the playbin in NULL state (uri + audio-sink set) or None on
+        failure. Any previously held playbin is torn down first. Shared by
+        :meth:`prepare_sound` and :meth:`play_sound`.
         """
         if not os.path.exists(sound_file):
             file_path = f"{ASSETS_ROOT_PATH}/{sound_file}"
@@ -1276,17 +1276,18 @@ class GstMediaServer:
                     f"Sound file {sound_file} not found in assets directory "
                     "or given path."
                 )
-                return
+                return None
         else:
             file_path = sound_file
 
         if self._playbin is not None:
             self._playbin.set_state(Gst.State.NULL)
+            self._playbin = None
 
         playbin = Gst.ElementFactory.make("playbin", "player")
         if not playbin:
             self._logger.error("Failed to create playbin element")
-            return
+            return None
 
         # Build file URI
         if os.name == "nt":
@@ -1300,13 +1301,73 @@ class GstMediaServer:
 
         playbin.set_property("uri", uri)
         playbin.set_property("audio-sink", self._build_audiosink_tee_bin())
+        return playbin
+
+    def prepare_sound(self, sound_file: str) -> bool:
+        """Preroll a sound for a warmup-free :meth:`start_prepared_sound`.
+
+        Builds the playbin and drives it to PAUSED, blocking until the async
+        state change (sink open + decode + ring-buffer fill) completes. This
+        is the slow part of ``set_state(PLAYING)``; doing it ahead of time
+        means the subsequent flip to PLAYING makes the first sample hit the
+        speaker essentially immediately.
+
+        Args:
+            sound_file: Path to the sound file, or a name resolved against
+                the assets directory.
+
+        Returns:
+            True when the pipeline is prerolled and ready, False on any
+            failure (caller should fall back to :meth:`play_sound`).
+
+        """
+        playbin = self._make_playbin_for(sound_file)
+        if playbin is None:
+            return False
+
+        self._playbin = playbin
+        playbin.set_state(Gst.State.PAUSED)
+        ret, _state, _pending = playbin.get_state(self._PREROLL_TIMEOUT_NS)
+        if ret in (Gst.StateChangeReturn.SUCCESS, Gst.StateChangeReturn.NO_PREROLL):
+            return True
+
+        self._logger.warning(
+            "playbin preroll for %s did not complete (state change: %s)",
+            sound_file,
+            ret,
+        )
+        playbin.set_state(Gst.State.NULL)
+        self._playbin = None
+        return False
+
+    def start_prepared_sound(self) -> None:
+        """Start a sound previously prerolled via :meth:`prepare_sound`.
+
+        No-op if nothing has been prepared. The first sample hits the
+        speaker essentially immediately since preroll already happened.
+        """
+        if self._playbin is None:
+            return
 
         if self._head_wobbler is not None:
             self._head_wobbler.reset()
             self._head_wobbler.start()
 
-        self._playbin = playbin
-        playbin.set_state(Gst.State.PLAYING)
+        self._playbin.set_state(Gst.State.PLAYING)
+
+    def play_sound(self, sound_file: str) -> None:
+        """Play a sound file on the robot's speaker.
+
+        Uses GStreamer's playbin element with a platform-aware audio sink.
+        This is used for daemon-side sounds (wake-up, sleep, etc.).
+
+        Args:
+            sound_file: Path to the sound file to play. If the file is not
+                found at the given path, it is looked up in the assets directory.
+
+        """
+        if self.prepare_sound(sound_file):
+            self.start_prepared_sound()
 
     def stop_sound(self) -> None:
         """Stop the currently playing sound file.


### PR DESCRIPTION
## Summary

Preroll move-paired sounds so audio starts deterministically (~1 ms) instead of a variable 15-50 ms after the motion clock. `audio_lead_ms = 0` then truly means "audio and motion start together".

## Problem

Every `play_sound()` rebuilds its audio player from scratch - detect the format, spin up the decoder, open the ALSA device. That takes 15-50 ms and is never the same twice (spikes past 100 ms under CPU load), while the motion starts instantly: the gesture always leads the sound by an amount no fixed `audio_lead_ms` can cancel.

## Solution

Build the player **before** the go signal:

- `prepare_sound()` prerolls the playbin to `PAUSED` (the slow part: sink open + decode + buffer fill)
- `start_prepared_sound()` flips it to `PLAYING` at t0 (~1 ms, deterministic, load-independent)
- `Backend._play_move` prerolls off the event loop (executor) before the motion clock starts, then starts the prepared sound at the requested lead

## Benchmarks

On the robot (wireless CM4, daemon running, `wake_up.wav`, 20 runs - time from the `PLAYING` request to the first buffer reaching the daemon's own ALSA sink):

| start path | median | max | stdev |
|---|---|---|---|
| cold - today's `play_sound()` at t0 | 16.1 ms | 46.5 ms | 7.3 ms |
| primed - this PR, preroll before t0 | 0.9 ms | 1.4 ms | 0.2 ms |

With 3 CPU cores saturated, cold median rises to ~48 ms with spikes >100 ms (measured with the fuller probe in `scripts/measure_playbin_warmup.py`, which rebuilds the daemon's complete tee sink bin); primed stays at 1-4 ms regardless of load.

## How to reproduce

Standalone script, no reachy_mini import: `python3 warmup_minimal.py /path/to/wake_up.wav 20`

<details>
<summary><code>warmup_minimal.py</code></summary>

```python
#!/usr/bin/env python3
"""cold = NULL->PLAYING at t0 (today). primed = preroll to PAUSED before t0,
then PAUSED->PLAYING at t0 (this PR). Latency = t0 until the first buffer
reaches the sink pad of the exact sink the daemon uses."""
import statistics, sys, threading, time
import gi
gi.require_version("Gst", "1.0")
from gi.repository import Gst

Gst.init(None)
FILE = sys.argv[1]
RUNS = int(sys.argv[2]) if len(sys.argv) > 2 else 15

def make_playbin():
    sink = Gst.ElementFactory.make("alsasink")
    sink.set_property("device", "reachymini_audio_sink")
    if sink.set_state(Gst.State.READY) == Gst.StateChangeReturn.FAILURE:
        sink.set_state(Gst.State.NULL)
        sink = Gst.ElementFactory.make("autoaudiosink")  # non-robot fallback
    else:
        sink.set_state(Gst.State.NULL)
    p = Gst.ElementFactory.make("playbin")
    p.set_property("uri", Gst.filename_to_uri(FILE))
    p.set_property("audio-sink", sink)
    return p, sink

def first_buffer_latency(p, sink, primed):
    got, stamp = threading.Event(), []
    def probe(pad, info):
        stamp.append(time.monotonic()); got.set()
        return Gst.PadProbeReturn.REMOVE
    if primed:
        p.set_state(Gst.State.PAUSED)
        p.get_state(Gst.CLOCK_TIME_NONE)      # preroll done, BEFORE t0
    pad = (sink.get_static_pad("sink")
           or sink.iterate_sinks().next()[1].get_static_pad("sink"))
    pad.add_probe(Gst.PadProbeType.BUFFER, probe)
    t0 = time.monotonic()
    p.set_state(Gst.State.PLAYING)
    got.wait(5); time.sleep(0.1); p.set_state(Gst.State.NULL)
    return (stamp[0] - t0) * 1000 if stamp else float("nan")

cold, primed = [], []
for _ in range(RUNS):
    p, s = make_playbin(); cold.append(first_buffer_latency(p, s, False))
    p, s = make_playbin(); primed.append(first_buffer_latency(p, s, True))

for name, xs in (("cold", cold), ("primed", primed)):
    print(f"{name:7s} n={len(xs)}  median={statistics.median(xs):6.1f} ms  "
          f"max={max(xs):6.1f} ms  stdev={statistics.stdev(xs):5.1f} ms")
```

</details>

## Limitations / open questions (why this is a draft)

- [ ] End-to-end validation on a patched daemon is still to be done (motion start vs first audible sample, e.g. the antenna-collision mic test). The benchmarks above validate the GStreamer mechanism in isolation, not the full `play_move` path. Motor chain latency is out of scope.
- [ ] The executor treatment done for `_play_move` is also needed for the synchronous `play_sound()` callers (`wake_up`/`goto_sleep`)
- [ ] The preroll-failure fallback just re-runs a preroll; restore a true legacy path or drop it
- [ ] The prepared playbin is single-slot: a concurrent `play_sound` during the lead window swaps it under the move

## Related

- #1133 introduced `audio_lead_ms` as an empirical knob; this PR gives it back a single meaning (artistic offset)
- The head wobbler solved the same class of problem in April by trusting GStreamer's clock instead of latency constants (cb328c59861033f0498e00a7dec7ba58f8443b5e)
- The JS SDK hardcodes `audioLeadMs = -100` (`ts/lib/reachy-mini.ts:1645`) - that constant should not ship in this week's frozen SDK release, regardless of this PR's fate
- #1330 fixes the playbin's end of life (teardown on EOS/error); this PR fixes its start. Complementary; expect a `media_server.py` conflict for whichever lands second

Made with [Cursor](https://cursor.com)
