### PR TITLE
feat(daemon): reset to sleep from any inherited motor state

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -1194,6 +1194,11 @@ class Backend:
     # a (velocity-eased) tick short of the commanded endpoint.
     INIT_TARGET_ATOL: float = 1e-2
 
+    # Radius (magic units) around SLEEP_HEAD_POSE within which the robot counts
+    # as already down. Shared by goto_sleep's "no travel needed" branch and
+    # is_at_sleep_pose() so the trajectory and the skip can't drift apart.
+    SLEEP_POSE_MAGIC_ATOL: float = 10.0
+
     def is_awake_at_init_pose(self) -> bool:
         """Motors on and init is the pose the controller is actively holding.
 
@@ -1220,6 +1225,20 @@ class Backend:
                 )
             )
         )
+
+    def is_at_sleep_pose(self) -> bool:
+        """Head physically resting within the sleep-pose radius.
+
+        Reads the measured pose, not the commanded target: a limp robot has no
+        meaningful target, and the whole point is to tell a robot parked down by
+        a clean leave sequence from one left limp mid-pose by a crashed app.
+        """
+        if self.current_head_pose is None:
+            return False
+        _, _, dist_to_sleep_pose = distance_between_poses(
+            self.get_current_head_pose(), self.SLEEP_HEAD_POSE
+        )
+        return bool(dist_to_sleep_pose <= self.SLEEP_POSE_MAGIC_ATOL)
 
     async def wake_up(self, *, force: bool = False) -> None:
         """Wake up the robot - go to the initial head position and play the wake up emote and sound.
@@ -1270,13 +1289,7 @@ class Backend:
             - If we are far from the initial position, we move there first.
             - If we are close to the initial position, we move directly to the sleep position.
         """
-        # Stop head wobbling so leftover speech offsets don't fight the
-        # sleep pose during the goto. Head tracking is also a primary
-        # aim source, so it must be disabled before moving to sleep.
-        if self._media_server is not None:
-            self._media_server.disable_wobbling()
-        self.set_speech_offsets((0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
-        self.disable_head_tracking()
+        self._quiesce_aim_sources()
 
         # Magic units
         _, _, dist_to_sleep_pose = distance_between_poses(
@@ -1288,7 +1301,7 @@ class Backend:
         sleep_time = 2.0
 
         # Thresholds found empirically.
-        if dist_to_sleep_pose > 10:
+        if dist_to_sleep_pose > self.SLEEP_POSE_MAGIC_ATOL:
             if dist_to_init_pose > 30:
                 # Move to the initial position
                 await self.goto_target(
@@ -1316,6 +1329,57 @@ class Backend:
 
         # Rest limp at the sleep pose, like a fresh boot.
         self.set_motor_control_mode(MotorControlMode.Disabled)
+
+    def _quiesce_aim_sources(self) -> None:
+        """Silence every secondary head-aim source before a scripted move.
+
+        Wobbling and leftover speech offsets are added on top of the commanded
+        target, and head tracking is a primary aim source in its own right, so
+        any of them left running would fight the trajectory.
+        """
+        if self._media_server is not None:
+            self._media_server.disable_wobbling()
+        self.set_speech_offsets((0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+        self.disable_head_tracking()
+
+    async def reset_to_sleep(self) -> None:
+        """Put the robot to sleep from ANY motor state the last app left behind.
+
+        ``goto_sleep()`` assumes it inherits a robot under position control.
+        When that assumption is broken it degrades silently instead of failing:
+        under gravity compensation the control loop ignores position targets
+        outright, so the whole trajectory is written into the void and the final
+        torque cut drops the head from wherever it happened to be. Motors left
+        limp - globally or per-motor via ``set_torque(ids=...)`` - are just as
+        bad, and none of these paths are hypothetical: a crashed app, a killed
+        tab or a dropped Wi-Fi link all skip the client's own cleanup.
+
+        So re-establish the assumption first, then reuse the normal sequence:
+        torque on (``enable_motors`` pins every target to the measured pose, so
+        nothing snaps), lift to the init pose, then ``goto_sleep()``, which ends
+        limp at the sleep pose. The lift is what makes the result predictable -
+        it collapses every possible inherited pose into the one starting point
+        the sleep trajectory was tuned for.
+        """
+        # Ordered: quiesce first so tracking can't re-aim the head between the
+        # torque coming back and the lift starting.
+        self._quiesce_aim_sources()
+        self.set_motor_control_mode(MotorControlMode.Enabled)
+
+        _, _, magic_distance = distance_between_poses(
+            self.get_current_head_pose(), self.INIT_HEAD_POSE
+        )
+        await self.goto_target(
+            self.INIT_HEAD_POSE,
+            antennas=self.INIT_ANTENNAS_JOINT_POSITIONS,
+            # Same magic-unit scaling as wake_up, floored so a head already at
+            # init still gets a real (if brief) move rather than a zero-length
+            # one, and capped so a fully drooped head doesn't crawl back up.
+            duration=float(np.clip(magic_distance * 20 / 1000, 0.3, 1.5)),
+        )
+        await asyncio.sleep(0.2)
+
+        await self.goto_sleep()
 
     # Motor control modes
     @abstractmethod
@@ -2864,15 +2928,26 @@ class Backend:
             task.cancel()
         self._idle_reset_task = None
 
+    def _already_idle(self) -> bool:
+        """Nothing left to do: the robot is limp AND physically at the sleep pose.
+
+        Both halves matter. A well-behaved client (e.g. the mobile app, which
+        sleeps then disables on leave) satisfies them and must not get a
+        redundant trajectory + sound. Limp *anywhere else* is the crashed-app
+        signature - torque cut mid-pose, head drooped - and does need the reset,
+        which is why the motor mode alone is not a sufficient test.
+        """
+        return (
+            self.get_motor_control_mode() == MotorControlMode.Disabled
+            and self.is_at_sleep_pose()
+        )
+
     def _maybe_start_idle_reset(self, grace_s: float) -> None:
-        """Kick off a goto_sleep if the robot is still awake. Runs on the loop."""
+        """Kick off a sleep reset if the robot isn't already idle. Runs on the loop."""
         try:
             if not self.ready.is_set() or self.is_shutting_down:
                 return
-            # Already limp / asleep: a well-behaved client (e.g. the mobile app,
-            # which sleeps + disables on leave) leaves nothing to do, so we skip
-            # the redundant trajectory + sound.
-            if self.get_motor_control_mode() == MotorControlMode.Disabled:
+            if self._already_idle():
                 return
             self._cancel_idle_reset()
             self._idle_reset_task = asyncio.create_task(self._async_idle_reset(grace_s))
@@ -2885,10 +2960,12 @@ class Backend:
         Starts with a debounce (``grace_s``): a fast reconnect or a local app
         grabbing the robot cancels the task during that window, so no motion
         happens at all on transient drops. Only if the slot stays free past the
-        grace period do we actually goto_sleep.
+        grace period do we actually reset.
 
-        Mirrors the reference leave behaviour clients already run by hand
-        (gotoSleep -> motors off). ``goto_sleep()`` finishes with
+        Goes through ``reset_to_sleep()`` rather than ``goto_sleep()`` directly:
+        the client that just vanished may have left the motors limp or in
+        gravity compensation, and a bare ``goto_sleep()`` degrades silently in
+        both cases. ``reset_to_sleep()`` finishes with
         ``set_motor_control_mode(Disabled)``, which also clears
         ``gravity_compensation_mode`` - so the next session's ``ensureAwake()``
         correctly triggers a fresh wake.
@@ -2900,15 +2977,15 @@ class Backend:
             # held the slot). Re-check before committing to the trajectory.
             if self.is_shutting_down:
                 return
-            if self.get_motor_control_mode() == MotorControlMode.Disabled:
+            if self._already_idle():
                 return
-            await self.goto_sleep()
+            await self.reset_to_sleep()
         except asyncio.CancelledError:
             # A new session (or local app) grabbed the robot before/mid-reset:
             # let it take over without noise.
             raise
         except Exception:
-            self.logger.warning("Idle reset goto_sleep failed", exc_info=True)
+            self.logger.warning("Idle reset to sleep failed", exc_info=True)
         finally:
             # Only clear the handle if it still points at *this* task: a
             # concurrent _cancel_idle_reset()+reschedule may have already

--- a/src/reachy_mini/daemon/backend/robot/backend.py
+++ b/src/reachy_mini/daemon/backend/robot/backend.py
@@ -92,6 +92,12 @@ class RobotBackend(Backend):
 
         self.motor_control_mode = self._infer_control_mode()
         self._torque_enabled = self.motor_control_mode != MotorControlMode.Disabled
+        # set_motor_torque_ids() drives the controller under the global mode's
+        # back, so afterwards `motor_control_mode` describes an intent the
+        # hardware no longer matches. This flag records that divergence so the
+        # next set_motor_control_mode() does the real work instead of
+        # short-circuiting on an equal-looking mode.
+        self._partial_torque_override = False
         self.logger.info(f"Motor control mode: {self.motor_control_mode}")
         self.last_alive: float | None = None
 
@@ -601,9 +607,13 @@ class RobotBackend(Backend):
 
     def set_motor_control_mode(self, mode: MotorControlMode) -> None:
         """Set the motor control mode."""
-        # Check if the mode is already set
-        if mode == self.motor_control_mode:
+        # Check if the mode is already set. A pending per-motor override means
+        # the stored mode no longer describes the hardware, so re-apply it even
+        # when it looks unchanged - that re-torques the motors an app detorqued
+        # individually.
+        if mode == self.motor_control_mode and not self._partial_torque_override:
             return
+        self._partial_torque_override = False
 
         if mode == MotorControlMode.Enabled:
             if self.motor_control_mode == MotorControlMode.GravityCompensation:
@@ -651,6 +661,10 @@ class RobotBackend(Backend):
             self.c.enable_torque_on_ids(ids_int)
         else:
             self.c.disable_torque_on_ids(ids_int)
+
+        # Either direction leaves a subset in a state the global mode doesn't
+        # know about, so both must force the next mode set to re-apply.
+        self._partial_torque_override = True
 
     def _infer_control_mode(self) -> MotorControlMode:
         assert self.c is not None, "Motor controller not initialized or already closed."

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -557,9 +557,11 @@ class Daemon:
             if goto_sleep_on_stop:
                 try:
                     self.logger.info("Putting Reachy Mini to sleep...")
-                    self.backend.set_motor_control_mode(MotorControlMode.Enabled)
-                    await self.backend.goto_sleep()
-                    self.backend.set_motor_control_mode(MotorControlMode.Disabled)
+                    # Whatever the last app left behind (gravity compensation,
+                    # limp motors, a per-motor torque cut), reset_to_sleep
+                    # re-establishes position control before moving and ends
+                    # limp at the sleep pose - so no explicit disable here.
+                    await self.backend.reset_to_sleep()
                 except Exception as e:
                     self.logger.error(f"Error while putting Reachy Mini to sleep: {e}")
                     self._status.state = DaemonState.ERROR

--- a/tests/unit_tests/test_backend_idle_reset.py
+++ b/tests/unit_tests/test_backend_idle_reset.py
@@ -23,27 +23,32 @@ GRACE_S = 0.02
 def _fake_backend(
     *,
     motor_mode: MotorControlMode = MotorControlMode.Enabled,
+    at_sleep_pose: bool = False,
     shutting_down: bool = False,
 ) -> SimpleNamespace:
-    return SimpleNamespace(
+    fake = SimpleNamespace(
         IDLE_RESET_DEBOUNCE_S=GRACE_S,
         IDLE_RESET_HANDOFF_GRACE_S=GRACE_S * 10,
         is_shutting_down=shutting_down,
         get_motor_control_mode=lambda: motor_mode,
-        goto_sleep=AsyncMock(),
+        is_at_sleep_pose=lambda: at_sleep_pose,
+        reset_to_sleep=AsyncMock(),
         logger=SimpleNamespace(warning=lambda *a, **k: None),
         _idle_reset_task=None,
     )
+    # Bind the real predicate so these tests exercise it, not a stub.
+    fake._already_idle = lambda: Backend._already_idle(fake)
+    return fake
 
 
 @pytest.mark.asyncio
 async def test_idle_reset_sleeps_after_debounce() -> None:
-    """When the slot stays free past the grace period, goto_sleep runs."""
+    """When the slot stays free past the grace period, the reset runs."""
     fake = _fake_backend()
     task = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))
     fake._idle_reset_task = task
     await task
-    fake.goto_sleep.assert_awaited_once()
+    fake.reset_to_sleep.assert_awaited_once()
     assert fake._idle_reset_task is None
 
 
@@ -57,27 +62,51 @@ async def test_cancel_during_debounce_skips_motion() -> None:
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
-    fake.goto_sleep.assert_not_awaited()
+    fake.reset_to_sleep.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_idle_reset_skips_when_already_disabled() -> None:
-    """Re-check after the grace period: skip goto_sleep if already limp."""
-    fake = _fake_backend(motor_mode=MotorControlMode.Disabled)
+async def test_idle_reset_skips_when_limp_at_the_sleep_pose() -> None:
+    """Nothing to do: a clean leave sequence already left the robot down."""
+    fake = _fake_backend(motor_mode=MotorControlMode.Disabled, at_sleep_pose=True)
     task = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))
     fake._idle_reset_task = task
     await task
-    fake.goto_sleep.assert_not_awaited()
+    fake.reset_to_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_idle_reset_runs_when_limp_away_from_the_sleep_pose() -> None:
+    """The crashed-app signature: torque cut mid-pose, head left drooping.
+
+    Regression guard for the motor-mode-only skip this replaced, which read
+    "limp" as "already asleep" and left the robot hanging wherever it died.
+    """
+    fake = _fake_backend(motor_mode=MotorControlMode.Disabled, at_sleep_pose=False)
+    task = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))
+    fake._idle_reset_task = task
+    await task
+    fake.reset_to_sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_idle_reset_runs_in_gravity_compensation() -> None:
+    """Gravity compensation is awake, however limp it feels to the hand."""
+    fake = _fake_backend(motor_mode=MotorControlMode.GravityCompensation)
+    task = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))
+    fake._idle_reset_task = task
+    await task
+    fake.reset_to_sleep.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_idle_reset_skips_when_shutting_down() -> None:
-    """Re-check after the grace period: skip goto_sleep if shutdown started."""
+    """Re-check after the grace period: skip the reset if shutdown started."""
     fake = _fake_backend(shutting_down=True)
     task = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))
     fake._idle_reset_task = task
     await task
-    fake.goto_sleep.assert_not_awaited()
+    fake.reset_to_sleep.assert_not_awaited()
 
 
 def test_handoff_release_gets_the_long_grace() -> None:
@@ -150,7 +179,7 @@ async def test_remote_acquire_cancels_pending_handoff_grace_reset() -> None:
 
     # Wait well past the handoff grace: the cancelled reset must never fire.
     await asyncio.sleep(fake.IDLE_RESET_HANDOFF_GRACE_S * 1.5)
-    fake.goto_sleep.assert_not_awaited()
+    fake.reset_to_sleep.assert_not_awaited()
     assert fake._idle_reset_task is None
 
 
@@ -169,7 +198,7 @@ async def test_handoff_grace_reset_fires_when_no_successor_arrives() -> None:
     await asyncio.sleep(0)
 
     await asyncio.sleep(fake.IDLE_RESET_HANDOFF_GRACE_S * 1.5)
-    fake.goto_sleep.assert_awaited_once()
+    fake.reset_to_sleep.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -178,7 +207,7 @@ async def test_finally_does_not_clobber_newer_task() -> None:
 
     Regression guard: without the ``is current_task()`` check, the old task's
     ``finally`` would blindly null ``_idle_reset_task``, so a later
-    ``_cancel_idle_reset`` would miss the newer in-flight goto_sleep.
+    ``_cancel_idle_reset`` would miss the newer in-flight reset.
     """
     fake = _fake_backend()
     task_a = asyncio.ensure_future(Backend._async_idle_reset(fake, GRACE_S))

--- a/tests/unit_tests/test_backend_reset_to_sleep.py
+++ b/tests/unit_tests/test_backend_reset_to_sleep.py
@@ -1,0 +1,141 @@
+"""Backend.reset_to_sleep: sleep the robot from any inherited motor state.
+
+``goto_sleep`` assumes position control. When the last app broke that
+assumption - gravity compensation, global torque cut, or a per-motor
+``set_torque(ids=...)`` - it degrades silently: the control loop ignores the
+position targets, so the trajectory is written into the void and the closing
+torque cut drops the head from wherever it was. ``reset_to_sleep`` re-torques
+first, lifts to init, and only then sleeps.
+
+Same lightweight-fake approach as ``test_backend_idle_reset``: the method only
+touches a handful of ``self`` attributes, so it is exercised unbound.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+
+from reachy_mini.daemon.backend.abstract import Backend
+from reachy_mini.io.protocol import MotorControlMode
+
+
+def _fake_backend(*, head_pose: np.ndarray | None = None) -> SimpleNamespace:
+    """Build a backend whose motor + motion primitives record their call order."""
+    calls: list[str] = []
+    if head_pose is None:
+        head_pose = Backend.SLEEP_HEAD_POSE.copy()
+
+    fake = SimpleNamespace(
+        INIT_HEAD_POSE=Backend.INIT_HEAD_POSE,
+        INIT_ANTENNAS_JOINT_POSITIONS=Backend.INIT_ANTENNAS_JOINT_POSITIONS,
+        SLEEP_HEAD_POSE=Backend.SLEEP_HEAD_POSE,
+        SLEEP_POSE_MAGIC_ATOL=Backend.SLEEP_POSE_MAGIC_ATOL,
+        current_head_pose=head_pose,
+        get_current_head_pose=lambda: head_pose,
+        calls=calls,
+    )
+    fake._quiesce_aim_sources = MagicMock(side_effect=lambda: calls.append("quiesce"))
+    fake.set_motor_control_mode = MagicMock(
+        side_effect=lambda mode: calls.append(f"mode:{mode.value}")
+    )
+    fake.goto_target = AsyncMock(side_effect=lambda *a, **kw: calls.append("goto"))
+    fake.goto_sleep = AsyncMock(side_effect=lambda: calls.append("sleep"))
+    return fake
+
+
+def _drooped_pose() -> np.ndarray:
+    """Build a head pose hanging well away from both init and sleep."""
+    pose = Backend.INIT_HEAD_POSE.copy()
+    pose[2, 3] -= 0.03
+    pose[0, 3] += 0.02
+    return pose
+
+
+def _far_pose() -> np.ndarray:
+    """Build a head pose far enough that an unclamped duration would overshoot."""
+    pose = Backend.INIT_HEAD_POSE.copy()
+    pose[0, 3] += 0.2
+    return pose
+
+
+@pytest.mark.asyncio
+async def test_torque_is_restored_before_any_motion() -> None:
+    """The ordering that makes the whole thing work, locked in.
+
+    Enabling after the goto would mean commanding a limp robot; quiescing
+    after the enable would let head tracking re-aim between the two.
+    """
+    fake = _fake_backend(head_pose=_drooped_pose())
+    await Backend.reset_to_sleep(fake)
+    assert fake.calls == [
+        "quiesce",
+        f"mode:{MotorControlMode.Enabled.value}",
+        "goto",
+        "sleep",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lift_targets_the_init_pose() -> None:
+    """The lift goes to init (head AND antennas), not straight to sleep.
+
+    Collapsing every inherited pose into init is what makes the following
+    sleep trajectory predictable, since that is the start it was tuned for.
+    """
+    fake = _fake_backend(head_pose=_drooped_pose())
+    await Backend.reset_to_sleep(fake)
+
+    args, kwargs = fake.goto_target.call_args
+    assert np.allclose(args[0], Backend.INIT_HEAD_POSE)
+    assert np.allclose(kwargs["antennas"], Backend.INIT_ANTENNAS_JOINT_POSITIONS)
+
+
+@pytest.mark.asyncio
+async def test_lift_duration_stays_within_bounds() -> None:
+    """Never zero-length (silent no-op) and never a crawl, whatever the distance."""
+    for pose in (Backend.INIT_HEAD_POSE.copy(), _drooped_pose(), _far_pose()):
+        fake = _fake_backend(head_pose=pose)
+        await Backend.reset_to_sleep(fake)
+        duration = fake.goto_target.call_args.kwargs["duration"]
+        assert 0.3 <= duration <= 1.5
+
+
+@pytest.mark.asyncio
+async def test_sleep_still_runs_when_already_near_init() -> None:
+    """A robot already at init must still be slept, not just re-torqued."""
+    fake = _fake_backend(head_pose=Backend.INIT_HEAD_POSE.copy())
+    await Backend.reset_to_sleep(fake)
+    fake.goto_sleep.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# is_at_sleep_pose: the predicate the idle reset skips on
+# ---------------------------------------------------------------------------
+
+
+def _sleep_pose_backend(head_pose: np.ndarray | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        SLEEP_HEAD_POSE=Backend.SLEEP_HEAD_POSE,
+        SLEEP_POSE_MAGIC_ATOL=Backend.SLEEP_POSE_MAGIC_ATOL,
+        current_head_pose=head_pose,
+        get_current_head_pose=lambda: head_pose,
+    )
+
+
+def test_is_at_sleep_pose_true_at_the_sleep_pose() -> None:
+    """The pose the sleep trajectory ends on must read as asleep."""
+    assert Backend.is_at_sleep_pose(_sleep_pose_backend(Backend.SLEEP_HEAD_POSE.copy()))
+
+
+def test_is_at_sleep_pose_false_at_init() -> None:
+    """Init is the canonical "awake" pose - it must never read as asleep."""
+    assert not Backend.is_at_sleep_pose(
+        _sleep_pose_backend(Backend.INIT_HEAD_POSE.copy())
+    )
+
+
+def test_is_at_sleep_pose_false_before_first_kinematics_update() -> None:
+    """No measured pose yet: claim nothing, so the caller does the work."""
+    assert not Backend.is_at_sleep_pose(_sleep_pose_backend(None))


### PR DESCRIPTION
## Problem

`goto_sleep()` assumes it inherits a robot under position control. A crashed app, a killed tab or a dropped Wi-Fi link skip the client's own cleanup and can leave the robot in gravity compensation, globally limp, or with a per-motor torque cut. In all three cases `goto_sleep()` degrades silently: the control loop ignores position targets, the sleep trajectory is written into the void, and the final torque cut drops the head from wherever it happened to be.

Follow-up to #1294 / #1311.

## What changes

- **`reset_to_sleep()`**: re-establish the assumption first, then reuse the normal sequence. Quiesce aim sources (wobbling, speech offsets, head tracking), torque on (`enable_motors` pins every target to the measured pose, so nothing snaps), lift to the init pose - duration clamped to [0.3, 1.5] s so a fully drooped head never crawls back up and a head already at init still gets a real move - then `goto_sleep()`, ending limp at the sleep pose. Both the daemon's sleep path and the idle reset now go through it.
- **`_already_idle()`** replaces the motor-mode-only skip in the idle reset: motors disabled AND measured pose within the sleep radius. The radius (`SLEEP_POSE_MAGIC_ATOL`) is shared with `goto_sleep`'s "no travel needed" branch so the trajectory and the skip cannot drift apart. A robot left limp mid-pose by a crashed app is no longer mistaken for one parked down by a clean leave sequence.
- **Per-motor torque tracking** (`RobotBackend`): `set_motor_torque_ids()` records a `_partial_torque_override`, so the next `set_motor_control_mode()` re-applies the mode even when it looks unchanged instead of short-circuiting on a stale equal-looking value - that re-torques motors an app detorqued individually.

## Tests

- `test_backend_reset_to_sleep.py` (new): locks in the ordering that makes the whole thing work (quiesce -> enable -> lift -> sleep), the lift target and duration clamp, and the `is_at_sleep_pose` predicate (true at sleep pose, false at init, false before the first kinematics update).
- `test_backend_idle_reset.py` (updated): the idle reset now skips only when limp AND at the sleep pose; limp mid-pose triggers the reset.

17/17 unit tests pass locally.

Made with [Cursor](https://cursor.com)