### PR TITLE
fix(startup-check): log instead of print so boot results reach the log file

### DIFF
--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -834,7 +834,7 @@ def main() -> None:
 
     if args.wireless_version:
         # Check and fix ownership of /venvs directory
-        check_and_fix_venvs_ownership(custom_logger=logging.getLogger())
+        check_and_fix_venvs_ownership()
 
         # Check and update bluetooth service if needed
         check_and_update_bluetooth_service()

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -10,6 +10,7 @@ managing the robot's state.
 import argparse
 import asyncio
 import logging
+import sys
 import types
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -486,20 +487,41 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
     return app
 
 
-def run_app(args: Args) -> None:
-    """Run the FastAPI app with Uvicorn."""
-    # Configure logging to ensure all logs go to stderr (captured by systemd)
-    import sys
+def configure_root_logging(log_level: str, log_file: str | None = None) -> None:
+    """Install the daemon's log handlers on the root logger.
+
+    Call this before anything that logs, in particular before the wireless
+    startup checks: an unconfigured root logger sits at its WARNING default
+    with no handlers, so every INFO emitted before this point is discarded
+    and every WARNING falls back to logging.lastResort.
+
+    stderr is what systemd captures into the journal. A log file, when asked
+    for, is added alongside rather than instead.
+    """
+    formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
 
     root_logger = logging.getLogger()
-    root_logger.setLevel(args.log_level)
-
-    # Create handler that writes to stderr with immediate flush
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setLevel(args.log_level)
-    handler.setFormatter(logging.Formatter("%(name)s - %(levelname)s - %(message)s"))
+    root_logger.setLevel(log_level)
+    # Drop anything a library installed at import time, then own the config.
     root_logger.handlers.clear()
+
+    # Handler that writes to stderr with immediate flush
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(log_level)
+    handler.setFormatter(formatter)
     root_logger.addHandler(handler)
+
+    if log_file:
+        file_handler = logging.FileHandler(log_file, mode="a")
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+
+
+def run_app(args: Args) -> None:
+    """Run the FastAPI app with Uvicorn."""
+    # Handlers are installed by configure_root_logging() in main(), before the
+    # startup checks; this is only the handle used by the hooks below.
+    root_logger = logging.getLogger()
 
     # Surface a persisted rename so an operator isn't puzzled when the
     # advertised name differs from the --robot-name they passed.
@@ -824,13 +846,10 @@ def main() -> None:
     if persisted_robot_name:
         args.robot_name = persisted_robot_name
 
-    if args.log_file:
-        file_handler = logging.FileHandler(args.log_file, mode="a")
-        file_handler.setFormatter(
-            logging.Formatter("%(name)s - %(levelname)s - %(message)s")
-        )
-        logging.getLogger().addHandler(file_handler)
-        logging.getLogger().setLevel(args.log_level)
+    # Before the startup checks, not after: run_app() used to be the first
+    # thing to configure logging, which left everything logged here going to
+    # an unconfigured root logger (WARNING, no handlers) and silently dropped.
+    configure_root_logging(args.log_level, args.log_file)
 
     if args.wireless_version:
         # Check and fix ownership of /venvs directory

--- a/src/reachy_mini/utils/wireless_version/startup_check.py
+++ b/src/reachy_mini/utils/wireless_version/startup_check.py
@@ -14,14 +14,11 @@ logger = logging.getLogger(__name__)
 USER = "pollen"
 
 
-def check_and_fix_venvs_ownership(
-    venvs_path: str = "/venvs", custom_logger: logging.Logger | None = None
-) -> None:
+def check_and_fix_venvs_ownership(venvs_path: str = "/venvs") -> None:
     """For wireless units, check if files under venvs_path are owned by user pollen and fix if needed.
 
     Args:
         venvs_path: Path to the virtual environments directory (default: /venvs)
-        custom_logger: Optional logger to use instead of the module logger
 
     """
     import pwd
@@ -30,17 +27,17 @@ def check_and_fix_venvs_ownership(
         # Get pollen user's UID
         pollen_uid = pwd.getpwnam(USER).pw_uid
     except KeyError:
-        print(f"User '{USER}' does not exist on this system")
+        logger.error(f"User '{USER}' does not exist on this system")
         return
 
     venvs_dir = Path(venvs_path)
 
     if not venvs_dir.exists():
-        print(f"Directory {venvs_path} does not exist")
+        logger.error(f"Directory {venvs_path} does not exist")
         return
 
     if not venvs_dir.is_dir():
-        print(f"{venvs_path} exists but is not a directory")
+        logger.error(f"{venvs_path} exists but is not a directory")
         return
 
     # Check if any files are not owned by pollen
@@ -50,16 +47,16 @@ def check_and_fix_venvs_ownership(
             try:
                 if item.stat().st_uid != pollen_uid:
                     needs_fix = True
-                    print(f"Found file not owned by {USER}: {item}")
+                    logger.warning(f"Found file not owned by {USER}: {item}")
                     break
             except (PermissionError, OSError) as e:
-                print(f"Cannot check ownership of {item}: {e}")
+                logger.warning(f"Cannot check ownership of {item}: {e}")
     except (PermissionError, OSError) as e:
-        print(f"Cannot access {venvs_path}: {e}")
+        logger.error(f"Cannot access {venvs_path}: {e}")
         return
 
     if needs_fix:
-        print(f"Fixing ownership of {venvs_path} to {USER}:{USER}")
+        logger.info(f"Fixing ownership of {venvs_path} to {USER}:{USER}")
         try:
             # Run chown with sudo to fix ownership
             subprocess.run(
@@ -68,13 +65,13 @@ def check_and_fix_venvs_ownership(
                 capture_output=True,
                 text=True,
             )
-            print(f"Successfully fixed ownership of {venvs_path}")
+            logger.info(f"Successfully fixed ownership of {venvs_path}")
         except subprocess.CalledProcessError as e:
-            print(f"Failed to fix ownership: {e.stderr}")
+            logger.error(f"Failed to fix ownership: {e.stderr}")
         except Exception as e:
-            print(f"Unexpected error while fixing ownership: {e}")
+            logger.error(f"Unexpected error while fixing ownership: {e}")
     else:
-        print(f"All files under {venvs_path} are owned by {USER}")
+        logger.info(f"All files under {venvs_path} are owned by {USER}")
 
 
 def check_and_update_bluetooth_service() -> None:
@@ -103,7 +100,7 @@ def check_and_update_bluetooth_service() -> None:
     target_commands = Path("/bluetooth/commands")
 
     if not source.exists():
-        print(f"Source bluetooth service not found at {source}")
+        logger.warning(f"Source bluetooth service not found at {source}")
         return
 
     needs_update = False
@@ -111,20 +108,20 @@ def check_and_update_bluetooth_service() -> None:
 
     # Check if bluetooth_service.py needs update
     if not target.exists():
-        print(f"Bluetooth service not installed at {target}, copying...")
+        logger.info(f"Bluetooth service not installed at {target}, copying...")
         needs_update = True
     else:
         try:
             if not filecmp.cmp(str(source), str(target), shallow=False):
-                print("Bluetooth service has changed, updating...")
+                logger.info("Bluetooth service has changed, updating...")
                 needs_update = True
         except Exception as e:
-            print(f"Error comparing bluetooth service files: {e}")
+            logger.error(f"Error comparing bluetooth service files: {e}")
 
     # Check if commands folder needs update
     if source_commands.exists():
         if not target_commands.exists():
-            print("Commands folder not installed, copying...")
+            logger.info("Commands folder not installed, copying...")
             needs_commands_update = True
         else:
             # Compare each command file
@@ -142,22 +139,22 @@ def check_and_update_bluetooth_service() -> None:
                     break
 
     if not needs_update and not needs_commands_update:
-        print("Bluetooth service and commands are up to date")
+        logger.info("Bluetooth service and commands are up to date")
         return
 
     try:
         if needs_update:
-            print(f"Copying {source} to {target}")
+            logger.info(f"Copying {source} to {target}")
             subprocess.run(
                 ["sudo", "cp", str(source), str(target)],
                 check=True,
                 capture_output=True,
                 text=True,
             )
-            print("Successfully copied bluetooth service")
+            logger.info("Successfully copied bluetooth service")
 
         if needs_commands_update:
-            print(f"Syncing commands folder to {target_commands}")
+            logger.info(f"Syncing commands folder to {target_commands}")
             subprocess.run(
                 ["sudo", "mkdir", "-p", str(target_commands)],
                 check=True,
@@ -170,21 +167,21 @@ def check_and_update_bluetooth_service() -> None:
                 capture_output=True,
                 text=True,
             )
-            print("Successfully synced commands folder")
+            logger.info("Successfully synced commands folder")
 
         # Restart the bluetooth service
-        print("Restarting bluetooth service...")
+        logger.info("Restarting bluetooth service...")
         subprocess.run(
             ["sudo", "systemctl", "restart", "reachy-mini-bluetooth"],
             check=True,
             capture_output=True,
             text=True,
         )
-        print("Successfully restarted bluetooth service")
+        logger.info("Successfully restarted bluetooth service")
     except subprocess.CalledProcessError as e:
-        print(f"Failed to update bluetooth service: {e.stderr}")
+        logger.error(f"Failed to update bluetooth service: {e.stderr}")
     except Exception as e:
-        print(f"Unexpected error while updating bluetooth service: {e}")
+        logger.error(f"Unexpected error while updating bluetooth service: {e}")
 
 
 def check_and_update_wireless_launcher() -> None:
@@ -207,49 +204,49 @@ def check_and_update_wireless_launcher() -> None:
     target = Path("/etc/systemd/system/reachy-mini-daemon.service")
 
     if not source.exists():
-        print(f"Source service file not found at {source}")
+        logger.warning(f"Source service file not found at {source}")
         return
 
     # Check if target exists
     if not target.exists():
-        print(f"Wireless daemon service not installed at {target}")
+        logger.warning(f"Wireless daemon service not installed at {target}")
         return
 
     # Compare files
     try:
         if filecmp.cmp(str(source), str(target), shallow=False):
-            print("Wireless daemon service is up to date")
+            logger.info("Wireless daemon service is up to date")
             return
         else:
-            print("Wireless daemon service has changed, updating...")
+            logger.info("Wireless daemon service has changed, updating...")
     except Exception as e:
-        print(f"Error comparing service files: {e}")
+        logger.error(f"Error comparing service files: {e}")
         return
 
     # Update service file
     try:
-        print(f"Copying {source} to {target}")
+        logger.info(f"Copying {source} to {target}")
         subprocess.run(
             ["sudo", "cp", str(source), str(target)],
             check=True,
             capture_output=True,
             text=True,
         )
-        print("Successfully copied service file")
+        logger.info("Successfully copied service file")
 
         # Reload systemd daemon
-        print("Reloading systemd daemon...")
+        logger.info("Reloading systemd daemon...")
         subprocess.run(
             ["sudo", "systemctl", "daemon-reload"],
             check=True,
             capture_output=True,
             text=True,
         )
-        print("Successfully reloaded systemd")
+        logger.info("Successfully reloaded systemd")
     except subprocess.CalledProcessError as e:
-        print(f"Failed to update service: {e.stderr}")
+        logger.error(f"Failed to update service: {e.stderr}")
     except Exception as e:
-        print(f"Unexpected error while updating service: {e}")
+        logger.error(f"Unexpected error while updating service: {e}")
 
 
 def check_and_sync_apps_venv_sdk() -> None:
@@ -269,13 +266,13 @@ def check_and_sync_apps_venv_sdk() -> None:
     try:
         daemon_info = get_install_source("reachy_mini")
     except Exception as e:
-        print(f"Could not get daemon SDK info: {e}")
+        logger.error(f"Could not get daemon SDK info: {e}")
         return
 
     # Check apps_venv exists
     apps_venv_python = Path("/venvs/apps_venv/bin/python")
     if not apps_venv_python.exists():
-        print("apps_venv not found, skipping SDK sync")
+        logger.info("apps_venv not found, skipping SDK sync")
         return
 
     # Get apps_venv install info by reading metadata directly (avoid importing from apps_venv)
@@ -299,20 +296,20 @@ def check_and_sync_apps_venv_sdk() -> None:
             timeout=10,
         )
         if result.returncode != 0:
-            print(f"Could not get apps_venv SDK info: {result.stderr}")
+            logger.error(f"Could not get apps_venv SDK info: {result.stderr}")
             return
         apps_info = json.loads(result.stdout.strip())
     except subprocess.TimeoutExpired:
-        print("Timeout getting apps_venv SDK info")
+        logger.error("Timeout getting apps_venv SDK info")
         return
     except Exception as e:
-        print(f"Error getting apps_venv SDK info: {e}")
+        logger.error(f"Error getting apps_venv SDK info: {e}")
         return
 
-    print(
+    logger.info(
         f"Daemon: {daemon_info['version']} (source={daemon_info['source']}, ref={daemon_info.get('git_ref')})"
     )
-    print(
+    logger.info(
         f"Apps:   {apps_info['version']} (source={apps_info['source']}, ref={apps_info.get('git_ref')})"
     )
 
@@ -325,7 +322,7 @@ def check_and_sync_apps_venv_sdk() -> None:
         needs_sync = apps_info["version"] != daemon_info["version"]
 
     if not needs_sync:
-        print("Apps venv SDK is up to date")
+        logger.info("Apps venv SDK is up to date")
         return
 
     # Build install command
@@ -341,13 +338,13 @@ def check_and_sync_apps_venv_sdk() -> None:
     try:
         result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=300, env=resolved_env, cwd=Path.home())
         if result.returncode == 0:
-            print("Successfully synced apps_venv SDK")
+            logger.info("Successfully synced apps_venv SDK")
         else:
-            print(f"Failed to sync apps_venv SDK: {result.stderr}")
+            logger.error(f"Failed to sync apps_venv SDK: {result.stderr}")
     except subprocess.TimeoutExpired:
-        print("Timeout syncing apps_venv SDK")
+        logger.error("Timeout syncing apps_venv SDK")
     except Exception as e:
-        print(f"Error syncing apps_venv SDK: {e}")
+        logger.error(f"Error syncing apps_venv SDK: {e}")
 
 
 def check_and_fix_restore_venv() -> None:
@@ -360,7 +357,7 @@ def check_and_fix_restore_venv() -> None:
     restore_python = Path("/restore/venvs/mini_daemon/bin/python")
 
     if not restore_python.exists():
-        print("Restore venv not found, skipping")
+        logger.info("Restore venv not found, skipping")
         return
 
     # Check if editable install
@@ -372,14 +369,14 @@ def check_and_fix_restore_venv() -> None:
             timeout=30,
         )
     except subprocess.TimeoutExpired:
-        print("Timeout checking restore venv")
+        logger.error("Timeout checking restore venv")
         return
     except Exception as e:
-        print(f"Error checking restore venv: {e}")
+        logger.error(f"Error checking restore venv: {e}")
         return
 
     if "Editable project location" in result.stdout:
-        print("Legacy editable install detected in restore venv, reinstalling...")
+        logger.warning("Legacy editable install detected in restore venv, reinstalling...")
         try:
             subprocess.run(
                 [str(restore_python), "-m", "pip", "install", "reachy-mini==1.2.8"],
@@ -388,15 +385,15 @@ def check_and_fix_restore_venv() -> None:
                 text=True,
                 timeout=300,
             )
-            print("Successfully reinstalled reachy-mini in restore venv")
+            logger.info("Successfully reinstalled reachy-mini in restore venv")
         except subprocess.CalledProcessError as e:
-            print(f"Failed to reinstall in restore venv: {e.stderr}")
+            logger.error(f"Failed to reinstall in restore venv: {e.stderr}")
         except subprocess.TimeoutExpired:
-            print("Timeout reinstalling in restore venv")
+            logger.error("Timeout reinstalling in restore venv")
         except Exception as e:
-            print(f"Error reinstalling in restore venv: {e}")
+            logger.error(f"Error reinstalling in restore venv: {e}")
     else:
-        print("Restore venv install is correct")
+        logger.info("Restore venv install is correct")
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_daemon_logging_config.py
+++ b/tests/unit_tests/test_daemon_logging_config.py
@@ -1,0 +1,83 @@
+"""Tests for the daemon's root logging configuration.
+
+The wireless launcher starts the daemon with neither --log-file nor any
+prior logging setup, so anything logged before the handlers are installed
+goes to a root logger sitting at its WARNING default with no handlers:
+INFO is dropped outright and WARNING falls back to logging.lastResort
+without a formatter. The startup checks run in exactly that window, which
+is why configure_root_logging has to happen before them.
+
+configure_root_logging is called inside each test body rather than in a
+fixture: logging.StreamHandler binds sys.stderr at construction time, and
+pytest swaps sys.stderr between the fixture and the call phase.
+"""
+
+import logging
+
+import pytest
+
+from reachy_mini.daemon.app.main import configure_root_logging
+
+
+@pytest.fixture
+def clean_root():
+    """Root logger back to Python defaults, restored afterwards."""
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    root.handlers.clear()
+    root.setLevel(logging.WARNING)
+    yield
+    root.handlers.clear()
+    root.handlers.extend(saved_handlers)
+    root.setLevel(saved_level)
+
+
+def test_unconfigured_root_drops_info(clean_root, capsys):
+    """Without configuration, INFO is lost. This is what the fix prevents."""
+    logging.getLogger("reachy_mini.some.module").info("startup check result")
+
+    assert capsys.readouterr().err == ""
+
+
+def test_configure_sends_info_to_stderr(clean_root, capsys):
+    """systemd captures stderr, so INFO must reach it to land in the journal."""
+    configure_root_logging("INFO")
+    logging.getLogger("reachy_mini.some.module").info("startup check result")
+
+    err = capsys.readouterr().err
+    assert "startup check result" in err
+    assert "reachy_mini.some.module" in err, "records must carry the module name"
+    assert "INFO" in err, "records must carry the level"
+
+
+def test_log_file_is_added_alongside_stderr_not_instead(clean_root, capsys, tmp_path):
+    """A --log-file must not cost us the journal."""
+    logfile = tmp_path / "daemon.log"
+    configure_root_logging("INFO", str(logfile))
+    logging.getLogger("reachy_mini.some.module").warning("something odd")
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+
+    assert "something odd" in capsys.readouterr().err
+    assert "something odd" in logfile.read_text()
+
+
+def test_configure_is_idempotent(clean_root, capsys):
+    """Calling it twice must not double every log line."""
+    configure_root_logging("INFO")
+    configure_root_logging("INFO")
+    logging.getLogger("reachy_mini.some.module").info("once")
+
+    assert capsys.readouterr().err.count("once") == 1
+
+
+def test_level_is_honoured(clean_root, capsys):
+    """A quieter level still filters, so --log-level keeps working."""
+    configure_root_logging("WARNING")
+    log = logging.getLogger("reachy_mini.some.module")
+    log.info("chatty")
+    log.warning("important")
+
+    err = capsys.readouterr().err
+    assert "chatty" not in err
+    assert "important" in err


### PR DESCRIPTION
Closes #1336.

`main.py` attaches its `--log-file` handler to the root logger, but every check in `startup_check.py` reported through `print()`, so none of it reached the log file. The module already defined a `logger` it never used, and `custom_logger` was accepted and ignored (`main.py` passed the root logger into the void).

## 1. print -> logging

Mechanical conversion of the 57 `print()` statements to `logger.info` / `logger.warning` / `logger.error`.

`print(json.dumps(r))` in the apps_venv probe is left alone: it is a string of Python source run in a subprocess, not a log call.

## 2. The regression this would have caused, and the fix

Converting to logging is only safe if a handler exists when the checks run. It did not.

`run_app()` was the first thing to install handlers, and it runs **after** the startup checks. Until then the root logger sits at its `WARNING` default with **no handlers**, so all `logger.info(...)` were discarded and `logger.warning(...)` were unformatted.

=> So the handler setup moves out of `run_app()` into `configure_root_logging()`, called from `main()` before the checks. 

## Testing

- 5 unit tests
- Tested before/after on my wireless and pasted the results below. Things to look at:

BEFORE:  launcher.sh[942]: Bluetooth service and commands are up to date
AFTER:   launcher.sh[936]: reachy_mini.utils.wireless_version.startup_check - INFO - Bluetooth service and commands are up to date

Also the "~/.asoundrc correctly configured for Reachy Mini Audio." was dropped, now it's present.