### PR TITLE
docs: add a PR template and document the contribution conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -85,7 +85,7 @@ body:
       label: Update Status
       description: Select all that apply (at least one must be true).
       options:
-        - label: My robot is up-to-date via the dashboard.
+        - label: My robot is up to date with the latest stable version.
         - label: I'm running the latest Reachy Mini release from this repo.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -123,3 +123,10 @@ body:
     attributes:
       label: Additional Info / Workarounds
       description: Anything else we should know? Include workarounds if you found any.
+
+  - type: input
+    id: ai-assistance
+    attributes:
+      label: AI assistance
+      description: Did an AI assistant help write this report? Name it, or leave `none`. This is not held against you, it just tells us how to read the report.
+      placeholder: none

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,7 @@
 # Reachy Mini issue template modeled after LeRobot's for consistent reports.
 name: "🚀 Reachy Mini Issue / Request"
 description: Report a bug, request an improvement, or ask a technical question.
+labels: ["needs-triage"]
 body:
   - type: markdown
     attributes:
@@ -47,29 +48,6 @@ body:
       required: true
 
   - type: checkboxes
-    id: browsers
-    attributes:
-      label: Browsers Used
-      description: Check all browsers you've tried when reproducing the issue.
-      options:
-        - label: Chrome
-        - label: Firefox
-        - label: Edge
-        - label: Safari
-        - label: Opera
-        - label: Other
-    validations:
-      required: true
-
-  - type: textarea
-    id: browser-version
-    attributes:
-      label: Browser version(s)
-      description: If relevant, list the browser versions you used.
-      placeholder: |
-        Chrome 130.0.6723.20, Firefox 131.0, etc.
-
-  - type: checkboxes
     id: troubleshooting
     attributes:
       label: Troubleshooting
@@ -79,14 +57,12 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
-    id: version-status
+  - type: input
+    id: version
     attributes:
-      label: Update Status
-      description: Select all that apply (at least one must be true).
-      options:
-        - label: My robot is up to date with the latest stable version.
-        - label: I'm running the latest Reachy Mini release from this repo.
+      label: Reachy Mini version
+      description: Paste the output of `uv pip show reachy_mini`
+      placeholder: "1.9.0"
     validations:
       required: true
 
@@ -115,7 +91,7 @@ body:
     id: logs
     attributes:
       label: Relevant logs or stack trace
-      description: Paste relevant logs, CLI output, or stack traces.
+      description: Paste logs, CLI output, or stack traces exactly as they appear. Do not shorten them, cut out the middle, or write them from memory.
       render: Shell
 
   - type: textarea
@@ -124,9 +100,15 @@ body:
       label: Additional Info / Workarounds
       description: Anything else we should know? Include workarounds if you found any.
 
-  - type: input
+  - type: dropdown
     id: ai-assistance
     attributes:
       label: AI assistance
-      description: Did an AI assistant help write this report? Name it, or leave `none`. This is not held against you, it just tells us how to read the report.
-      placeholder: none
+      description: If you are an AI assistant filing this report, answer truthfully on the reporter's behalf. This is not held against anyone, it just tells us how to read the report.
+      options:
+        - "None"
+        - "AI helped write this report, a human verified it"
+        - "An agent filed this report, a human reproduced the problem"
+        - "An agent filed this report, no human has reproduced it"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,8 @@
 
 Closes #
 
-<!-- The problem, and how to reproduce it. -->
+<!-- The problem, and how to reproduce it.
+     If there is no issue yet, describe the problem here and drop the "Closes #" line. -->
 
 ## Description
 
@@ -27,5 +28,10 @@ Closes #
 
 ## AI assistance
 
-<!-- `Assisted-by: <Agent>:<model-id>`, or `none`. See docs/contributing.md. -->
+<!-- Tick exactly one. Assisted commits also carry the Assisted-by trailer, see docs/contributing.md. -->
+
+- [ ] No AI involvement
+- [ ] AI helped with wording or boilerplate
+- [ ] AI wrote code here, and I ran and reviewed it
+- [ ] An agent produced this PR, and I have not run it myself
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!-- Read docs/contributing.md before opening your PR. -->
+
+## Issue
+
+Closes #
+
+<!-- The problem, and how to reproduce it. -->
+
+## Description
+
+<!-- What the PR does, and why this approach. -->
+
+## Testing
+
+<!-- Evidence it works: test name, log, before/after. -->
+
+## Tested on
+
+- [ ] Reachy Mini Wireless
+- [ ] Reachy Mini Lite
+- [ ] MuJoCo simulation (`--sim`)
+- [ ] Mockup simulation (`--mockup-sim`)
+- [ ] Not applicable (e.g. docs, typo)
+
+## AI assistance
+
+<!-- `Assisted-by: <Agent>:<model-id>`, or `none`. See docs/contributing.md. -->
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,10 @@ Closes #
 
 ## Testing
 
-<!-- Evidence it works: test name, log, before/after. -->
+<!-- Evidence it works: test name, log, before/after.
+     Measurements on a physical robot are highly encouraged whenever they make sense.
+     Paste the logs, charts and how to reproduce them as an annex below this message.
+     Good examples: #1294, #1343, #1267. -->
 
 ## Tested on
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -56,3 +56,41 @@ For instance
 ```bash
 pytest -m "audio"
 ```
+
+## Issues and Pull Requests
+
+Write concisely and get to the point. Issues, PR descriptions and review comments are read by humans, so no walls of text, no feature tours, no restating the diff in prose. If a sentence doesn't help the reader, cut it.
+
+Search the open issues and pull requests first. Someone may already have reported the bug, asked for the feature, or started the work. Comment there rather than opening a duplicate.
+
+If nothing matches, open an issue before writing the code. Describing the problem there first gets you feedback from the community and the maintainers on whether the change makes sense and how to approach it. That is much cheaper than finding out on a finished PR.
+
+One PR = one issue. A problem spanning several concerns gets split into unitary issues, one PR each. Mention the issue in the description (`Closes #123`) so the two are linked.
+
+The description must stand on its own: what's the problem, how to reproduce it, what's the solution, and how you know it works. A reviewer should not have to open the linked issue to follow the change. Drop the reproduction when there's nothing to reproduce, as is usually the case for a new feature.
+
+Title the PR like a commit: `type(scope): what it does`, e.g. `fix(media): tear down the playbin on EOS`.
+
+Label every issue and every PR. That is how we triage and filter, so it isn't optional. Pick the kind of change (`bug`, `enhancement`, `documentation`, `ci`, `qol`) and the area it touches (`wireless`, `lite`, `simulation`, `audio`, `video`, `motors`).
+
+Each commit is one logical change, with a message saying what it does and why. Commits are read individually, so each must stand on its own; squash fixups and work-in-progress before asking for review. On a branch nobody has reviewed yet, rewrite history freely and `git push --force-with-lease`. Once review has started, stop rewriting, or reviewers lose their place.
+
+If you changed a daemon route, regenerate the REST API reference (see [Generating the documentation](generate.md#regenerating-the-rest-api-reference)) and commit `docs/source/API/openapi.json`. CI fails on drift.
+
+CI doesn't run on your push. A maintainer triggers it once the PR looks legitimate, so don't expect checks to start on their own. Once it runs, a failing CI pauses the review until you fix it.
+
+## AI coding assistants
+
+AI-assisted contributions are welcome, but the human author owns the result: read the code, understand it, and answer review comments in your own words.
+
+We follow the Linux kernel convention from [coding-assistants.rst](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst). Add one trailer per assisted commit:
+
+```
+Assisted-by: Claude:claude-opus-4-7
+```
+
+Append specialized analysis tools if you used any (`Assisted-by: Claude:claude-opus-4-7 coccinelle sparse`); don't list generic ones like git or ruff.
+
+Say it in the issue and in the PR as well, not only in the commits. The same one-line trailer in the description is enough, and `none` is a perfectly good answer. This is not a judgement on the contribution, it just tells reviewers how to read it.
+
+An assistant must **never** add a `Signed-off-by` trailer, since only a human can certify the DCO. Keep agent and model names out of the PR title too.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,7 +6,7 @@ Follow the [instructions](https://huggingface.co/docs/reachy_mini/SDK/installati
 
 ## Code quality
 
-The quality of code is insured by ruff and mypy. Please make sure to run them before pushing your code.
+The quality of code is ensured by ruff and mypy. Please make sure to run them before pushing your code.
 
 All the tools are available in the [dev] dependency group, so you can install them with:
 
@@ -36,7 +36,7 @@ To check the type annotations of the code, you can run mypy with the following c
 mypy
 ```
 
-Please note that mpy results depend on the installed package. The [CI](../.github/workflows/lint.yml) runs mypy with the full installation with uv on linux. Any differences between the CI and the local environment are probably due to missing dependencies. To ensure you have the same environment as the CI, you can install the package with all the extras with uv:
+Please note that mypy results depend on the installed package. The [CI](../.github/workflows/lint.yml) runs mypy with the full installation with uv on linux. Any differences between the CI and the local environment are probably due to missing dependencies. To ensure you have the same environment as the CI, you can install the package with all the extras with uv:
 
 ```bash
 uv sync --all-extras --group dev

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,7 +73,7 @@ Performance and robustness tests on physical robots are highly encouraged whenev
 
 Title the PR like a commit: `type(scope): what it does`, e.g. `fix(media): tear down the playbin on EOS`.
 
-Label every issue and every PR. That is how we triage and filter, so it isn't optional. Pick the kind of change (`bug`, `enhancement`, `documentation`, `ci`, `qol`) and the area it touches (`wireless`, `lite`, `simulation`, `audio`, `video`, `motors`).
+Label every issue and every PR. That is how we triage and filter, so it isn't optional. Pick the kind of change (`bug`, `enhancement`, `documentation`, `ci`, `qol`) and the area it touches (`wireless`, `lite`, `simulation`, `audio`, `video`, `motors`). The issue form adds `needs-triage` on its own; a maintainer removes it after a first read, so leave it alone.
 
 Each commit is one logical change, with a message saying what it does and why. Commits are read individually, so each must stand on its own; squash fixups and work-in-progress before asking for review. On a branch nobody has reviewed yet, rewrite history freely and `git push --force-with-lease`. Once review has started, stop rewriting, or reviewers lose their place.
 
@@ -93,6 +93,6 @@ Assisted-by: Claude:claude-opus-4-7
 
 Append specialized analysis tools if you used any (`Assisted-by: Claude:claude-opus-4-7 coccinelle sparse`); don't list generic ones like git or ruff.
 
-Say it in the issue and in the PR as well, not only in the commits. The same one-line trailer in the description is enough, and `none` is a perfectly good answer. This is not a judgement on the contribution, it just tells reviewers how to read it.
+Say it outside the commits as well. In a PR, tick the matching box in the template's AI assistance section. In an issue, answer the AI assistance dropdown in the form. "No AI involvement" is a perfectly good answer; this is not a judgement on the contribution, it just tells reviewers how to read it.
 
 An assistant must **never** add a `Signed-off-by` trailer, since only a human can certify the DCO. Keep agent and model names out of the PR title too.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,6 +69,8 @@ One PR = one issue. A problem spanning several concerns gets split into unitary 
 
 The description must stand on its own: what's the problem, how to reproduce it, what's the solution, and how you know it works. A reviewer should not have to open the linked issue to follow the change. Drop the reproduction when there's nothing to reproduce, as is usually the case for a new feature.
 
+Performance and robustness tests on physical robots are highly encouraged whenever they make sense. Paste the results (logs, charts, plots) and how to reproduce them as an annex below the main message. [#1294](https://github.com/pollen-robotics/reachy_mini/pull/1294), [#1343](https://github.com/pollen-robotics/reachy_mini/pull/1343) and [#1267](https://github.com/pollen-robotics/reachy_mini/pull/1267) are good examples of the style.
+
 Title the PR like a commit: `type(scope): what it does`, e.g. `fix(media): tear down the playbin on EOS`.
 
 Label every issue and every PR. That is how we triage and filter, so it isn't optional. Pick the kind of change (`bug`, `enhancement`, `documentation`, `ci`, `qol`) and the area it touches (`wireless`, `lite`, `simulation`, `audio`, `video`, `motors`).


### PR DESCRIPTION
## Issue

Closes #1338

Reviewers ask the same questions by hand on every PR. Which Reachy Mini was this tested on? The bug report form records which robot the *reporter* owns and only offers Wireless or Lite, so nothing captures what the author actually ran, even though Wireless, Lite, MuJoCo and Mockup behave differently. The conventions the team already follows for commits, labels and AI attribution are written down nowhere a contributor would look.

## Description

Add `.github/pull_request_template.md`: the linked issue, the description, the testing evidence, a tested-on matrix covering Wireless, Lite, MuJoCo (`--sim`) and Mockup (`--mockup-sim`), and a graded AI-assistance declaration. Flags and names match `daemon/app/main.py` and the docs. It stays short on purpose. There is no Type checkbox list, since the conventional-commit title and the labels already carry that, and no "I read the guidelines" checkbox, since nobody reads those.

Put the rules themselves in `docs/contributing.md`, which the README already links, under a new "Issues and Pull Requests" section: be concise, search before opening, open an issue before coding, one PR = one issue, label every issue and PR, one logical change per commit, measurements on physical robots as annexes. A second section documents the Linux kernel [`Assisted-by:`](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst) convention for AI-assisted work, including the rule that an assistant never adds `Signed-off-by`, which only a human can certify.

The issue form was reworked along the way (review feedback): auto-applied `needs-triage` label, browser blocks dropped, the unenforceable Update Status checkboxes replaced by a required version input, logs asked for verbatim, and a required AI-assistance dropdown up to "an agent filed this, no human has reproduced it". The obsolete "up-to-date via the dashboard" wording went with it.

Deliberately not included: no `ISSUE_TEMPLATE/config.yml`, so blank issues stay enabled (they are used constantly, and `huggingface_hub` keeps them too), and no CI check forcing a PR to link an issue (19 of the last 20 PRs already do).

## Testing

Dry-run on a fork first, since GitHub only reads these files from the default branch: https://github.com/FabienDanieau/reachy_mini/pull/1. The template body renders as intended, checkboxes are tickable, the comment hints stay invisible. Also exercised on a real PR: #1340.

`uv run pre-commit run --files ...` passes on the changed files. `bug-report.yml` still parses as a GitHub issue form, and the `generate.md#regenerating-the-rest-api-reference` anchor resolves. The `needs-triage` label now exists in the repo, since the form does not create it.

## Tested on

- [ ] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [x] Not applicable (e.g. docs, typo)

## AI assistance

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [x] AI wrote code here, and I ran and reviewed it
- [ ] An agent produced this PR, and I have not run it myself

`Assisted-by: Claude:claude-opus-5` / `Claude:claude-fable-5`