### PR TITLE
feat(daemon): persisted first wake-up flag over the data channel

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -35,6 +35,7 @@ from reachy_mini.io.protocol import (
     DeleteHfTokenCmd,
     DoaSnapshot,
     FaceTarget,
+    GetFirstWakeUpCmd,
     GetHardwareIdCmd,
     GetImuCmd,
     GetMicrophoneVolumeCmd,
@@ -63,6 +64,7 @@ from reachy_mini.io.protocol import (
     SetAntennasCmd,
     SetAutomaticBodyYawCmd,
     SetBodyYawCmd,
+    SetFirstWakeUpCmd,
     SetFullTargetCmd,
     SetGravityCompensationCmd,
     SetHeadJointsCmd,
@@ -1766,6 +1768,36 @@ class Backend:
                     "status": "ok" if ok else "error",
                 }
             )
+
+        elif isinstance(cmd, (GetFirstWakeUpCmd, SetFirstWakeUpCmd)):
+            # First wake-up wizard completion is a persistent, robot-wide
+            # flag stored in the daemon config file (next to startup_app &
+            # co) so the post-connection setup wizard only ever shows once,
+            # whichever client connects. Read/write helpers are fail-safe
+            # (never raise) so a storage error can't break the command loop.
+            from reachy_mini.daemon.startup_app_config import (
+                get_first_wake_up_completed,
+                set_first_wake_up_completed,
+            )
+
+            if isinstance(cmd, SetFirstWakeUpCmd):
+                ok = set_first_wake_up_completed(cmd.is_completed)
+                send_response(
+                    {
+                        "command": "set_first_wake_up",
+                        "status": "ok" if ok else "error",
+                        "is_completed": cmd.is_completed
+                        if ok
+                        else get_first_wake_up_completed(),
+                    }
+                )
+            else:  # GetFirstWakeUpCmd
+                send_response(
+                    {
+                        "command": "get_first_wake_up",
+                        "is_completed": get_first_wake_up_completed(),
+                    }
+                )
 
         elif isinstance(
             cmd,

--- a/src/reachy_mini/daemon/startup_app_config.py
+++ b/src/reachy_mini/daemon/startup_app_config.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 _KEY = "startup_app"
 _EQ_KEY = "speaker_eq_gains"
 _TURN_KEY = "turn_enabled"
+_FIRST_WAKE_UP_KEY = "first_wake_up_completed"
 # equalizer-10bands accepts per-band gains in [-24, +12] dB.
 _EQ_GAIN_MIN, _EQ_GAIN_MAX = -24.0, 12.0
 
@@ -88,6 +89,26 @@ def get_speaker_eq_gains() -> list[float] | None:
     return None
 
 
+def _get_bool(key: str) -> bool | None:
+    """Return the boolean at `key`, or None when unset or malformed.
+
+    A present-but-malformed value is warned about (so the user knows their
+    hand-edited config was ignored) and treated as unset.
+    """
+    config = _read()
+    if key not in config:
+        return None
+    value = config[key]
+    if isinstance(value, bool):
+        return value
+    logger.warning(
+        "Ignoring invalid '%s' in daemon config (need true or false); "
+        "using the built-in default.",
+        key,
+    )
+    return None
+
+
 def get_turn_enabled() -> bool | None:
     """Return whether the media server should offer TURN relay candidates.
 
@@ -96,30 +117,53 @@ def get_turn_enabled() -> bool | None:
     turning it off saves a background thread refreshing credentials on a
     robot that is only ever reached from its own network.
     """
-    config = _read()
-    if _TURN_KEY not in config:
-        return None
-    value = config[_TURN_KEY]
-    if isinstance(value, bool):
-        return value
-    # Present but malformed: warn so the user knows it was ignored.
-    logger.warning(
-        "Ignoring invalid '%s' in daemon config (need true or false); "
-        "using the built-in default.",
-        _TURN_KEY,
-    )
-    return None
+    return _get_bool(_TURN_KEY)
 
 
-def set_startup_app(name: str | None) -> None:
-    """Persist the startup app name; a falsy name clears it."""
+def _update(key: str, value: object | None) -> None:
+    """Read-modify-write a single config key; `None` clears it.
+
+    Other keys are preserved. May raise OSError on a write error; callers
+    that must never raise (e.g. the daemon command loop) wrap it themselves.
+    """
     config = _read()
-    if name:
-        config[_KEY] = name
+    if value is None:
+        config.pop(key, None)
     else:
-        config.pop(_KEY, None)
+        config[key] = value
 
     path = _config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w") as f:
         json.dump(config, f, indent=2)
+
+
+def set_startup_app(name: str | None) -> None:
+    """Persist the startup app name; a falsy name clears it."""
+    _update(_KEY, name if name else None)
+
+
+def get_first_wake_up_completed() -> bool:
+    """Return True if the first wake-up setup wizard has been completed.
+
+    Robot-wide, persistent flag (not per-session): the mobile / desktop apps
+    run a one-time, post-connection hardware diagnostic wizard, and gate it on
+    this so it only ever shows once, whichever client connects. Defaults to
+    False (wizard pending) when unset or malformed, so a config problem can
+    never trap the daemon command loop.
+    """
+    return _get_bool(_FIRST_WAKE_UP_KEY) is True
+
+
+def set_first_wake_up_completed(is_completed: bool) -> bool:
+    """Persist the first wake-up completion flag. Returns True on success.
+
+    Fail-safe: a write error is logged and reported as False instead of
+    raising, so a storage problem can't break the daemon command loop.
+    """
+    try:
+        _update(_FIRST_WAKE_UP_KEY, bool(is_completed))
+        return True
+    except OSError as e:
+        logger.warning(f"Could not persist first-wake-up flag: {e}")
+        return False

--- a/src/reachy_mini/daemon/startup_app_config.py
+++ b/src/reachy_mini/daemon/startup_app_config.py
@@ -134,8 +134,13 @@ def _update(key: str, value: object | None) -> None:
 
     path = _config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w") as f:
+    # Write to a sibling then rename: a crash mid-write would otherwise
+    # truncate the file, and the next _update() rebuilds it from the empty
+    # dict _read() returns for unparseable JSON, dropping every other key.
+    tmp = path.with_suffix(".json.tmp")
+    with tmp.open("w") as f:
         json.dump(config, f, indent=2)
+    tmp.replace(path)
 
 
 def set_startup_app(name: str | None) -> None:

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -382,6 +382,22 @@ class DeleteHfTokenCmd(BaseModel):
     type: Literal["delete_hf_token"] = "delete_hf_token"
 
 
+# First wake-up setup wizard. A persistent, robot-wide boolean (not
+# per-session): once the owner has run the post-connection hardware
+# diagnostic wizard the daemon remembers it so it only ever shows once.
+class GetFirstWakeUpCmd(BaseModel):
+    """Query whether the first wake-up setup wizard has been completed."""
+
+    type: Literal["get_first_wake_up"] = "get_first_wake_up"
+
+
+class SetFirstWakeUpCmd(BaseModel):
+    """Mark the first wake-up setup wizard completed (or reset it)."""
+
+    type: Literal["set_first_wake_up"] = "set_first_wake_up"
+    is_completed: bool = True
+
+
 class SetSpeechOffsetsCmd(BaseModel):
     """Set head-wobbler speech offsets (composed with target pose before IK)."""
 
@@ -865,6 +881,8 @@ AnyCommand = Annotated[
     | GetRobotNameCmd
     | SetRobotNameCmd
     | DeleteHfTokenCmd
+    | GetFirstWakeUpCmd
+    | SetFirstWakeUpCmd
     | SubscribeLogsCmd
     | UnsubscribeLogsCmd
     | SubscribePoseCmd

--- a/tests/unit_tests/test_backend_process_command.py
+++ b/tests/unit_tests/test_backend_process_command.py
@@ -23,6 +23,7 @@ from reachy_mini.io.protocol import (
     AudioParamPair,
     ClearIncomingAudioCmd,
     DeleteHfTokenCmd,
+    GetFirstWakeUpCmd,
     GetHardwareIdCmd,
     GetImuCmd,
     GetMicrophoneVolumeCmd,
@@ -39,6 +40,7 @@ from reachy_mini.io.protocol import (
     SetAntennasCmd,
     SetAutomaticBodyYawCmd,
     SetBodyYawCmd,
+    SetFirstWakeUpCmd,
     SetFullTargetCmd,
     SetGravityCompensationCmd,
     SetHeadJointsCmd,
@@ -461,6 +463,51 @@ def test_delete_hf_token_error(
     monkeypatch.setattr(hf_auth, "delete_hf_token", lambda: False)
     responses = _dispatch(sim_backend, DeleteHfTokenCmd())
     assert responses == [{"command": "delete_hf_token", "status": "error"}]
+
+
+# ------------------------------------------------------------------
+# First wake-up flag
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def first_wake_up_config(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the daemon config at a throwaway path."""
+    from reachy_mini.daemon import startup_app_config
+
+    monkeypatch.setattr(
+        startup_app_config, "_config_path", lambda: tmp_path / "daemon_config.json"
+    )
+
+
+def test_first_wake_up_round_trips(
+    sim_backend: Any, first_wake_up_config: None
+) -> None:
+    """Get defaults to False; a successful set acks ok and persists."""
+    assert _dispatch(sim_backend, GetFirstWakeUpCmd()) == [
+        {"command": "get_first_wake_up", "is_completed": False}
+    ]
+    assert _dispatch(sim_backend, SetFirstWakeUpCmd(is_completed=True)) == [
+        {"command": "set_first_wake_up", "status": "ok", "is_completed": True}
+    ]
+    assert _dispatch(sim_backend, GetFirstWakeUpCmd()) == [
+        {"command": "get_first_wake_up", "is_completed": True}
+    ]
+
+
+def test_first_wake_up_write_failure_acks_stored_value(
+    sim_backend: Any, first_wake_up_config: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed set acks status error with the STORED value, not the requested one."""
+    from reachy_mini.daemon import startup_app_config
+
+    def boom(*a: Any, **k: Any) -> None:
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(startup_app_config, "_update", boom)
+    assert _dispatch(sim_backend, SetFirstWakeUpCmd(is_completed=True)) == [
+        {"command": "set_first_wake_up", "status": "error", "is_completed": False}
+    ]
 
 
 # ------------------------------------------------------------------

--- a/tests/unit_tests/test_first_wake_up.py
+++ b/tests/unit_tests/test_first_wake_up.py
@@ -70,10 +70,13 @@ def test_set_preserves_other_config_keys(config_path: Path):
 
 
 def test_set_is_failsafe_on_write_error(
-    config_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    def boom(*a, **k):
-        raise OSError("read-only filesystem")
-
-    monkeypatch.setattr(startup_app_config.Path, "open", boom)
+    # A plain file where the config's parent dir should be, so the write
+    # fails for real instead of patching pathlib globally.
+    blocked = tmp_path / "blocked"
+    blocked.write_text("not a directory")
+    monkeypatch.setattr(
+        startup_app_config, "_config_path", lambda: blocked / "daemon_config.json"
+    )
     assert startup_app_config.set_first_wake_up_completed(True) is False

--- a/tests/unit_tests/test_first_wake_up.py
+++ b/tests/unit_tests/test_first_wake_up.py
@@ -1,0 +1,79 @@
+"""Unit tests for the persisted first-wake-up flag helpers.
+
+Exercise ``get_first_wake_up_completed`` / ``set_first_wake_up_completed``
+against a tmp daemon config path (monkeypatched ``_config_path``) so the real
+user config dir is never touched. The helpers are deliberately fail-safe: a
+missing file or any read/write error degrades to "not completed" / "write
+failed" instead of raising, so a storage problem can't break the command loop.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from reachy_mini.daemon import startup_app_config
+
+
+@pytest.fixture
+def config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the module at a throwaway daemon_config.json under a tmp dir."""
+    path = tmp_path / "reachy_mini" / "daemon_config.json"
+    monkeypatch.setattr(startup_app_config, "_config_path", lambda: path)
+    return path
+
+
+def test_defaults_to_false_when_unset(config_path: Path):
+    assert startup_app_config.get_first_wake_up_completed() is False
+
+
+def test_set_true_then_get_round_trips(config_path: Path):
+    assert startup_app_config.set_first_wake_up_completed(True) is True
+    assert startup_app_config.get_first_wake_up_completed() is True
+
+
+def test_set_false_then_get_round_trips(config_path: Path):
+    startup_app_config.set_first_wake_up_completed(True)
+    assert startup_app_config.set_first_wake_up_completed(False) is True
+    assert startup_app_config.get_first_wake_up_completed() is False
+
+
+def test_set_creates_parent_dirs(config_path: Path):
+    assert not config_path.parent.exists()
+    startup_app_config.set_first_wake_up_completed(True)
+    assert config_path.is_file()
+
+
+def test_get_is_failsafe_on_corrupt_json(config_path: Path):
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("{ not valid json")
+    assert startup_app_config.get_first_wake_up_completed() is False
+
+
+def test_get_defaults_false_when_flag_missing_from_file(config_path: Path):
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text('{"startup_app": "face_tracker"}')
+    assert startup_app_config.get_first_wake_up_completed() is False
+
+
+def test_get_defaults_false_on_malformed_flag(config_path: Path):
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text('{"first_wake_up_completed": "yes"}')
+    assert startup_app_config.get_first_wake_up_completed() is False
+
+
+def test_set_preserves_other_config_keys(config_path: Path):
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text('{"startup_app": "face_tracker"}')
+    startup_app_config.set_first_wake_up_completed(True)
+    assert startup_app_config.get_startup_app() == "face_tracker"
+    assert startup_app_config.get_first_wake_up_completed() is True
+
+
+def test_set_is_failsafe_on_write_error(
+    config_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    def boom(*a, **k):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(startup_app_config.Path, "open", boom)
+    assert startup_app_config.set_first_wake_up_completed(True) is False

--- a/tests/unit_tests/test_startup_app_config.py
+++ b/tests/unit_tests/test_startup_app_config.py
@@ -1,0 +1,112 @@
+"""Unit tests for the generic daemon-config helpers.
+
+``_update`` / ``_get_bool`` are the shared primitives behind every per-key
+accessor in ``startup_app_config`` (startup app, TURN toggle, first-wake-up
+flag). Exercise them directly against a tmp config path (monkeypatched
+``_config_path``) so the real user config dir is never touched.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reachy_mini.daemon import startup_app_config
+
+
+@pytest.fixture
+def config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the module at a throwaway daemon_config.json under a tmp dir."""
+    path = tmp_path / "reachy_mini" / "daemon_config.json"
+    monkeypatch.setattr(startup_app_config, "_config_path", lambda: path)
+    return path
+
+
+def _stored(config_path: Path) -> dict:
+    return json.loads(config_path.read_text())
+
+
+# ─── _update ─────────────────────────────────────────────────────────────
+
+
+def test_update_creates_file_and_parent_dirs(config_path: Path):
+    assert not config_path.parent.exists()
+    startup_app_config._update("some_key", "value")
+    assert _stored(config_path) == {"some_key": "value"}
+
+
+def test_update_overwrites_existing_key(config_path: Path):
+    startup_app_config._update("some_key", "old")
+    startup_app_config._update("some_key", "new")
+    assert _stored(config_path) == {"some_key": "new"}
+
+
+def test_update_preserves_other_keys(config_path: Path):
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text('{"startup_app": "face_tracker", "turn_enabled": true}')
+    startup_app_config._update("some_key", 42)
+    assert _stored(config_path) == {
+        "startup_app": "face_tracker",
+        "turn_enabled": True,
+        "some_key": 42,
+    }
+
+
+def test_update_none_clears_key(config_path: Path):
+    startup_app_config._update("some_key", "value")
+    startup_app_config._update("some_key", None)
+    assert _stored(config_path) == {}
+
+
+def test_update_none_on_absent_key_is_noop(config_path: Path):
+    startup_app_config._update("some_key", None)
+    assert _stored(config_path) == {}
+
+
+def test_update_recovers_from_corrupt_file(config_path: Path):
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("{ not valid json")
+    startup_app_config._update("some_key", "value")
+    assert _stored(config_path) == {"some_key": "value"}
+
+
+def test_update_raises_on_write_error(
+    config_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    def boom(*a, **k):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(startup_app_config.Path, "open", boom)
+    with pytest.raises(OSError):
+        startup_app_config._update("some_key", "value")
+
+
+# ─── _get_bool ───────────────────────────────────────────────────────────
+
+
+def test_get_bool_none_when_file_missing(config_path: Path):
+    assert startup_app_config._get_bool("some_flag") is None
+
+
+def test_get_bool_none_when_key_missing(config_path: Path):
+    startup_app_config._update("other_key", True)
+    assert startup_app_config._get_bool("some_flag") is None
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_get_bool_round_trips(config_path: Path, value: bool):
+    startup_app_config._update("some_flag", value)
+    assert startup_app_config._get_bool("some_flag") is value
+
+
+@pytest.mark.parametrize("malformed", ["yes", 1, 0, [], {}, None])
+def test_get_bool_none_and_warns_on_malformed(
+    config_path: Path,
+    malformed: object,
+    caplog: pytest.LogCaptureFixture,
+):
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"some_flag": malformed}))
+    with caplog.at_level("WARNING"):
+        assert startup_app_config._get_bool("some_flag") is None
+    assert "some_flag" in caplog.text

--- a/tests/unit_tests/test_startup_app_config.py
+++ b/tests/unit_tests/test_startup_app_config.py
@@ -58,7 +58,9 @@ def test_update_none_clears_key(config_path: Path):
     assert _stored(config_path) == {}
 
 
-def test_update_none_on_absent_key_is_noop(config_path: Path):
+def test_update_none_on_absent_key_writes_empty_config(config_path: Path):
+    # Not a no-op on disk: clearing a key a fresh install never had still
+    # creates the config file, holding an empty object.
     startup_app_config._update("some_key", None)
     assert _stored(config_path) == {}
 
@@ -70,13 +72,15 @@ def test_update_recovers_from_corrupt_file(config_path: Path):
     assert _stored(config_path) == {"some_key": "value"}
 
 
-def test_update_raises_on_write_error(
-    config_path: Path, monkeypatch: pytest.MonkeyPatch
-):
-    def boom(*a, **k):
-        raise OSError("read-only filesystem")
-
-    monkeypatch.setattr(startup_app_config.Path, "open", boom)
+def test_update_raises_on_write_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # A plain file where the config's parent dir should be: mkdir and open
+    # fail for real, without patching pathlib globally (which would also
+    # break the _read() at the top of _update, masking what is under test).
+    blocked = tmp_path / "blocked"
+    blocked.write_text("not a directory")
+    monkeypatch.setattr(
+        startup_app_config, "_config_path", lambda: blocked / "daemon_config.json"
+    )
     with pytest.raises(OSError):
         startup_app_config._update("some_key", "value")
 

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -1429,6 +1429,9 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
      * and skip the wizard on `null`).
      */
     getFirstWakeUp(): Promise<boolean | null> {
+        // Fail-open, so this never rejects: the wizard gate runs right after
+        // connect, which is exactly when the channel may not be open yet.
+        if (!this._dc || this._dc.readyState !== 'open') return Promise.resolve(null);
         return this._slotRoundtrip(
             () => this._firstWakeUpResolve,
             (next) => { this._firstWakeUpResolve = next; },
@@ -1441,6 +1444,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
      * Resolves with the stored value (or `null` on channel-closed).
      */
     setFirstWakeUp(isCompleted: boolean): Promise<boolean | null> {
+        if (!this._dc || this._dc.readyState !== 'open') return Promise.resolve(null);
         return this._slotRoundtrip(
             () => this._firstWakeUpResolve,
             (next) => { this._firstWakeUpResolve = next; },

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -226,6 +226,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
     private _hardwareIdResolve: ((v: string | null) => void) | null = null;
     private _volumeResolve: ((v: number | null) => void) | null = null;
     private _micVolumeResolve: ((v: number | null) => void) | null = null;
+    private _firstWakeUpResolve: ((v: boolean | null) => void) | null = null;
     private _trackedFaceResolve: ((v: FaceTarget | null) => void) | null = null;
     private _robotNameResolve: ((v: string | null) => void) | null = null;
     private _deleteHfTokenResolve: ((v: boolean | null) => void) | null = null;
@@ -813,6 +814,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
         if (this._hardwareIdResolve) { this._hardwareIdResolve(null); this._hardwareIdResolve = null; }
         if (this._volumeResolve) { this._volumeResolve(null); this._volumeResolve = null; }
         if (this._micVolumeResolve) { this._micVolumeResolve(null); this._micVolumeResolve = null; }
+        if (this._firstWakeUpResolve) { this._firstWakeUpResolve(null); this._firstWakeUpResolve = null; }
         if (this._trackedFaceResolve) { this._trackedFaceResolve(null); this._trackedFaceResolve = null; }
         if (this._applyAudioConfigResolve) { this._applyAudioConfigResolve(false); this._applyAudioConfigResolve = null; }
         if (this._readAudioParameterResolve) { this._readAudioParameterResolve(null); this._readAudioParameterResolve = null; }
@@ -864,6 +866,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
         if (this._hardwareIdResolve) { this._hardwareIdResolve(null); this._hardwareIdResolve = null; }
         if (this._volumeResolve) { this._volumeResolve(null); this._volumeResolve = null; }
         if (this._micVolumeResolve) { this._micVolumeResolve(null); this._micVolumeResolve = null; }
+        if (this._firstWakeUpResolve) { this._firstWakeUpResolve(null); this._firstWakeUpResolve = null; }
         if (this._trackedFaceResolve) { this._trackedFaceResolve(null); this._trackedFaceResolve = null; }
         if (this._applyAudioConfigResolve) { this._applyAudioConfigResolve(false); this._applyAudioConfigResolve = null; }
         if (this._readAudioParameterResolve) { this._readAudioParameterResolve(null); this._readAudioParameterResolve = null; }
@@ -1415,6 +1418,33 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
             () => this._micVolumeResolve,
             (next) => { this._micVolumeResolve = next; },
             { type: 'set_microphone_volume', volume: clampVolume(volume) },
+        );
+    }
+
+    /**
+     * Query whether the first wake-up setup wizard has been completed.
+     * Robot-wide, persisted on the robot. Resolves `false` when pending,
+     * `true` when done, or `null` when the channel isn't open / the daemon
+     * predates the `get_first_wake_up` command (callers should fail-open
+     * and skip the wizard on `null`).
+     */
+    getFirstWakeUp(): Promise<boolean | null> {
+        return this._slotRoundtrip(
+            () => this._firstWakeUpResolve,
+            (next) => { this._firstWakeUpResolve = next; },
+            { type: 'get_first_wake_up' },
+        );
+    }
+
+    /**
+     * Persist the first wake-up wizard completion flag on the robot.
+     * Resolves with the stored value (or `null` on channel-closed).
+     */
+    setFirstWakeUp(isCompleted: boolean): Promise<boolean | null> {
+        return this._slotRoundtrip(
+            () => this._firstWakeUpResolve,
+            (next) => { this._firstWakeUpResolve = next; },
+            { type: 'set_first_wake_up', is_completed: isCompleted },
         );
     }
 
@@ -2221,6 +2251,15 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
             if (this._micVolumeResolve) {
                 this._micVolumeResolve(data.status === 'error' ? null : (data.volume as number));
                 this._micVolumeResolve = null;
+            }
+            return;
+        }
+        if (data.command === 'get_first_wake_up' || data.command === 'set_first_wake_up') {
+            if (this._firstWakeUpResolve) {
+                this._firstWakeUpResolve(
+                    data.status === 'error' ? null : !!data.is_completed,
+                );
+                this._firstWakeUpResolve = null;
             }
             return;
         }

--- a/ts/lib/types.ts
+++ b/ts/lib/types.ts
@@ -365,6 +365,15 @@ export interface ReachyMiniInstance extends EventTarget {
      * channel isn't open, or the daemon predates the `get_robot_name` command.
      */
     getRobotName(): Promise<string | null>;
+
+    /**
+     * Query whether the first wake-up setup wizard has been completed
+     * (robot-wide, persisted). `null` when the channel isn't open or the
+     * daemon predates the command (callers should fail-open).
+     */
+    getFirstWakeUp(): Promise<boolean | null>;
+    /** Persist the first wake-up wizard completion flag on the robot. */
+    setFirstWakeUp(isCompleted: boolean): Promise<boolean | null>;
     /**
      * Set and persist the robot display name. Applied live by the daemon
      * (status + central relay + mDNS), so it takes effect right away without a


### PR DESCRIPTION
## Issue

Extracted from #1286 (first wake-up wizard support).

The mobile app runs a one-time, post-connection hardware diagnostic wizard ("first wake-up"). Whether it has been completed must live on the robot, not in the app, so the wizard shows once per robot whichever client connects. The daemon currently has no way to store or expose that flag, so the app-side wizard can't ship gated.

## Description

- New data-channel commands `get_first_wake_up` / `set_first_wake_up` (`protocol.py` + handler in `abstract.py`).
- The flag is a `first_wake_up_completed` key in the existing `daemon_config.json` (no new file), through shared generic helpers in `startup_app_config.py`: `_get_bool(key)` for validated reads (now also backing `get_turn_enabled`) and `_update(key, value)` for read-modify-write. Read/write is fail-safe: errors degrade to "not completed" / "write failed" instead of raising, so a storage problem can't break the command loop.
- JS SDK: `getFirstWakeUp()` / `setFirstWakeUp(isCompleted)` on the existing `_slotRoundtrip` helper. Both resolve `null` when the channel is closed or the daemon predates the command, so clients fail-open (skip the wizard).

Purely additive; no HTTP route added. The BLE IDENTIFY half of #1286 will come separately.

## Testing

- `tests/unit_tests/test_startup_app_config.py` (17 new tests): direct coverage of the generic `_update` / `_get_bool` helpers (create/overwrite/clear, other keys preserved, corrupt-file recovery, write-error propagation, malformed-value warnings).
- `tests/unit_tests/test_first_wake_up.py` (9 new tests): default-to-false, roundtrip, reset, malformed value, other config keys preserved, fail-safe on corrupt JSON and write errors.
- `test_backend_process_command.py`, `test_backend_wake_up.py`, `test_autostart_app.py` still green (101 tests total); ruff and `npm run typecheck:sdk` clean.
- On-robot smoke test pending: `get_first_wake_up` -> false, `set` -> true, survives daemon restart.

## Tested on

- [ ] Reachy Mini Wireless (unit tests only so far; on-robot smoke test pending)
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)

## AI assistance

Assisted-by: Cursor:fable-5

