### PR TITLE
feat(api): expose IMU on REST state routes and WebRTC state snapshot

### DIFF
--- a/docs/source/API/daemon.mdx
+++ b/docs/source/API/daemon.mdx
@@ -180,6 +180,8 @@ released its media handles before the local app opens them.
 
 [[autodoc]] reachy_mini.daemon.app.routers.state.get_doa
 
+[[autodoc]] reachy_mini.daemon.app.routers.state.get_imu
+
 [[autodoc]] reachy_mini.daemon.app.routers.state.get_full_state
 
 [[autodoc]] reachy_mini.daemon.app.routers.state.ws_full_state

--- a/docs/source/API/openapi.json
+++ b/docs/source/API/openapi.json
@@ -2347,6 +2347,33 @@
         }
       }
     },
+    "/api/state/imu": {
+      "get": {
+        "summary": "Get Imu",
+        "description": "Get the latest IMU reading (accelerometer, gyroscope, quaternion, temperature).\n\nAccelerations are in m/s\u00b2, angular rates in rad/s, the quaternion is\nw-first and the temperature in \u00b0C.\nReturns None on versions without an IMU (Lite, simulation) or when the\ncached reading has gone stale.",
+        "operationId": "get_imu_api_state_imu_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ImuData"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get Imu Api State Imu Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/state/full": {
       "get": {
         "summary": "Get Full State",
@@ -2461,6 +2488,16 @@
               "type": "boolean",
               "default": false,
               "title": "With Doa"
+            }
+          },
+          {
+            "name": "with_imu",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "With Imu"
             }
           },
           {
@@ -3342,6 +3379,16 @@
                 "type": "null"
               }
             ]
+          },
+          "imu": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ImuData"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -3451,6 +3498,44 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
+      },
+      "ImuData": {
+        "properties": {
+          "accelerometer": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Accelerometer"
+          },
+          "gyroscope": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Gyroscope"
+          },
+          "quaternion": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Quaternion"
+          },
+          "temperature": {
+            "type": "number",
+            "title": "Temperature"
+          }
+        },
+        "type": "object",
+        "required": [
+          "accelerometer",
+          "gyroscope",
+          "quaternion",
+          "temperature"
+        ],
+        "title": "ImuData",
+        "description": "IMU sensor reading (BMI088, wireless version only).\n\nThe payload half of :class:`ImuDataMsg`, reused wherever the reading\nis carried without the legacy WS discriminator (state snapshots,\nREST replies)."
       },
       "InterpolationTechnique": {
         "type": "string",

--- a/src/reachy_mini/daemon/app/models.py
+++ b/src/reachy_mini/daemon/app/models.py
@@ -8,7 +8,7 @@ from numpy.typing import NDArray
 from pydantic import BaseModel
 from scipy.spatial.transform import Rotation as R
 
-from reachy_mini.io.protocol import DoaSnapshot, MotorControlMode
+from reachy_mini.io.protocol import DoaSnapshot, ImuData, MotorControlMode
 
 
 class Matrix4x4Pose(BaseModel):
@@ -157,3 +157,4 @@ class FullState(BaseModel):
     timestamp: datetime | None = None
     passive_joints: list[float] | None = None
     doa: DoAInfo | None = None
+    imu: ImuData | None = None

--- a/src/reachy_mini/daemon/app/routers/state.py
+++ b/src/reachy_mini/daemon/app/routers/state.py
@@ -13,6 +13,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 
 from ....daemon.backend.abstract import Backend
+from ....io.protocol import ImuData
 from ..dependencies import get_backend, ws_get_backend
 from ..models import AnyPose, DoAInfo, FullState, as_any_pose
 
@@ -70,6 +71,20 @@ async def get_doa(
     return backend.read_doa()
 
 
+@router.get("/imu")
+async def get_imu(
+    backend: Backend = Depends(get_backend),
+) -> ImuData | None:
+    """Get the latest IMU reading (accelerometer, gyroscope, quaternion, temperature).
+
+    Accelerations are in m/s², angular rates in rad/s, the quaternion is
+    w-first and the temperature in °C.
+    Returns None on versions without an IMU (Lite, simulation) or when the
+    cached reading has gone stale.
+    """
+    return backend.get_imu_data()
+
+
 @router.get("/full")
 async def get_full_state(
     with_control_mode: bool = True,
@@ -83,6 +98,7 @@ async def get_full_state(
     with_target_antenna_positions: bool = False,
     with_passive_joints: bool = False,
     with_doa: bool = False,
+    with_imu: bool = False,
     use_pose_matrix: bool = False,
     backend: Backend = Depends(get_backend),
 ) -> FullState:
@@ -119,6 +135,8 @@ async def get_full_state(
             result["passive_joints"] = None
     if with_doa:
         result["doa"] = backend.read_doa()
+    if with_imu:
+        result["imu"] = backend.get_imu_data()
 
     result["timestamp"] = datetime.now(timezone.utc)
     return FullState.model_validate(result)
@@ -138,6 +156,7 @@ async def ws_full_state(
     with_target_antenna_positions: bool = False,
     with_passive_joints: bool = False,
     with_doa: bool = False,
+    with_imu: bool = False,
     use_pose_matrix: bool = False,
     backend: Backend = Depends(ws_get_backend),
 ) -> None:
@@ -159,6 +178,7 @@ async def ws_full_state(
                 with_target_antenna_positions=with_target_antenna_positions,
                 with_passive_joints=with_passive_joints,
                 with_doa=with_doa,
+                with_imu=with_imu,
                 use_pose_matrix=use_pose_matrix,
                 backend=backend,
             )

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -1594,6 +1594,8 @@ class Backend:
             # Sound Direction of Arrival (ReSpeaker mic array), or None when
             # unavailable. Cached, never blocks (see _doa_poll_loop).
             doa=self.read_doa(),
+            # IMU (wireless only), or None on Lite/sim or when the cache is stale.
+            imu=self.get_imu_data(),
         )
 
     def build_state_dict(self) -> dict[str, Any]:

--- a/src/reachy_mini/io/protocol.py
+++ b/src/reachy_mini/io/protocol.py
@@ -108,6 +108,20 @@ class DoaSnapshot(BaseModel):
     speech_detected: bool
 
 
+class ImuData(BaseModel):
+    """IMU sensor reading (BMI088, wireless version only).
+
+    The payload half of :class:`ImuDataMsg`, reused wherever the reading
+    is carried without the legacy WS discriminator (state snapshots,
+    REST replies).
+    """
+
+    accelerometer: list[float]
+    gyroscope: list[float]
+    quaternion: list[float]
+    temperature: float
+
+
 class StateSnapshot(BaseModel):
     """Present-state snapshot sent to WebRTC clients.
 
@@ -131,6 +145,9 @@ class StateSnapshot(BaseModel):
     is_move_running: bool
     face_target: FaceTarget
     doa: Optional[DoaSnapshot] = None
+    # IMU reading (wireless version), or None on Lite/sim or when the
+    # backend cache has gone stale.
+    imu: Optional[ImuData] = None
 
 
 class PoseFrame(BaseModel):
@@ -990,14 +1007,10 @@ class HeadPoseMsg(BaseModel):
     head_pose: list[list[float]]
 
 
-class ImuDataMsg(BaseModel):
+class ImuDataMsg(ImuData):
     """IMU sensor data (published at 50 Hz on wireless version)."""
 
     type: Literal["imu_data"] = "imu_data"
-    accelerometer: list[float]
-    gyroscope: list[float]
-    quaternion: list[float]
-    temperature: float
 
 
 class RecordedDataMsg(BaseModel):

--- a/tests/unit_tests/test_state_imu_api.py
+++ b/tests/unit_tests/test_state_imu_api.py
@@ -1,0 +1,140 @@
+"""Unit tests for the IMU exposure on the REST state routes + state snapshot.
+
+Two contracts are covered:
+
+- **Fail-silent**: on hardware without an IMU (Lite, simulation) every
+  surface answers ``null`` — HTTP 200, never an error.
+- **No discriminator leak**: the backend returns an ``ImuDataMsg`` (the
+  legacy WS message, carrying ``type="imu_data"``), but the REST and
+  snapshot fields are typed ``ImuData``, so the ``type`` key must never
+  reach a client.
+
+The IMU device itself is never touched: ``get_imu_data`` is stubbed, which
+is exactly the seam the real backend fills from its control-loop cache.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reachy_mini.daemon.app.routers import state
+from reachy_mini.daemon.backend.mockup_sim.backend import MockupSimBackend
+from reachy_mini.io.protocol import ImuDataMsg
+
+READING = ImuDataMsg(
+    accelerometer=[0.1, -0.2, 9.79],
+    gyroscope=[0.01, 0.02, -0.03],
+    quaternion=[1.0, 0.0, 0.0, 0.0],  # w-first
+    temperature=27.5,
+)
+
+EXPECTED = {
+    "accelerometer": [0.1, -0.2, 9.79],
+    "gyroscope": [0.01, 0.02, -0.03],
+    "quaternion": [1.0, 0.0, 0.0, 0.0],
+    "temperature": 27.5,
+}
+
+
+@pytest.fixture
+def backend() -> MockupSimBackend:
+    """Simulation backend: no audio, no IMU (inherits the None default)."""
+    backend = MockupSimBackend(use_audio=False)
+    # Seed the kinematics the way `run()` does on entry, so /state/full's
+    # default pose fields resolve without spinning the control loop.
+    backend.update_head_kinematics_model(
+        backend._head_joint_positions,
+        backend._antenna_joint_positions,
+    )
+    return backend
+
+
+@pytest.fixture
+def with_imu(backend, monkeypatch) -> MockupSimBackend:
+    """Same backend, but serving a fixed IMU reading (no hardware)."""
+    monkeypatch.setattr(backend, "get_imu_data", lambda: READING)
+    return backend
+
+
+# --------------------------------------------------------------------
+# Fail-silent: no IMU on this hardware
+# --------------------------------------------------------------------
+
+
+def test_get_imu_without_hardware(router_app, backend) -> None:
+    """GET /state/imu -> 200 with a null body when there is no IMU."""
+    client = router_app(state.router, backend=backend)
+
+    resp = client.get("/state/imu")
+
+    assert resp.status_code == 200
+    assert resp.json() is None
+
+
+def test_full_state_without_hardware(router_app, backend) -> None:
+    """/state/full?with_imu=true -> the key is present and null."""
+    client = router_app(state.router, backend=backend)
+
+    resp = client.get("/state/full", params={"with_imu": True})
+
+    assert resp.status_code == 200
+    assert resp.json()["imu"] is None
+
+
+def test_full_state_without_flag(router_app, with_imu) -> None:
+    """Without ``with_imu`` the IMU is not read: the field stays null."""
+    client = router_app(state.router, backend=with_imu)
+
+    resp = client.get("/state/full")
+
+    assert resp.status_code == 200
+    assert resp.json().get("imu") is None
+
+
+# --------------------------------------------------------------------
+# Positive path: a reading is served, without the WS discriminator
+# --------------------------------------------------------------------
+
+
+def test_get_imu_returns_reading(router_app, with_imu) -> None:
+    """GET /state/imu -> the four fields, and no legacy ``type`` key."""
+    client = router_app(state.router, backend=with_imu)
+
+    resp = client.get("/state/imu")
+
+    assert resp.status_code == 200
+    assert resp.json() == EXPECTED
+    assert "type" not in resp.json()
+
+
+def test_full_state_carries_imu(router_app, with_imu) -> None:
+    """/state/full?with_imu=true -> the same object, also without ``type``."""
+    client = router_app(state.router, backend=with_imu)
+
+    resp = client.get("/state/full", params={"with_imu": True})
+
+    assert resp.status_code == 200
+    assert resp.json()["imu"] == EXPECTED
+    assert "type" not in resp.json()["imu"]
+
+
+# --------------------------------------------------------------------
+# State snapshot (WebRTC pose push + get_state reply)
+# --------------------------------------------------------------------
+
+
+def test_snapshot_carries_imu(with_imu) -> None:
+    """The snapshot serializes the reading through the ``ImuData`` schema."""
+    payload = json.loads(with_imu.build_state_snapshot().model_dump_json())
+
+    assert payload["imu"] == EXPECTED
+    assert "type" not in payload["imu"]
+
+
+def test_snapshot_without_hardware(backend) -> None:
+    """No IMU -> the snapshot still has the key, set to null."""
+    payload = json.loads(backend.build_state_snapshot().model_dump_json())
+
+    assert payload["imu"] is None

--- a/tests/unit_tests/test_state_imu_api.py
+++ b/tests/unit_tests/test_state_imu_api.py
@@ -98,26 +98,19 @@ def test_full_state_without_flag(router_app, with_imu) -> None:
 # --------------------------------------------------------------------
 
 
-def test_get_imu_returns_reading(router_app, with_imu) -> None:
-    """GET /state/imu -> the four fields, and no legacy ``type`` key."""
+def test_imu_reading_on_both_routes(router_app, with_imu) -> None:
+    """``/state/imu`` and ``/state/full?with_imu=true`` serve the same object.
+
+    Only the four ``ImuData`` fields: the legacy ``type`` discriminator
+    (``ImuDataMsg``) never reaches the client on either route.
+    """
     client = router_app(state.router, backend=with_imu)
 
-    resp = client.get("/state/imu")
+    direct = client.get("/state/imu")
+    full = client.get("/state/full", params={"with_imu": True})
 
-    assert resp.status_code == 200
-    assert resp.json() == EXPECTED
-    assert "type" not in resp.json()
-
-
-def test_full_state_carries_imu(router_app, with_imu) -> None:
-    """/state/full?with_imu=true -> the same object, also without ``type``."""
-    client = router_app(state.router, backend=with_imu)
-
-    resp = client.get("/state/full", params={"with_imu": True})
-
-    assert resp.status_code == 200
-    assert resp.json()["imu"] == EXPECTED
-    assert "type" not in resp.json()["imu"]
+    assert direct.status_code == full.status_code == 200
+    assert direct.json() == full.json()["imu"] == EXPECTED
 
 
 # --------------------------------------------------------------------

--- a/ts/lib/imu.test.ts
+++ b/ts/lib/imu.test.ts
@@ -105,3 +105,17 @@ describe('getImu - degraded paths', () => {
         await expect(r.getImu()).rejects.toThrow(/Data channel not open/);
     });
 });
+
+describe('robotState.imu mirror', () => {
+    it('is set by a state frame and cleared again by imu: null', () => {
+        const { r, internals } = makeInstance();
+
+        internals._handleRobotMessage({ state: { imu: READING } });
+        expect(r.robotState.imu).toEqual(READING);
+
+        // The daemon nulls the field once its cache goes stale; the mirror
+        // must clear rather than serve a frozen reading.
+        internals._handleRobotMessage({ state: { imu: null } });
+        expect(r.robotState.imu).toBeUndefined();
+    });
+});

--- a/ts/lib/reachy-mini.ts
+++ b/ts/lib/reachy-mini.ts
@@ -2155,6 +2155,7 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
                 is_move_running?: boolean;
                 face_target?: FaceTarget;
                 doa?: { angle: number; speech_detected: boolean } | null;
+                imu?: ImuData | null;
             };
             if (s.head_pose) this._robotState.head = s.head_pose.flat();
             if (s.antennas) this._robotState.antennas = [s.antennas[0], s.antennas[1]];
@@ -2166,6 +2167,9 @@ export class ReachyMini extends EventTarget implements ReachyMiniInstance {
             // DoA is null when there's no mic array / no reading yet - reflect
             // that by clearing our mirror so stale angles don't linger.
             if ('doa' in s) this._robotState.doa = s.doa ?? undefined;
+            // Same for the IMU: the daemon sends null once its 0.5 s cache
+            // goes stale, so a frozen last reading must not linger either.
+            if ('imu' in s) this._robotState.imu = s.imu ?? undefined;
             this._emit('state', { ...this._robotState });
         }
         if (data.error) {

--- a/ts/lib/types.ts
+++ b/ts/lib/types.ts
@@ -98,6 +98,11 @@ export interface RobotState {
      * (or no reading yet). Refreshed by the daemon at ~10 Hz.
      */
     doa?: DoA;
+    /**
+     * Latest IMU reading, or absent on robots without one (Lite, simulator)
+     * and while the daemon's cached reading is stale.
+     */
+    imu?: ImuData;
 }
 
 /** SDK constructor options. */


### PR DESCRIPTION
### Motivation

The wireless Reachy Mini's IMU (BMI088) was only reachable through the legacy WS protocol (`GetImuCmd` + 50 Hz `ImuDataMsg` broadcast on `/ws/sdk`). The newer API surfaces — the REST `/state/*` routes and the WebRTC state frames parsed by the JS SDK — had no IMU at all. This PR brings them to parity. The Lite and the simulator have no IMU: on those, every new surface fails silently (`null`/`undefined`, never an error), matching the existing `/state/doa` contract.

### What changed

**Wire model** (`src/reachy_mini/io/protocol.py`)
- New `ImuData` model carrying the four payload fields: `accelerometer` (3, m/s²), `gyroscope` (3, rad/s), `quaternion` (4, w-first), `temperature` (°C).
- `ImuDataMsg` now subclasses `ImuData`, adding only the `type: "imu_data"` discriminator — wire-compatible for existing clients (same fields and values; only JSON key order shifts, which nothing consumes: `ws_client.py` discriminates by model, not position).
- `StateSnapshot` gains an optional `imu` field (backward-safe for released JS SDKs: new optional field, existing fields untouched).

**Backend** (`src/reachy_mini/daemon/backend/abstract.py`)
- `build_state_snapshot()` fills `imu` from the existing `get_imu_data()` cache. This single point feeds both the 30 Hz WebRTC pose-channel push and the `get_state` reply on every transport. Because the snapshot field is typed `ImuData`, the legacy `type` discriminator never leaks into snapshot JSON. No robot-backend changes — the cache refresh already runs in the control loop.

**REST** (`daemon/app/models.py`, `daemon/app/routers/state.py`)
- `GET /state/imu` → the reading, or HTTP 200 with `null` on IMU-less robots / stale cache.
- `with_imu: bool = false` flag on `GET /state/full` and the streaming `WS /state/ws/full`, adding an `imu` field to `FullState` — so REST clients can also stream IMU at any requested frequency.

**TS SDK** (`ts/lib/types.ts`, `ts/lib/reachy-mini.ts`)
- `RobotState` gains optional `imu` (reusing the `ImuData` interface #1315 introduced), mirrored from incoming state frames. The mirror clears when the daemon sends `imu: null` (stale cache / no IMU), so consumers never act on a frozen reading — same pattern as `doa`.

### Not in scope

- A dedicated 50 Hz WebRTC IMU data channel. The 30 Hz pose-channel piggyback covers tilt/pickup/motion detection; the `pose` channel (`subscribe_pose`) is the template if a sensor-rate use case appears later.
- IMU configuration/calibration endpoints.
- Legacy WS protocol and Python SDK (`reachy.imu`) — already working, unchanged.

### Testing

New `tests/unit_tests/test_state_imu_api.py` (7 tests): fail-silent nulls against the mockup backend on all three surfaces; positive path with a stubbed reading; and the assertion that the `type` discriminator never reaches REST or snapshot JSON. On the JS side, `imu.test.ts` gains a `robotState.imu` mirror test pinning both the set and the stale-`null` clear. Verified alongside the pose-stream, DoA, protocol-sync, process-command, and WS server/client suites; `npm run typecheck:sdk` and the IMU vitest suite pass. (Pre-existing, unrelated: `test_daemon_wireless_client_disconnection` fails on a clean tree too.)

### Relation to #1315

Complementary: #1315 gave the JS SDK a one-shot `getImu()` over the `get_imu` data-channel command; this PR adds the *streamed* IMU in the 30 Hz state snapshot plus the REST endpoints, backed by the same daemon cache. Rebased on current main now that #1315 has landed — this branch reuses its `ImuData` interface and extends its `imu.test.ts` suite with the state-mirror test.

