### PR TITLE
fix(examples): throttle minimal_demo's set_target loop to 100 Hz

### DIFF
--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -26,6 +26,7 @@ with ReachyMini(media_backend="no_media") as mini:
                 mm=False,
             )
             mini.set_target(head=head_pose, antennas=[antennas_offset, antennas_offset])
+            time.sleep(0.01)  # 100 Hz; unthrottled floods the daemon and lags the motion
     except KeyboardInterrupt:
         pass
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -26,7 +26,7 @@ with ReachyMini(media_backend="no_media") as mini:
                 mm=False,
             )
             mini.set_target(head=head_pose, antennas=[antennas_offset, antennas_offset])
-            time.sleep(0.01)  # 100 Hz; unthrottled floods the daemon and lags the motion
+            time.sleep(0.01)  # 100 Hz
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
Closes #1344. Unthrottled the loop emitted ~13000 `set_target`/s from a laptop against the 50 Hz control loop, which generated a very jerky movement.