### PR TITLE
ci(release): make RCs visible, keep note edits, and ship RCs to npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,11 @@ on:
   release:
     types:
       - created
+  # Dispatched by the Release workflow with --ref <tag> after the PyPI publish.
+  # A `release` event is not usable there: releases created with GITHUB_TOKEN don't
+  # trigger workflows (recursion guard), and later RCs / the final promotion only
+  # *edit* an existing release, which never emits `created`.
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -141,8 +146,10 @@ jobs:
         if: github.event_name == 'pull_request'
         run: npm pack --dry-run
 
+      # workflow_dispatch is the Release workflow shipping a tag (rc → `rc`, X.Y.Z →
+      # `latest`); the version-compute step above already treats it like a release.
       - name: Publish (release)
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         run: npm publish --tag "${{ steps.ver.outputs.release_tag }}"
 
       - name: Publish (main)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -94,6 +94,24 @@ jobs:
           done
           exit $fail
 
+      # post-release and publish-npm dispatch other workflows with this token, which
+      # needs Actions: write on top of contents/pull-requests.
+      - name: Check RELEASE_PAT can dispatch workflows
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          echo "### RELEASE_PAT workflow dispatch" >> "$GITHUB_STEP_SUMMARY"
+          # Listing workflow runs needs Actions: read; dispatching needs Actions: write,
+          # which has no read-only probe — so this catches "no Actions scope at all".
+          if gh api "repos/${{ github.repository }}/actions/workflows" --jq '.total_count' >/dev/null 2>&1; then
+            echo "✅ RELEASE_PAT can read Actions (grant 'Actions: write' for dispatch)"
+            echo "- ✅ Actions scope present (needs *write* to dispatch npm-publish/docs)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "❌ RELEASE_PAT has no Actions access — npm-publish and the docs build won't be dispatched"
+            echo "- ❌ Actions scope missing on \`RELEASE_PAT\`" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
       - name: Check the pypi environment exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -381,6 +399,31 @@ jobs:
           print-hash: true
 
   # ============================================================
+  # 2b. PUBLISH — npm (TS SDK), by dispatching npm-publish.yml at this tag
+  #
+  # npm-publish only publishes on a `release` event, which never fires here: releases
+  # created with GITHUB_TOKEN don't trigger workflows (recursion guard), and later RCs
+  # and the final promotion only *edit* an existing release (no `created` event). So the
+  # SDK silently stopped shipping. Dispatch it explicitly instead — it reads the version
+  # from pyproject.toml at the tag, so rc tags land on the `rc` dist-tag and X.Y.Z on
+  # `latest`. Needs RELEASE_PAT (Actions: write); GITHUB_TOKEN would be recursion-guarded.
+  # ============================================================
+  publish-npm:
+    permissions: {}
+    needs: [prepare, publish-pypi]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch npm-publish at ${{ needs.prepare.outputs.tag }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh workflow run npm-publish.yml --repo "${{ github.repository }}" --ref "$TAG"
+          echo "Dispatched npm-publish at $TAG — see the 'Publish npm' workflow."
+          echo "- npm publish dispatched at \`$TAG\`" >> "$GITHUB_STEP_SUMMARY"
+
+  # ============================================================
   # 3. RELEASE NOTES — AI-drafted, one GitHub release per minor
   #
   #   - minor-prerelease : if no release exists for this minor, generate notes with OpenCode
@@ -446,8 +489,10 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
           GITHUB_TOKEN_RELEASE_NOTES: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NOTES_MODEL: ${{ vars.RELEASE_NOTES_MODEL }}
           RELEASE_NOTES_HEAD: ${{ needs.prepare.outputs.tag }}
+          EXISTING_TAG: ${{ steps.check_draft.outputs.existing_tag }}
         run: |
           # OpenCode reads the huggingface provider credential from its auth store, not from
           # HF_TOKEN env — write it non-interactively so `opencode run` doesn't hang on login.
@@ -457,9 +502,29 @@ jobs:
           mkdir -p "$HOME/.config/opencode"
           jq -n '{provider:{huggingface:{options:{headers:{"X-HF-Bill-To":"pollen-robotics"}}}}}' \
             > "$HOME/.config/opencode/opencode.json"
+
+          # Later RC: seed from the release's current notes so manual edits survive — the
+          # validation loop then only appends PRs merged since, and calls no model at all
+          # when nothing changed. First RC (no release yet) generates from scratch.
+          SEED_ARG=""
+          if [[ -n "$EXISTING_TAG" ]]; then
+            mkdir -p /tmp/seed
+            if gh release view "$EXISTING_TAG" --json body -q '.body' > /tmp/seed/notes.md \
+               && [[ -s /tmp/seed/notes.md ]]; then
+              # The body is stored without the "# <title>" first line; put it back so the
+              # seeded file matches the generator's format (title + body).
+              TITLE=$(gh release view "$EXISTING_TAG" --json name -q '.name')
+              { echo "# ${TITLE}"; cat /tmp/seed/notes.md; } > /tmp/seed/seeded.md
+              SEED_ARG="--seed /tmp/seed/seeded.md"
+              echo "Seeding notes from release $EXISTING_TAG"
+            else
+              echo "::warning::Could not read notes from $EXISTING_TAG — regenerating from scratch."
+            fi
+          fi
+
           python -m utils.release_notes.generate_release_notes \
             --since "${{ needs.prepare.outputs.since_tag }}" \
-            --${{ needs.prepare.outputs.bump_type }}
+            --${{ needs.prepare.outputs.bump_type }} $SEED_ARG
 
       - name: Create or update GitHub release
         if: ${{ inputs.release_type != 'minor-release' }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,11 +3,12 @@
 # Adapted (trimmed) from huggingface/huggingface_hub's release.yml. One workflow_dispatch
 # trigger, three release types:
 #   - minor-prerelease : cut a release candidate (e.g. 1.10.0rc1) from main, create the
-#                        v1.10-release branch, publish to PyPI, draft AI release notes, and
-#                        open an RC-test PR in reachy_mini_conversation_app.
+#                        v1.10-release branch, publish to PyPI, publish/refresh this minor's
+#                        GitHub prerelease with freshly generated AI notes, and open an
+#                        RC-test PR in reachy_mini_conversation_app.
 #   - minor-release    : promote the latest RC to the final version (e.g. 1.10.0), publish,
-#                        promote the draft release, and open a PR bumping main to the next
-#                        .dev0 (e.g. 1.11.0.dev0).
+#                        promote that prerelease to the final release, and open a PR
+#                        bumping main to the next .dev0 (e.g. 1.11.0.dev0).
 #   - patch-release    : bump the patch on an existing vX.Y-release branch (e.g. 1.10.1) and
 #                        publish. Not marked "latest" on GitHub.
 #
@@ -380,17 +381,19 @@ jobs:
           print-hash: true
 
   # ============================================================
-  # 3. RELEASE NOTES — AI-drafted, one draft GitHub release per minor
+  # 3. RELEASE NOTES — AI-drafted, one GitHub release per minor
   #
   #   - minor-prerelease : if no release exists for this minor, generate notes with OpenCode
-  #                        and create a draft prerelease. Subsequent RCs are no-ops.
-  #   - minor-release    : promote the existing draft to the final tag (removes prerelease).
+  #                        and publish a prerelease. Each later RC retags that same release
+  #                        to the new RC tag and refreshes its notes (so the releases page
+  #                        always shows the latest RC as a published prerelease).
+  #   - minor-release    : promote that release to the final tag (removes prerelease).
   #   - patch-release    : generate notes for the patch range and create a release.
   # ============================================================
   release-notes:
     permissions:
       contents: write
-    # Gate on publish so we never draft/promote a GitHub release for a version that
+    # Gate on publish so we never publish/promote a GitHub release for a version that
     # failed to reach PyPI (a failed publish must stop the pipeline here).
     needs: [prepare, publish-pypi]
     runs-on: ubuntu-latest
@@ -400,38 +403,45 @@ jobs:
           ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
 
-      # --- Prerelease / patch: skip if a release already exists for this minor ---
-      - name: Check for existing release
+      # --- Find the release object for this minor, if any ---
+      # One release per minor version, reused across RCs: each prerelease retags it to the
+      # new RC and refreshes its notes, so the releases page always shows the latest RC as
+      # a published prerelease. A patch release always gets its own release.
+      - name: Find existing release for this minor
         if: ${{ inputs.release_type != 'minor-release' }}
         id: check_draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.prepare.outputs.version }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
           MINOR=$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
-          EXISTING=$(gh release list --json tagName --limit 100 \
-            | jq -r ".[] | select(.tagName | startswith(\"v${MINOR}.\")) | .tagName" | head -1)
-          if [[ -n "$EXISTING" && "${{ inputs.release_type }}" == "minor-prerelease" ]]; then
-            echo "Release already exists for v${MINOR}: $EXISTING — skipping notes"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+          EXISTING=""
+          if [[ "$RELEASE_TYPE" == "minor-prerelease" ]]; then
+            EXISTING=$(gh release list --json tagName --limit 100 \
+              | jq -r ".[] | select(.tagName | startswith(\"v${MINOR}.\")) | .tagName" | head -1)
+            if [[ -n "$EXISTING" ]]; then
+              echo "Reusing release $EXISTING for v${MINOR} — will retag and refresh its notes"
+            else
+              echo "No release yet for v${MINOR} — will create one"
+            fi
           fi
+          echo "existing_tag=$EXISTING" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        if: ${{ inputs.release_type != 'minor-release' && steps.check_draft.outputs.skip != 'true' }}
+        if: ${{ inputs.release_type != 'minor-release' }}
         with:
           python-version: "3.12"
       - name: Install dependencies
-        if: ${{ inputs.release_type != 'minor-release' && steps.check_draft.outputs.skip != 'true' }}
+        if: ${{ inputs.release_type != 'minor-release' }}
         run: pip install PyGithub
 
       - name: Install OpenCode
-        if: ${{ inputs.release_type != 'minor-release' && steps.check_draft.outputs.skip != 'true' }}
+        if: ${{ inputs.release_type != 'minor-release' }}
         run: curl -fsSL https://opencode.ai/install | bash -s -- --version ${{ vars.OPENCODE_VERSION }}
 
       - name: Generate release notes with OpenCode
-        if: ${{ inputs.release_type != 'minor-release' && steps.check_draft.outputs.skip != 'true' }}
+        if: ${{ inputs.release_type != 'minor-release' }}
         timeout-minutes: 30
         env:
           HF_TOKEN: ${{ secrets.RELEASE_NOTES_HF_TOKEN }}
@@ -451,12 +461,13 @@ jobs:
             --since "${{ needs.prepare.outputs.since_tag }}" \
             --${{ needs.prepare.outputs.bump_type }}
 
-      - name: Create GitHub release
-        if: ${{ inputs.release_type != 'minor-release' && steps.check_draft.outputs.skip != 'true' }}
+      - name: Create or update GitHub release
+        if: ${{ inputs.release_type != 'minor-release' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag }}
           IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
+          EXISTING_TAG: ${{ steps.check_draft.outputs.existing_tag }}
         run: |
           set -euo pipefail
           NOTES_FILE=""
@@ -469,16 +480,24 @@ jobs:
           fi
           TITLE=$(head -1 "$NOTES_FILE" | sed 's/^# //')
           tail -n +2 "$NOTES_FILE" > "${NOTES_FILE}.body"
-          # Prerelease → draft (reviewed, then promoted by minor-release).
-          # Patch → publish directly but NOT "latest" (keeps the current minor highlighted).
-          if [[ "$IS_PRERELEASE" == "true" ]]; then
-            gh release create "$TAG" --draft --prerelease --title "$TITLE" --notes-file "${NOTES_FILE}.body"
+
+          if [[ -n "$EXISTING_TAG" ]]; then
+            # Reuse this minor's release: point it at the new RC tag and refresh the notes.
+            # --draft=false publishes it so the desktop app can list it via the GitHub API.
+            gh release edit "$EXISTING_TAG" \
+              --tag "$TAG" --title "$TITLE" --notes-file "${NOTES_FILE}.body" \
+              --prerelease --draft=false --latest=false
+          elif [[ "$IS_PRERELEASE" == "true" ]]; then
+            # First RC of this minor: published prerelease (not a draft), never "latest".
+            gh release create "$TAG" --prerelease --latest=false \
+              --title "$TITLE" --notes-file "${NOTES_FILE}.body"
           else
+            # Patch release: published, but NOT "latest" (keeps the current minor highlighted).
             gh release create "$TAG" --latest=false --title "$TITLE" --notes-file "${NOTES_FILE}.body"
           fi
 
-      # --- Minor release: promote the existing draft to the final tag ---
-      - name: Promote draft release to final version
+      # --- Minor release: promote this minor's release to the final tag ---
+      - name: Promote release to final version
         if: ${{ inputs.release_type == 'minor-release' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -492,7 +511,7 @@ jobs:
           if [[ -n "$EXISTING_TAG" ]]; then
             gh release edit "$EXISTING_TAG" --tag "$TAG" --prerelease=false --latest --draft=false
           else
-            echo "::warning::No draft release for v${MINOR}. Creating one with auto-generated notes."
+            echo "::warning::No release found for v${MINOR}. Creating one with auto-generated notes."
             gh release create "$TAG" --title "v${VERSION}" --generate-notes --latest
           fi
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,6 +83,16 @@ python -m utils.release_notes.generate_release_notes --since v1.9.0 --minor
 
 The GitHub prerelease is editable before you run `minor-release` — polish tone there.
 
-**Note:** every `minor-prerelease` run regenerates the notes and overwrites that release's
-body, so hand edits are lost if you cut another RC. Do the final polish after the last RC,
-just before `minor-release` (which never regenerates — it publishes the body as-is).
+**Your edits survive later RCs.** The first RC of a minor generates the notes from
+scratch. Every later RC *seeds* from the release's current body (`--seed`) and runs only
+the validation loop, which appends the PRs merged since and drops stale ones — the
+surrounding prose, including anything you rewrote by hand, is left alone. If no new PRs
+landed since the last RC, validation passes immediately and the model is never called.
+
+`minor-release` never regenerates at all: it publishes the body as-is, so the last thing
+you edited is exactly what ships.
+
+**One caveat when editing.** The validation loop enforces an exact match against the PR
+manifest, so a `#1234` reference that is *not* part of this release gets treated as an
+extra and removed on the next RC. Prose is safe; a hand-added issue link or a "thanks,
+see #999" is not. Write those without the `#` (or add them after the last RC).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,8 +16,8 @@ statically in `pyproject.toml` (single source of truth): `main` carries
 | Mode | Trigger from | What it does |
 |------|--------------|--------------|
 | `dry-run` | anywhere | Read-only preflight: checks every secret/var is set, that `RELEASE_PAT` can push both repos, that the `pypi` environment exists, that OpenCode + the model + the HF token work (tiny live call), and previews the versions each mode would produce. Tags nothing, publishes nothing, opens no PR. Run this first. |
-| `minor-prerelease` | `main` | Reads `X.Y.Z.dev0` → cuts `X.Y.Zrc<N>` (RC starts at 1), creates/reuses `vX.Y-release`, tags, publishes to PyPI, AI-drafts a **draft** GitHub release, and opens an RC-test PR in `reachy_mini_conversation_app`. |
-| `minor-release` | `main` | Promotes the latest RC → `X.Y.Z`, publishes to PyPI, promotes the draft release to the final tag (marked *latest*), triggers the docs build, and opens a PR bumping `main` to `X.(Y+1).0.dev0`. |
+| `minor-prerelease` | `main` | Reads `X.Y.Z.dev0` → cuts `X.Y.Zrc<N>` (RC starts at 1), creates/reuses `vX.Y-release`, tags, publishes to PyPI, regenerates the AI release notes, and publishes/refreshes **this minor's GitHub prerelease** (one release per minor: each RC retags it and refreshes its notes, so the releases page always shows the newest RC as a published prerelease). Also opens an RC-test PR in `reachy_mini_conversation_app`. |
+| `minor-release` | `main` | Promotes the latest RC → `X.Y.Z`, publishes to PyPI, promotes that prerelease to the final tag (marked *latest*, prerelease flag cleared), triggers the docs build, and opens a PR bumping `main` to `X.(Y+1).0.dev0`. |
 | `patch-release` | `vX.Y-release` | Bumps the patch (`X.Y.Z+1`), tags, publishes. Not marked *latest*. |
 
 Typical flow: `minor-prerelease` → validate the RC (its PR CI in the conversation app,
@@ -36,7 +36,7 @@ prepare ──▶ publish-pypi ──┬──▶ release-notes
 
 `prepare` pushes the version-bump commit **and the tag before** publishing, so the tag
 already exists once publishing starts. Everything after `prepare` is gated on a
-successful `publish-pypi`: if the publish fails, no GitHub release is drafted/promoted,
+successful `publish-pypi`: if the publish fails, no GitHub release is published/promoted,
 no RC-test PR and no bump PR are opened — the pipeline stops.
 
 **If `publish-pypi` fails:** do **not** re-trigger the whole workflow (`prepare` would
@@ -81,4 +81,8 @@ python -m utils.release_notes.generate_release_notes --since v1.9.0 --minor
 # → .release-notes/RELEASE_NOTES_v1.10.0.md
 ```
 
-The draft GitHub release is editable before you run `minor-release` — polish tone there.
+The GitHub prerelease is editable before you run `minor-release` — polish tone there.
+
+**Note:** every `minor-prerelease` run regenerates the notes and overwrites that release's
+body, so hand edits are lost if you cut another RC. Do the final polish after the last RC,
+just before `minor-release` (which never regenerates — it publishes the body as-is).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -92,7 +92,12 @@ landed since the last RC, validation passes immediately and the model is never c
 `minor-release` never regenerates at all: it publishes the body as-is, so the last thing
 you edited is exactly what ships.
 
-**One caveat when editing.** The validation loop enforces an exact match against the PR
-manifest, so a `#1234` reference that is *not* part of this release gets treated as an
-extra and removed on the next RC. Prose is safe; a hand-added issue link or a "thanks,
-see #999" is not. Write those without the `#` (or add them after the last RC).
+**One caveat when editing.** Validation scrapes the notes for `#<number>` and treats every
+match as a PR that must be in this release. So a reference that is *not* part of the
+release — an issue number, a PR from another repo, a "thanks, see #999" — is classified as
+an extra, and the fix-up step removes **the whole line containing it** on the next RC.
+
+Plain prose is safe, as are the generated `by @author in #1234` lines. To link an issue,
+use the full URL (`https://github.com/pollen-robotics/reachy_mini/issues/1338`): it renders
+the same and the regex only matches a bare `#` followed by digits. Edits made after the
+last RC are safe regardless, since `minor-release` never regenerates.

--- a/utils/release_notes/generate_release_notes.py
+++ b/utils/release_notes/generate_release_notes.py
@@ -154,19 +154,32 @@ def run_opencode_skill(
         return False
 
 
-def main(since_tag: str, bump_type: str = "patch", max_iterations: int = 3) -> int:
+def main(since_tag: str, bump_type: str = "patch", max_iterations: int = 3, seed: str | None = None) -> int:
     """Run the full release notes generation pipeline.
 
     Args:
         since_tag: Git tag to compare against (e.g., "v1.3.7")
         bump_type: Version bump type ("major", "minor", or "patch")
         max_iterations: Maximum validation/fix iterations
+        seed: Existing notes to start from instead of generating a new draft. Used on
+            later RCs so manual edits survive: the validation loop only appends the PRs
+            that are missing and drops stale ones. No model call at all if nothing changed.
 
     Returns:
         Exit code (0 for success, non-zero for failure)
 
     """
     t_total_start = time.monotonic()
+
+    # Read the seed before the output dir is wiped below (it may live inside it).
+    seed_text = None
+    if seed:
+        seed_path = Path(seed)
+        if not seed_path.exists() or seed_path.stat().st_size == 0:
+            print(f"Warning: seed {seed_path} missing or empty — generating from scratch", file=sys.stderr)
+        else:
+            seed_text = seed_path.read_text()
+            print(f"Seeding from {seed_path} ({len(seed_text):,} bytes)")
 
     # 0. Validate the configured model before doing any expensive work.
     #    OpenCode exits 0 on unknown models, so a typo here would otherwise
@@ -206,25 +219,32 @@ def main(since_tag: str, bump_type: str = "patch", max_iterations: int = 3) -> i
 
     print(f"Fetched {len(pr_numbers)} PRs")
 
-    # 4. Generate initial draft with OpenCode
-    print("\nGenerating release notes with OpenCode...")
+    # 4. Get an initial draft: reuse the seed if given, otherwise generate one.
     t_agent_start = time.monotonic()
     agent_calls = 0
-    if not run_opencode_skill("reachy-mini-release-notes", version):
-        print("Failed to generate initial release notes", file=sys.stderr)
-        return 1
-    agent_calls += 1
-
-    # OpenCode can exit 0 without writing the expected file (e.g. auth/quota
-    # issues). Fail fast instead of falling through to a 0-byte output.
     initial_output = OUTPUT_DIR / f"RELEASE_NOTES_{version}.md"
-    if not initial_output.exists() or initial_output.stat().st_size == 0:
-        print(
-            f"Error: OpenCode did not produce {initial_output} (or file is empty). "
-            f"Check OpenCode logs above for the real error.",
-            file=sys.stderr,
-        )
-        return 1
+
+    if seed_text is not None:
+        # Later RC: start from the current (possibly hand-edited) notes and let the
+        # validation loop reconcile them against the manifest.
+        initial_output.write_text(seed_text)
+        print(f"Using seeded notes as the draft ({initial_output})")
+    else:
+        print("\nGenerating release notes with OpenCode...")
+        if not run_opencode_skill("reachy-mini-release-notes", version):
+            print("Failed to generate initial release notes", file=sys.stderr)
+            return 1
+        agent_calls += 1
+
+        # OpenCode can exit 0 without writing the expected file (e.g. auth/quota
+        # issues). Fail fast instead of falling through to a 0-byte output.
+        if not initial_output.exists() or initial_output.stat().st_size == 0:
+            print(
+                f"Error: OpenCode did not produce {initial_output} (or file is empty). "
+                f"Check OpenCode logs above for the real error.",
+                file=sys.stderr,
+            )
+            return 1
 
     # 5. Validation loop
     validation_iterations = 0
@@ -351,9 +371,17 @@ Examples:
         default=3,
         help="Maximum validation/fix iterations (default: 3)",
     )
+    parser.add_argument(
+        "--seed",
+        help=(
+            "Start from these existing notes instead of generating a new draft. "
+            "The validation loop then only adds missing PRs and drops stale ones, so "
+            "manual edits survive. Used for RCs after the first."
+        ),
+    )
     args = parser.parse_args()
 
-    sys.exit(main(args.since, args.bump_type, args.max_iterations))
+    sys.exit(main(args.since, args.bump_type, args.max_iterations, args.seed))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

No separate issue — follow-up to the release CI landed in #1269 / #1283. Three problems surfaced on the first real v1.10 RC cycle.

**1. Later RCs produced no release.** `v1.10.0rc1` failed in the notes job (billing), `v1.10.0rc2` created the release as a **draft**, and `v1.10.0rc3` ([run 31615298113](https://github.com/pollen-robotics/reachy_mini/actions/runs/31615298113)) hit the skip branch — `Release already exists for v1.10: v1.10.0rc2 — skipping notes`. So the releases page still showed rc2 with rc2-era notes, rc3 existed only as a git tag, and being a **draft** it wasn't returned by the releases API at all, so the desktop app couldn't list it.

**2. Regenerating every RC would destroy manual edits** — the obvious fix to (1) trades one problem for another.

**3. The TS SDK stopped shipping to npm.** `npm-publish` only publishes on a `release` event, which never fires here: releases created with `GITHUB_TOKEN` don't trigger workflows (recursion guard), and later RCs plus the final promotion only *edit* an existing release, which never emits `created`. Over the last 60 runs it had fired on `pull_request` (54) and `push` (6) and **never** on `release` — so no 1.10 RC reached npm, and **`v1.10.0` would not have either**.

## Description

**One release per minor that walks forward.** `minor-prerelease` retags this minor's release to the new RC, refreshes it, and publishes it as a **prerelease** instead of a draft, so it is API-listable and always reflects the newest RC. `minor-release` is unchanged: it promotes the same object to the final tag and clears the prerelease flag. Patch releases still get their own release.

**Notes are seeded, not regenerated.** The first RC generates from scratch; later RCs seed from the release's current body (new `--seed` flag on `generate_release_notes.py`) and run only the validation loop, which appends PRs merged since and drops stale ones, leaving the surrounding prose — and your edits — alone. If nothing new landed, validation passes on the first iteration and the model is never called, so most RCs are free. This reuses the existing `reachy-mini-release-notes:validate` skill rather than adding machinery.

**npm ships again, by explicit dispatch.** Rather than guessing release event types (`edited` would republish on every note tweak and fail on an unchanged version), the release workflow dispatches `npm-publish.yml` at the tag after the PyPI publish. `npm-publish` gains a `workflow_dispatch` trigger and publishes on `release || workflow_dispatch`; its version-compute already treats non-push/PR events as a release, so nothing else changed there. The dry-run preflight now also checks the Actions scope on `RELEASE_PAT`, which the dispatch needs.

## Testing

**Seeding** — seeded the live rc2 notes with a canary line, then ran the real pipeline against a range where 25 PRs were missing:

```
Seeding from /tmp/seedtest/seeded.md (5,274 bytes)
Validation iteration 1/3...  Missing 25 PRs: #1182, #1211, ... #1348
Validation iteration 2/3...  Release notes match the manifest exactly
Agent calls: 1 | Validation iterations: 2 | Total time: 264.1s
```

The canary survived and all 25 PRs were appended. An earlier attempt against the full range was interrupted because the machine was suspended mid-run, not because anything stalled — it had correctly seeded and invoked the validate skill with exactly the right missing-PR list. The generate step is capped at `timeout-minutes: 30` in CI.

That run also surfaced a caveat now documented in `RELEASE.md`: the loop enforces an exact manifest match, so a `#1234` reference that isn't part of the release gets removed as an extra. Prose is safe; hand-added issue links are not. Note `since_tag` for a prerelease is the last **stable** tag (the regex excludes rc), so it is identical for every RC of a minor and the seed's PRs are always a subset of the manifest.

**npm** — replayed the version-compute step for a `workflow_dispatch` event: `1.10.0rc4` → `1.10.0-rc.4` on dist-tag `rc`, `1.10.0` → `latest` (Pierre's PEP 440 → semver fix in #1273 carries it).

Not verified end to end: this workflow only runs from `main` via `workflow_dispatch`. The next `minor-prerelease` is the real proof — it should retag the existing release to `v1.10.0rc4`, publish it as a prerelease, refresh the notes in place, and dispatch `npm-publish` so `1.10.0-rc.4` lands on the `rc` dist-tag.

## Tested on

- [ ] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [x] Not applicable (release CI only)

## AI assistance

`Assisted-by: Claude:claude-opus-5`
