### PR TITLE
ci(release): cut every RC from main, and run notes tooling from main

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -324,13 +324,14 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$RELEASE_TYPE" == "minor-prerelease" ]]; then
-            if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
-              git fetch origin "$BRANCH"
-              git checkout "$BRANCH"
-              git pull origin "$BRANCH"
-            else
-              git checkout -b "$BRANCH"
-            fi
+            # Every RC is a fresh snapshot of main. Previously the branch was only
+            # created at rc1 and then reused, so rc2+ silently shipped the rc1 code with
+            # a new version number (v1.10.0rc4 was cut 53 commits behind main).
+            # WARNING: this discards anything committed straight onto the release branch —
+            # land fixes on main and cut another RC instead of pushing here.
+            git fetch origin main
+            git checkout -B "$BRANCH" origin/main
+            echo "Release branch $BRANCH reset to origin/main ($(git rev-parse --short HEAD))"
           else
             if ! git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
               echo "::error::Branch $BRANCH does not exist. Run a minor-prerelease first."
@@ -365,7 +366,11 @@ jobs:
           else
             git tag "$TAG" -m "${TAG} release"
           fi
-          git push -u --tags origin "$BRANCH"
+          # Resetting the branch to main makes this a non-fast-forward push. Only this
+          # workflow writes to the branch, and --force-with-lease still refuses if the
+          # remote moved since our fetch.
+          git push --force-with-lease -u origin "$BRANCH"
+          git push origin "$TAG"
 
   # ============================================================
   # 2. PUBLISH — PyPI via OIDC Trusted Publishing (no stored token)
@@ -441,9 +446,14 @@ jobs:
     needs: [prepare, publish-pypi]
     runs-on: ubuntu-latest
     steps:
+      # Check out main, not the tag: this job only needs the notes tooling and the
+      # OpenCode skill, and those must be the current ones. Checking out the tag ran
+      # whatever tooling that release branch happened to carry, which is how a tag cut
+      # before a tooling change failed with "unrecognized arguments: --seed".
+      # The PR range comes from the API via RELEASE_NOTES_HEAD, not from this checkout.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: ${{ needs.prepare.outputs.tag }}
+          ref: main
           fetch-depth: 0
 
       # --- Find the release object for this minor, if any ---

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -101,16 +101,25 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           echo "### RELEASE_PAT workflow dispatch" >> "$GITHUB_STEP_SUMMARY"
-          # Listing workflow runs needs Actions: read; dispatching needs Actions: write,
-          # which has no read-only probe — so this catches "no Actions scope at all".
-          if gh api "repos/${{ github.repository }}/actions/workflows" --jq '.total_count' >/dev/null 2>&1; then
-            echo "✅ RELEASE_PAT can read Actions (grant 'Actions: write' for dispatch)"
-            echo "- ✅ Actions scope present (needs *write* to dispatch npm-publish/docs)" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "❌ RELEASE_PAT has no Actions access — npm-publish and the docs build won't be dispatched"
-            echo "- ❌ Actions scope missing on \`RELEASE_PAT\`" >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
+          # Probe Actions: *write* without side effects by dispatching a workflow id that
+          # cannot exist: 404 means we were allowed through and only the workflow was
+          # missing, 403 means the token lacks the permission. Reading the workflow list
+          # is useless here — this repo is public, so it succeeds even with no Actions
+          # permission at all (which is how a missing scope slipped through before).
+          CODE=$(gh api -X POST "repos/${{ github.repository }}/actions/workflows/0/dispatches" \
+            -f ref=main --include 2>&1 | grep -oE 'HTTP/[0-9.]+ [0-9]{3}' | grep -oE '[0-9]{3}$' | head -1)
+          case "$CODE" in
+            404)
+              echo "✅ RELEASE_PAT has Actions: write (npm-publish/docs dispatch will work)"
+              echo "- ✅ \`RELEASE_PAT\` has Actions: write" >> "$GITHUB_STEP_SUMMARY" ;;
+            403)
+              echo "❌ RELEASE_PAT lacks Actions: write — npm-publish and the docs build cannot be dispatched."
+              echo "   Fix: fine-grained PAT → Repository permissions → Add permissions → Actions: Read and write."
+              echo "- ❌ \`RELEASE_PAT\` lacks Actions: write" >> "$GITHUB_STEP_SUMMARY"; exit 1 ;;
+            *)
+              echo "⚠️ unexpected status $CODE probing Actions: write — not failing preflight"
+              echo "- ⚠️ Actions: write probe returned $CODE" >> "$GITHUB_STEP_SUMMARY" ;;
+          esac
 
       - name: Check the pypi environment exists
         env:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ statically in `pyproject.toml` (single source of truth): `main` carries
 | Mode | Trigger from | What it does |
 |------|--------------|--------------|
 | `dry-run` | anywhere | Read-only preflight: checks every secret/var is set, that `RELEASE_PAT` can push both repos, that the `pypi` environment exists, that OpenCode + the model + the HF token work (tiny live call), and previews the versions each mode would produce. Tags nothing, publishes nothing, opens no PR. Run this first. |
-| `minor-prerelease` | `main` | Reads `X.Y.Z.dev0` → cuts `X.Y.Zrc<N>` (RC starts at 1), creates/reuses `vX.Y-release`, tags, publishes to PyPI, regenerates the AI release notes, and publishes/refreshes **this minor's GitHub prerelease** (one release per minor: each RC retags it and refreshes its notes, so the releases page always shows the newest RC as a published prerelease). Also opens an RC-test PR in `reachy_mini_conversation_app`. |
+| `minor-prerelease` | `main` | Reads `X.Y.Z.dev0` → cuts `X.Y.Zrc<N>` (RC starts at 1), **resets `vX.Y-release` to `main`** so every RC is a fresh snapshot, tags, publishes to PyPI, regenerates the AI release notes, and publishes/refreshes **this minor's GitHub prerelease** (one release per minor: each RC retags it and refreshes its notes, so the releases page always shows the newest RC as a published prerelease). Also opens an RC-test PR in `reachy_mini_conversation_app`. |
 | `minor-release` | `main` | Promotes the latest RC → `X.Y.Z`, publishes to PyPI, promotes that prerelease to the final tag (marked *latest*, prerelease flag cleared), triggers the docs build, and opens a PR bumping `main` to `X.(Y+1).0.dev0`. |
 | `patch-release` | `vX.Y-release` | Bumps the patch (`X.Y.Z+1`), tags, publishes. Not marked *latest*. |
 
@@ -29,7 +29,8 @@ Always run `dry-run` first to confirm secrets/vars/access are set.
 ## Job graph & recovery
 
 ```
-prepare ──▶ publish-pypi ──┬──▶ release-notes
+prepare ──▶ publish-pypi ──┬──▶ publish-npm      (dispatches the npm workflow at the tag)
+                           ├──▶ release-notes
                            ├──▶ test-downstream   (prerelease only)
                            └──▶ post-release       (minor-release only)
 ```
@@ -44,6 +45,15 @@ error on the now-existing tag). Instead **re-run the `publish-pypi` job from the
 UI** ("Re-run failed jobs"); once it succeeds, `release-notes` and the rest run off it.
 No re-tagging needed. If the tag/branch are wrong and you must start over, delete the tag
 (and the `vX.Y-release` branch if it was just created) before re-triggering.
+
+## The release branch
+
+`vX.Y-release` is **reset to `main` on every `minor-prerelease`** (force-pushed), so each
+RC ships exactly what is on `main` at that moment. Anything committed straight onto the
+release branch is discarded — land the fix on `main` and cut another RC.
+
+`minor-release` and `patch-release` do *not* reset: they build on the branch as the last
+RC left it, so the final release is the code you actually tested.
 
 ## One-time setup
 


### PR DESCRIPTION
## Issue

No separate issue — follow-up to #1349, from the first run of it ([run 31677845948](https://github.com/pollen-robotics/reachy_mini/actions/runs/31677845948)).

**RCs after the first shipped stale code.** `prepare` created `vX.Y-release` at rc1 and afterwards only checked it out again — it never brought `main` in. So rc2, rc3 and rc4 were the rc1 tree with nothing but a new version number:

```
v1.10-release: Release: v1.10.0rc4 / rc3 / rc2 / rc1
               └─ forked from main at 8855786f9 (Jul 20)
commits on main not in v1.10-release: 53
```

`v1.10.0rc4` was published to PyPI **53 commits behind `main`**. This also explains an earlier oddity where rc3's notes found 14 PRs while the same command run against `main` found 39.

**`release-notes` failed with `unrecognized arguments: --seed`.** Same root cause: the job runs the *workflow* from `main` (which passes `--seed`) but checked out the **tag** for the source, and that tag carried the pre-#1349 tooling.

## Description

`minor-prerelease` now resets `vX.Y-release` to `origin/main` before tagging, so every RC is a fresh snapshot of `main`. The push becomes non-fast-forward, so it uses `--force-with-lease` — only this workflow writes to that branch, and the lease still refuses if the remote moved since the fetch. `minor-release` and `patch-release` are unchanged: they build on the branch as the last RC left it, so the final release is the code that was actually tested, and cherry-picking a fix for a patch release still works.

The trade-off, now documented in `RELEASE.md`: anything committed straight onto the release branch is discarded by the next RC. Land fixes on `main` and cut another RC.

`release-notes` checks out `main` instead of the tag. It only needs the notes tooling and the OpenCode skill, and both should be the current ones; the PR range still comes from the API via `RELEASE_NOTES_HEAD`, not from the checkout. This removes the whole class of "the tag carries old tooling" failure.

## Testing

Facts above were read from the repo rather than inferred: `git rev-list --count origin/v1.10-release..origin/main` → 53, the release branch contains only the four `Release:` commits, and `git show v1.10.0rc4:utils/release_notes/generate_release_notes.py | grep -c '"--seed"'` → 0, which is exactly the argparse error seen in the run.

Workflow parses (`yaml.safe_load`). Not verified end to end — this only runs from `main` via `workflow_dispatch`, so the proof is the next `minor-prerelease`: `v1.10-release` should be reset to `main` (53 commits of delta gone), `v1.10.0rc5` cut from it, and `release-notes` should get past `--seed`.

Note `v1.10.0rc4` on PyPI is stale and should be superseded by a fresh RC rather than used for validation.

## Tested on

- [ ] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [x] Not applicable (release CI only)

## AI assistance

`Assisted-by: Claude:claude-opus-5`