### PR TITLE
fix(host): slight UI tweaks

### DIFF
--- a/ts/host/src/components/SignInView.tsx
+++ b/ts/host/src/components/SignInView.tsx
@@ -167,11 +167,7 @@ export function SignInView({
           disabled={busy}
           startIcon={
             busy ? (
-              <CircularProgress
-                size={18}
-                thickness={5}
-                sx={{ color: 'text.secondary' }}
-              />
+              <CircularProgress size={18} thickness={5} color="primary" />
             ) : (
               <Box
                 component="img"


### PR DESCRIPTION
<!-- Read docs/contributing.md before opening your PR. -->

## Issue

In the host web UI, the spinner shown inside the "Continue with Hugging Face" button during the OAuth redirect is grey, while the rest of the busy button (border and label) stays in the primary color.

## Description

One-line change in SignInView: the CircularProgress used sx color text.secondary, it now uses color="primary" so it matches the button it sits in.

## Testing

Visual check only: the disabled button already pins its border and label to theme.palette.primary.main, the spinner now uses the same palette entry.

## Tested on

- [ ] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [x] Not applicable (e.g. docs, typo)

## AI assistance

<!-- Tick exactly one. Assisted commits also carry the Assisted-by trailer, see docs/contributing.md. -->

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [ ] AI wrote code here, and I ran and reviewed it
- [x] An agent produced this PR, and I have not run it myself

Made with [Cursor](https://cursor.com)