### PR TITLE
fix(motion): keep recorded-move loading off the daemon event loop

### DIFF
--- a/src/reachy_mini/daemon/app/routers/move.py
+++ b/src/reachy_mini/daemon/app/routers/move.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisco
 from huggingface_hub.errors import RepositoryNotFoundError
 from pydantic import BaseModel
 
-from reachy_mini.motion.recorded_move import RecordedMoves
+from reachy_mini.motion.recorded_move import RecordedMoves, get_recorded_moves
 from reachy_mini.utils.interpolation import InterpolationTechnique
 
 from ....daemon.backend.abstract import Backend
@@ -161,15 +161,26 @@ async def play_goto_sleep(backend: Backend = Depends(get_backend)) -> MoveUUID:
     return create_move_task(backend.goto_sleep())
 
 
+async def load_recorded_moves(dataset_name: str) -> RecordedMoves:
+    """Load a recorded-move library without blocking the event loop.
+
+    Building a library reads the whole dataset, and downloads it first when the
+    HF cache is cold. Both are synchronous, so running them inline would freeze
+    every other route and the state stream until they finish - unreachable HF
+    turns one emotion into a dead daemon. Hand it to a worker thread instead.
+    """
+    try:
+        return await asyncio.to_thread(get_recorded_moves, dataset_name)
+    except RepositoryNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
 @router.get("/recorded-move-datasets/list/{dataset_name:path}")
 async def list_recorded_move_dataset(
     dataset_name: str,
 ) -> list[str]:
     """List available recorded moves in a dataset."""
-    try:
-        moves = RecordedMoves(dataset_name)
-    except RepositoryNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+    moves = await load_recorded_moves(dataset_name)
 
     return moves.list_moves()
 
@@ -181,10 +192,7 @@ async def play_recorded_move_dataset(
     backend: Backend = Depends(get_backend),
 ) -> MoveUUID:
     """Request the robot to play a predefined recorded move from a dataset."""
-    try:
-        recorded_moves = RecordedMoves(dataset_name)
-    except RepositoryNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+    recorded_moves = await load_recorded_moves(dataset_name)
     try:
         move = recorded_moves.get(move_name)
     except ValueError as e:

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -2696,16 +2696,16 @@ class Backend:
         """
         from reachy_mini.motion.recorded_move import (
             DEFAULT_EMOTIONS_DATASET,
-            RecordedMoves,
+            get_recorded_moves,
         )
 
         dataset = cmd.dataset_name or DEFAULT_EMOTIONS_DATASET
         try:
-            # On a cold cache RecordedMoves() triggers a blocking
+            # On a cold cache building the library triggers a blocking
             # snapshot_download: run it in a worker thread so it cannot stall
             # the daemon's event loop (and its pose stream) mid-session.
             move = await asyncio.to_thread(
-                lambda: RecordedMoves(dataset).get(cmd.move_name)
+                lambda: get_recorded_moves(dataset).get(cmd.move_name)
             )
         except Exception as e:
             self.logger.warning(

--- a/src/reachy_mini/motion/recorded_move.py
+++ b/src/reachy_mini/motion/recorded_move.py
@@ -2,6 +2,7 @@ import bisect  # noqa: D100
 import json
 import logging
 import os
+import threading
 from glob import glob
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -171,6 +172,9 @@ class RecordedMoves:
     Uses local cache only to avoid blocking network calls during playback.
     The dataset should be pre-downloaded at daemon startup via preload_default_datasets().
     If not cached, falls back to network download (which may cause delays).
+
+    Constructing this re-reads every move file, so daemon code should go through
+    :func:`get_recorded_moves` to reuse a single instance per dataset.
     """
 
     def __init__(self, hf_dataset_name: str):
@@ -233,3 +237,42 @@ class RecordedMoves:
     def list_moves(self) -> List[str]:
         """List all moves in the loaded library."""
         return list(self.moves.keys())
+
+
+# Built libraries, keyed by dataset name, plus one lock per dataset. Building a
+# library parses every move file in the dataset, and on a cold cache downloads
+# it first, so we keep one instance instead of redoing that per request.
+_libraries: Dict[str, RecordedMoves] = {}
+_library_locks: Dict[str, threading.Lock] = {}
+_libraries_guard = threading.Lock()
+
+
+def get_recorded_moves(dataset_name: str) -> RecordedMoves:
+    """Return the shared :class:`RecordedMoves` for ``dataset_name``.
+
+    Blocking: a cold cache downloads the dataset, so call this from a worker
+    thread (``asyncio.to_thread``) and never from the daemon's event loop.
+
+    Args:
+        dataset_name: The HuggingFace dataset holding the moves.
+
+    Returns:
+        The library for that dataset, built on first use and reused after.
+
+    """
+    with _libraries_guard:
+        library = _libraries.get(dataset_name)
+        if library is not None:
+            return library
+        lock = _library_locks.setdefault(dataset_name, threading.Lock())
+
+    # Per-dataset lock: concurrent requests for the same cold dataset wait on a
+    # single build instead of each starting its own download, while requests for
+    # other datasets stay unblocked.
+    with lock:
+        library = _libraries.get(dataset_name)
+        if library is None:
+            library = RecordedMoves(dataset_name)
+            with _libraries_guard:
+                _libraries[dataset_name] = library
+        return library

--- a/tests/unit_tests/test_recorded_moves_cache.py
+++ b/tests/unit_tests/test_recorded_moves_cache.py
@@ -1,0 +1,129 @@
+"""Cover the shared recorded-move library cache.
+
+Exercises ``motion/recorded_move.py``'s ``get_recorded_moves``: the memoization
+and the per-dataset single-flight lock that stop a cold HF cache from
+rebuilding — and re-downloading — a library on every playback request. No
+hardware and no network: ``snapshot_download`` is stubbed out.
+"""
+
+import json
+import threading
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+import numpy as np
+import pytest
+
+import reachy_mini.motion.recorded_move as recorded_move
+from reachy_mini.motion.recorded_move import get_recorded_moves
+
+DATASET = "pollen-robotics/some-library"
+
+
+@pytest.fixture(autouse=True)
+def clear_library_cache() -> Iterator[None]:
+    """Isolate the module-level caches so tests don't leak into each other."""
+    recorded_move._libraries.clear()
+    recorded_move._library_locks.clear()
+    yield
+    recorded_move._libraries.clear()
+    recorded_move._library_locks.clear()
+
+
+@pytest.fixture
+def dataset_dir(tmp_path: Path) -> Path:
+    """A minimal on-disk dataset: one two-frame move, no sidecar sound."""
+    frame: dict[str, Any] = {
+        "head": np.eye(4).tolist(),
+        "antennas": [0.0, 0.0],
+        "body_yaw": 0.0,
+    }
+    (tmp_path / "hello.json").write_text(
+        json.dumps(
+            {
+                "description": "test move",
+                "time": [0.0, 0.1],
+                "set_target_data": [frame, frame],
+            }
+        )
+    )
+    return tmp_path
+
+
+def _stub_snapshot_download(
+    monkeypatch: pytest.MonkeyPatch,
+    dataset_dir: Path,
+    on_call: Callable[[], None] | None = None,
+) -> list[str]:
+    """Replace snapshot_download with a local stub, returning its call log."""
+    calls: list[str] = []
+
+    def fake_snapshot_download(repo_id: str, **kwargs: Any) -> str:
+        calls.append(repo_id)
+        if on_call is not None:
+            on_call()
+        return str(dataset_dir)
+
+    monkeypatch.setattr(recorded_move, "snapshot_download", fake_snapshot_download)
+    return calls
+
+
+def test_library_is_built_once_and_reused(
+    monkeypatch: pytest.MonkeyPatch, dataset_dir: Path
+) -> None:
+    """Repeated requests reuse one instance instead of re-reading the dataset."""
+    calls = _stub_snapshot_download(monkeypatch, dataset_dir)
+
+    first = get_recorded_moves(DATASET)
+    second = get_recorded_moves(DATASET)
+
+    assert first is second
+    assert calls == [DATASET], "library rebuilt on the second request"
+    assert first.list_moves() == ["hello"]
+
+
+def test_distinct_datasets_get_distinct_libraries(
+    monkeypatch: pytest.MonkeyPatch, dataset_dir: Path
+) -> None:
+    """The cache keys on the dataset name, so libraries don't alias."""
+    _stub_snapshot_download(monkeypatch, dataset_dir)
+
+    assert get_recorded_moves(DATASET) is not get_recorded_moves("other/library")
+
+
+def test_concurrent_requests_share_a_single_build(
+    monkeypatch: pytest.MonkeyPatch, dataset_dir: Path
+) -> None:
+    """Simultaneous requests for a cold dataset trigger one download, not N.
+
+    Without the per-dataset lock, every in-flight request starts its own
+    ``snapshot_download`` — which on a cold cache means N concurrent downloads.
+    """
+    started = threading.Event()
+
+    def slow_download() -> None:
+        # Hold the first build open long enough for the others to pile up.
+        started.set()
+        threading.Event().wait(0.2)
+
+    calls = _stub_snapshot_download(monkeypatch, dataset_dir, on_call=slow_download)
+
+    results: list[recorded_move.RecordedMoves] = []
+    results_lock = threading.Lock()
+
+    def worker() -> None:
+        library = get_recorded_moves(DATASET)
+        with results_lock:
+            results.append(library)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    threads[0].start()
+    assert started.wait(timeout=5), "first build never started"
+    for thread in threads[1:]:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert calls == [DATASET], f"expected 1 download, got {len(calls)}"
+    assert len(results) == 8
+    assert all(library is results[0] for library in results)


### PR DESCRIPTION
## Issue

No issue filed yet, so the problem is described here per the template.
Happy to split it out if you'd rather track it separately.

Playing any recorded move on a robot that can't reach huggingface.co takes the
whole daemon down. The client sees a disconnect, not a failed download.

`play_recorded_move_dataset` builds `RecordedMoves(dataset_name)` per request.
The constructor calls `snapshot_download(local_files_only=True)` and, on
`LocalEntryNotFoundError`, **falls back to a networked `snapshot_download()`**.
That is a synchronous call inside an `async def` route, so it blocks the uvicorn
event loop: `/api/daemon/status`, `/api/state/full` and the state WebSocket all
stop answering until it returns.

Reproduce on a robot with an empty HF cache and huggingface.co blocked (or just
firewall it):

```bash
# hangs, and takes every other endpoint with it
curl -m 150 http://<robot>:8000/api/move/recorded-move-datasets/list/pollen-robotics/reachy-mini-emotions-library
curl -m 6   http://<robot>:8000/api/daemon/status   # HTTP 000 while the above runs
```

The cache is empty in the first place because the wireless launcher starts the
daemon without `--preload-datasets`, so `preload_default_datasets()` never runs,
and its failures are swallowed with a warning either way.

## Description

Load libraries through a memoized `get_recorded_moves()` and `await` it via
`asyncio.to_thread` in both HTTP routes. `_async_play_recorded_move` (the WebRTC
data-channel path) already did exactly this — the two HTTP routes never got the
same treatment.

Three effects:

- **The event loop stays free.** A cold cache still makes *that* request slow,
  but the daemon keeps serving everything else, so a blocked HF surfaces as one
  failed move instead of a dead robot.
- **A warm library isn't re-parsed per request.** Building the emotions library
  reads 172 files; it now happens once per dataset.
- **Concurrent cold-cache requests share one download.** A per-dataset lock
  collapses N in-flight requests into a single build; other datasets stay
  unblocked.

Deliberately *not* changed here, to keep this to one concern — happy to open
follow-ups:

- The network fallback is kept, so behaviour on a reachable HF is unchanged. An
  alternative is cache-only playback returning 503, but that regresses robots
  that legitimately download on first use.
- `--preload-datasets` still isn't passed by the wireless launcher.
- `Anne-Charlotte/music` (surfaced in the desktop app's Dances tab) isn't in
  `DEFAULT_DATASETS`, so it is never preloaded.

## Testing

`tests/unit_tests/test_recorded_moves_cache.py`, 3 cases, no hardware or
network (`snapshot_download` stubbed):

- a library is built once and reused
- distinct datasets get distinct libraries
- 8 concurrent requests for a cold dataset produce exactly 1 download

```
$ uv run pytest tests/unit_tests/test_recorded_moves_cache.py -q
3 passed in 298.17s

$ ruff check .                     # All checks passed!
$ mypy src/reachy_mini/motion/recorded_move.py \
       src/reachy_mini/daemon/app/routers/move.py \
       src/reachy_mini/daemon/backend/abstract.py
Success: no issues found in 3 source files
```

No route signatures or response models changed, so `docs/source/API/openapi.json`
is unaffected.

**Scope of the hardware evidence:** the failure below was measured on a physical
Reachy Mini Wireless, and the recovery numbers come from warming that robot's HF
cache. This patch itself has not been run on the robot — it is covered by the
unit tests above. Flagging that explicitly so a reviewer can decide whether to
ask for an on-robot run before merging.

## Tested on

- [x] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [ ] Not applicable (e.g. docs, typo)

## AI assistance

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [ ] AI wrote code here, and I ran and reviewed it
- [x] An agent produced this PR, and I have not run it myself

---

## Annex — measurements on a physical robot

Reachy Mini Wireless, daemon 1.8.3, Debian 13 aarch64, CN network (mobile ISP).

**HF reachability, measured from the robot over SSH** (not from the dev machine —
a local TUN proxy silently tunnels the dev machine's traffic and reports a false
success):

```
$ curl -m 12 -o /dev/null -w "%{http_code} %{time_total}s\n" https://huggingface.co
000 12.001134s
$ curl -m 12 -o /dev/null -w "%{http_code} %{time_total}s\n" https://hf-mirror.com
200 0.225316s
$ getent hosts huggingface.co
2a03:2880:f102:183:face:b00c:0:25de     huggingface.co
```

DNS returns a Facebook-owned IPv6 block, so the connection never establishes.
`~/.cache/huggingface` did not exist on the robot.

**Before** — cold cache, HF unreachable:

```
list endpoint    HTTP 000, timed out at 150.005s
/api/daemon/status   HTTP 000 (6s timeout)  <- collateral damage
/api/state/full      HTTP 000 (6s timeout)  <- collateral damage
```

**After** — same robot, cache warmed via `HF_ENDPOINT=https://hf-mirror.com`
(emotions 172 files / 8.6M, dances 21 files / 484K):

```
list endpoint                        HTTP 200 in 0.958s (85 moves)
POST .../emotions-library/curious1   HTTP 200 in 0.81s
/api/daemon/status polled at 3.3 Hz throughout playback:
    25 ok / 0 failed, max latency 0.999s
```

The "after" figures are with a warm cache and therefore show the path this patch
keeps fast; the patch's distinct contribution is that the "before" row no longer
takes the other two endpoints down with it.
