### PR TITLE
fix(apps): scrub PYTHONPATH and GST_PYTHONPATH_1_0 from app subprocess env

### DIFF
--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -186,6 +186,15 @@ class AppManager:
             #   * The app ends up using .venv's plugin scanner binary and registry cache,
             #     which can mask issues specific to apps_venv's own gstreamer install.
             # See pollen-robotics/reachy-mini-desktop-app#185.
+            #
+            # PYTHONPATH and GST_PYTHONPATH_1_0 belong to the same set and are the
+            # most damaging members: they point at the daemon's own site-packages and
+            # take precedence over the target interpreter's. An app launched with
+            # apps_venv's Python therefore imports `reachy_mini` and `gi` from the
+            # *daemon's* venv, so an app pinned to a different SDK than the daemon
+            # fails at import time (ModuleNotFoundError for `reachy_mini.io.jsonrpc`
+            # and `gi` respectively). apps_venv's own gstreamer_bundle.pth sets both
+            # afresh at interpreter startup.
             app_env = os.environ.copy()
             for key in (
                 "GST_PLUGIN_PATH_1_0",
@@ -196,6 +205,8 @@ class AppManager:
                 "PYGI_DLL_DIRS",
                 "XDG_DATA_DIRS",
                 "XDG_CONFIG_DIRS",
+                "PYTHONPATH",
+                "GST_PYTHONPATH_1_0",
             ):
                 app_env.pop(key, None)
 

--- a/tests/unit_tests/test_app.py
+++ b/tests/unit_tests/test_app.py
@@ -9,6 +9,7 @@ import uvicorn
 from reachy_mini import ReachyMiniApp
 from reachy_mini.apps import AppInfo, SourceKind
 from reachy_mini.apps.manager import AppManager, AppState
+from reachy_mini.apps.sources import local_common_venv
 from reachy_mini.daemon.app.main import Args, create_app
 from reachy_mini.daemon.daemon import Daemon
 from reachy_mini.reachy_mini import ReachyMini
@@ -165,3 +166,64 @@ async def test_faulty_app() -> None:
         await daemon.stop(goto_sleep_on_stop=False)
         server.should_exit = True
         server_thread.join(timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_start_app_scrubs_leaking_env_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The app subprocess must not inherit env vars pointing at the daemon's venv.
+
+    PYTHONPATH and GST_PYTHONPATH_1_0 are set by the daemon's own
+    gstreamer_bundle.pth and take precedence over the target interpreter's
+    site-packages. Leaking them makes an app launched with apps_venv's Python
+    import `reachy_mini` and `gi` from the daemon's venv instead, which breaks
+    whenever the two environments hold different SDK versions.
+    """
+    leaking = {
+        "PYTHONPATH": "/daemon_venv/lib/python3.12/site-packages",
+        "GST_PYTHONPATH_1_0": "/daemon_venv/lib/python3.12/site-packages/gstreamer_python",
+        "GST_REGISTRY_1_0": "/daemon_venv/registry.bin",
+        "XDG_DATA_DIRS": "/daemon_venv/share",
+    }
+    for key, value in leaking.items():
+        monkeypatch.setenv(key, value)
+
+    captured_env: dict[str, str] = {}
+
+    class _FakeProcess:
+        returncode = 0
+
+        def __init__(self) -> None:
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+            self.stdout.feed_eof()
+            self.stderr.feed_eof()
+
+        async def wait(self) -> int:
+            return 0
+
+    async def fake_exec(*args: object, **kwargs: object) -> _FakeProcess:
+        captured_env.update(kwargs["env"])  # type: ignore[arg-type]
+        return _FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(
+        local_common_venv, "get_app_module", lambda *a, **k: "some_app.main"
+    )
+    monkeypatch.setattr(
+        local_common_venv, "get_app_python", lambda *a, **k: "/apps_venv/bin/python"
+    )
+
+    app_mngr = AppManager()
+    await app_mngr.start_app("some_app")
+    try:
+        assert captured_env, "subprocess was never launched"
+        for key in leaking:
+            assert key not in captured_env, (
+                f"{key} leaked into the app subprocess environment"
+            )
+        # A neutral variable must still be forwarded.
+        assert "PATH" in captured_env
+    finally:
+        await app_mngr.stop_current_app()


### PR DESCRIPTION
Fixes #1359.

### Problem

`AppManager.start_app` scrubs GStreamer/XDG variables from the app subprocess environment, but not `PYTHONPATH` or `GST_PYTHONPATH_1_0`. Both are set by the daemon's own `gstreamer_bundle.pth` and point into the **daemon's** `site-packages`, and both take precedence over the target interpreter's own `site-packages`. An app launched with `apps_venv`'s Python therefore imports `reachy_mini` and `gi` from the daemon's venv.

These belong to the same set the existing scrub list already handles (added for pollen-robotics/reachy-mini-desktop-app#185) — they were just missed.

### Why it matters

Invisible while the daemon and `apps_venv` hold the same SDK version, because importing from the wrong venv lands on identical code. It breaks as soon as they diverge — the normal case for an app pinned to a newer SDK than the installed daemon.

`reachy_mini_conversation_app` requires `reachy-mini>=1.10.0rc2` while the newest stable is `1.9.0`. On a stable daemon it installs into `apps_venv` correctly and then cannot start:

```
ModuleNotFoundError: No module named 'reachy_mini.io.jsonrpc'   # PYTHONPATH leak
ModuleNotFoundError: No module named 'gi'                        # GST_PYTHONPATH_1_0 leak (after the first is fixed)
```

`GST_PYTHONPATH_1_0` isolated on its own:

```console
$ env -u PYTHONPATH GST_PYTHONPATH_1_0="<daemon_venv>/.../gstreamer_python/lib/python3.12/site-packages" \
    ./apps_venv/bin/python -c "import gi"
ModuleNotFoundError: No module named 'gi'

$ env -u PYTHONPATH -u GST_PYTHONPATH_1_0 ./apps_venv/bin/python -c "import gi; print('ok')"
ok
```

### Change

Adds both names to the existing scrub tuple, with a comment explaining why. `apps_venv`'s own `gstreamer_bundle.pth` sets both afresh at interpreter startup, matching the rationale documented for the existing entries.

### Test

Adds `test_start_app_scrubs_leaking_env_vars`, which stubs `create_subprocess_exec` and asserts the leaking variables are absent from the child environment while a neutral one (`PATH`) is still forwarded. Verified it fails on `main` and passes with this change.

### Verification

With the fix applied, `POST /api/apps/start-app/reachy_mini_conversation_app` reaches `state: running` against a daemon whose SDK differs from `apps_venv`, and the robot moves. Checked on macOS 15 (Apple Silicon), Python 3.12.12, daemon in `--sim --desktop-app-daemon`.

`ruff check` passes repo-wide.
