### PR TITLE
Daemon credential store

### DIFF
--- a/src/reachy_mini/apps/sources/hf_auth.py
+++ b/src/reachy_mini/apps/sources/hf_auth.py
@@ -367,6 +367,7 @@ async def exchange_code_for_token(
             session.status = "error"
             session.error_message = AUTHENTICATION_FAILED_MESSAGE
             return {"status": "error", "message": session.error_message}
+        token_data["access_token"] = access_token
 
     except Exception as error:
         logger.warning(
@@ -377,9 +378,13 @@ async def exchange_code_for_token(
         return {"status": "error", "message": session.error_message}
 
     try:
-        landed = _persist_login(
-            _token_fields(token_data, None), session.lifecycle_generation
-        )
+        with _store_lock:
+            if _oauth_sessions.get(session.session_id) is not session:
+                landed = False
+            else:
+                landed = _persist_login(
+                    _token_fields(token_data, None), session.lifecycle_generation
+                )
     except OSError as error:
         logger.warning(
             "[HF Auth] Could not save OAuth credentials (%s)", type(error).__name__
@@ -451,10 +456,8 @@ def get_oauth_session_status(session_id: str) -> dict[str, Any]:
 
 def cancel_oauth_session(session_id: str) -> bool:
     """Cancel an OAuth session."""
-    if session_id in _oauth_sessions:
-        del _oauth_sessions[session_id]
-        return True
-    return False
+    with _store_lock:
+        return _oauth_sessions.pop(session_id, None) is not None
 
 
 def is_oauth_configured() -> bool:
@@ -525,11 +528,27 @@ def _cleanup_expired_device_sessions() -> None:
         _device_code_sessions.pop(sid, None)
 
 
-def _persist_device_oauth_token(response: Any, expected_generation: int) -> str:
-    """Store a device-code token in the daemon's own record and return the username."""
-    if not _persist_login(_token_fields(response, None), expected_generation):
-        raise _LoginSuperseded
-    user_info = whoami(token=response["access_token"])
+def _persist_device_oauth_token(
+    response: Any, session: DeviceCodeSession
+) -> str:
+    """Commit a device-code login and return its optional username."""
+    with _store_lock:
+        if (
+            session.cancel_event.is_set()
+            or _device_code_sessions.get(session.session_id) is not session
+            or not _persist_login(
+                _token_fields(response, None), session.lifecycle_generation
+            )
+        ):
+            raise _LoginSuperseded
+        session.status = "authorized"
+        session.username = ""
+        session.expires_at = time.time() + _AUTHORIZED_SESSION_TTL_S
+
+    try:
+        user_info = whoami(token=response["access_token"])
+    except Exception:  # noqa: BLE001 - username is optional
+        return ""
     if not isinstance(user_info, dict):
         return ""
     return str(user_info.get("name") or "")
@@ -608,9 +627,7 @@ async def _run_device_code_poll(session: DeviceCodeSession, device_info: Any) ->
         return
 
     try:
-        username = await asyncio.to_thread(
-            _persist_device_oauth_token, response, session.lifecycle_generation
-        )
+        username = await asyncio.to_thread(_persist_device_oauth_token, response, session)
     except _LoginSuperseded:
         logger.info("[HF Auth] Device-code login superseded: %s", session.session_id)
         session.status = "cancelled"
@@ -625,10 +642,6 @@ async def _run_device_code_poll(session: DeviceCodeSession, device_info: Any) ->
         return
 
     session.username = username or ""
-    session.status = "authorized"
-    # Bound the authorized session's lifetime so _cleanup reclaims it after the
-    # frontend has read the result (rather than leaking until daemon restart).
-    session.expires_at = time.time() + _AUTHORIZED_SESSION_TTL_S
 
     # Notify a *running* central relay so it reconnects with the new token. A
     # token-less boot has no relay instance yet, so the status route starts one.
@@ -683,11 +696,14 @@ def cancel_device_code_session(session_id: str) -> bool:
     While awaiting the thread the task stays referenced by the executor, so it
     is safe to drop the session here and let the poll unwind cooperatively.
     """
-    session = _device_code_sessions.pop(session_id, None)
-    if session is None:
-        return False
-    session.cancel_event.set()
-    return True
+    with _store_lock:
+        session = _device_code_sessions.get(session_id)
+        if session is None or session.status != "pending":
+            return False
+        _device_code_sessions.pop(session_id)
+        session.cancel_event.set()
+        session.status = "cancelled"
+        return True
 
 
 def _notify_relay_of_token_change(new_token: Optional[str] = None) -> None:

--- a/src/reachy_mini/apps/sources/hf_auth.py
+++ b/src/reachy_mini/apps/sources/hf_auth.py
@@ -1,6 +1,8 @@
-"""HuggingFace authentication management for private spaces."""
+"""Hugging Face authentication for private resources."""
 
 import asyncio
+import base64
+import hashlib
 import json
 import logging
 import os
@@ -10,7 +12,8 @@ import threading
 import time
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
+from urllib.parse import urlencode
 
 import aiohttp
 from huggingface_hub import HfApi, whoami
@@ -19,14 +22,12 @@ from huggingface_hub.errors import HfHubHTTPError
 
 logger = logging.getLogger(__name__)
 
-# One OAuth app registered at huggingface.co/settings/connected-applications,
-# with both redirect URIs below. HF_OAUTH_CLIENT_ID overrides it per robot.
+# The OAuth app registers both redirects; HF_OAUTH_CLIENT_ID can override it.
 _DEFAULT_OAUTH_CLIENT_ID = "71146982-8184-45a2-b05a-d561b3cd701d"
 
-OAUTH_CLIENT_ID: Optional[str] = os.environ.get(
+OAUTH_CLIENT_ID: str | None = os.environ.get(
     "HF_OAUTH_CLIENT_ID", _DEFAULT_OAUTH_CLIENT_ID
 )
-OAUTH_CLIENT_SECRET: Optional[str] = os.environ.get("HF_OAUTH_CLIENT_SECRET")
 # The robot only reads at runtime. Publishing an app happens on a dev machine.
 OAUTH_SCOPES = "openid profile read-repos"
 
@@ -43,11 +44,11 @@ LOGIN_EXPIRED_MESSAGE = "Login expired. Please try again."
 _CANCELLED_SESSION_MESSAGE = "Sign-in was cancelled. Please try again."
 CREDENTIAL_SAVE_FAILED_MESSAGE = "Could not save credentials. Please try again."
 
-# The daemon owns this file. Credentials the user holds elsewhere are never read:
-# a token issued to the CLI was not issued to the robot (RFC 9700).
+# CLI credentials belong to the user, so the daemon never reads them (RFC 9700).
 _STORE_FILENAME = "reachy_mini_daemon_credentials.json"
 _STORE_VERSION = 1
 _REFRESH_MARGIN_S = 300
+_OAUTH_SESSION_TTL_S = 600
 
 _store_lock = threading.RLock()
 
@@ -56,19 +57,17 @@ _store_lock = threading.RLock()
 class HfCredential:
     """The daemon bearer and the lifecycle it belongs to, read as one value."""
 
-    token: Optional[str] = field(repr=False)
+    token: str | None = field(repr=False)
     lifecycle_generation: int
 
 
 @dataclass(frozen=True)
 class _Stored:
-    """On-disk shape of the daemon credential store."""
-
     version: int = _STORE_VERSION
     signed_out: bool = False
-    access_token: Optional[str] = None
-    refresh_token: Optional[str] = None
-    expires_at: Optional[int] = None
+    access_token: str | None = None
+    refresh_token: str | None = None
+    expires_at: int | None = None
     lifecycle_generation: int = 0
 
 
@@ -77,9 +76,9 @@ def _store_path() -> Path:
 
 
 def _write_store(stored: _Stored) -> None:
-    """Replace the store atomically. mkstemp already restricts the mode to 0600."""
     path = _store_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    # mkstemp makes the file owner-only (0600 on POSIX).
     descriptor, name = tempfile.mkstemp(
         dir=path.parent, prefix=f".{path.name}.", text=True
     )
@@ -113,8 +112,7 @@ def _read_store() -> _Stored:
         return _Stored(signed_out=True)
 
 
-def _token_fields(response: Any, fallback_refresh: Optional[str]) -> dict[str, Any]:
-    """Map a Hugging Face token response onto the fields we store."""
+def _token_fields(response: Any, fallback_refresh: str | None) -> dict[str, Any]:
     expires_in = response.get("expires_in")
     return {
         "signed_out": False,
@@ -125,7 +123,6 @@ def _token_fields(response: Any, fallback_refresh: Optional[str]) -> dict[str, A
 
 
 def _persist_login(fields: dict[str, Any], expected_generation: int) -> bool:
-    """Store a completed login unless the credential lifecycle moved on meanwhile."""
     with _store_lock:
         current = _read_store()
         if current.lifecycle_generation != expected_generation:
@@ -140,104 +137,40 @@ def _persist_login(fields: dict[str, Any], expected_generation: int) -> bool:
         return True
 
 
-def current_lifecycle_generation() -> int:
-    """Return the generation a login must still match when it completes."""
-    return _read_store().lifecycle_generation
-
-
-# In-memory storage for OAuth sessions (device-flow-like pattern)
-_oauth_sessions: dict[str, "OAuthSession"] = {}
-
-
 @dataclass
 class OAuthSession:
-    """Represents an OAuth authorization session."""
+    """A pending redirect OAuth login."""
 
     session_id: str
-    user_code: str  # Short code shown to user (e.g., "ABCD-1234")
-    state: str  # CSRF protection
-    code_verifier: str  # PKCE code verifier
-    wireless_version: bool  # To know which redirect URI to use
-    use_localhost: bool = False  # Force localhost callback (desktop app proxy)
-    status: str = "pending"  # pending, authorized, expired, error
-    access_token: Optional[str] = None
-    username: Optional[str] = None
-    error_message: Optional[str] = None
+    code_verifier: str
+    redirect_uri: str
+    status: str = "pending"
+    username: str | None = None
+    error_message: str | None = None
     lifecycle_generation: int = 0
-    created_at: float = field(default_factory=time.time)
     expires_at: float = field(
-        default_factory=lambda: time.time() + 600
-    )  # 10 min expiry
+        default_factory=lambda: time.time() + _OAUTH_SESSION_TTL_S
+    )
 
 
-def _generate_user_code() -> str:
-    """Generate a short, easy-to-type user code like 'ABCD-1234'."""
-    letters = "".join(secrets.choice("ABCDEFGHJKLMNPQRSTUVWXYZ") for _ in range(4))
-    numbers = "".join(secrets.choice("0123456789") for _ in range(4))
-    return f"{letters}-{numbers}"
-
-
-def _generate_pkce_pair() -> tuple[str, str]:
-    """Generate PKCE code_verifier and code_challenge.
-
-    Returns:
-        Tuple of (code_verifier, code_challenge)
-
-    """
-    import base64
-    import hashlib
-
-    # Generate code_verifier (43-128 characters, URL-safe)
-    code_verifier = secrets.token_urlsafe(32)
-
-    # Generate code_challenge = BASE64URL(SHA256(code_verifier))
-    digest = hashlib.sha256(code_verifier.encode()).digest()
-    code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
-
-    return code_verifier, code_challenge
+_oauth_sessions: dict[str, OAuthSession] = {}
 
 
 def _cleanup_expired_sessions() -> None:
-    """Remove expired OAuth sessions."""
     now = time.time()
-    expired = [sid for sid, s in _oauth_sessions.items() if s.expires_at < now]
-    for sid in expired:
-        del _oauth_sessions[sid]
-
-
-def get_oauth_redirect_uri(wireless_version: bool, use_localhost: bool = False) -> str:
-    """Get the appropriate OAuth redirect URI based on robot type.
-
-    Args:
-        wireless_version: True for wireless robots, False for Lite.
-        use_localhost: When True, force localhost callback (for desktop app
-            proxy — the app forwards localhost:8000 to the robot).
-
-    Returns:
-        The redirect URI to use for OAuth.
-
-    """
-    if use_localhost:
-        return OAUTH_REDIRECT_URI_LITE
-    if wireless_version:
-        return OAUTH_REDIRECT_URI_WIRELESS
-    else:
-        return OAUTH_REDIRECT_URI_LITE
+    expired = [
+        session_id
+        for session_id, session in _oauth_sessions.items()
+        if session.expires_at < now
+    ]
+    for session_id in expired:
+        del _oauth_sessions[session_id]
 
 
 def create_oauth_session(
     wireless_version: bool, use_localhost: bool = False
 ) -> dict[str, Any]:
-    """Create a new OAuth authorization session.
-
-    Args:
-        wireless_version: True for wireless robots, False for Lite.
-        use_localhost: When True, force localhost callback (desktop app proxy).
-
-    Returns:
-        Session info including auth_url to redirect the user to.
-
-    """
+    """Create a redirect OAuth session."""
     _cleanup_expired_sessions()
 
     if not OAUTH_CLIENT_ID:
@@ -246,25 +179,23 @@ def create_oauth_session(
             "message": "OAuth not configured. Set HF_OAUTH_CLIENT_ID environment variable.",
         }
 
-    redirect_uri = get_oauth_redirect_uri(wireless_version, use_localhost)
+    redirect_uri = (
+        OAUTH_REDIRECT_URI_WIRELESS
+        if wireless_version and not use_localhost
+        else OAUTH_REDIRECT_URI_LITE
+    )
     state = secrets.token_urlsafe(32)
-
-    # Generate PKCE pair for secure public client auth
-    code_verifier, code_challenge = _generate_pkce_pair()
+    code_verifier = secrets.token_urlsafe(32)
+    digest = hashlib.sha256(code_verifier.encode()).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
 
     session = OAuthSession(
-        session_id=state,  # Use state as session ID for simplicity
-        user_code="",  # Not needed for this flow
-        state=state,
+        session_id=state,
         code_verifier=code_verifier,
-        wireless_version=wireless_version,
-        use_localhost=use_localhost,
-        lifecycle_generation=current_lifecycle_generation(),
+        redirect_uri=redirect_uri,
+        lifecycle_generation=_read_store().lifecycle_generation,
     )
     _oauth_sessions[state] = session
-
-    # Build HuggingFace OAuth authorization URL with PKCE
-    from urllib.parse import urlencode
 
     params = {
         "client_id": OAUTH_CLIENT_ID,
@@ -282,43 +213,23 @@ def create_oauth_session(
         "session_id": state,
         "auth_url": auth_url,
         "redirect_uri": redirect_uri,
-        "expires_in": 600,  # 10 minutes
+        "expires_in": _OAUTH_SESSION_TTL_S,
     }
 
 
-def get_oauth_session(session_id: str) -> Optional[OAuthSession]:
-    """Get an OAuth session by ID."""
+def get_oauth_session(session_id: str) -> OAuthSession | None:
+    """Return an active redirect OAuth session."""
     _cleanup_expired_sessions()
     return _oauth_sessions.get(session_id)
-
-
-def get_session_by_state(state: str) -> Optional[OAuthSession]:
-    """Get an OAuth session by its state parameter."""
-    _cleanup_expired_sessions()
-    for session in _oauth_sessions.values():
-        if session.state == state:
-            return session
-    return None
 
 
 async def exchange_code_for_token(
     code: str,
     state: str,
-    wireless_version: bool,
 ) -> dict[str, Any]:
-    """Exchange an authorization code for an access token.
-
-    Args:
-        code: The authorization code from HuggingFace
-        state: The state parameter for CSRF verification
-        wireless_version: True for wireless robots, False for Lite.
-
-    Returns:
-        Result dict with status and token/error info
-
-    """
-    session = get_session_by_state(state)
-    if not session:
+    """Exchange an OAuth authorization code for daemon credentials."""
+    session = get_oauth_session(state)
+    if session is None:
         return {
             "status": "error",
             "message": "Invalid or expired session. Please try again.",
@@ -329,18 +240,13 @@ async def exchange_code_for_token(
         session.error_message = "OAuth not configured"
         return {"status": "error", "message": "OAuth not configured"}
 
-    redirect_uri = get_oauth_redirect_uri(
-        session.wireless_version, session.use_localhost
-    )
-
-    # Exchange code for token using PKCE
     token_url = "https://huggingface.co/oauth/token"
     data = {
         "grant_type": "authorization_code",
         "client_id": OAUTH_CLIENT_ID,
         "code": code,
-        "redirect_uri": redirect_uri,
-        "code_verifier": session.code_verifier,  # PKCE verification
+        "redirect_uri": session.redirect_uri,
+        "code_verifier": session.code_verifier,
     }
 
     try:
@@ -356,11 +262,8 @@ async def exchange_code_for_token(
                     session.error_message = AUTHENTICATION_FAILED_MESSAGE
                     return {"status": "error", "message": session.error_message}
 
-                import json
-
                 token_data = json.loads(response_text)
 
-        # HuggingFace returns accessToken (camelCase)
         access_token = token_data.get("access_token") or token_data.get("accessToken")
         if not access_token:
             logger.warning("[HF Auth] OAuth response did not include an access token")
@@ -397,30 +300,28 @@ async def exchange_code_for_token(
         session.error_message = _CANCELLED_SESSION_MESSAGE
         return {"status": "error", "message": session.error_message}
 
-    # Get username
     username = ""
     try:
         user_info = whoami(token=access_token)
         if isinstance(user_info, dict):
             username = user_info.get("name", "") or user_info.get("fullname", "")
-    except Exception:
-        pass  # Username is optional
+    except Exception as error:  # noqa: BLE001 - username is optional
+        logger.debug(
+            "[HF Auth] Could not resolve OAuth username (%s)", type(error).__name__
+        )
 
-    # Update session
     session.status = "authorized"
-    session.access_token = access_token
     session.username = username
 
-    # Notify central relay of new token for immediate reconnection
     try:
         from reachy_mini.media.central_signaling_relay import notify_token_change
 
         await notify_token_change(access_token)
         logger.info("[HF Auth] Notified central relay of OAuth login")
-    except ImportError:
-        pass  # Central relay not available
-    except Exception as e:
-        logger.debug(f"[HF Auth] Could not notify relay: {e}")
+    except Exception as error:  # noqa: BLE001 - relay notification is best effort
+        logger.debug(
+            "[HF Auth] Could not notify relay (%s)", type(error).__name__
+        )
 
     return {
         "status": "success",
@@ -429,19 +330,9 @@ async def exchange_code_for_token(
 
 
 def get_oauth_session_status(session_id: str) -> dict[str, Any]:
-    """Check the status of an OAuth session.
-
-    Used for polling from the frontend.
-
-    Args:
-        session_id: The session ID to check
-
-    Returns:
-        Status dict with authorization state
-
-    """
+    """Return the status of a redirect OAuth session."""
     session = get_oauth_session(session_id)
-    if not session:
+    if session is None:
         return {"status": "expired", "message": "Session expired or not found"}
 
     result: dict[str, Any] = {"status": session.status}
@@ -465,24 +356,8 @@ def is_oauth_configured() -> bool:
     return bool(OAUTH_CLIENT_ID)
 
 
-# =============================================================================
-# Device Code OAuth (RFC 8628) — refresh-capable, redirect-free login
-# =============================================================================
-# No redirect URI, so it does not depend on reaching the robot at a fixed
-# hostname. The phone shows a short code and the robot polls Hugging Face. It
-# uses the hub's first-party device-code client, so it works without
-# HF_OAUTH_CLIENT_ID. We call the hub's private request, poll and refresh
-# helpers because the public login() would write into the user's shared store.
-
-# In-memory storage for device-code login sessions, polled by the frontend.
-_device_code_sessions: dict[str, "DeviceCodeSession"] = {}
-
-# Long enough for the client to read the result and the relay to start once.
+# Device-code OAuth uses private hub helpers to avoid writing shared credentials.
 _AUTHORIZED_SESSION_TTL_S = 300
-
-
-class _LoginSuperseded(Exception):
-    """Raised when a login completes after sign-out or another login replaced it."""
 
 
 class _DeviceCodeCancelled(Exception):
@@ -491,63 +366,56 @@ class _DeviceCodeCancelled(Exception):
 
 @dataclass
 class DeviceCodeSession:
-    """A pending device-code OAuth login, polled in the background."""
+    """A device-code OAuth login polled in the background."""
 
     session_id: str
-    user_code: str
-    verification_uri: str
-    verification_uri_complete: str
-    status: str = "pending"  # pending, authorized, error, expired, cancelled
-    username: Optional[str] = None
-    error_message: Optional[str] = None
+    status: str = "pending"
+    username: str | None = None
+    error_message: str | None = None
     lifecycle_generation: int = 0
-    relay_started: bool = False  # set once the central relay has been brought up
-    created_at: float = field(default_factory=time.time)
+    relay_started: bool = False
     expires_at: float = field(default_factory=lambda: time.time() + 900)
-    # Keep a strong reference to the polling task so it is not garbage-collected.
-    task: Optional["asyncio.Task[None]"] = None
-    # Set to request cancellation. The polling thread observes it in on_pending.
+    task: asyncio.Task[None] | None = None
     cancel_event: threading.Event = field(default_factory=threading.Event)
 
 
-def _cleanup_expired_device_sessions() -> None:
-    """Remove finished or expired device-code sessions.
+_device_code_sessions: dict[str, DeviceCodeSession] = {}
 
-    Authorized sessions are included: without this they would live in memory
-    until the daemon restarts. `start_device_code_login` sets their `expires_at`
-    to a short TTL once authorized so this prunes them shortly after use.
-    """
+
+def _cleanup_expired_device_sessions() -> None:
     now = time.time()
     stale = [
-        sid
-        for sid, s in _device_code_sessions.items()
-        if s.expires_at < now
-        and s.status in ("pending", "authorized", "expired", "error", "cancelled")
+        session_id
+        for session_id, session in _device_code_sessions.items()
+        if session.expires_at < now
     ]
-    for sid in stale:
-        _device_code_sessions.pop(sid, None)
+    for session_id in stale:
+        _device_code_sessions.pop(session_id, None)
 
 
-def _persist_device_oauth_token(
+def _complete_device_login(
     response: Any, session: DeviceCodeSession
-) -> str:
-    """Commit a device-code login and return its optional username."""
+) -> str | None:
     with _store_lock:
         if (
             session.cancel_event.is_set()
             or _device_code_sessions.get(session.session_id) is not session
-            or not _persist_login(
-                _token_fields(response, None), session.lifecycle_generation
-            )
         ):
-            raise _LoginSuperseded
+            return None
+        if not _persist_login(
+            _token_fields(response, None), session.lifecycle_generation
+        ):
+            return None
         session.status = "authorized"
         session.username = ""
         session.expires_at = time.time() + _AUTHORIZED_SESSION_TTL_S
 
     try:
         user_info = whoami(token=response["access_token"])
-    except Exception:  # noqa: BLE001 - username is optional
+    except Exception as error:  # noqa: BLE001 - username is optional
+        logger.debug(
+            "[HF Auth] Could not resolve device username (%s)", type(error).__name__
+        )
         return ""
     if not isinstance(user_info, dict):
         return ""
@@ -555,29 +423,25 @@ def _persist_device_oauth_token(
 
 
 async def start_device_code_login() -> dict[str, Any]:
-    """Begin a device-code OAuth login and poll for completion in the background.
-
-    Returns immediately with the user code and verification URL to display, plus a
-    `session_id` the frontend polls via `get_device_code_session_status`.
-    """
+    """Begin a device-code OAuth login."""
     _cleanup_expired_device_sessions()
+    lifecycle_generation = _read_store().lifecycle_generation
 
     try:
         from huggingface_hub.utils._oauth_device import request_device_code
 
         device_info = await asyncio.to_thread(request_device_code)
-    except Exception as e:  # noqa: BLE001 — surface any failure to the caller
-        logger.error("[HF Auth] Failed to request device code (%s)", type(e).__name__)
+    except Exception as error:  # noqa: BLE001 - callers always get a result
+        logger.error(
+            "[HF Auth] Failed to request device code (%s)", type(error).__name__
+        )
         return {"status": "error", "message": AUTHENTICATION_UNAVAILABLE_MESSAGE}
 
     session_id = secrets.token_urlsafe(16)
     session = DeviceCodeSession(
         session_id=session_id,
-        user_code=device_info["user_code"],
-        verification_uri=device_info["verification_uri"],
-        verification_uri_complete=device_info["verification_uri_complete"],
         expires_at=time.time() + int(device_info.get("expires_in", 900)),
-        lifecycle_generation=current_lifecycle_generation(),
+        lifecycle_generation=lifecycle_generation,
     )
     _device_code_sessions[session_id] = session
     session.task = asyncio.create_task(_run_device_code_poll(session, device_info))
@@ -585,26 +449,23 @@ async def start_device_code_login() -> dict[str, Any]:
     return {
         "status": "pending",
         "session_id": session_id,
-        "user_code": session.user_code,
-        "verification_uri": session.verification_uri,
-        "verification_uri_complete": session.verification_uri_complete,
+        "user_code": device_info["user_code"],
+        "verification_uri": device_info["verification_uri"],
+        "verification_uri_complete": device_info["verification_uri_complete"],
         "interval": int(device_info.get("interval", 5)),
         "expires_in": int(device_info.get("expires_in", 900)),
     }
 
 
 async def _run_device_code_poll(session: DeviceCodeSession, device_info: Any) -> None:
-    """Poll Hugging Face until the user authorizes the device, then persist the token."""
     from huggingface_hub.errors import DeviceCodeError
     from huggingface_hub.utils._oauth_device import poll_device_token
 
     def _abort_if_cancelled() -> None:
-        # Raising from the hub's per-poll hook frees the worker within one interval.
         if session.cancel_event.is_set():
             raise _DeviceCodeCancelled
 
     try:
-        # poll_device_token blocks (time.sleep between polls) — keep it off the loop.
         response = await asyncio.to_thread(
             poll_device_token, device_info, on_pending=_abort_if_cancelled
         )
@@ -627,11 +488,7 @@ async def _run_device_code_poll(session: DeviceCodeSession, device_info: Any) ->
         return
 
     try:
-        username = await asyncio.to_thread(_persist_device_oauth_token, response, session)
-    except _LoginSuperseded:
-        logger.info("[HF Auth] Device-code login superseded: %s", session.session_id)
-        session.status = "cancelled"
-        return
+        username = await asyncio.to_thread(_complete_device_login, response, session)
     except Exception as error:  # noqa: BLE001
         logger.error(
             "[HF Auth] Failed to persist device-code token (%s)",
@@ -641,26 +498,28 @@ async def _run_device_code_poll(session: DeviceCodeSession, device_info: Any) ->
         session.error_message = CREDENTIAL_SAVE_FAILED_MESSAGE
         return
 
-    session.username = username or ""
+    if username is None:
+        logger.info("[HF Auth] Device-code login superseded: %s", session.session_id)
+        session.status = "cancelled"
+        return
+    session.username = username
 
-    # Notify a *running* central relay so it reconnects with the new token. A
-    # token-less boot has no relay instance yet, so the status route starts one.
     try:
         from reachy_mini.media.central_signaling_relay import notify_token_change
 
         await notify_token_change(response.get("access_token"))
         logger.info("[HF Auth] Notified central relay of device-code login")
-    except ImportError:
-        pass  # Central relay not available (e.g. Lite version)
-    except Exception as e:  # noqa: BLE001
-        logger.debug("[HF Auth] Could not notify relay: %s", e)
+    except Exception as error:  # noqa: BLE001
+        logger.debug(
+            "[HF Auth] Could not notify relay (%s)", type(error).__name__
+        )
 
 
 def get_device_code_session_status(session_id: str) -> dict[str, Any]:
-    """Check the status of a device-code login session (polled by the frontend)."""
+    """Return the status of a device-code OAuth session."""
     _cleanup_expired_device_sessions()
     session = _device_code_sessions.get(session_id)
-    if not session:
+    if session is None:
         return {"status": "expired", "message": "Session expired or not found"}
 
     result: dict[str, Any] = {"status": session.status}
@@ -672,12 +531,7 @@ def get_device_code_session_status(session_id: str) -> dict[str, Any]:
 
 
 def consume_device_session_relay_pending(session_id: str) -> bool:
-    """Return True exactly once after a session becomes authorized.
-
-    Lets the HTTP layer (which holds the daemon handle) start the central relay a
-    single time on a token-less boot, without the background poll task needing a
-    reference to the daemon.
-    """
+    """Return whether an authorized session still needs to start the relay."""
     session = _device_code_sessions.get(session_id)
     if session is None or session.status != "authorized" or session.relay_started:
         return False
@@ -686,16 +540,7 @@ def consume_device_session_relay_pending(session_id: str) -> bool:
 
 
 def cancel_device_code_session(session_id: str) -> bool:
-    """Cancel a pending device-code session and stop its polling thread.
-
-    Signals the polling thread via `cancel_event` (observed by `on_pending`),
-    which unwinds `poll_device_token` within ~one poll interval and frees the
-    worker thread. We deliberately do not call `task.cancel()`: cancelling the
-    asyncio task while the worker thread is still running would orphan the
-    thread and surface a stray "Future exception was never retrieved" warning.
-    While awaiting the thread the task stays referenced by the executor, so it
-    is safe to drop the session here and let the poll unwind cooperatively.
-    """
+    """Cancel a pending device-code session."""
     with _store_lock:
         session = _device_code_sessions.get(session_id)
         if session is None or session.status != "pending":
@@ -706,56 +551,31 @@ def cancel_device_code_session(session_id: str) -> bool:
         return True
 
 
-def _notify_relay_of_token_change(new_token: Optional[str] = None) -> None:
-    """Notify the central signaling relay of a token change.
-
-    This is called after login/logout to trigger reconnection with the
-    new (or no) token. It handles the async call in a background task.
-    """
+def _notify_relay_of_token_change(new_token: str | None = None) -> None:
     try:
         from reachy_mini.media.central_signaling_relay import notify_token_change
 
-        # Try to get the running event loop
         try:
             loop = asyncio.get_running_loop()
-            # If we're already in an async context, schedule as task
-            loop.create_task(notify_token_change(new_token))
         except RuntimeError:
-            # No running loop - run in new loop (blocking but quick)
             asyncio.run(notify_token_change(new_token))
+        else:
+            loop.create_task(notify_token_change(new_token))
 
         logger.info("[HF Auth] Notified central relay of token change")
-    except ImportError:
-        # Central relay module not available (e.g., Lite version)
-        pass
-    except Exception as e:
-        logger.debug(f"[HF Auth] Could not notify relay: {e}")
+    except Exception as error:  # noqa: BLE001 - relay notification is best effort
+        logger.debug(
+            "[HF Auth] Could not notify relay (%s)", type(error).__name__
+        )
 
 
 def save_hf_token(token: str) -> dict[str, Any]:
-    """Save a HuggingFace access token securely.
-
-    Validates the token against the Hugging Face API and, if valid,
-    stores it using the standard Hugging Face authentication mechanism
-    for reuse across sessions.
-
-    Args:
-        token: The HuggingFace access token to save.
-
-    Returns:
-        A dict containing:
-        - "status": "success" or "error"
-        - "username": the associated Hugging Face username if successful
-        - "message": an error description if unsuccessful
-
-    """
+    """Validate and store a manually entered Hugging Face token."""
+    lifecycle_generation = _read_store().lifecycle_generation
     try:
-        # Validate token first by making an API call
-        api = HfApi(token=token)
-        user_info = api.whoami()
+        user_info = HfApi(token=token).whoami()
 
-        generation = current_lifecycle_generation()
-        if not _persist_login({"access_token": token}, generation):
+        if not _persist_login({"access_token": token}, lifecycle_generation):
             return {"status": "error", "message": AUTHENTICATION_FAILED_MESSAGE}
 
         _notify_relay_of_token_change(token)
@@ -806,7 +626,7 @@ def get_hf_credential(force_refresh: bool = False) -> HfCredential:
         return HfCredential(refreshed.access_token, refreshed.lifecycle_generation)
 
 
-def get_hf_token() -> Optional[str]:
+def get_hf_token() -> str | None:
     """Return the daemon-owned token, refreshing it when it is close to expiry."""
     return get_hf_credential().token
 
@@ -835,12 +655,7 @@ def delete_hf_token() -> bool:
 
 
 def check_token_status() -> dict[str, Any]:
-    """Check if a token is stored and valid.
-
-    Returns:
-        Status dict with is_logged_in and username.
-
-    """
+    """Return whether the daemon credentials are valid."""
     token = get_hf_token()
     if not token:
         return {"is_logged_in": False, "username": None}

--- a/src/reachy_mini/apps/sources/hf_auth.py
+++ b/src/reachy_mini/apps/sources/hf_auth.py
@@ -1,52 +1,145 @@
 """HuggingFace authentication management for private spaces."""
 
 import asyncio
+import json
 import logging
 import os
 import secrets
 import tempfile
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any, Optional
 
 import aiohttp
-from huggingface_hub import HfApi, get_token, login, logout, whoami
+from huggingface_hub import HfApi, whoami
 from huggingface_hub.constants import HF_TOKEN_PATH
 from huggingface_hub.errors import HfHubHTTPError
 
 logger = logging.getLogger(__name__)
 
-# =============================================================================
-# OAuth Configuration
-# =============================================================================
-# Register ONE OAuth app at https://huggingface.co/settings/connected-applications
-# with TWO redirect URIs:
-#   - http://reachy-mini.local:8000/api/hf-auth/oauth/callback  (wireless)
-#   - http://localhost:8000/api/hf-auth/oauth/callback          (lite)
-#
-# Then set HF_OAUTH_CLIENT_ID on all robots (same value for all).
-#
-# Environment variables:
-#   HF_OAUTH_CLIENT_ID     - Required for OAuth login
-#   HF_OAUTH_CLIENT_SECRET - Optional (for confidential clients)
-#
-# Pollen's HuggingFace OAuth app - works for all Reachy Mini robots
+# One OAuth app registered at huggingface.co/settings/connected-applications,
+# with both redirect URIs below. HF_OAUTH_CLIENT_ID overrides it per robot.
 _DEFAULT_OAUTH_CLIENT_ID = "71146982-8184-45a2-b05a-d561b3cd701d"
 
 OAUTH_CLIENT_ID: Optional[str] = os.environ.get(
     "HF_OAUTH_CLIENT_ID", _DEFAULT_OAUTH_CLIENT_ID
 )
 OAUTH_CLIENT_SECRET: Optional[str] = os.environ.get("HF_OAUTH_CLIENT_SECRET")
-OAUTH_SCOPES = os.environ.get(
-    "HF_OAUTH_SCOPES",
-    "openid profile read-repos write-repos manage-repos inference-api",
-)
+# The robot only reads at runtime. Publishing an app happens on a dev machine.
+OAUTH_SCOPES = "openid profile read-repos"
 
 # Fixed redirect URIs (must match what's registered with HuggingFace)
 OAUTH_REDIRECT_URI_WIRELESS = "http://reachy-mini.local:8000/api/hf-auth/oauth/callback"
 OAUTH_REDIRECT_URI_LITE = "http://localhost:8000/api/hf-auth/oauth/callback"
+
+# Reach HTTP responses, so never carry provider text, exception detail, or tokens.
+AUTHENTICATION_FAILED_MESSAGE = "Authentication failed. Please try again."
+_CANCELLED_SESSION_MESSAGE = "Sign-in was cancelled. Please try again."
+CREDENTIAL_SAVE_FAILED_MESSAGE = "Could not save credentials. Please try again."
+
+# The daemon owns this file. Credentials the user holds elsewhere are never read:
+# a token issued to the CLI was not issued to the robot (RFC 9700).
+_STORE_FILENAME = "reachy_mini_daemon_credentials.json"
+_STORE_VERSION = 1
+_REFRESH_MARGIN_S = 300
+
+_store_lock = threading.RLock()
+
+
+@dataclass(frozen=True)
+class HfCredential:
+    """The daemon bearer and the lifecycle it belongs to, read as one value."""
+
+    token: Optional[str] = field(repr=False)
+    lifecycle_generation: int
+
+
+@dataclass(frozen=True)
+class _Stored:
+    """On-disk shape of the daemon credential store."""
+
+    version: int = _STORE_VERSION
+    signed_out: bool = False
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+    expires_at: Optional[int] = None
+    lifecycle_generation: int = 0
+
+
+def _store_path() -> Path:
+    return Path(HF_TOKEN_PATH).with_name(_STORE_FILENAME)
+
+
+def _write_store(stored: _Stored) -> None:
+    """Replace the store atomically. mkstemp already restricts the mode to 0600."""
+    path = _store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", text=True
+    )
+    temporary = Path(name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(asdict(stored), output, separators=(",", ":"))
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _read_store() -> _Stored:
+    path = _store_path()
+    if not path.exists():
+        return _Stored(signed_out=True)
+    try:
+        stored = _Stored(**json.loads(path.read_text(encoding="utf-8")))
+        if stored.version != _STORE_VERSION or stored.lifecycle_generation < 0:
+            raise ValueError("unsupported credential record")
+        if not stored.signed_out and not stored.access_token:
+            raise ValueError("credential record has no token")
+        return stored
+    except (OSError, TypeError, ValueError) as error:
+        logger.warning(
+            "[HF Auth] Unreadable credential store (%s)", type(error).__name__
+        )
+        return _Stored(signed_out=True)
+
+
+def _token_fields(response: Any, fallback_refresh: Optional[str]) -> dict[str, Any]:
+    """Map a Hugging Face token response onto the fields we store."""
+    expires_in = response.get("expires_in")
+    return {
+        "signed_out": False,
+        "access_token": response["access_token"],
+        "refresh_token": response.get("refresh_token") or fallback_refresh,
+        "expires_at": int(time.time()) + int(expires_in) if expires_in else None,
+    }
+
+
+def _persist_login(fields: dict[str, Any], expected_generation: int) -> bool:
+    """Store a completed login unless the credential lifecycle moved on meanwhile."""
+    with _store_lock:
+        current = _read_store()
+        if current.lifecycle_generation != expected_generation:
+            return False
+        _write_store(
+            replace(
+                _Stored(),
+                **fields,
+                lifecycle_generation=current.lifecycle_generation + 1,
+            )
+        )
+        return True
+
+
+def current_lifecycle_generation() -> int:
+    """Return the generation a login must still match when it completes."""
+    return _read_store().lifecycle_generation
+
 
 # In-memory storage for OAuth sessions (device-flow-like pattern)
 _oauth_sessions: dict[str, "OAuthSession"] = {}
@@ -66,29 +159,11 @@ class OAuthSession:
     access_token: Optional[str] = None
     username: Optional[str] = None
     error_message: Optional[str] = None
+    lifecycle_generation: int = 0
     created_at: float = field(default_factory=time.time)
     expires_at: float = field(
         default_factory=lambda: time.time() + 600
     )  # 10 min expiry
-
-
-def configure_oauth(
-    client_id: str,
-    client_secret: Optional[str] = None,
-    scopes: str = "openid profile read-repos",
-) -> None:
-    """Configure OAuth credentials.
-
-    Args:
-        client_id: HuggingFace OAuth client ID
-        client_secret: OAuth client secret (optional for public clients)
-        scopes: Space-separated OAuth scopes
-
-    """
-    global OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_SCOPES
-    OAUTH_CLIENT_ID = client_id
-    OAUTH_CLIENT_SECRET = client_secret
-    OAUTH_SCOPES = scopes
 
 
 def _generate_user_code() -> str:
@@ -180,6 +255,7 @@ def create_oauth_session(
         code_verifier=code_verifier,
         wireless_version=wireless_version,
         use_localhost=use_localhost,
+        lifecycle_generation=current_lifecycle_generation(),
     )
     _oauth_sessions[state] = session
 
@@ -288,33 +364,21 @@ async def exchange_code_for_token(
         session.error_message = f"Token request error: {type(e).__name__}: {e}"
         return {"status": "error", "message": session.error_message}
 
-    # Save token directly to HuggingFace token file
-    # (login() doesn't work well with OAuth tokens)
-    temporary_path: Optional[Path] = None
     try:
-        token_path = Path(HF_TOKEN_PATH)
-        token_path.parent.mkdir(parents=True, exist_ok=True)
-        fd, temporary_name = tempfile.mkstemp(
-            dir=token_path.parent,
-            prefix=f".{token_path.name}.",
-            text=True,
+        landed = _persist_login(
+            _token_fields(token_data, None), session.lifecycle_generation
         )
-        temporary_path = Path(temporary_name)
-        os.close(fd)
-        temporary_path.chmod(0o600)
-        with temporary_path.open("w") as token_file:
-            token_file.write(access_token)
-            token_file.flush()
-            os.fsync(token_file.fileno())
-        os.replace(temporary_path, token_path)
-        temporary_path = None
-    except Exception as e:
+    except OSError as error:
+        logger.warning(
+            "[HF Auth] Could not save OAuth credentials (%s)", type(error).__name__
+        )
         session.status = "error"
-        session.error_message = f"Failed to save token: {type(e).__name__}: {e}"
+        session.error_message = CREDENTIAL_SAVE_FAILED_MESSAGE
         return {"status": "error", "message": session.error_message}
-    finally:
-        if temporary_path is not None:
-            temporary_path.unlink(missing_ok=True)
+    if not landed:
+        session.status = "error"
+        session.error_message = _CANCELLED_SESSION_MESSAGE
+        return {"status": "error", "message": session.error_message}
 
     # Get username
     username = ""
@@ -389,35 +453,25 @@ def is_oauth_configured() -> bool:
 # =============================================================================
 # Device Code OAuth (RFC 8628) — refresh-capable, redirect-free login
 # =============================================================================
-# Unlike the authorization-code flow above, the device-code flow:
-#   - needs NO redirect URI, so it does not depend on the robot being reachable
-#     at a fixed hostname (reachy-mini.local) — the phone only displays a short
-#     code + URL and the robot polls Hugging Face for the result.
-#   - yields a refresh token. huggingface_hub persists it next to the access
-#     token (HF_STORED_TOKENS_PATH) and `get_token()` transparently renews the
-#     access token when it is close to expiry, so a long-running robot never
-#     needs the user to re-authenticate by hand.
-#
-# It uses Hugging Face's first-party device-code OAuth client (shipped in
-# huggingface_hub via DEVICE_CODE_OAUTH_CLIENT_ID), not the Pollen OAuth app,
-# so it works even when HF_OAUTH_CLIENT_ID is not configured.
+# No redirect URI, so it does not depend on reaching the robot at a fixed
+# hostname. The phone shows a short code and the robot polls Hugging Face. It
+# uses the hub's first-party device-code client, so it works without
+# HF_OAUTH_CLIENT_ID. We call the hub's private request, poll and refresh
+# helpers because the public login() would write into the user's shared store.
 
 # In-memory storage for device-code login sessions, polled by the frontend.
 _device_code_sessions: dict[str, "DeviceCodeSession"] = {}
 
-# How long an authorized session is kept so the frontend can read the result and
-# the relay can be started once, after which _cleanup removes it (a token-less
-# boot polls for a few seconds; 5 min is a generous margin).
+# Long enough for the client to read the result and the relay to start once.
 _AUTHORIZED_SESSION_TTL_S = 300
 
 
-class _DeviceCodeCancelled(Exception):
-    """Raised inside poll_device_token's on_pending hook to abort a cancelled login.
+class _LoginSuperseded(Exception):
+    """Raised when a login completes after sign-out or another login replaced it."""
 
-    poll_device_token runs in a worker thread and blocks for up to ~15 min;
-    raising from its per-poll hook is what actually stops that thread (see
-    cancel_device_code_session), rather than only detaching the asyncio task.
-    """
+
+class _DeviceCodeCancelled(Exception):
+    """Raised in poll_device_token's on_pending hook to stop its worker thread."""
 
 
 @dataclass
@@ -431,12 +485,13 @@ class DeviceCodeSession:
     status: str = "pending"  # pending, authorized, error, expired, cancelled
     username: Optional[str] = None
     error_message: Optional[str] = None
+    lifecycle_generation: int = 0
     relay_started: bool = False  # set once the central relay has been brought up
     created_at: float = field(default_factory=time.time)
     expires_at: float = field(default_factory=lambda: time.time() + 900)
     # Keep a strong reference to the polling task so it is not garbage-collected.
     task: Optional["asyncio.Task[None]"] = None
-    # Set to request cancellation; observed by the polling thread's on_pending hook.
+    # Set to request cancellation. The polling thread observes it in on_pending.
     cancel_event: threading.Event = field(default_factory=threading.Event)
 
 
@@ -458,26 +513,14 @@ def _cleanup_expired_device_sessions() -> None:
         _device_code_sessions.pop(sid, None)
 
 
-def _persist_device_oauth_token(response: Any) -> tuple[str, str]:
-    """Persist a device-code token response so `get_token()` can auto-refresh it.
-
-    huggingface_hub stores the access token, its `refresh_token` and `expires_at`
-    in HF_STORED_TOKENS_PATH and marks it as the active token. `get_token()` then
-    transparently exchanges the refresh token for a new access token shortly
-    before expiry — no user interaction required.
-
-    Returns:
-        Tuple of (token_name, username).
-
-    """
-    # Private but pinned exactly (see pyproject); guarded by the contract test in
-    # tests/unit_tests/test_hf_hub_private_api_contract.py. `response` is typed Any
-    # because it is an opaque huggingface_hub payload (a private OAuthTokenResponse
-    # TypedDict) that we only ever pass straight back to the hub — annotating it as
-    # dict[str, Any] would clash with the hub's TypedDict under mypy --strict.
-    from huggingface_hub._login import _save_oauth_token
-
-    return _save_oauth_token(response)
+def _persist_device_oauth_token(response: Any, expected_generation: int) -> str:
+    """Store a device-code token in the daemon's own record and return the username."""
+    if not _persist_login(_token_fields(response, None), expected_generation):
+        raise _LoginSuperseded
+    user_info = whoami(token=response["access_token"])
+    if not isinstance(user_info, dict):
+        return ""
+    return str(user_info.get("name") or "")
 
 
 async def start_device_code_login() -> dict[str, Any]:
@@ -506,6 +549,7 @@ async def start_device_code_login() -> dict[str, Any]:
         verification_uri=device_info["verification_uri"],
         verification_uri_complete=device_info["verification_uri_complete"],
         expires_at=time.time() + int(device_info.get("expires_in", 900)),
+        lifecycle_generation=current_lifecycle_generation(),
     )
     _device_code_sessions[session_id] = session
     session.task = asyncio.create_task(_run_device_code_poll(session, device_info))
@@ -527,9 +571,7 @@ async def _run_device_code_poll(session: DeviceCodeSession, device_info: Any) ->
     from huggingface_hub.utils._oauth_device import poll_device_token
 
     def _abort_if_cancelled() -> None:
-        # poll_device_token calls this after each "authorization pending" poll,
-        # just before it sleeps; raising here unwinds it and frees the worker
-        # thread within ~one poll interval instead of blocking to expiry.
+        # Raising from the hub's per-poll hook frees the worker within one interval.
         if session.cancel_event.is_set():
             raise _DeviceCodeCancelled
 
@@ -554,11 +596,20 @@ async def _run_device_code_poll(session: DeviceCodeSession, device_info: Any) ->
         return
 
     try:
-        _, username = await asyncio.to_thread(_persist_device_oauth_token, response)
-    except Exception as e:  # noqa: BLE001
-        logger.error("[HF Auth] Failed to persist device-code token: %s", e)
+        username = await asyncio.to_thread(
+            _persist_device_oauth_token, response, session.lifecycle_generation
+        )
+    except _LoginSuperseded:
+        logger.info("[HF Auth] Device-code login superseded: %s", session.session_id)
+        session.status = "cancelled"
+        return
+    except Exception as error:  # noqa: BLE001
+        logger.error(
+            "[HF Auth] Failed to persist device-code token (%s)",
+            type(error).__name__,
+        )
         session.status = "error"
-        session.error_message = f"Failed to save token: {type(e).__name__}: {e}"
+        session.error_message = CREDENTIAL_SAVE_FAILED_MESSAGE
         return
 
     session.username = username or ""
@@ -568,7 +619,7 @@ async def _run_device_code_poll(session: DeviceCodeSession, device_info: Any) ->
     session.expires_at = time.time() + _AUTHORIZED_SESSION_TTL_S
 
     # Notify a *running* central relay so it reconnects with the new token. A
-    # token-less boot has no relay instance yet; the status route starts one.
+    # token-less boot has no relay instance yet, so the status route starts one.
     try:
         from reachy_mini.media.central_signaling_relay import notify_token_change
 
@@ -675,11 +726,10 @@ def save_hf_token(token: str) -> dict[str, Any]:
         api = HfApi(token=token)
         user_info = api.whoami()
 
-        # Persist token for future runs (no prompt since token is provided)
-        # add_to_git_credential=False keeps it from touching git credentials.
-        login(token=token, add_to_git_credential=False)
+        generation = current_lifecycle_generation()
+        if not _persist_login({"access_token": token}, generation):
+            return {"status": "error", "message": AUTHENTICATION_FAILED_MESSAGE}
 
-        # Notify central relay of new token for immediate reconnection
         _notify_relay_of_token_change(token)
 
         return {
@@ -687,40 +737,73 @@ def save_hf_token(token: str) -> dict[str, Any]:
             "username": user_info.get("name", ""),
         }
     except (HfHubHTTPError, ValueError):
-        # ValueError can be raised by `login()` on invalid token (v1.x behavior)
         return {
             "status": "error",
             "message": "Invalid token or network error",
         }
-    except Exception as e:
-        return {
-            "status": "error",
-            "message": str(e),
-        }
+    except Exception as error:  # noqa: BLE001 - callers always get a dict
+        logger.warning(
+            "[HF Auth] Could not save credentials (%s)", type(error).__name__
+        )
+        return {"status": "error", "message": CREDENTIAL_SAVE_FAILED_MESSAGE}
+
+
+def get_hf_credential(force_refresh: bool = False) -> HfCredential:
+    """Return the daemon bearer and its lifecycle generation as one atomic read."""
+    with _store_lock:
+        stored = _read_store()
+        expires_at = stored.expires_at
+        expired = expires_at is not None and expires_at <= time.time()
+        # Also the answer when a due refresh fails: never hand out an expired token.
+        usable = HfCredential(
+            None if expired else stored.access_token, stored.lifecycle_generation
+        )
+        due = force_refresh or (
+            expires_at is not None and expires_at <= time.time() + _REFRESH_MARGIN_S
+        )
+        if not stored.refresh_token or not due:
+            return usable
+
+        from huggingface_hub.utils._oauth_device import refresh_access_token
+
+        try:
+            response = refresh_access_token(stored.refresh_token)
+        except Exception as error:  # noqa: BLE001 - a stale token must not raise
+            logger.warning(
+                "[HF Auth] Could not refresh credentials (%s)", type(error).__name__
+            )
+            return usable
+        refreshed = replace(stored, **_token_fields(response, stored.refresh_token))
+        _write_store(refreshed)
+        return HfCredential(refreshed.access_token, refreshed.lifecycle_generation)
 
 
 def get_hf_token() -> Optional[str]:
-    """Get stored HuggingFace token.
-
-    Returns:
-        The stored token, or None if no token is stored.
-
-    """
-    return get_token()
+    """Return the daemon-owned token, refreshing it when it is close to expiry."""
+    return get_hf_credential().token
 
 
 def delete_hf_token() -> bool:
-    """Delete stored HuggingFace token(s).
+    """Sign the robot out, leaving credentials the daemon does not own alone."""
+    with _store_lock:
+        try:
+            current = _read_store()
+            _write_store(
+                _Stored(
+                    signed_out=True,
+                    lifecycle_generation=current.lifecycle_generation + 1,
+                )
+            )
+        except OSError as error:
+            logger.warning("[HF Auth] Could not sign out (%s)", type(error).__name__)
+            return False
+        for session in _device_code_sessions.values():
+            session.cancel_event.set()
+        _oauth_sessions.clear()
+        _device_code_sessions.clear()
 
-    Note: logout() without arguments logs out from all saved access tokens.
-    """
-    try:
-        logout()
-        # Notify central relay that user logged out
-        _notify_relay_of_token_change(None)
-        return True
-    except Exception:
-        return False
+    _notify_relay_of_token_change(None)
+    return True
 
 
 def check_token_status() -> dict[str, Any]:

--- a/src/reachy_mini/apps/sources/hf_auth.py
+++ b/src/reachy_mini/apps/sources/hf_auth.py
@@ -36,6 +36,10 @@ OAUTH_REDIRECT_URI_LITE = "http://localhost:8000/api/hf-auth/oauth/callback"
 
 # Reach HTTP responses, so never carry provider text, exception detail, or tokens.
 AUTHENTICATION_FAILED_MESSAGE = "Authentication failed. Please try again."
+AUTHENTICATION_UNAVAILABLE_MESSAGE = (
+    "Hugging Face authentication is unavailable. Please try again."
+)
+LOGIN_EXPIRED_MESSAGE = "Login expired. Please try again."
 _CANCELLED_SESSION_MESSAGE = "Sign-in was cancelled. Please try again."
 CREDENTIAL_SAVE_FAILED_MESSAGE = "Could not save credentials. Please try again."
 
@@ -344,8 +348,12 @@ async def exchange_code_for_token(
             async with http_session.post(token_url, data=data) as response:
                 response_text = await response.text()
                 if response.status != 200:
+                    logger.warning(
+                        "[HF Auth] OAuth token exchange returned HTTP %s",
+                        response.status,
+                    )
                     session.status = "error"
-                    session.error_message = f"Token exchange failed (HTTP {response.status}): {response_text}"
+                    session.error_message = AUTHENTICATION_FAILED_MESSAGE
                     return {"status": "error", "message": session.error_message}
 
                 import json
@@ -355,13 +363,17 @@ async def exchange_code_for_token(
         # HuggingFace returns accessToken (camelCase)
         access_token = token_data.get("access_token") or token_data.get("accessToken")
         if not access_token:
+            logger.warning("[HF Auth] OAuth response did not include an access token")
             session.status = "error"
-            session.error_message = f"No access token. Response: {token_data}"
+            session.error_message = AUTHENTICATION_FAILED_MESSAGE
             return {"status": "error", "message": session.error_message}
 
-    except Exception as e:
+    except Exception as error:
+        logger.warning(
+            "[HF Auth] OAuth token request failed (%s)", type(error).__name__
+        )
         session.status = "error"
-        session.error_message = f"Token request error: {type(e).__name__}: {e}"
+        session.error_message = AUTHENTICATION_UNAVAILABLE_MESSAGE
         return {"status": "error", "message": session.error_message}
 
     try:
@@ -536,11 +548,8 @@ async def start_device_code_login() -> dict[str, Any]:
 
         device_info = await asyncio.to_thread(request_device_code)
     except Exception as e:  # noqa: BLE001 — surface any failure to the caller
-        logger.error("[HF Auth] Failed to request device code: %s", e)
-        return {
-            "status": "error",
-            "message": f"Could not start login: {type(e).__name__}: {e}",
-        }
+        logger.error("[HF Auth] Failed to request device code (%s)", type(e).__name__)
+        return {"status": "error", "message": AUTHENTICATION_UNAVAILABLE_MESSAGE}
 
     session_id = secrets.token_urlsafe(16)
     session = DeviceCodeSession(
@@ -584,15 +593,18 @@ async def _run_device_code_poll(session: DeviceCodeSession, device_info: Any) ->
         logger.info("[HF Auth] Device-code login cancelled: %s", session.session_id)
         session.status = "cancelled"
         return
-    except DeviceCodeError as e:
-        logger.info("[HF Auth] Device-code login failed: %s", e)
-        session.status = "expired" if "expired" in str(e).lower() else "error"
-        session.error_message = str(e)
+    except DeviceCodeError as error:
+        logger.info("[HF Auth] Device-code login failed (%s)", type(error).__name__)
+        expired = "expired" in str(error).lower()
+        session.status = "expired" if expired else "error"
+        session.error_message = (
+            LOGIN_EXPIRED_MESSAGE if expired else AUTHENTICATION_FAILED_MESSAGE
+        )
         return
-    except Exception as e:  # noqa: BLE001
-        logger.error("[HF Auth] Device-code polling error: %s", e)
+    except Exception as error:  # noqa: BLE001
+        logger.error("[HF Auth] Device-code polling error (%s)", type(error).__name__)
         session.status = "error"
-        session.error_message = f"{type(e).__name__}: {e}"
+        session.error_message = AUTHENTICATION_UNAVAILABLE_MESSAGE
         return
 
     try:

--- a/src/reachy_mini/apps/sources/hf_space.py
+++ b/src/reachy_mini/apps/sources/hf_space.py
@@ -111,7 +111,7 @@ def _build_app_info(item: SpaceData | None) -> AppInfo | None:
     )
 
 
-def _list_all_spaces_with_hf_api(token: str | None) -> list[SpaceData]:
+def _list_all_spaces_with_hf_api(token: str | bool | None) -> list[SpaceData]:
     """List spaces with Hugging Face Hub API using an optional token."""
     api = HfApi()
     spaces = api.list_spaces(
@@ -181,7 +181,7 @@ async def list_available_apps() -> list[AppInfo]:
 
 async def list_all_apps() -> list[AppInfo]:
     """List all apps available on Hugging Face Spaces (including private ones when authenticated)."""
-    token = hf_auth.get_hf_token()
+    token = hf_auth.get_hf_token() or False
     try:
         data = await asyncio.to_thread(_list_all_spaces_with_hf_api, token)
     except Exception as exc:

--- a/src/reachy_mini/apps/sources/local_common_venv.py
+++ b/src/reachy_mini/apps/sources/local_common_venv.py
@@ -489,7 +489,7 @@ async def install_package(
 
         # Check if this is a private space installation
         is_private = app.extra.get("private", False)
-        token = None
+        token: str | bool | None = False
 
         if is_private:
             # Get token for private spaces

--- a/src/reachy_mini/daemon/app/main.py
+++ b/src/reachy_mini/daemon/app/main.py
@@ -144,7 +144,7 @@ def create_app(args: Args, health_check_event: asyncio.Event | None = None) -> F
         def preload_with_logging() -> None:
             """Download datasets with logging."""
             try:
-                preload_default_datasets()
+                preload_default_datasets(token=False)
                 logger.info("Recorded move datasets pre-loaded successfully")
             except Exception as e:
                 logger.warning(f"Failed to pre-load some datasets: {e}")

--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -359,7 +359,7 @@ async def oauth_callback(
     """
     if error:
         # OAuth error from HF
-        session = hf_auth.get_session_by_state(state) if state else None
+        session = hf_auth.get_oauth_session(state) if state else None
         if session:
             session.status = "error"
             session.error_message = error_description or error
@@ -380,15 +380,9 @@ async def oauth_callback(
             status_code=400,
         )
 
-    # Determine if wireless based on the callback URL
-    host = request.headers.get("host", "")
-    wireless_version = "reachy-mini.local" in host
-
-    # Exchange code for token
     result = await hf_auth.exchange_code_for_token(
         code=code,
         state=state,
-        wireless_version=wireless_version,
     )
 
     if result["status"] == "success":

--- a/src/reachy_mini/daemon/app/routers/move.py
+++ b/src/reachy_mini/daemon/app/routers/move.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisco
 from huggingface_hub.errors import RepositoryNotFoundError
 from pydantic import BaseModel
 
-from reachy_mini.motion.recorded_move import RecordedMoves
+from reachy_mini.motion.recorded_move import RecordedMoves, dataset_token
 from reachy_mini.utils.interpolation import InterpolationTechnique
 
 from ....daemon.backend.abstract import Backend
@@ -167,7 +167,7 @@ async def list_recorded_move_dataset(
 ) -> list[str]:
     """List available recorded moves in a dataset."""
     try:
-        moves = RecordedMoves(dataset_name)
+        moves = RecordedMoves(dataset_name, token=dataset_token(dataset_name))
     except RepositoryNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
 
@@ -182,7 +182,7 @@ async def play_recorded_move_dataset(
 ) -> MoveUUID:
     """Request the robot to play a predefined recorded move from a dataset."""
     try:
-        recorded_moves = RecordedMoves(dataset_name)
+        recorded_moves = RecordedMoves(dataset_name, token=dataset_token(dataset_name))
     except RepositoryNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     try:

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -2697,6 +2697,7 @@ class Backend:
         from reachy_mini.motion.recorded_move import (
             DEFAULT_EMOTIONS_DATASET,
             RecordedMoves,
+            dataset_token,
         )
 
         dataset = cmd.dataset_name or DEFAULT_EMOTIONS_DATASET
@@ -2705,7 +2706,9 @@ class Backend:
             # snapshot_download: run it in a worker thread so it cannot stall
             # the daemon's event loop (and its pose stream) mid-session.
             move = await asyncio.to_thread(
-                lambda: RecordedMoves(dataset).get(cmd.move_name)
+                lambda: RecordedMoves(dataset, token=dataset_token(dataset)).get(
+                    cmd.move_name
+                )
             )
         except Exception as e:
             self.logger.warning(
@@ -2749,9 +2752,11 @@ class Backend:
         reported but deliberately not fatal - ``play_recorded_move`` will
         retry the download on demand at playback time.
         """
-        from reachy_mini.motion.recorded_move import preload_dataset
+        from reachy_mini.motion.recorded_move import dataset_token, preload_dataset
 
-        local_path = await asyncio.to_thread(preload_dataset, cmd.dataset_name)
+        local_path = await asyncio.to_thread(
+            preload_dataset, cmd.dataset_name, dataset_token(cmd.dataset_name)
+        )
         if local_path is None:
             send_response(
                 {

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -196,9 +196,9 @@ class Daemon:
             return
 
         try:
-            from huggingface_hub import get_token
+            from reachy_mini.apps.sources.hf_auth import get_hf_token
 
-            hf_token = get_token()
+            hf_token = get_hf_token()
         except Exception as e:
             self.logger.debug(f"No HF token available, central signaling disabled: {e}")
             return

--- a/src/reachy_mini/media/central_signaling_relay.py
+++ b/src/reachy_mini/media/central_signaling_relay.py
@@ -560,17 +560,12 @@ class CentralSignalingRelay:
         else:
             self._token_updated.set()
 
-    def _refresh_token(self) -> Optional[str]:
-        """Refresh the HF token from huggingface_hub.
+    def _refresh_token(self, force_refresh: bool = False) -> Optional[str]:
+        """Re-read the daemon-owned credentials, refreshing them when asked."""
+        from reachy_mini.apps.sources.hf_auth import get_hf_credential
 
-        Returns:
-            The current HF token, or None if not available
-
-        """
         try:
-            from huggingface_hub import get_token
-
-            token = get_token()
+            token = get_hf_credential(force_refresh).token
             if token != self.hf_token:
                 if token:
                     logger.info("[Central Relay] HF token detected (user logged in)")
@@ -578,9 +573,20 @@ class CentralSignalingRelay:
                     logger.debug("[Central Relay] No HF token available")
                 self.hf_token = token
             return token
-        except Exception as e:
-            logger.debug(f"[Central Relay] Could not get HF token: {e}")
+        except Exception as error:
+            logger.debug(
+                "[Central Relay] Could not get HF token (%s)", type(error).__name__
+            )
             return self.hf_token
+
+    async def _recover_from_unauthorized(self, failed_token: Optional[str]) -> bool:
+        """Refresh after a 401 and report whether a retry is worth attempting."""
+        token = await asyncio.to_thread(self._refresh_token, True)
+        if token and token != failed_token:
+            logger.info("[Central Relay] Refreshed credentials after a 401")
+            return True
+        self._set_state(RelayState.ERROR, "Authentication failed")
+        return False
 
     async def _close_connections(self) -> None:
         """Close all connections.
@@ -1173,9 +1179,8 @@ class CentralSignalingRelay:
                 events_url, headers=headers, timeout=timeout
             ) as response:
                 if response.status == 401:
-                    self._set_state(
-                        RelayState.ERROR, "Authentication failed - token may be invalid"
-                    )
+                    if await self._recover_from_unauthorized(self.hf_token):
+                        self._token_updated.set()
                     return
                 elif response.status != 200:
                     self._set_state(
@@ -1625,6 +1630,20 @@ class CentralSignalingRelay:
 _relay_instance: Optional[CentralSignalingRelay] = None
 
 
+def _daemon_token() -> Optional[str]:
+    """Return the daemon-owned token, or None when the robot is signed out."""
+    from reachy_mini.apps.sources.hf_auth import get_hf_token
+
+    try:
+        return get_hf_token()
+    except Exception as error:  # noqa: BLE001 - the relay degrades without a token
+        logger.debug(
+            "[Central Relay] Could not read daemon credentials (%s)",
+            type(error).__name__,
+        )
+        return None
+
+
 def get_relay() -> Optional[CentralSignalingRelay]:
     """Get the global relay instance.
 
@@ -1684,14 +1703,8 @@ async def start_central_relay(
     if _relay_instance is not None:
         return _relay_instance
 
-    # Try to get HF token if not provided
     if hf_token is None:
-        try:
-            from huggingface_hub import get_token
-
-            hf_token = get_token()
-        except Exception:
-            pass
+        hf_token = _daemon_token()
 
     _relay_instance = CentralSignalingRelay(
         central_uri=central_uri,
@@ -1730,12 +1743,7 @@ async def notify_token_change(new_token: Optional[str] = None) -> None:
         return
 
     if new_token is None:
-        try:
-            from huggingface_hub import get_token
-
-            new_token = get_token()
-        except Exception:
-            pass
+        new_token = _daemon_token()
 
     await _relay_instance.update_token(new_token)
 

--- a/src/reachy_mini/media/webrtc_utils.py
+++ b/src/reachy_mini/media/webrtc_utils.py
@@ -151,9 +151,9 @@ class TurnCredentials:
         """
         period = self._ttl * _TURN_REFRESH_RATIO
         try:
-            from huggingface_hub import get_token
+            from reachy_mini.apps.sources.hf_auth import get_hf_token
 
-            token = get_token()
+            token = get_hf_token()
             if not token:
                 # Steady state on a robot nobody has logged in; say so once.
                 if not self._warned_no_token:

--- a/src/reachy_mini/motion/recorded_move.py
+++ b/src/reachy_mini/motion/recorded_move.py
@@ -35,22 +35,22 @@ DEFAULT_DATASETS = [
 ]
 
 
-def preload_dataset(dataset_name: str) -> str | None:
-    """Pre-download a HuggingFace dataset to local cache.
+def dataset_token(dataset_name: str) -> str | bool | None:
+    """Return the credentials a dataset needs, sending none for public defaults."""
+    if dataset_name in DEFAULT_DATASETS:
+        return False
+    from reachy_mini.apps.sources.hf_auth import get_hf_token
 
-    This function downloads the dataset with network access, so it should be
-    called during daemon startup (not during playback) to avoid blocking.
+    return get_hf_token() or False
 
-    Args:
-        dataset_name: The HuggingFace dataset name (e.g., "pollen-robotics/reachy-mini-emotions-library")
 
-    Returns:
-        The local path to the cached dataset, or None if download failed.
-
-    """
+def preload_dataset(dataset_name: str, token: str | bool | None = None) -> str | None:
+    """Download a dataset into the local cache and return its path."""
     try:
         logger.info(f"Pre-downloading dataset: {dataset_name}")
-        local_path: str = snapshot_download(dataset_name, repo_type="dataset")
+        local_path: str = snapshot_download(
+            dataset_name, repo_type="dataset", token=token
+        )
         logger.info(f"Dataset {dataset_name} cached at: {local_path}")
         return local_path
     except Exception as e:
@@ -58,19 +58,13 @@ def preload_dataset(dataset_name: str) -> str | None:
         return None
 
 
-def preload_default_datasets() -> dict[str, str | None]:
-    """Pre-download all default recorded move datasets.
-
-    Should be called during daemon startup to ensure datasets are cached
-    before any playback requests.
-
-    Returns:
-        A dict mapping dataset names to their local paths (or None if failed).
-
-    """
+def preload_default_datasets(
+    token: str | bool | None = None,
+) -> dict[str, str | None]:
+    """Download the default recorded-move datasets into the local cache."""
     results = {}
     for dataset in DEFAULT_DATASETS:
-        results[dataset] = preload_dataset(dataset)
+        results[dataset] = preload_dataset(dataset, token=token)
     return results
 
 
@@ -173,7 +167,7 @@ class RecordedMoves:
     If not cached, falls back to network download (which may cause delays).
     """
 
-    def __init__(self, hf_dataset_name: str):
+    def __init__(self, hf_dataset_name: str, token: str | bool | None = None) -> None:
         """Initialize RecordedMoves."""
         self.hf_dataset_name = hf_dataset_name
         # Try local cache first (instant, no network)
@@ -182,6 +176,7 @@ class RecordedMoves:
                 self.hf_dataset_name,
                 repo_type="dataset",
                 local_files_only=True,
+                token=token,
             )
         except LocalEntryNotFoundError:
             # Fallback: download from network (slow, but ensures it works)
@@ -192,6 +187,7 @@ class RecordedMoves:
             self.local_path = snapshot_download(
                 self.hf_dataset_name,
                 repo_type="dataset",
+                token=token,
             )
         self.moves: Dict[str, Any] = {}
         self.sounds: Dict[str, Optional[Path]] = {}

--- a/src/reachy_mini/vision/face_detector.py
+++ b/src/reachy_mini/vision/face_detector.py
@@ -64,7 +64,9 @@ class FaceDetector:
         self, score_threshold: float = 0.6, nms_threshold: float = 0.3
     ) -> None:
         """Create the YuNet detector, confined to one CPU thread."""
-        model_path = hf_hub_download(_MODEL_REPO, _MODEL_FILE, revision=_MODEL_REVISION)
+        model_path = hf_hub_download(
+            _MODEL_REPO, _MODEL_FILE, revision=_MODEL_REVISION, token=False
+        )
         options = ort.SessionOptions()
         # Confine the detector to one thread so it can't spread across cores and starve the loop.
         options.intra_op_num_threads = 1

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -14,6 +14,19 @@ import usb.util
 from reachy_mini.media.audio_control_utils import CONTROL_SUCCESS, ReSpeaker
 
 
+@pytest.fixture(autouse=True)
+def _isolated_hf_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    """Keep the credential store and HF environment out of the real user config."""
+    from reachy_mini.apps.sources import hf_auth
+
+    root = tmp_path_factory.mktemp("hf-home")
+    monkeypatch.setattr(hf_auth, "HF_TOKEN_PATH", str(root / "token"))
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+
 def _webrtc_plugin_available() -> bool:
     """True when the gst-plugins-rs webrtc elements register (libgstrswebrtc.so)."""
     try:

--- a/tests/unit_tests/test_apps_hf_auth.py
+++ b/tests/unit_tests/test_apps_hf_auth.py
@@ -1,10 +1,4 @@
-"""Tests for the HuggingFace auth source module (in-memory, no network).
-
-Covers the OAuth-session lifecycle on the module-global `_oauth_sessions`
-dict, the pure helpers, and the token functions with `huggingface_hub`
-symbols monkeypatched. The real aiohttp token POST in
-`exchange_code_for_token` is not exercised; only its early error branches.
-"""
+"""Tests for Hugging Face authentication."""
 
 import time
 from dataclasses import replace
@@ -30,36 +24,6 @@ def _clear_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(hf_auth, "_oauth_sessions", {})
 
 
-# ---- Pure helpers
-
-
-def test_generate_user_code_format() -> None:
-    """User code is 4 letters, dash, 4 digits, no ambiguous letters."""
-    code = hf_auth._generate_user_code()
-    letters, numbers = code.split("-")
-    assert len(letters) == 4 and letters.isalpha()
-    assert len(numbers) == 4 and numbers.isdigit()
-    assert not set(letters) & set("IO")
-
-
-def test_generate_pkce_pair_distinct_urlsafe() -> None:
-    """PKCE pair is two distinct URL-safe strings (no padding on challenge)."""
-    verifier, challenge = hf_auth._generate_pkce_pair()
-    assert verifier != challenge
-    assert len(verifier) >= 43
-    assert not challenge.endswith("=")
-
-
-def test_get_oauth_redirect_uri_variants() -> None:
-    """Redirect URI honours wireless flag and localhost override."""
-    assert hf_auth.get_oauth_redirect_uri(True) == hf_auth.OAUTH_REDIRECT_URI_WIRELESS
-    assert hf_auth.get_oauth_redirect_uri(False) == hf_auth.OAUTH_REDIRECT_URI_LITE
-    assert (
-        hf_auth.get_oauth_redirect_uri(True, use_localhost=True)
-        == hf_auth.OAUTH_REDIRECT_URI_LITE
-    )
-
-
 def test_is_oauth_configured_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
     """is_oauth_configured reflects the client-id constant."""
     monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "some-id")
@@ -68,18 +32,28 @@ def test_is_oauth_configured_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
     assert hf_auth.is_oauth_configured() is False
 
 
-# ---- OAuth-session lifecycle
-
-
-def test_create_oauth_session_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A configured session yields an auth URL and registers the session."""
+@pytest.mark.parametrize(
+    ("wireless_version", "use_localhost", "expected_redirect"),
+    [
+        (False, False, hf_auth.OAUTH_REDIRECT_URI_LITE),
+        (True, False, hf_auth.OAUTH_REDIRECT_URI_WIRELESS),
+        (True, True, hf_auth.OAUTH_REDIRECT_URI_LITE),
+    ],
+)
+def test_create_oauth_session_selects_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+    wireless_version: bool,
+    use_localhost: bool,
+    expected_redirect: str,
+) -> None:
+    """Lite, Wireless, and desktop-proxied Wireless use the registered URI."""
     monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
-    result = hf_auth.create_oauth_session(wireless_version=True)
+    result = hf_auth.create_oauth_session(wireless_version, use_localhost)
     assert result["status"] == "success"
     assert result["auth_url"].startswith("https://huggingface.co/oauth/authorize?")
-    assert result["redirect_uri"] == hf_auth.OAUTH_REDIRECT_URI_WIRELESS
+    assert result["redirect_uri"] == expected_redirect
     assert result["expires_in"] == 600
-    assert result["session_id"] in hf_auth._oauth_sessions
+    assert hf_auth._oauth_sessions[result["session_id"]].redirect_uri == expected_redirect
 
 
 def test_create_oauth_session_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -91,15 +65,12 @@ def test_create_oauth_session_not_configured(monkeypatch: pytest.MonkeyPatch) ->
     assert hf_auth._oauth_sessions == {}
 
 
-def test_get_oauth_session_and_by_state(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Sessions are retrievable by id and by state."""
+def test_get_oauth_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sessions are retrievable by their state-backed ID."""
     monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
     sid = hf_auth.create_oauth_session(wireless_version=True)["session_id"]
-    session = hf_auth.get_oauth_session(sid)
-    assert session is not None
-    assert hf_auth.get_session_by_state(session.state) is session
+    assert hf_auth.get_oauth_session(sid) is not None
     assert hf_auth.get_oauth_session("nope") is None
-    assert hf_auth.get_session_by_state("nope") is None
 
 
 def test_get_oauth_session_status_states(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -137,18 +108,6 @@ def test_cancel_oauth_session(monkeypatch: pytest.MonkeyPatch) -> None:
     assert hf_auth.cancel_oauth_session(sid) is False
 
 
-def test_cleanup_expired_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Expired sessions are pruned; live ones remain."""
-    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
-    live = hf_auth.create_oauth_session(wireless_version=True)["session_id"]
-    stale = hf_auth.create_oauth_session(wireless_version=True)["session_id"]
-    hf_auth._oauth_sessions[stale].expires_at = time.time() - 1
-
-    hf_auth._cleanup_expired_sessions()
-    assert live in hf_auth._oauth_sessions
-    assert stale not in hf_auth._oauth_sessions
-
-
 def test_expired_session_not_returned(monkeypatch: pytest.MonkeyPatch) -> None:
     """Getters trigger cleanup, so an expired session reads as gone."""
     monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "cid")
@@ -158,13 +117,10 @@ def test_expired_session_not_returned(monkeypatch: pytest.MonkeyPatch) -> None:
     assert hf_auth.get_oauth_session_status(sid)["status"] == "expired"
 
 
-# ---- exchange_code_for_token early error branches (no aiohttp)
-
-
 @pytest.mark.asyncio
 async def test_exchange_code_invalid_session() -> None:
     """Unknown state returns an invalid-session error before any network."""
-    result = await hf_auth.exchange_code_for_token("code", "unknown-state", True)
+    result = await hf_auth.exchange_code_for_token("code", "unknown-state")
     assert result["status"] == "error"
     assert "Invalid or expired session" in result["message"]
 
@@ -178,12 +134,9 @@ async def test_exchange_code_not_configured(monkeypatch: pytest.MonkeyPatch) -> 
     assert session is not None
 
     monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "")
-    result = await hf_auth.exchange_code_for_token("code", session.state, True)
+    result = await hf_auth.exchange_code_for_token("code", session.session_id)
     assert result == {"status": "error", "message": "OAuth not configured"}
     assert session.status == "error"
-
-
-# ---- Token functions (against the daemon's own store)
 
 
 def _validating_api(monkeypatch: pytest.MonkeyPatch, name: str = "alice") -> MagicMock:
@@ -201,7 +154,7 @@ def test_save_then_read_round_trips_through_the_owned_store(
 
     assert hf_auth.save_hf_token("tok") == {"status": "success", "username": "alice"}
     assert hf_auth.get_hf_token() == "tok"
-    assert hf_auth.current_lifecycle_generation() == 1
+    assert hf_auth.get_hf_credential().lifecycle_generation == 1
 
 
 def test_save_rejects_an_invalid_token_without_storing_it(
@@ -251,7 +204,7 @@ def test_sign_out_leaves_credentials_the_daemon_does_not_own(
 
     assert hf_auth.get_hf_token() is None
     assert cli_token.read_text(encoding="utf-8") == "cli-token"
-    assert hf_auth.current_lifecycle_generation() == 2
+    assert hf_auth.get_hf_credential().lifecycle_generation == 2
 
 
 def test_sign_out_reports_a_write_failure(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -260,14 +213,22 @@ def test_sign_out_reports_a_write_failure(monkeypatch: pytest.MonkeyPatch) -> No
     assert hf_auth.delete_hf_token() is False
 
 
-def test_a_login_completing_after_sign_out_is_refused(
+def test_manual_login_completing_after_sign_out_is_refused(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A login that lost its race with sign-out must not authorize the robot."""
-    generation = hf_auth.current_lifecycle_generation()
-    assert hf_auth.delete_hf_token() is True
+    api = _validating_api(monkeypatch)
 
-    assert hf_auth._persist_login({"access_token": "late-token"}, generation) is False
+    def _sign_out_during_validation() -> dict[str, str]:
+        assert hf_auth.delete_hf_token() is True
+        return {"name": "alice"}
+
+    api.whoami.side_effect = _sign_out_during_validation
+
+    assert hf_auth.save_hf_token("late-token") == {
+        "status": "error",
+        "message": hf_auth.AUTHENTICATION_FAILED_MESSAGE,
+    }
     assert hf_auth.get_hf_token() is None
 
 

--- a/tests/unit_tests/test_apps_hf_auth.py
+++ b/tests/unit_tests/test_apps_hf_auth.py
@@ -7,12 +7,21 @@ symbols monkeypatched. The real aiohttp token POST in
 """
 
 import time
+from dataclasses import replace
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from huggingface_hub.errors import HfHubHTTPError
 
 from reachy_mini.apps.sources import hf_auth
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the credential store at a throwaway directory."""
+    monkeypatch.setattr(hf_auth, "HF_TOKEN_PATH", str(tmp_path / "token"))
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *_a: None)
 
 
 @pytest.fixture(autouse=True)
@@ -57,18 +66,6 @@ def test_is_oauth_configured_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
     assert hf_auth.is_oauth_configured() is True
     monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", "")
     assert hf_auth.is_oauth_configured() is False
-
-
-def test_configure_oauth_sets_globals(monkeypatch: pytest.MonkeyPatch) -> None:
-    """configure_oauth overwrites the module OAuth globals."""
-    # Guard originals so mutation of module state doesn't leak.
-    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_ID", None)
-    monkeypatch.setattr(hf_auth, "OAUTH_CLIENT_SECRET", None)
-    monkeypatch.setattr(hf_auth, "OAUTH_SCOPES", "")
-    hf_auth.configure_oauth("cid", client_secret="secret", scopes="openid")
-    assert hf_auth.OAUTH_CLIENT_ID == "cid"
-    assert hf_auth.OAUTH_CLIENT_SECRET == "secret"
-    assert hf_auth.OAUTH_SCOPES == "openid"
 
 
 # ---- OAuth-session lifecycle
@@ -186,101 +183,167 @@ async def test_exchange_code_not_configured(monkeypatch: pytest.MonkeyPatch) -> 
     assert session.status == "error"
 
 
-# ---- Token functions (huggingface_hub monkeypatched)
+# ---- Token functions (against the daemon's own store)
 
 
-def test_save_hf_token_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Valid token validates, persists via login, and returns the username."""
+def _validating_api(monkeypatch: pytest.MonkeyPatch, name: str = "alice") -> MagicMock:
     api = MagicMock()
-    api.whoami.return_value = {"name": "alice"}
-    hf_api = MagicMock(return_value=api)
-    login = MagicMock()
-    monkeypatch.setattr(hf_auth, "HfApi", hf_api)
-    monkeypatch.setattr(hf_auth, "login", login)
-    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *a: None)
-
-    result = hf_auth.save_hf_token("tok")
-    assert result == {"status": "success", "username": "alice"}
-    hf_api.assert_called_once_with(token="tok")
-    login.assert_called_once_with(token="tok", add_to_git_credential=False)
+    api.whoami.return_value = {"name": name}
+    monkeypatch.setattr(hf_auth, "HfApi", MagicMock(return_value=api))
+    return api
 
 
-def test_save_hf_token_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
-    """HfHubHTTPError/ValueError maps to the generic invalid-token message."""
+def test_save_then_read_round_trips_through_the_owned_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A saved token is validated, stored, and read back without huggingface_hub."""
+    _validating_api(monkeypatch)
+
+    assert hf_auth.save_hf_token("tok") == {"status": "success", "username": "alice"}
+    assert hf_auth.get_hf_token() == "tok"
+    assert hf_auth.current_lifecycle_generation() == 1
+
+
+def test_save_rejects_an_invalid_token_without_storing_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token the Hub rejects is never written to the store."""
     api = MagicMock()
     api.whoami.side_effect = ValueError("bad")
     monkeypatch.setattr(hf_auth, "HfApi", MagicMock(return_value=api))
-    monkeypatch.setattr(hf_auth, "login", MagicMock())
-    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *a: None)
+
+    assert hf_auth.save_hf_token("tok") == {
+        "status": "error",
+        "message": "Invalid token or network error",
+    }
+    assert hf_auth.get_hf_token() is None
+
+
+def test_save_reports_a_write_failure_without_leaking_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A store write failure returns a stable message rather than raising."""
+    _validating_api(monkeypatch)
+    monkeypatch.setattr(
+        hf_auth, "_write_store", MagicMock(side_effect=OSError("secret-marker"))
+    )
 
     result = hf_auth.save_hf_token("tok")
-    assert result == {"status": "error", "message": "Invalid token or network error"}
+
+    assert result == {
+        "status": "error",
+        "message": hf_auth.CREDENTIAL_SAVE_FAILED_MESSAGE,
+    }
+    assert "secret-marker" not in result["message"]
 
 
-def test_save_hf_token_unexpected_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Other exceptions surface their string in the error message."""
-    api = MagicMock()
-    api.whoami.side_effect = RuntimeError("kaboom")
-    monkeypatch.setattr(hf_auth, "HfApi", MagicMock(return_value=api))
-    monkeypatch.setattr(hf_auth, "login", MagicMock())
-    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *a: None)
+def test_sign_out_leaves_credentials_the_daemon_does_not_own(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Signing out tombstones our record and never touches the CLI token file."""
+    cli_token = Path(hf_auth.HF_TOKEN_PATH)
+    cli_token.parent.mkdir(parents=True, exist_ok=True)
+    cli_token.write_text("cli-token", encoding="utf-8")
+    _validating_api(monkeypatch)
+    assert hf_auth.save_hf_token("tok")["status"] == "success"
 
-    result = hf_auth.save_hf_token("tok")
-    assert result == {"status": "error", "message": "kaboom"}
-
-
-def test_save_hf_token_hfhub_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """HfHubHTTPError from login maps to the invalid-token message."""
-    api = MagicMock()
-    api.whoami.return_value = {"name": "alice"}
-    login = MagicMock(side_effect=HfHubHTTPError("nope", response=MagicMock()))
-    monkeypatch.setattr(hf_auth, "HfApi", MagicMock(return_value=api))
-    monkeypatch.setattr(hf_auth, "login", login)
-    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *a: None)
-
-    result = hf_auth.save_hf_token("tok")
-    assert result == {"status": "error", "message": "Invalid token or network error"}
-
-
-def test_get_hf_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    """get_hf_token delegates to huggingface_hub.get_token."""
-    monkeypatch.setattr(hf_auth, "get_token", MagicMock(return_value="tok"))
-    assert hf_auth.get_hf_token() == "tok"
-
-
-def test_delete_hf_token_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Successful logout returns True and notifies the relay of no token."""
-    logout = MagicMock()
-    notify = MagicMock()
-    monkeypatch.setattr(hf_auth, "logout", logout)
-    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", notify)
     assert hf_auth.delete_hf_token() is True
-    logout.assert_called_once_with()
-    notify.assert_called_once_with(None)
+
+    assert hf_auth.get_hf_token() is None
+    assert cli_token.read_text(encoding="utf-8") == "cli-token"
+    assert hf_auth.current_lifecycle_generation() == 2
 
 
-def test_delete_hf_token_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A logout error is swallowed and returns False."""
-    monkeypatch.setattr(hf_auth, "logout", MagicMock(side_effect=RuntimeError("x")))
-    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *a: None)
+def test_sign_out_reports_a_write_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A store write failure during sign-out is reported, not raised."""
+    monkeypatch.setattr(hf_auth, "_write_store", MagicMock(side_effect=OSError("nope")))
     assert hf_auth.delete_hf_token() is False
 
 
-def test_check_token_status_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No stored token means logged out."""
-    monkeypatch.setattr(hf_auth, "get_token", MagicMock(return_value=None))
-    assert hf_auth.check_token_status() == {"is_logged_in": False, "username": None}
+def test_a_login_completing_after_sign_out_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A login that lost its race with sign-out must not authorize the robot."""
+    generation = hf_auth.current_lifecycle_generation()
+    assert hf_auth.delete_hf_token() is True
+
+    assert hf_auth._persist_login({"access_token": "late-token"}, generation) is False
+    assert hf_auth.get_hf_token() is None
 
 
-def test_check_token_status_valid(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A valid token reports logged in with the username."""
-    monkeypatch.setattr(hf_auth, "get_token", MagicMock(return_value="tok"))
-    monkeypatch.setattr(hf_auth, "whoami", MagicMock(return_value={"name": "alice"}))
-    assert hf_auth.check_token_status() == {"is_logged_in": True, "username": "alice"}
+@pytest.mark.parametrize(
+    ("stored", "whoami_result", "expected"),
+    [
+        (None, None, {"is_logged_in": False, "username": None}),
+        ("tok", {"name": "alice"}, {"is_logged_in": True, "username": "alice"}),
+        ("tok", RuntimeError("x"), {"is_logged_in": False, "username": None}),
+    ],
+)
+def test_check_token_status_reflects_the_store(
+    monkeypatch: pytest.MonkeyPatch,
+    stored: str | None,
+    whoami_result: object,
+    expected: dict[str, object],
+) -> None:
+    """Status is derived from our record plus a Hub identity check."""
+    if stored:
+        _validating_api(monkeypatch)
+        assert hf_auth.save_hf_token(stored)["status"] == "success"
+    if isinstance(whoami_result, Exception):
+        monkeypatch.setattr(hf_auth, "whoami", MagicMock(side_effect=whoami_result))
+    else:
+        monkeypatch.setattr(hf_auth, "whoami", MagicMock(return_value=whoami_result))
+
+    assert hf_auth.check_token_status() == expected
 
 
-def test_check_token_status_whoami_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A whoami failure downgrades to logged out."""
-    monkeypatch.setattr(hf_auth, "get_token", MagicMock(return_value="tok"))
-    monkeypatch.setattr(hf_auth, "whoami", MagicMock(side_effect=RuntimeError("x")))
-    assert hf_auth.check_token_status() == {"is_logged_in": False, "username": None}
+def test_an_expiring_token_is_refreshed_and_rotated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token close to expiry is exchanged, and the rotated refresh token sticks."""
+    _validating_api(monkeypatch)
+    assert hf_auth.save_hf_token("first")["status"] == "success"
+    hf_auth._write_store(
+        replace(
+            hf_auth._read_store(),
+            refresh_token="r1",
+            expires_at=int(time.time()) + 5,
+        )
+    )
+    exchanged: list[str] = []
+
+    def _refresh(refresh_token: str) -> dict[str, object]:
+        exchanged.append(refresh_token)
+        return {"access_token": "second", "refresh_token": "r2", "expires_in": 3600}
+
+    monkeypatch.setattr(
+        "huggingface_hub.utils._oauth_device.refresh_access_token", _refresh
+    )
+
+    assert hf_auth.get_hf_token() == "second"
+    assert exchanged == ["r1"]
+    assert hf_auth._read_store().refresh_token == "r2"
+
+
+def test_a_failed_refresh_does_not_hand_out_an_expired_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the exchange fails an already-expired token is withheld, not returned."""
+    _validating_api(monkeypatch)
+    assert hf_auth.save_hf_token("first")["status"] == "success"
+    hf_auth._write_store(
+        replace(
+            hf_auth._read_store(),
+            refresh_token="r1",
+            expires_at=int(time.time()) - 1,
+        )
+    )
+
+    def _boom(_refresh_token: str) -> dict[str, object]:
+        raise RuntimeError("secret-marker")
+
+    monkeypatch.setattr(
+        "huggingface_hub.utils._oauth_device.refresh_access_token", _boom
+    )
+
+    assert hf_auth.get_hf_token() is None

--- a/tests/unit_tests/test_central_signaling_relay.py
+++ b/tests/unit_tests/test_central_signaling_relay.py
@@ -934,6 +934,9 @@ class _FakeHTTPSession:
         self.posts.append((url, json, headers))
         return _FakeResponse(self._status)
 
+    def get(self, url: str, **_kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(self._status)
+
     async def close(self) -> None:
         self.closed = True
 
@@ -1134,3 +1137,44 @@ def test_notify_token_change_forwards_to_instance(
     monkeypatch.setattr(m, "_relay_instance", fake)
     asyncio.run(m.notify_token_change("newtok"))
     assert fake.token == "newtok"
+
+
+def test_relay_recovers_from_an_unauthorized_sse_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 401 mid-session refreshes the daemon credentials and asks to reconnect."""
+    from reachy_mini.apps.sources import hf_auth
+
+    relay = _make_relay()
+    relay.hf_token = "stale"
+    relay._http_session = _FakeHTTPSession(status=401)  # type: ignore[assignment]
+    monkeypatch.setattr(
+        hf_auth,
+        "get_hf_credential",
+        lambda force_refresh=False: hf_auth.HfCredential("fresh", 1),
+    )
+
+    asyncio.run(relay._handle_central_sse())
+
+    assert relay.hf_token == "fresh"
+    assert relay._token_updated.is_set()
+
+
+def test_relay_reports_a_401_it_cannot_recover_from(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrecoverable 401 surfaces as ERROR rather than a silent reconnect loop."""
+    from reachy_mini.apps.sources import hf_auth
+
+    relay = _make_relay()
+    relay.hf_token = "stale"
+    relay._http_session = _FakeHTTPSession(status=401)  # type: ignore[assignment]
+    monkeypatch.setattr(
+        hf_auth,
+        "get_hf_credential",
+        lambda force_refresh=False: hf_auth.HfCredential("stale", 1),
+    )
+
+    asyncio.run(relay._handle_central_sse())
+
+    assert relay.state is RelayState.ERROR

--- a/tests/unit_tests/test_hf_auth.py
+++ b/tests/unit_tests/test_hf_auth.py
@@ -35,10 +35,10 @@ class _ClientSession:
 
 
 @pytest.mark.asyncio
-async def test_oauth_token_uses_huggingface_configured_path(
+async def test_oauth_token_is_stored_in_the_daemon_record(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """OAuth persistence should honor the path selected by huggingface_hub."""
+    """Redirect OAuth persists to the daemon's own store, not the shared token file."""
     token_path = tmp_path / "private-hf-home" / "token"
     session = hf_auth.OAuthSession(
         session_id="session",
@@ -49,17 +49,10 @@ async def test_oauth_token_uses_huggingface_configured_path(
     )
     hf_auth._oauth_sessions[session.session_id] = session
     monkeypatch.setattr(hf_auth, "HF_TOKEN_PATH", str(token_path))
+    monkeypatch.delenv("HF_TOKEN", raising=False)
     monkeypatch.setattr(hf_auth.aiohttp, "ClientSession", _ClientSession)
     monkeypatch.setattr(hf_auth, "whoami", lambda **_kwargs: {"name": "tester"})
     monkeypatch.setattr(central_signaling_relay, "notify_token_change", AsyncMock())
-    real_replace = os.replace
-    replacement_observation: dict[str, int] = {}
-
-    def observe_secure_replace(source: str | Path, destination: str | Path) -> None:
-        replacement_observation["mode"] = Path(source).stat().st_mode & 0o777
-        real_replace(source, destination)
-
-    monkeypatch.setattr(hf_auth.os, "replace", observe_secure_replace)
 
     try:
         result = await hf_auth.exchange_code_for_token("code", "state", False)
@@ -67,39 +60,35 @@ async def test_oauth_token_uses_huggingface_configured_path(
         hf_auth._oauth_sessions.clear()
 
     assert result == {"status": "success", "username": "tester"}
-    assert replacement_observation == {"mode": 0o600}
-    assert token_path.read_text() == "oauth-token"
-    assert token_path.stat().st_mode & 0o777 == 0o600
+    assert hf_auth.get_hf_token() == "oauth-token"
+    assert not token_path.exists()
+    assert hf_auth._store_path().stat().st_mode & 0o777 == 0o600
 
 
 @pytest.mark.asyncio
-async def test_oauth_token_is_not_retained_when_permissions_cannot_be_enforced(
+async def test_lite_first_run_ignores_credentials_on_the_same_machine(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Permission failure must happen before token bytes reach persistent storage."""
-    token_path = tmp_path / "private-hf-home" / "token"
-    session = hf_auth.OAuthSession(
-        session_id="session",
-        user_code="",
-        state="state",
-        code_verifier="verifier",
-        wireless_version=False,
-    )
-    hf_auth._oauth_sessions[session.session_id] = session
+    """On Lite the daemon must not adopt the user's own CLI or environment token."""
+    token_path = tmp_path / "user-hf-home" / "token"
+    token_path.parent.mkdir(parents=True)
+    token_path.write_text("the-users-own-token", encoding="utf-8")
     monkeypatch.setattr(hf_auth, "HF_TOKEN_PATH", str(token_path))
+    monkeypatch.setenv("HF_TOKEN", "the-users-env-token")
     monkeypatch.setattr(hf_auth.aiohttp, "ClientSession", _ClientSession)
+    monkeypatch.setattr(hf_auth, "whoami", lambda **_kwargs: {"name": "tester"})
+    monkeypatch.setattr(central_signaling_relay, "notify_token_change", AsyncMock())
 
-    def deny_chmod(_path: Path, _mode: int) -> None:
-        raise PermissionError("permissions unavailable")
+    assert hf_auth.get_hf_token() is None
 
-    monkeypatch.setattr(Path, "chmod", deny_chmod)
-
+    start = hf_auth.create_oauth_session(wireless_version=False, use_localhost=True)
     try:
-        result = await hf_auth.exchange_code_for_token("code", "state", False)
+        result = await hf_auth.exchange_code_for_token(
+            "code", start["session_id"], False
+        )
     finally:
         hf_auth._oauth_sessions.clear()
 
-    assert result["status"] == "error"
-    assert result["message"].startswith("Failed to save token: PermissionError")
-    assert not token_path.exists()
-    assert list(token_path.parent.iterdir()) == []
+    assert result == {"status": "success", "username": "tester"}
+    assert hf_auth.get_hf_token() == "oauth-token"
+    assert token_path.read_text(encoding="utf-8") == "the-users-own-token"

--- a/tests/unit_tests/test_hf_auth.py
+++ b/tests/unit_tests/test_hf_auth.py
@@ -20,7 +20,7 @@ class _TokenResponse:
         pass
 
     async def text(self) -> str:
-        return '{"access_token": "oauth-token"}'
+        return '{"accessToken": "oauth-token"}'
 
 
 class _ClientSession:
@@ -63,6 +63,41 @@ async def test_oauth_token_is_stored_in_the_daemon_record(
     assert hf_auth.get_hf_token() == "oauth-token"
     assert not token_path.exists()
     assert hf_auth._store_path().stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.asyncio
+async def test_cancelling_redirect_oauth_while_exchanging_refuses_the_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def cancel_then_return_token(_response: _TokenResponse) -> str:
+        assert hf_auth.cancel_oauth_session("session") is True
+        return '{"access_token": "late-token"}'
+
+    session = hf_auth.OAuthSession(
+        session_id="session",
+        user_code="",
+        state="state",
+        code_verifier="verifier",
+        wireless_version=False,
+    )
+    hf_auth._oauth_sessions[session.session_id] = session
+    monkeypatch.setattr(_TokenResponse, "text", cancel_then_return_token)
+    monkeypatch.setattr(hf_auth.aiohttp, "ClientSession", _ClientSession)
+    monkeypatch.setattr(hf_auth, "whoami", lambda **_kwargs: {"name": "tester"})
+    relay_notify = AsyncMock()
+    monkeypatch.setattr(central_signaling_relay, "notify_token_change", relay_notify)
+
+    try:
+        result = await hf_auth.exchange_code_for_token("code", "state", False)
+    finally:
+        hf_auth._oauth_sessions.clear()
+
+    assert result == {
+        "status": "error",
+        "message": hf_auth._CANCELLED_SESSION_MESSAGE,
+    }
+    assert hf_auth.get_hf_token() is None
+    relay_notify.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_hf_auth.py
+++ b/tests/unit_tests/test_hf_auth.py
@@ -41,11 +41,9 @@ async def test_oauth_token_is_stored_in_the_daemon_record(
     """Redirect OAuth persists to the daemon's own store, not the shared token file."""
     token_path = tmp_path / "private-hf-home" / "token"
     session = hf_auth.OAuthSession(
-        session_id="session",
-        user_code="",
-        state="state",
+        session_id="state",
         code_verifier="verifier",
-        wireless_version=False,
+        redirect_uri=hf_auth.OAUTH_REDIRECT_URI_LITE,
     )
     hf_auth._oauth_sessions[session.session_id] = session
     monkeypatch.setattr(hf_auth, "HF_TOKEN_PATH", str(token_path))
@@ -55,14 +53,15 @@ async def test_oauth_token_is_stored_in_the_daemon_record(
     monkeypatch.setattr(central_signaling_relay, "notify_token_change", AsyncMock())
 
     try:
-        result = await hf_auth.exchange_code_for_token("code", "state", False)
+        result = await hf_auth.exchange_code_for_token("code", "state")
     finally:
         hf_auth._oauth_sessions.clear()
 
     assert result == {"status": "success", "username": "tester"}
     assert hf_auth.get_hf_token() == "oauth-token"
     assert not token_path.exists()
-    assert hf_auth._store_path().stat().st_mode & 0o777 == 0o600
+    if os.name != "nt":
+        assert hf_auth._store_path().stat().st_mode & 0o777 == 0o600
 
 
 @pytest.mark.asyncio
@@ -70,15 +69,13 @@ async def test_cancelling_redirect_oauth_while_exchanging_refuses_the_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def cancel_then_return_token(_response: _TokenResponse) -> str:
-        assert hf_auth.cancel_oauth_session("session") is True
+        assert hf_auth.cancel_oauth_session("state") is True
         return '{"access_token": "late-token"}'
 
     session = hf_auth.OAuthSession(
-        session_id="session",
-        user_code="",
-        state="state",
+        session_id="state",
         code_verifier="verifier",
-        wireless_version=False,
+        redirect_uri=hf_auth.OAUTH_REDIRECT_URI_LITE,
     )
     hf_auth._oauth_sessions[session.session_id] = session
     monkeypatch.setattr(_TokenResponse, "text", cancel_then_return_token)
@@ -88,7 +85,7 @@ async def test_cancelling_redirect_oauth_while_exchanging_refuses_the_token(
     monkeypatch.setattr(central_signaling_relay, "notify_token_change", relay_notify)
 
     try:
-        result = await hf_auth.exchange_code_for_token("code", "state", False)
+        result = await hf_auth.exchange_code_for_token("code", "state")
     finally:
         hf_auth._oauth_sessions.clear()
 
@@ -118,9 +115,7 @@ async def test_lite_first_run_ignores_credentials_on_the_same_machine(
 
     start = hf_auth.create_oauth_session(wireless_version=False, use_localhost=True)
     try:
-        result = await hf_auth.exchange_code_for_token(
-            "code", start["session_id"], False
-        )
+        result = await hf_auth.exchange_code_for_token("code", start["session_id"])
     finally:
         hf_auth._oauth_sessions.clear()
 

--- a/tests/unit_tests/test_hf_auth_device_code.py
+++ b/tests/unit_tests/test_hf_auth_device_code.py
@@ -139,9 +139,10 @@ def test_poll_success_persists_token_and_notifies_relay(
 
     persisted: dict[str, Any] = {}
 
-    def _fake_persist(response: dict[str, Any]) -> tuple[str, str]:
+    def _fake_persist(response: dict[str, Any], generation: int) -> str:
         persisted["response"] = response
-        return ("oauth-alice", "alice")
+        persisted["generation"] = generation
+        return "alice"
 
     monkeypatch.setattr(hf_auth, "_persist_device_oauth_token", _fake_persist)
 
@@ -331,7 +332,7 @@ def test_authorized_session_gets_bounded_ttl(
         monkeypatch, poll_device_token=lambda info, **kw: token_response
     )
     monkeypatch.setattr(
-        hf_auth, "_persist_device_oauth_token", lambda resp: ("name", "user")
+        hf_auth, "_persist_device_oauth_token", lambda resp, generation: "user"
     )
 
     session = hf_auth.DeviceCodeSession(
@@ -374,3 +375,33 @@ def test_cleanup_prunes_authorized_after_expiry() -> None:
 
     assert "live" in hf_auth._device_code_sessions
     assert "stale" not in hf_auth._device_code_sessions
+
+
+def test_wireless_first_run_links_the_robot_with_a_refreshable_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh robot finishes the mobile device-code flow holding its own token."""
+    _install_fake_oauth_device(
+        monkeypatch,
+        request_device_code=lambda: dict(_DEVICE_INFO),
+        poll_device_token=lambda info, **kw: {
+            "access_token": "device-token",
+            "refresh_token": "r1",
+            "expires_in": 3600,
+        },
+    )
+    monkeypatch.setattr(hf_auth, "whoami", lambda **_kwargs: {"name": "alice"})
+    monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *_a: None)
+
+    assert hf_auth.check_token_status() == {"is_logged_in": False, "username": None}
+
+    async def scenario() -> dict[str, Any]:
+        start = await hf_auth.start_device_code_login()
+        task = hf_auth._device_code_sessions[start["session_id"]].task
+        assert task is not None
+        await task
+        return hf_auth.get_device_code_session_status(start["session_id"])
+
+    assert asyncio.run(scenario()) == {"status": "authorized", "username": "alice"}
+    assert hf_auth.get_hf_token() == "device-token"
+    assert hf_auth._read_store().refresh_token == "r1"

--- a/tests/unit_tests/test_hf_auth_device_code.py
+++ b/tests/unit_tests/test_hf_auth_device_code.py
@@ -116,7 +116,8 @@ def test_start_returns_error_when_request_fails(
     result = asyncio.run(hf_auth.start_device_code_login())
 
     assert result["status"] == "error"
-    assert "network down" in result["message"]
+    assert result["message"] == hf_auth.AUTHENTICATION_UNAVAILABLE_MESSAGE
+    assert "network down" not in result["message"]
     assert hf_auth._device_code_sessions == {}
 
 

--- a/tests/unit_tests/test_hf_auth_device_code.py
+++ b/tests/unit_tests/test_hf_auth_device_code.py
@@ -13,6 +13,7 @@ import sys
 import time
 import types
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -140,9 +141,12 @@ def test_poll_success_persists_token_and_notifies_relay(
 
     persisted: dict[str, Any] = {}
 
-    def _fake_persist(response: dict[str, Any], generation: int) -> str:
+    def _fake_persist(
+        response: dict[str, Any], session: hf_auth.DeviceCodeSession
+    ) -> str:
         persisted["response"] = response
-        persisted["generation"] = generation
+        persisted["generation"] = session.lifecycle_generation
+        session.status = "authorized"
         return "alice"
 
     monkeypatch.setattr(hf_auth, "_persist_device_oauth_token", _fake_persist)
@@ -324,6 +328,41 @@ def test_poll_aborts_when_cancel_event_set(monkeypatch: pytest.MonkeyPatch) -> N
     assert session.status == "cancelled"
 
 
+def test_cancel_after_device_poll_refuses_the_returned_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _return_token_after_cancel(
+        device_info: Any, *, on_pending: Any = None
+    ) -> dict[str, Any]:
+        (session_id,) = hf_auth._device_code_sessions
+        assert hf_auth.cancel_device_code_session(session_id) is True
+        return {"access_token": "late-token"}
+
+    _install_fake_oauth_device(
+        monkeypatch,
+        request_device_code=lambda: dict(_DEVICE_INFO),
+        poll_device_token=_return_token_after_cancel,
+    )
+    monkeypatch.setattr(hf_auth, "whoami", lambda **_kwargs: {"name": "alice"})
+    import reachy_mini.media.central_signaling_relay as relay_module
+
+    relay_notify = AsyncMock()
+    monkeypatch.setattr(relay_module, "notify_token_change", relay_notify)
+
+    async def scenario() -> hf_auth.DeviceCodeSession:
+        start = await hf_auth.start_device_code_login()
+        session = hf_auth._device_code_sessions[start["session_id"]]
+        assert session.task is not None
+        await session.task
+        return session
+
+    session = asyncio.run(scenario())
+
+    assert session.status == "cancelled"
+    assert hf_auth.get_hf_token() is None
+    relay_notify.assert_not_awaited()
+
+
 def test_authorized_session_gets_bounded_ttl(
     monkeypatch: pytest.MonkeyPatch, device_code_error: type[Exception]
 ) -> None:
@@ -332,9 +371,7 @@ def test_authorized_session_gets_bounded_ttl(
     _install_fake_oauth_device(
         monkeypatch, poll_device_token=lambda info, **kw: token_response
     )
-    monkeypatch.setattr(
-        hf_auth, "_persist_device_oauth_token", lambda resp, generation: "user"
-    )
+    monkeypatch.setattr(hf_auth, "whoami", lambda **_kwargs: {"name": "user"})
 
     session = hf_auth.DeviceCodeSession(
         session_id="s10",
@@ -343,6 +380,7 @@ def test_authorized_session_gets_bounded_ttl(
         verification_uri_complete="https://hf.co/oauth/device",
         expires_at=time.time() + 900,  # original device-code expiry
     )
+    hf_auth._device_code_sessions[session.session_id] = session
 
     before = time.time()
     asyncio.run(hf_auth._run_device_code_poll(session, dict(_DEVICE_INFO)))
@@ -391,7 +429,10 @@ def test_wireless_first_run_links_the_robot_with_a_refreshable_token(
             "expires_in": 3600,
         },
     )
-    monkeypatch.setattr(hf_auth, "whoami", lambda **_kwargs: {"name": "alice"})
+    def _fail_username_lookup(**_kwargs: Any) -> None:
+        raise RuntimeError
+
+    monkeypatch.setattr(hf_auth, "whoami", _fail_username_lookup)
     monkeypatch.setattr(hf_auth, "_notify_relay_of_token_change", lambda *_a: None)
 
     assert hf_auth.check_token_status() == {"is_logged_in": False, "username": None}
@@ -403,6 +444,6 @@ def test_wireless_first_run_links_the_robot_with_a_refreshable_token(
         await task
         return hf_auth.get_device_code_session_status(start["session_id"])
 
-    assert asyncio.run(scenario()) == {"status": "authorized", "username": "alice"}
+    assert asyncio.run(scenario()) == {"status": "authorized", "username": ""}
     assert hf_auth.get_hf_token() == "device-token"
     assert hf_auth._read_store().refresh_token == "r1"

--- a/tests/unit_tests/test_hf_auth_device_code.py
+++ b/tests/unit_tests/test_hf_auth_device_code.py
@@ -1,12 +1,4 @@
-"""Unit tests for the device-code OAuth flow in ``apps.sources.hf_auth``.
-
-These cover only our orchestration (session lifecycle, status polling, relay
-notification, error mapping); the Hugging Face device-code protocol itself lives
-in ``huggingface_hub`` and is stubbed here so the tests are deterministic and run
-regardless of the installed ``huggingface_hub`` version.
-"""
-
-from __future__ import annotations
+"""Tests for the device-code OAuth flow."""
 
 import asyncio
 import sys
@@ -16,6 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from huggingface_hub.errors import DeviceCodeError
 
 from reachy_mini.apps.sources import hf_auth
 
@@ -26,26 +19,6 @@ def _clear_sessions() -> Any:
     hf_auth._device_code_sessions.clear()
     yield
     hf_auth._device_code_sessions.clear()
-
-
-@pytest.fixture
-def device_code_error() -> type[Exception]:
-    """Return ``huggingface_hub``'s ``DeviceCodeError``, creating a stand-in on
-    older hub versions and wiring it where ``hf_auth`` imports it from."""
-    try:
-        from huggingface_hub.errors import DeviceCodeError  # type: ignore
-
-        return DeviceCodeError
-    except ImportError:
-        import huggingface_hub.errors as hub_errors  # type: ignore
-
-        class DeviceCodeError(Exception):  # noqa: N818 — mirror hub naming
-            def __init__(self, message: str, error_code: str | None = None) -> None:
-                super().__init__(message)
-                self.error_code = error_code
-
-        hub_errors.DeviceCodeError = DeviceCodeError  # type: ignore[attr-defined]
-        return DeviceCodeError
 
 
 def _install_fake_oauth_device(
@@ -73,11 +46,6 @@ _DEVICE_INFO = {
 }
 
 
-# --------------------------------------------------------------------------- #
-# start_device_code_login
-# --------------------------------------------------------------------------- #
-
-
 def test_start_returns_user_code_and_registers_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -85,11 +53,7 @@ def test_start_returns_user_code_and_registers_session(
         monkeypatch, request_device_code=lambda: dict(_DEVICE_INFO)
     )
 
-    # Stub the background poll so the test does not depend on its timing.
-    async def _noop_poll(session: Any, device_info: Any) -> None:
-        return None
-
-    monkeypatch.setattr(hf_auth, "_run_device_code_poll", _noop_poll)
+    monkeypatch.setattr(hf_auth, "_run_device_code_poll", AsyncMock())
 
     async def scenario() -> dict[str, Any]:
         result = await hf_auth.start_device_code_login()
@@ -122,13 +86,8 @@ def test_start_returns_error_when_request_fails(
     assert hf_auth._device_code_sessions == {}
 
 
-# --------------------------------------------------------------------------- #
-# _run_device_code_poll
-# --------------------------------------------------------------------------- #
-
-
 def test_poll_success_persists_token_and_notifies_relay(
-    monkeypatch: pytest.MonkeyPatch, device_code_error: type[Exception]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     token_response = {
         "access_token": "hf_new_token",
@@ -139,17 +98,7 @@ def test_poll_success_persists_token_and_notifies_relay(
         monkeypatch, poll_device_token=lambda info, **kw: token_response
     )
 
-    persisted: dict[str, Any] = {}
-
-    def _fake_persist(
-        response: dict[str, Any], session: hf_auth.DeviceCodeSession
-    ) -> str:
-        persisted["response"] = response
-        persisted["generation"] = session.lifecycle_generation
-        session.status = "authorized"
-        return "alice"
-
-    monkeypatch.setattr(hf_auth, "_persist_device_oauth_token", _fake_persist)
+    monkeypatch.setattr(hf_auth, "whoami", lambda **_kwargs: {"name": "alice"})
 
     notified: dict[str, Any] = {}
 
@@ -160,36 +109,26 @@ def test_poll_success_persists_token_and_notifies_relay(
 
     monkeypatch.setattr(relay_module, "notify_token_change", _fake_notify)
 
-    session = hf_auth.DeviceCodeSession(
-        session_id="s1",
-        user_code="ABCD-1234",
-        verification_uri="https://hf.co/oauth/device",
-        verification_uri_complete="https://hf.co/oauth/device",
-    )
+    session = hf_auth.DeviceCodeSession(session_id="s1")
     hf_auth._device_code_sessions["s1"] = session
 
     asyncio.run(hf_auth._run_device_code_poll(session, dict(_DEVICE_INFO)))
 
     assert session.status == "authorized"
     assert session.username == "alice"
-    assert persisted["response"] is token_response
+    assert hf_auth.get_hf_token() == "hf_new_token"
     assert notified["token"] == "hf_new_token"
 
 
 def test_poll_expired_maps_to_expired_status(
-    monkeypatch: pytest.MonkeyPatch, device_code_error: type[Exception]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _expire(info: Any, **kw: Any) -> dict[str, Any]:
-        raise device_code_error("Device code expired. Please try again.")
+        raise DeviceCodeError("Device code expired. Please try again.")
 
     _install_fake_oauth_device(monkeypatch, poll_device_token=_expire)
 
-    session = hf_auth.DeviceCodeSession(
-        session_id="s2",
-        user_code="ABCD-1234",
-        verification_uri="https://hf.co/oauth/device",
-        verification_uri_complete="https://hf.co/oauth/device",
-    )
+    session = hf_auth.DeviceCodeSession(session_id="s2")
 
     asyncio.run(hf_auth._run_device_code_poll(session, dict(_DEVICE_INFO)))
 
@@ -198,28 +137,18 @@ def test_poll_expired_maps_to_expired_status(
 
 
 def test_poll_denied_maps_to_error_status(
-    monkeypatch: pytest.MonkeyPatch, device_code_error: type[Exception]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _deny(info: Any, **kw: Any) -> dict[str, Any]:
-        raise device_code_error("Authorization was denied. Please try again.")
+        raise DeviceCodeError("Authorization was denied. Please try again.")
 
     _install_fake_oauth_device(monkeypatch, poll_device_token=_deny)
 
-    session = hf_auth.DeviceCodeSession(
-        session_id="s3",
-        user_code="ABCD-1234",
-        verification_uri="https://hf.co/oauth/device",
-        verification_uri_complete="https://hf.co/oauth/device",
-    )
+    session = hf_auth.DeviceCodeSession(session_id="s3")
 
     asyncio.run(hf_auth._run_device_code_poll(session, dict(_DEVICE_INFO)))
 
     assert session.status == "error"
-
-
-# --------------------------------------------------------------------------- #
-# get_device_code_session_status / consume_device_session_relay_pending
-# --------------------------------------------------------------------------- #
 
 
 def test_status_unknown_session_is_expired() -> None:
@@ -229,9 +158,6 @@ def test_status_unknown_session_is_expired() -> None:
 def test_status_authorized_includes_username() -> None:
     session = hf_auth.DeviceCodeSession(
         session_id="s4",
-        user_code="ABCD-1234",
-        verification_uri="https://hf.co/oauth/device",
-        verification_uri_complete="https://hf.co/oauth/device",
         status="authorized",
         username="bob",
     )
@@ -244,9 +170,6 @@ def test_status_authorized_includes_username() -> None:
 def test_consume_relay_pending_fires_once() -> None:
     session = hf_auth.DeviceCodeSession(
         session_id="s5",
-        user_code="ABCD-1234",
-        verification_uri="https://hf.co/oauth/device",
-        verification_uri_complete="https://hf.co/oauth/device",
         status="authorized",
     )
     hf_auth._device_code_sessions["s5"] = session
@@ -258,9 +181,6 @@ def test_consume_relay_pending_fires_once() -> None:
 def test_consume_relay_pending_false_while_pending() -> None:
     session = hf_auth.DeviceCodeSession(
         session_id="s6",
-        user_code="ABCD-1234",
-        verification_uri="https://hf.co/oauth/device",
-        verification_uri_complete="https://hf.co/oauth/device",
         status="pending",
     )
     hf_auth._device_code_sessions["s6"] = session
@@ -269,12 +189,7 @@ def test_consume_relay_pending_false_while_pending() -> None:
 
 
 def test_cancel_session_removes_it() -> None:
-    session = hf_auth.DeviceCodeSession(
-        session_id="s7",
-        user_code="ABCD-1234",
-        verification_uri="https://hf.co/oauth/device",
-        verification_uri_complete="https://hf.co/oauth/device",
-    )
+    session = hf_auth.DeviceCodeSession(session_id="s7")
     hf_auth._device_code_sessions["s7"] = session
 
     assert hf_auth.cancel_device_code_session("s7") is True
@@ -284,17 +199,11 @@ def test_cancel_session_removes_it() -> None:
 
 def test_cancel_signals_the_polling_thread() -> None:
     """Cancel must set the event the polling thread observes, not just drop it."""
-    session = hf_auth.DeviceCodeSession(
-        session_id="s8",
-        user_code="ABCD-1234",
-        verification_uri="https://hf.co/oauth/device",
-        verification_uri_complete="https://hf.co/oauth/device",
-    )
+    session = hf_auth.DeviceCodeSession(session_id="s8")
     hf_auth._device_code_sessions["s8"] = session
 
     assert session.cancel_event.is_set() is False
     assert hf_auth.cancel_device_code_session("s8") is True
-    # We keep the local reference, so we can assert the thread would stop.
     assert session.cancel_event.is_set() is True
 
 
@@ -303,9 +212,6 @@ def test_poll_aborts_when_cancel_event_set(monkeypatch: pytest.MonkeyPatch) -> N
     calls = {"on_pending": 0}
 
     def _fake_poll(device_info: Any, *, on_pending: Any = None) -> dict[str, Any]:
-        # Mimic the hub: invoke on_pending each pending cycle. With the event
-        # already set it raises _DeviceCodeCancelled on the first call, so the
-        # (real) blocking loop never runs.
         for _ in range(1000):
             if on_pending is not None:
                 calls["on_pending"] += 1
@@ -314,12 +220,7 @@ def test_poll_aborts_when_cancel_event_set(monkeypatch: pytest.MonkeyPatch) -> N
 
     _install_fake_oauth_device(monkeypatch, poll_device_token=_fake_poll)
 
-    session = hf_auth.DeviceCodeSession(
-        session_id="s9",
-        user_code="ABCD-1234",
-        verification_uri="https://hf.co/oauth/device",
-        verification_uri_complete="https://hf.co/oauth/device",
-    )
+    session = hf_auth.DeviceCodeSession(session_id="s9")
     session.cancel_event.set()
 
     asyncio.run(hf_auth._run_device_code_poll(session, dict(_DEVICE_INFO)))
@@ -364,7 +265,7 @@ def test_cancel_after_device_poll_refuses_the_returned_token(
 
 
 def test_authorized_session_gets_bounded_ttl(
-    monkeypatch: pytest.MonkeyPatch, device_code_error: type[Exception]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """On success the session's expires_at is shortened to the authorized TTL."""
     token_response = {"access_token": "hf_x", "refresh_token": "r", "expires_in": 10}
@@ -375,10 +276,7 @@ def test_authorized_session_gets_bounded_ttl(
 
     session = hf_auth.DeviceCodeSession(
         session_id="s10",
-        user_code="ABCD-1234",
-        verification_uri="https://hf.co/oauth/device",
-        verification_uri_complete="https://hf.co/oauth/device",
-        expires_at=time.time() + 900,  # original device-code expiry
+        expires_at=time.time() + 900,
     )
     hf_auth._device_code_sessions[session.session_id] = session
 
@@ -393,17 +291,11 @@ def test_cleanup_prunes_authorized_after_expiry() -> None:
     """Authorized sessions are reclaimed once past expires_at (no leak)."""
     live = hf_auth.DeviceCodeSession(
         session_id="live",
-        user_code="A",
-        verification_uri="u",
-        verification_uri_complete="u",
         status="authorized",
         expires_at=time.time() + 300,
     )
     stale = hf_auth.DeviceCodeSession(
         session_id="stale",
-        user_code="B",
-        verification_uri="u",
-        verification_uri_complete="u",
         status="authorized",
         expires_at=time.time() - 1,
     )
@@ -429,6 +321,7 @@ def test_wireless_first_run_links_the_robot_with_a_refreshable_token(
             "expires_in": 3600,
         },
     )
+
     def _fail_username_lookup(**_kwargs: Any) -> None:
         raise RuntimeError
 

--- a/tests/unit_tests/test_hf_hub_private_api_contract.py
+++ b/tests/unit_tests/test_hf_hub_private_api_contract.py
@@ -100,7 +100,7 @@ def test_device_code_error_is_exception() -> None:
     [
         ("huggingface_hub.utils._oauth_device", "request_device_code"),
         ("huggingface_hub.utils._oauth_device", "poll_device_token"),
-        ("huggingface_hub._login", "_save_oauth_token"),
+        ("huggingface_hub.utils._oauth_device", "refresh_access_token"),
         ("huggingface_hub.errors", "DeviceCodeError"),
     ],
 )

--- a/tests/unit_tests/test_router_hf_auth.py
+++ b/tests/unit_tests/test_router_hf_auth.py
@@ -1,6 +1,7 @@
 """Unit tests for the HuggingFace auth router (delegating to apps.sources.hf_auth)."""
 
 import types
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -198,6 +199,42 @@ def test_oauth_session_delete_not_found(monkeypatch, router_app):
     assert resp.status_code == 404
 
 
+def test_device_oauth_start_keeps_mobile_contract(monkeypatch, router_app):
+    """The mobile setup endpoint returns the Hugging Face device-code fields."""
+    payload = {
+        "status": "pending",
+        "session_id": "s1",
+        "user_code": "ABCD-1234",
+        "verification_uri": "https://huggingface.co/oauth/device",
+        "verification_uri_complete": "https://huggingface.co/oauth/device?code",
+        "interval": 5,
+        "expires_in": 900,
+    }
+    monkeypatch.setattr(src, "start_device_code_login", AsyncMock(return_value=payload))
+    client = router_app(hf_auth.router)
+
+    resp = client.post("/hf-auth/oauth/device/start")
+
+    assert resp.status_code == 200
+    assert resp.json() == payload
+
+
+def test_device_oauth_status_keeps_mobile_contract(monkeypatch, router_app):
+    """The mobile setup status endpoint preserves authorized and username."""
+    monkeypatch.setattr(
+        src,
+        "get_device_code_session_status",
+        lambda _sid: {"status": "authorized", "username": "alice"},
+    )
+    monkeypatch.setattr(src, "consume_device_session_relay_pending", lambda _sid: False)
+    client = router_app(hf_auth.router)
+
+    resp = client.get("/hf-auth/oauth/device/status/s1")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "authorized", "username": "alice"}
+
+
 def test_central_robot_status_no_token(monkeypatch, router_app):
     """No stored token -> early return, no aiohttp/network involved."""
     monkeypatch.setattr(src, "get_hf_token", lambda: None)
@@ -215,7 +252,7 @@ def test_central_robot_status_no_token(monkeypatch, router_app):
 
 def test_oauth_callback_error_param(monkeypatch, router_app):
     """Callback with an OAuth error renders the failure page (no network)."""
-    monkeypatch.setattr(src, "get_session_by_state", lambda state: None)
+    monkeypatch.setattr(src, "get_oauth_session", lambda state: None)
     client = router_app(hf_auth.router)
 
     resp = client.get(

--- a/tests/unit_tests/test_webrtc_utils.py
+++ b/tests/unit_tests/test_webrtc_utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from reachy_mini.daemon import startup_app_config
+from reachy_mini.apps.sources import hf_auth
 from reachy_mini.media import webrtc_utils
 
 
@@ -190,7 +191,7 @@ def test_turn_credentials_refresh_once_populates_cache(monkeypatch) -> None:
         return _Resp()
 
     monkeypatch.setattr(webrtc_utils, "requests", type("R", (), {"get": _fake_get}))
-    monkeypatch.setattr("huggingface_hub.get_token", lambda: "hf_tok", raising=False)
+    monkeypatch.setattr(hf_auth, "get_hf_token", lambda: "hf_tok")
 
     assert creds._refresh_once() == 300.0  # half the 600 s TTL
     assert creds.turn_uris() == ["turn://u:p@relay.example:3478"]
@@ -208,7 +209,7 @@ def test_turn_credentials_network_failure_retries_soon(monkeypatch) -> None:
         raise RuntimeError("network down")
 
     monkeypatch.setattr(webrtc_utils, "requests", type("R", (), {"get": _boom}))
-    monkeypatch.setattr("huggingface_hub.get_token", lambda: "hf_tok", raising=False)
+    monkeypatch.setattr(hf_auth, "get_hf_token", lambda: "hf_tok")
 
     assert creds._refresh_once() == webrtc_utils._TURN_RETRY_AFTER_FAILURE_S
     assert creds.turn_uris() == ["turn://u:p@relay.example:3478"]
@@ -222,7 +223,7 @@ def test_turn_credentials_without_token_does_not_fetch(monkeypatch) -> None:
         raise AssertionError("must not request TURN creds without a token")
 
     monkeypatch.setattr(webrtc_utils, "requests", type("R", (), {"get": _unexpected}))
-    monkeypatch.setattr("huggingface_hub.get_token", lambda: None, raising=False)
+    monkeypatch.setattr(hf_auth, "get_hf_token", lambda: None)
 
     assert creds._refresh_once() > webrtc_utils._TURN_RETRY_AFTER_FAILURE_S
     assert creds.turn_uris() == []
@@ -240,7 +241,7 @@ def test_turn_credentials_without_token_logs_once(monkeypatch, caplog) -> None:
         "requests",
         type("R", (), {"get": lambda *a, **k: pytest.fail("must not fetch")}),
     )
-    monkeypatch.setattr("huggingface_hub.get_token", lambda: None, raising=False)
+    monkeypatch.setattr(hf_auth, "get_hf_token", lambda: None)
 
     with caplog.at_level("INFO", logger=webrtc_utils.__name__):
         delays = [creds._refresh_once() for _ in range(5)]


### PR DESCRIPTION
## Issue

Closes https://github.com/pollen-robotics/reachy_mini/issues/1366

## Description
- first of all, all the dead code in `hf_auth.py` was removed;
- the daemon now stores its HF credentials in a dedicated file with `0600` permissions (`mkstemp()` in `_write_store()` function). Manual token entry, redirect OAuth, and device-code OAuth all write to this store, and every daemon credential read uses it;
- sign-out writes a signed-out record and advances a lifecycle generation instead of calling `logout()`. This prevents an in-flight login from restoring credentials after sign-out while leaving the user’s CLI credentials untouched. Cancelling an OAuth session is also final: cancellation and credential persistence are coordinated so a late token response cannot be saved;
- all HF calls now choose their credentials explicitly. Private resources use the daemon-owned token, while the public emotions, dances, and face-detector repositories explicitly disable authentication. The daemon therefore never inherits credentials from `HF_TOKEN` or `hf auth login`;
- the central relay uses the same daemon-owned credentials and refreshes them after a `401`, allowing the robot to reconnect without restarting;
- there is intentionally no migration from the Hugging Face CLI token file or `HF_TOKEN`. 

Note, that after upgrading, an already linked robot appears signed out once and must be linked again.

## Testing

Tested on a wireless against live Hugging Face. Starting from signed out, a desktop-app login reached "Remote access enabled". The new file held a refresh token with a 30-day expiry at mode 600. The unit's existing token file wasn't read and stayed unchanged.

## Tested on

- [x] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [ ] Not applicable (e.g. docs, typo)

## AI assistance

<!-- Tick exactly one. Assisted commits also carry the Assisted-by trailer, see docs/contributing.md. -->

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [x] AI wrote code here, and I ran and reviewed it
- [ ] An agent produced this PR, and I have not run it myself

