### PR TITLE
feat(wireless): optional PRE argument for BLE update commands

### DIFF
--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -67,6 +67,7 @@ def get_hardware_id() -> str | None:
         return None
     return hashlib.sha256(raw.encode("ascii")).hexdigest()[:16]
 
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -352,7 +353,7 @@ class ResponseCharacteristic(Characteristic):
         self.notifying = False
         logger.info("Response notifications disabled")
         # Stop journal streaming if running (client disconnected without JOURNAL_STOP)
-        if hasattr(self.service, '_bt_service') and self.service._bt_service:
+        if hasattr(self.service, "_bt_service") and self.service._bt_service:
             self.service._bt_service._stop_journal()
 
     def send_notification(self, text: str):
@@ -718,7 +719,17 @@ class BluetoothCommandService:
         try:
             self._journal_buffer = ""
             self._journal_proc = subprocess.Popen(
-                ["stdbuf", "-oL", "journalctl", "-f", "-n", "20", "--no-pager", "-u", "reachy-mini-daemon"],
+                [
+                    "stdbuf",
+                    "-oL",
+                    "journalctl",
+                    "-f",
+                    "-n",
+                    "20",
+                    "--no-pager",
+                    "-u",
+                    "reachy-mini-daemon",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
             )
@@ -747,7 +758,9 @@ class BluetoothCommandService:
                 if data:
                     text = data.decode("utf-8", errors="replace")
                     self._journal_buffer += text
-                    logger.info(f"Journal buffered: {len(text)} bytes, total: {len(self._journal_buffer)}")
+                    logger.info(
+                        f"Journal buffered: {len(text)} bytes, total: {len(self._journal_buffer)}"
+                    )
                     # Cap buffer to ~32KB to avoid unbounded growth
                     if len(self._journal_buffer) > 32768:
                         self._journal_buffer = self._journal_buffer[-32768:]
@@ -883,9 +896,7 @@ class BluetoothCommandService:
                 # Locked out: reject WITHOUT comparing the PIN, so a correct
                 # guess landed mid-spree doesn't win and the lockout window is
                 # the real bottleneck. int()+1 rounds up so we never show "0s".
-                return (
-                    f"ERROR: Too many attempts. Try again in {int(remaining) + 1}s."
-                )
+                return f"ERROR: Too many attempts. Try again in {int(remaining) + 1}s."
             pin = command_str[4:].strip()
             if pin == self.pin_code:
                 self._reset_pin_throttle()
@@ -1123,7 +1134,9 @@ class BluetoothCommandService:
             self._ad_manager.RegisterAdvertisement(
                 self.adv.get_path(),
                 {},
-                reply_handler=lambda: logger.info("Advertisement re-asserted after disconnect"),
+                reply_handler=lambda: logger.info(
+                    "Advertisement re-asserted after disconnect"
+                ),
                 error_handler=lambda e: logger.warning(
                     f"Re-assert advertisement failed (non-fatal): {e}"
                 ),

--- a/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
+++ b/src/reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py
@@ -924,15 +924,23 @@ class BluetoothCommandService:
         # terminal DONE — it tails off into "Daemon unreachable" / "Unknown
         # job". Clients infer success by reconnecting and re-running
         # UPDATE_CHECK (current_version == latest), not by polling to the end.
-        elif upper == "UPDATE_CHECK":
+        # Both commands take an optional "PRE" argument (e.g. "UPDATE_CHECK
+        # PRE") that opts into pre-release builds — the BLE mirror of the
+        # `pre_release` flag the WebRTC `start_update` message already
+        # carries, so dev clients can track the RC channel over BLE too.
+        # Daemons that predate this argument ECHO the command back, which
+        # clients treat as "retry without PRE".
+        elif upper in ("UPDATE_CHECK", "UPDATE_CHECK PRE"):
             if not self._is_authed():
                 return "ERROR: Not connected. Please authenticate first."
-            self._run_async(_update_check)
+            pre_release = upper.endswith(" PRE")
+            self._run_async(lambda: _update_check(pre_release))
             return "OK: working"
-        elif upper == "UPDATE_START":
+        elif upper in ("UPDATE_START", "UPDATE_START PRE"):
             if not self._is_authed():
                 return "ERROR: Not connected. Please authenticate first."
-            self._run_async(_update_start)
+            pre_release = upper.endswith(" PRE")
+            self._run_async(lambda: _update_start(pre_release))
             return "OK: working"
         elif upper.startswith("UPDATE_INFO "):
             if not self._is_authed():
@@ -1312,13 +1320,17 @@ _UPDATE_HTTP_TIMEOUT_S = 30.0
 _UPDATE_MTU_BUDGET = 180
 
 
-def _update_check() -> str:
-    """Report whether a daemon update is available (compact JSON for BLE)."""
+def _update_check(pre_release: bool = False) -> str:
+    """Report whether a daemon update is available (compact JSON for BLE).
+
+    `pre_release` widens the reference to pre-release builds (RC channel);
+    set by the optional "PRE" argument of the UPDATE_CHECK command.
+    """
     try:
         data = _daemon_request(
             "GET",
             "/update/available",
-            {"pre_release": "false"},
+            {"pre_release": "true" if pre_release else "false"},
             timeout=_UPDATE_HTTP_TIMEOUT_S,
         )
         rm = (data or {}).get("update", {}).get("reachy_mini", {})
@@ -1383,13 +1395,17 @@ def _wifi_keyex() -> str:
         return f"ERROR: {e}"
 
 
-def _update_start() -> str:
-    """Trigger the daemon update (latest published release). Returns the job id."""
+def _update_start(pre_release: bool = False) -> str:
+    """Trigger the daemon update (latest published release). Returns the job id.
+
+    `pre_release` opts the install into pre-release builds (RC channel);
+    set by the optional "PRE" argument of the UPDATE_START command.
+    """
     try:
         data = _daemon_request(
             "POST",
             "/update/start",
-            {"pre_release": "false"},
+            {"pre_release": "true" if pre_release else "false"},
             timeout=_UPDATE_HTTP_TIMEOUT_S,
         )
         job_id = (data or {}).get("job_id") if isinstance(data, dict) else None

--- a/tests/unit_tests/test_ble_update_proxy.py
+++ b/tests/unit_tests/test_ble_update_proxy.py
@@ -126,6 +126,30 @@ def test_update_check_available(monkeypatch):
     assert out == {"available": True, "current": "1.8.1", "latest": "1.9.0"}
 
 
+def test_update_check_forwards_pre_release_flag(monkeypatch):
+    """The optional PRE argument must reach /update/available as pre_release=true."""
+    seen = {}
+
+    def fake(method, path, params=None, **k):
+        seen["params"] = params
+        return {
+            "update": {
+                "reachy_mini": {
+                    "is_available": True,
+                    "current_version": "1.9.0",
+                    "available_version": "1.10.0rc5",
+                }
+            }
+        }
+
+    monkeypatch.setattr(bt, "_daemon_request", fake)
+    bt._update_check(True)
+    assert seen["params"] == {"pre_release": "true"}
+    # Default stays pinned to the stable channel.
+    bt._update_check()
+    assert seen["params"] == {"pre_release": "false"}
+
+
 def test_update_check_busy_maps_to_in_progress(monkeypatch):
     _patch_daemon(monkeypatch, _http_error(400))
     assert bt._update_check() == "ERROR: Update in progress"
@@ -142,6 +166,21 @@ def test_update_check_daemon_unreachable(monkeypatch):
 def test_update_start_returns_job_id(monkeypatch):
     _patch_daemon(monkeypatch, {"job_id": "abc-123"})
     assert bt._update_start() == "OK: Update started abc-123"
+
+
+def test_update_start_forwards_pre_release_flag(monkeypatch):
+    """The optional PRE argument must reach /update/start as pre_release=true."""
+    seen = {}
+
+    def fake(method, path, params=None, **k):
+        seen["params"] = params
+        return {"job_id": "abc-123"}
+
+    monkeypatch.setattr(bt, "_daemon_request", fake)
+    assert bt._update_start(True) == "OK: Update started abc-123"
+    assert seen["params"] == {"pre_release": "true"}
+    bt._update_start()
+    assert seen["params"] == {"pre_release": "false"}
 
 
 def test_update_start_missing_job_id(monkeypatch):


### PR DESCRIPTION
## Issue

The BLE update proxy pins both `UPDATE_CHECK` and `UPDATE_START` to the stable channel (`pre_release=false`), so a client provisioning a robot over BLE can neither see nor install a release candidate. The WebRTC path already exposes this choice (`start_update` carries a `pre_release` flag); the BLE path has no equivalent, which blocks RC testing of the mobile app's over-BLE forced-update flow while `v1.10.0` only exists as an RC.

## Description

Both commands accept an optional `PRE` argument (`UPDATE_CHECK PRE`, `UPDATE_START PRE`) forwarded as `pre_release=true` to `/update/available` and `/update/start`. Bare commands keep the exact stable-channel behaviour, so existing clients are unaffected. Daemons that predate the argument ECHO the argumented form back (the standard unknown-command reply), which lets clients fall back to the bare command.

A separate `style(wireless)` commit runs `ruff-format` on `bluetooth_service.py` first: the file predates the formatting hook, which reflows it wholesale on any edit; formatting it in isolation keeps the functional diff readable.

## Testing

Two unit tests added to `test_ble_update_proxy.py` assert the `pre_release` param actually sent for the default and `PRE` variants of both commands (the suite is Linux-only, like the service).

Exercised on a Reachy Mini Wireless (daemon 1.9.0) by loading this branch's `bluetooth_service.py` on the robot and driving the real code paths against the live daemon HTTP API:

- `_handle_command(b"UPDATE_CHECK PRE")` -> `OK: working`, and the dispatched job hits `GET /update/available` with `pre_release=true`; the bare command keeps `pre_release=false`.
- Unauthenticated `UPDATE_START PRE` -> `ERROR: Not connected. Please authenticate first.` (no job scheduled).
- `UPDATE_START` was deliberately NOT triggered (it would actually install), and the GATT transport layer itself is untouched by this diff.

Note: on that 1.9.0 daemon the PRE check still reports `latest 1.9.0` because of the releases-dict key-order bug - end-to-end RC resolution needs #1351, as flagged below.

## Tested on

- [x] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [ ] Not applicable (e.g. docs, typo)

## AI assistance

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [x] AI wrote code here, and I ran and reviewed it
- [ ] An agent produced this PR, and I have not run it myself

Made with [Cursor](https://cursor.com)