### PR TITLE
fix(wireless): pick the highest PyPI version for pre-release checks

### DIFF
--- a/src/reachy_mini/utils/wireless_version/update_available.py
+++ b/src/reachy_mini/utils/wireless_version/update_available.py
@@ -55,10 +55,17 @@ def get_pypi_version(package_name: str, pre_release: bool) -> semver.Version:
     version = _semver_version(data["info"]["version"])
 
     if pre_release:
-        releases = list(data["releases"].keys())
-        pre_version = _semver_version(releases[-1])
-        if pre_version > version:
-            return pre_version
+        # PyPI serializes the releases dict in lexicographic key order, so
+        # its LAST entry is not the newest version: "1.9.0rc1" sorts after
+        # "1.10.0rc5". Scan the whole list for the highest parseable
+        # version instead of trusting the trailing entry.
+        for release in data["releases"]:
+            try:
+                candidate = _semver_version(release)
+            except ValueError:
+                continue  # legacy tag formats: not installable targets
+            if candidate > version:
+                version = candidate
 
     return version
 

--- a/tests/unit_tests/test_wireless_version.py
+++ b/tests/unit_tests/test_wireless_version.py
@@ -234,6 +234,37 @@ def test_get_pypi_version_prerelease(monkeypatch):
     assert (v.major, v.minor, v.patch) == (2, 1, 0)
 
 
+def test_get_pypi_version_prerelease_lexicographic_order(monkeypatch):
+    """Regression: the newest RC must win even when it isn't the LAST entry.
+
+    PyPI serializes the releases dict in lexicographic key order, so once a
+    two-digit minor exists the trailing entry is an OLD version ("1.9.0rc1"
+    sorts after "1.10.0rc5"). The old `releases[-1]` lookup then compared
+    1.9.0rc1 < 1.9.0 and fell back to stable - hiding every 1.10.0 RC from
+    the pre-release channel (BLE UPDATE_CHECK and /update/available alike).
+    """
+    payload = {
+        "info": {"version": "1.9.0"},
+        # Real pypi.org key order for these versions.
+        "releases": {"1.10.0rc5": [], "1.8.4": [], "1.9.0": [], "1.9.0rc1": []},
+    }
+    monkeypatch.setattr(update_available.requests, "get", lambda *a, **k: _FakeResponse(payload))
+    v = update_available.get_pypi_version("reachy-mini", pre_release=True)
+    assert (v.major, v.minor, v.patch) == (1, 10, 0)
+    assert v.prerelease == "rc.5"
+
+
+def test_get_pypi_version_prerelease_skips_unparseable(monkeypatch):
+    """Legacy tags that don't parse are skipped, not fatal."""
+    payload = {
+        "info": {"version": "1.9.0"},
+        "releases": {"0.1": [], "1.10.0rc5": [], "1.9.0": []},
+    }
+    monkeypatch.setattr(update_available.requests, "get", lambda *a, **k: _FakeResponse(payload))
+    v = update_available.get_pypi_version("reachy-mini", pre_release=True)
+    assert (v.major, v.minor, v.patch) == (1, 10, 0)
+
+
 def test_get_pypi_version_prerelease_pep440_info_version(monkeypatch):
     """Regression: pre-release compare must not crash on a PEP 440 info.version.
 


### PR DESCRIPTION
## Issue

`get_pypi_version(pre_release=True)` returns a stale version. Reproduce on any robot today: `curl "http://127.0.0.1:8000/update/available?pre_release=true"` reports `available_version: 1.9.0` while `1.10.0rc5` is live on PyPI. Every pre-release consumer is affected: `/update/available`, the WebRTC `start_update` `pre_release` flag, and BLE `UPDATE_CHECK` (plus the `PRE` variant proposed in #1368).

## Description

The function trusted the LAST entry of PyPI's `releases` dict as the newest pre-release. That dict is serialized in lexicographic key order, so once a two-digit minor exists the trailing entry is an old version: `1.9.0rc1` sorts after `1.10.0rc5`. The check then compared `1.9.0rc1 < 1.9.0` and fell back to stable.

Scan the whole releases list for the highest parseable version instead, skipping legacy tag formats that don't parse.

## Testing

- `test_get_pypi_version_prerelease_lexicographic_order` reproduces the bug with the real pypi.org key order (fails on `main`, passes here).
- `test_get_pypi_version_prerelease_skips_unparseable` covers legacy tags.
- Against live PyPI with the fix: `get_pypi_version('reachy-mini', True)` → `1.10.0-rc.5`, `get_pypi_version('reachy-mini', False)` → `1.9.0`.
- Full `test_wireless_version.py` suite passes (35 tests).

## Tested on

- [ ] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [ ] Not applicable (e.g. docs, typo)

## AI assistance

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [ ] AI wrote code here, and I ran and reviewed it
- [x] An agent produced this PR, and I have not run it myself

Made with [Cursor](https://cursor.com)