### PR TITLE
docs(sdk-js): document the Web Worker clock for backgrounded tabs

### DIFF
--- a/docs/source/SDK/javascript-sdk.md
+++ b/docs/source/SDK/javascript-sdk.md
@@ -305,6 +305,57 @@ arrive out of order are dropped (the channel is unordered). Against an older
 daemon that has no pose channel this is a no-op; fall back to `requestState()`
 polling there.
 
+## Handling backgrounded tabs
+
+When the tab is hidden (tab switch, phone lock), the browser pauses
+`requestAnimationFrame` entirely and clamps `setInterval`/`setTimeout` to
+~1 tick per second. Any robot-critical loop clocked by them - pose
+streaming via `setTarget()`, audio gain ramps, stream-health watchdogs,
+reconnect logic - freezes mid-motion until the tab comes back.
+
+Split your loop in two:
+
+- **Logic** (pose computation + `setTarget`, audio, health checks,
+  reconnects): clock it from a **Web Worker**. Worker timers are *not*
+  visibility-throttled, and the `message` events they post are delivered
+  on the main thread even while the tab is hidden.
+- **Visuals** (DOM updates, canvas, meters): keep them on
+  `requestAnimationFrame`. Pausing invisible paints is exactly what you
+  want, and it resumes on its own.
+
+```js
+// pose-heartbeat.worker.js - the whole file:
+setInterval(() => postMessage(0), 25); // ~40 Hz; the main thread down-samples
+```
+
+```js
+// app side
+let worker = null;
+try {
+    worker = new Worker(new URL("./pose-heartbeat.worker.js", import.meta.url), { type: "module" });
+    worker.onmessage = () => stepLogic(performance.now());
+} catch {
+    // Workers unavailable (rare): degrade to a throttled interval.
+    setInterval(() => stepLogic(performance.now()), 25);
+}
+```
+
+Two companion rules make this robust:
+
+- **Clamp your `dt`.** After a long hidden stretch the first tick sees a
+  huge time delta; clamp it (e.g. `Math.min(dt, 100)`) so filters and
+  interpolators don't jump.
+- **Resync on `visibilitychange`.** When the tab returns, call
+  `robot.requestState()` and run one logic step immediately instead of
+  waiting for the next scheduled tick, so the UI repaints from fresh state.
+
+Remember to `worker.terminate()` in your teardown. Full rationale and the
+host-shell variant live in
+[`ts/APP_CREATION_GUIDE.md`](../../../ts/APP_CREATION_GUIDE.md) §14.7; the
+[`pollen-robotics/sdk-js-demo-app`](https://huggingface.co/spaces/pollen-robotics/sdk-js-demo-app)
+Space meters the throttling live (Background resilience panel) and clocks
+its own pose editor off a worker.
+
 ## Robot onboarding & management
 
 These daemon-side commands power first-run setup and remote administration.

--- a/skills/create-js-app.md
+++ b/skills/create-js-app.md
@@ -66,6 +66,11 @@ contract - your app is agnostic of everything else.
 - Carry degrees through motion code below the UI layer - speak radians /
   magic-mm; convert at the UI boundary with `degToRad` / `radToDeg`.
 - Mutate `INIT_POSE` or `DEFAULT_SCALED_DURATION_PRESET` (deep-frozen).
+- Clock a **continuous** robot loop (pose streaming, audio pipeline,
+  stream-health watchdog) off `requestAnimationFrame` or `setInterval`
+  alone. Hidden tabs pause rAF and clamp intervals to ~1 Hz, freezing the
+  robot mid-motion. Clock logic from a **Web Worker** heartbeat and keep
+  rAF for visuals only - see guide §14.7.
 
 ## Procedure
 
@@ -182,7 +187,16 @@ colors inlined.
 
 - Gestures use degrees at the UI boundary, radians/magic-mm below it.
 - For smooth keyframed gestures, tween client-side with `requestAnimationFrame`
-  and feed `setHeadRpyDeg` / `setAntennasDeg` each frame.
+  and feed `setHeadRpyDeg` / `setAntennasDeg` each frame. rAF is fine for a
+  **short, user-triggered** gesture; it is NOT fine as the clock of a
+  continuous loop (next bullet).
+- If the app streams poses continuously (follow modes, idle sway, audio
+  reactivity, watchdogs), clock that logic from a **Web Worker** heartbeat:
+  hidden tabs pause rAF entirely and clamp `setInterval` to ~1 Hz, so a
+  rAF-clocked stream freezes the robot mid-motion on tab switch. Keep rAF
+  for visuals only, clamp `dt` after hidden stretches, resync on
+  `visibilitychange`, `worker.terminate()` in `onLeave`. Copy-paste recipe:
+  guide §14.7.
 - For long or audio-synced moves, prefer daemon-side `reachy.playMove(motion, { audioBlob })`.
 - Use `scaledDuration(current, target)` from `/animation` to size move
   durations instead of hardcoding. Full recipe: guide §14.
@@ -215,6 +229,8 @@ Never commit `dist/`. Full deploy details + FAQ: guide §11.
 - [ ] SDK pinned to the exact build string in `package.json`.
 - [ ] `handle.config` validated before use (if used).
 - [ ] Theme mirrored from `handle.theme` + `onThemeChange`.
+- [ ] Any continuous robot loop is clocked off a Web Worker heartbeat, not
+      rAF/`setInterval` (guide §14.7) - or the app has no such loop.
 - [ ] Mobile-first: tested in phone emulation, touch targets >= 44px.
 - [ ] `public/icon.svg` committed; frontmatter has `reachy_mini_js_app` tag
       and `short_description` <= 60 chars.

--- a/ts/APP_CREATION_GUIDE.md
+++ b/ts/APP_CREATION_GUIDE.md
@@ -1890,4 +1890,8 @@ Two companion rules make this robust:
 
 Remember to `worker.terminate()` in your `onLeave` cleanup. A complete
 reference implementation lives in the `reachy_mini_radio_js` app
-(`src/embed.ts` + `src/pose-heartbeat.worker.ts`).
+(`src/embed.ts` + `src/pose-heartbeat.worker.ts`), and the
+[`pollen-robotics/sdk-js-demo-app`](https://huggingface.co/spaces/pollen-robotics/sdk-js-demo-app)
+Space both applies the pattern to its pose editor and demos the throttling
+live: its **Background resilience** panel meters rAF vs `setInterval` vs a
+worker clock, with a recap of what each delivered while the tab was hidden.


### PR DESCRIPTION
<!-- Read docs/contributing.md before opening your PR. -->

## Issue

No issue filed. `docs/source/SDK/lifecycle-contract.md` links to a "Handling backgrounded tabs" section in the JavaScript SDK guide that never existed, so the link is dead. The underlying gotcha is also undocumented anywhere: hidden tabs pause `requestAnimationFrame` entirely and clamp `setInterval` to ~1 Hz, so any continuous robot loop (pose streaming, audio, watchdogs) silently stalls when the user switches tabs.

## Description

- Add the missing "Handling backgrounded tabs" section to `docs/source/SDK/javascript-sdk.md` (guide 14.7): clock continuous loops off a Web Worker heartbeat, clamp `dt`, resync on `visibilitychange`; keep visuals on rAF.
- Teach `skills/create-js-app.md` the same rule for agents: a new "Never" anti-pattern, an animation-step recipe pointing to guide 14.7, and a definition-of-done checkbox.
- Guide 14.7 also references the [`pollen-robotics/sdk-js-demo-app`](https://huggingface.co/spaces/pollen-robotics/sdk-js-demo-app) Space, which applies the pattern to its own pose editor and demos the throttling live in a "Background resilience" panel (rAF vs `setInterval` vs worker tick meters, with a recap of what each clock delivered while the tab was hidden).

## Testing

Markdown only, no code changes. The `lifecycle-contract.md` link to "Handling backgrounded tabs" now resolves. The pattern itself is exercised live by the demo Space referenced above: switch tabs mid-glide, the robot keeps moving, and the Background resilience recap shows rAF paused, interval clamped to ~1 Hz, worker at full rate.

## Tested on

- [ ] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [x] Not applicable (e.g. docs, typo)

## AI assistance

<!-- Tick exactly one. Assisted commits also carry the Assisted-by trailer, see docs/contributing.md. -->

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [x] AI wrote code here, and I ran and reviewed it
- [ ] An agent produced this PR, and I have not run it myself

Made with [Cursor](https://cursor.com)
