### PR TITLE
docs(js): fix reference app links (truncated names) and pin SDK to 1.10.0-rc.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ See and run `examples/minimal_demo.py` - demonstrates connection, head motion, a
 >
 > That guide is the **single source of truth** for building a Reachy Mini JS app: scaffolding, `public/icon.svg`, host shell, `sdk: static` deploy, `mountHost()` / `connectToHost()` API, local dev, FAQ, and the host ↔ embed architecture reference. Everything that used to live in `SPEC.md` and `APP_AUTHOR_GUIDE.md` is folded in.
 >
-> **Today's SDK pin** (used by all three reference apps): `@pollen-robotics/reachy-mini-sdk@1.8.0`. See [§10 SDK version pinning](ts/APP_CREATION_GUIDE.md#10-sdk-version-pinning).
+> **Today's SDK pin** (used by all three reference apps): `@pollen-robotics/reachy-mini-sdk@1.10.0-rc.5`. See [§10 SDK version pinning](ts/APP_CREATION_GUIDE.md#10-sdk-version-pinning).
 
 Browser apps that drive a Reachy Mini over WebRTC, deployed as Hugging Face Spaces. Any HF-authenticated user opens the Space URL from anywhere and reaches any robot they have access to, through the central signaling server.
 
@@ -150,9 +150,9 @@ Browser apps that drive a Reachy Mini over WebRTC, deployed as Hugging Face Spac
 
 | Reference app | Stack | Use it for |
 |---|---|---|
-| [`pollen-robotics/reachy_mini_minimal_conversation`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_minimal_conversation) | **Vanilla TS + Vite** | Smallest runtime, zero framework. |
-| [`pollen-robotics/reachy_mini_emotions`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_emotions) | React 19 + MUI 7 + Vite | UI-rich apps (rich components, theming, deep links). |
-| [`pollen-robotics/reachy_mini_telepresence`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_telepresence) | React 19 + MUI 7 + Vite | Camera / media-stream apps. |
+| [`tfrere/minimal-conversation`](https://huggingface.co/spaces/tfrere/minimal-conversation) | **Vanilla TS + Vite** | Smallest runtime, zero framework. |
+| [`tfrere/emotions`](https://huggingface.co/spaces/tfrere/emotions) | React 19 + MUI 7 + Vite | UI-rich apps (rich components, theming, deep links). |
+| [`tfrere/telepresence`](https://huggingface.co/spaces/tfrere/telepresence) | React 19 + MUI 7 + Vite | Camera / media-stream apps. |
 
 These are kept in lockstep with every SDK release. **Mimicking them is the fastest path to a working app.** The 3-file contract, deploy steps, gotchas, and SDK pin all live in [`ts/APP_CREATION_GUIDE.md`](ts/APP_CREATION_GUIDE.md) - read it before scaffolding anything non-trivial.
 

--- a/docs/source/SDK/javascript-sdk.md
+++ b/docs/source/SDK/javascript-sdk.md
@@ -6,8 +6,8 @@
 > shell, `sdk: static` deploy,
 > `mountHost()` / `connectToHost()` API, local dev, FAQ, and the host
 > ↔ embed contract. **Pin the SDK to
-> `@pollen-robotics/reachy-mini-sdk@1.8.0`** (the stable release
-> validated against the host shell + daemon).
+> `@pollen-robotics/reachy-mini-sdk@1.10.0-rc.5`** (the current release
+> candidate validated against the host shell + daemon).
 >
 > **This file** is the runtime API surface of the `ReachyMini` class
 > you receive from `handle.reachy` once `connectToHost()` resolves:
@@ -345,8 +345,8 @@ await robot.signOut();
 
 The three reference apps maintained alongside the SDK are the canonical worked examples. They all use the host shell pattern and the current SDK pin:
 
-- [`pollen-robotics/reachy_mini_minimal_conversation`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_minimal_conversation) — vanilla TS + Vite.
-- [`pollen-robotics/reachy_mini_emotions`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_emotions) — React 19 + MUI 7 + Vite.
-- [`pollen-robotics/reachy_mini_telepresence`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_telepresence) — React 19 + MUI 7 + Vite with camera + media streams.
+- [`tfrere/minimal-conversation`](https://huggingface.co/spaces/tfrere/minimal-conversation) — vanilla TS + Vite.
+- [`tfrere/emotions`](https://huggingface.co/spaces/tfrere/emotions) — React 19 + MUI 7 + Vite.
+- [`tfrere/telepresence`](https://huggingface.co/spaces/tfrere/telepresence) — React 19 + MUI 7 + Vite with camera + media streams.
 
 Clone the closest one and trim. See [`ts/APP_CREATION_GUIDE.md`](../../../ts/APP_CREATION_GUIDE.md) for the step-by-step.

--- a/skills/create-js-app.md
+++ b/skills/create-js-app.md
@@ -41,7 +41,7 @@ contract - your app is agnostic of everything else.
 - Go through the host shell: `mountHost()` in `dispatch.ts`,
   `connectToHost()` in `embed.ts`. Free OAuth + picker + top bar + leave.
 - Pin the **exact** SDK version everywhere it appears (npm dep AND any CDN
-  URL): `@pollen-robotics/reachy-mini-sdk@1.8.0`.
+  URL): `@pollen-robotics/reachy-mini-sdk@1.10.0-rc.5`.
 - Register `onLeave(() => safelyReturnToPose(handle.reachy))` so the robot
   returns to a safe rest pose when the user leaves.
 - Validate `handle.config` at the boundary before using it.
@@ -113,7 +113,7 @@ Svelte, Vue, or vanilla. The host doesn't care.
   "private": true,
   "type": "module",
   "scripts": { "dev": "vite", "build": "tsc -b && vite build", "preview": "vite preview" },
-  "dependencies": { "@pollen-robotics/reachy-mini-sdk": "1.8.0" },
+  "dependencies": { "@pollen-robotics/reachy-mini-sdk": "1.10.0-rc.5" },
   "devDependencies": { "typescript": "^5.5.4", "vite": "^5.4.10" }
 }
 ```

--- a/ts/APP_CREATION_GUIDE.md
+++ b/ts/APP_CREATION_GUIDE.md
@@ -1,9 +1,9 @@
 # App Creation Guide
 
-> ### Use `@pollen-robotics/reachy-mini-sdk@1.8.0` today
+> ### Use `@pollen-robotics/reachy-mini-sdk@1.10.0-rc.5` today
 >
-> Every reference app pins the same SDK release: **`1.8.0`** (the
-> stable npm release; npm versions are immutable, so this is fully
+> Every reference app pins the same SDK release: **`1.10.0-rc.5`** (the
+> current npm `rc` release; npm versions are immutable, so this is fully
 > reproducible — no commit suffix needed). The host shell, the embed
 > adapter, the SDK runtime, and the daemon on the robot are validated
 > end-to-end against that release. Mixing versions across these
@@ -13,7 +13,7 @@
 > Add this to your `package.json`:
 >
 > ```json
-> { "dependencies": { "@pollen-robotics/reachy-mini-sdk": "1.8.0" } }
+> { "dependencies": { "@pollen-robotics/reachy-mini-sdk": "1.10.0-rc.5" } }
 > ```
 
 **This is the single source of truth for building a Reachy Mini JS
@@ -111,13 +111,13 @@ Pick the reference closest to your needs and clone its repo from Hugging Face:
 
 | Reference app                       | Stack                       | Use it for                                  |
 |-------------------------------------|-----------------------------|---------------------------------------------|
-| [`pollen-robotics/reachy_mini_minimal_conversation`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_minimal_conversation) | **Vanilla TS + Vite**       | Smallest bundled runtime, no framework      |
-| [`pollen-robotics/reachy_mini_emotions`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_emotions)                         | React 19 + MUI 7 + Vite     | UI-rich app with rich components / theming  |
-| [`pollen-robotics/reachy_mini_telepresence`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_telepresence)                 | React 19 + MUI 7 + Vite     | App with camera / media streams             |
+| [`tfrere/minimal-conversation`](https://huggingface.co/spaces/tfrere/minimal-conversation) | **Vanilla TS + Vite**       | Smallest bundled runtime, no framework      |
+| [`tfrere/emotions`](https://huggingface.co/spaces/tfrere/emotions)                         | React 19 + MUI 7 + Vite     | UI-rich app with rich components / theming  |
+| [`tfrere/telepresence`](https://huggingface.co/spaces/tfrere/telepresence)                 | React 19 + MUI 7 + Vite     | App with camera / media streams             |
 
 ```bash
 # Example: start from the vanilla TS template
-git clone https://huggingface.co/spaces/pollen-robotics/reachy_mini_minimal_conversation my_new_app
+git clone https://huggingface.co/spaces/tfrere/minimal-conversation my_new_app
 cd my_new_app
 # Edit package.json `name`, README frontmatter (`title`, `emoji`,
 # `short_description`), public/icon.svg, and src/embed.ts to your app.
@@ -650,25 +650,25 @@ The current pinned version across all three reference apps:
 ```json
 {
   "dependencies": {
-    "@pollen-robotics/reachy-mini-sdk": "1.8.0"
+    "@pollen-robotics/reachy-mini-sdk": "1.10.0-rc.5"
   }
 }
 ```
 
-This is the stable `1.8.0` npm release, validated end-to-end against
-the host shell + daemon. npm versions are immutable, so pinning the
-exact version is fully reproducible — no commit suffix needed. **Use
-the same string in your `package.json`** unless you're explicitly
-tracking a newer release.
+This is the current `1.10.0-rc.5` npm release candidate, validated
+end-to-end against the host shell + daemon. npm versions are immutable,
+so pinning the exact version is fully reproducible — no commit suffix
+needed. **Use the same string in your `package.json`** unless you're
+explicitly tracking a newer release.
 
 > When a newer release is published, the source of truth is whichever
-> string is currently shared by [`reachy_mini_minimal_conversation`'s
-> `package.json`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_minimal_conversation/blob/main/package.json),
-> [`reachy_mini_emotions`'s `package.json`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_emotions/blob/main/package.json),
-> and [`reachy_mini_telepresence`'s `package.json`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_telepresence/blob/main/package.json).
+> string is currently shared by [`minimal-conversation`'s
+> `package.json`](https://huggingface.co/spaces/tfrere/minimal-conversation/blob/main/package.json),
+> [`emotions`'s `package.json`](https://huggingface.co/spaces/tfrere/emotions/blob/main/package.json),
+> and [`telepresence`'s `package.json`](https://huggingface.co/spaces/tfrere/telepresence/blob/main/package.json).
 > If those three diverge, fall back to whatever this guide says.
 
-### Why pin a specific build (not `^1.8.0` or a major like `@1`)?
+### Why pin a specific build (not `^1.10.0` or a major like `@1`)?
 
 The host shell, the embed adapter (`connectToHost`), the SDK, and the
 robot daemon negotiate over a versioned WebRTC data-channel protocol.
@@ -927,9 +927,9 @@ the edge:
 
 ```html
 <script type="module">
-  import { ReachyMini } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.8.0/+esm";
-  import { mountHost } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.8.0/host/dist/entry/auto.js";
-  import { connectToHost } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.8.0/host/dist/entry/embed.js";
+  import { ReachyMini } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.10.0-rc.5/+esm";
+  import { mountHost } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.10.0-rc.5/host/dist/entry/auto.js";
+  import { connectToHost } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.10.0-rc.5/host/dist/entry/embed.js";
 
   window.ReachyMini = ReachyMini;
   window.dispatchEvent(new Event("reachymini:ready"));
@@ -993,9 +993,9 @@ shell without touching your motion code. The four-step recipe:
    import { ReachyMini } from "https://cdn.jsdelivr.net/gh/pollen-robotics/reachy_mini@v1.7.2/js/reachy-mini.js";
 
    // AFTER (modern host shell, same SDK runtime API)
-   import { ReachyMini } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.8.0/+esm";
-   import { mountHost } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.8.0/host/dist/entry/auto.js";
-   import { connectToHost } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.8.0/host/dist/entry/embed.js";
+   import { ReachyMini } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.10.0-rc.5/+esm";
+   import { mountHost } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.10.0-rc.5/host/dist/entry/auto.js";
+   import { connectToHost } from "https://cdn.jsdelivr.net/npm/@pollen-robotics/reachy-mini-sdk@1.10.0-rc.5/host/dist/entry/embed.js";
    ```
 
 2. **Branch on `?embedded=1`.** Wrap your existing app boot in:
@@ -1467,7 +1467,7 @@ rolled out by the SDK team, not by every app team.
 - App bundles (`index-<hash>.js`): hashed by Vite, cache-busted
   on deploy.
 - `@pollen-robotics/reachy-mini-sdk` in `package.json`: pinned to
-  an **exact version** (today: `1.8.0`), not a range. See
+  an **exact version** (today: `1.10.0-rc.5`), not a range. See
   [§10 SDK version pinning](#10-sdk-version-pinning).
 - `@pollen-robotics/reachy-mini-sdk/host` subpath imports: same
   pin, same package.

--- a/ts/README.md
+++ b/ts/README.md
@@ -98,7 +98,7 @@ See the JSDoc header in [`reachy-mini-sdk.js`](./reachy-mini-sdk.js) for the ful
 
 For Hugging Face Spaces apps that need OAuth + a robot picker + iframe lifecycle management:
 
-- **[`APP_CREATION_GUIDE.md`](./APP_CREATION_GUIDE.md)** — single source of truth for app authors (scaffold, `sdk: static` deploy, host ↔ embed contract, invariants). Today's SDK pin: `1.8.0`.
+- **[`APP_CREATION_GUIDE.md`](./APP_CREATION_GUIDE.md)** — single source of truth for app authors (scaffold, `sdk: static` deploy, host ↔ embed contract, invariants). Today's SDK pin: `1.10.0-rc.5`.
 - [`host/README.md`](./host/README.md) — one-page tour of the host package layout
 
 ## Migration from `@pollen-robotics/reachy-mini-host`

--- a/ts/host/README.md
+++ b/ts/host/README.md
@@ -32,7 +32,7 @@ The same app code works in both modes; only the entry point differs.
 
 | Document | Audience | Read it when… |
 |----------|----------|----------------|
-| **[`../APP_CREATION_GUIDE.md`](../APP_CREATION_GUIDE.md)** | app authors **and** host maintainers | Single source of truth: scaffold, `sdk: static` deploy, host ↔ embed contract, invariants, protocol v1. Today's SDK pin: `1.8.0`. |
+| **[`../APP_CREATION_GUIDE.md`](../APP_CREATION_GUIDE.md)** | app authors **and** host maintainers | Single source of truth: scaffold, `sdk: static` deploy, host ↔ embed contract, invariants, protocol v1. Today's SDK pin: `1.10.0-rc.5`. |
 
 App authors and library maintainers both start with the
 **[App Creation Guide](../APP_CREATION_GUIDE.md)**: §1-§12 are the
@@ -130,9 +130,9 @@ with every release:
 
 | App | Stack | What it shows |
 |-----|-------|---------------|
-| [`pollen-robotics/reachy_mini_minimal_conversation`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_minimal_conversation) | Vanilla TypeScript | Smallest possible app. Tech-freedom proof. |
-| [`pollen-robotics/reachy_mini_emotions`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_emotions) | React + MUI | Plutchik emotion wheel + dance triggers. |
-| [`pollen-robotics/reachy_mini_telepresence`](https://huggingface.co/spaces/pollen-robotics/reachy_mini_telepresence) | React + MUI | Live video + head / body teleop. |
+| [`tfrere/minimal-conversation`](https://huggingface.co/spaces/tfrere/minimal-conversation) | Vanilla TypeScript | Smallest possible app. Tech-freedom proof. |
+| [`tfrere/emotions`](https://huggingface.co/spaces/tfrere/emotions) | React + MUI | Plutchik emotion wheel + dance triggers. |
+| [`tfrere/telepresence`](https://huggingface.co/spaces/tfrere/telepresence) | React + MUI | Live video + head / body teleop. |
 
 App authors are free to use any UI framework they want inside the iframe; the
 host doesn't care. This is a hard design rule, not an accident
@@ -149,7 +149,7 @@ incompatible postMessage changes
 (see [`APP_CREATION_GUIDE.md` §13.6](../APP_CREATION_GUIDE.md#136-protocol-v1-messages)).
 
 App authors should **pin to the exact version that the reference
-apps use** - today `1.8.0`, see
+apps use** - today `1.10.0-rc.5`, see
 [`APP_CREATION_GUIDE.md` §10](../APP_CREATION_GUIDE.md#10-sdk-version-pinning).
 
 ## License


### PR DESCRIPTION
## Summary

- The three JS reference apps were renamed on the Hub without the `reachy_mini_` prefix, so every doc link to them was a 404. All links now point to the live Spaces: [`tfrere/minimal-conversation`](https://huggingface.co/spaces/tfrere/minimal-conversation), [`tfrere/emotions`](https://huggingface.co/spaces/tfrere/emotions), [`tfrere/telepresence`](https://huggingface.co/spaces/tfrere/telepresence). Touched: `AGENTS.md`, `ts/APP_CREATION_GUIDE.md`, `docs/source/SDK/javascript-sdk.md`, `ts/host/README.md`.
- The documented SDK pin was stale (`1.8.0` while npm `latest` is `1.9.0`). Bumped everywhere to the latest release candidate **`1.10.0-rc.5`** (npm `rc` dist-tag): package.json snippets, jsDelivr CDN import examples, and the pinning guidance in guide section 10, `AGENTS.md`, `skills/create-js-app.md`, `ts/README.md` and `ts/host/README.md`.

This matters for the vibe-coding flow: `docs/source/vibe-code-with-your-agent.md` sends agents to `AGENTS.md` on main, which routes them to these files - dead links and a stale pin propagate straight into generated apps.

## Test plan

- [ ] The three Space links resolve (public Spaces, tagged `reachy_mini_js_app`).
- [ ] `npm view @pollen-robotics/reachy-mini-sdk dist-tags` shows `rc: 1.10.0-rc.5`.
- [ ] No remaining `1.8.0` or `spaces/pollen-robotics/reachy_mini_{minimal_conversation,emotions,telepresence}` mention in markdown files.

Made with [Cursor](https://cursor.com)