### PR TITLE
Build every speaker branch through one bin and survive an undecoable config

### DIFF
--- a/src/reachy_mini/daemon/startup_app_config.py
+++ b/src/reachy_mini/daemon/startup_app_config.py
@@ -45,12 +45,12 @@ def _read() -> dict:  # type: ignore[type-arg]
     """Load the config dict, or {} if missing/unreadable (best-effort)."""
     path = _config_path()
     try:
-        with path.open() as f:
+        with path.open(encoding="utf-8") as f:
             data = json.load(f)
         return data if isinstance(data, dict) else {}
     except FileNotFoundError:
         return {}
-    except (OSError, json.JSONDecodeError) as e:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
         logger.warning(f"Ignoring unreadable daemon config {path}: {e}")
         return {}
 
@@ -138,7 +138,7 @@ def _update(key: str, value: object | None) -> None:
     # truncate the file, and the next _update() rebuilds it from the empty
     # dict _read() returns for unparseable JSON, dropping every other key.
     tmp = path.with_suffix(".json.tmp")
-    with tmp.open("w") as f:
+    with tmp.open("w", encoding="utf-8") as f:
         json.dump(config, f, indent=2)
     tmp.replace(path)
 

--- a/src/reachy_mini/media/audio_base.py
+++ b/src/reachy_mini/media/audio_base.py
@@ -100,6 +100,63 @@ def make_speaker_eq(logger: logging.Logger) -> Optional[Gst.Element]:
     return eq_bin
 
 
+def make_audiosink_tee_bin(
+    logger: logging.Logger,
+    audiosink: Gst.Element,
+    wobbler_appsink: Gst.Element,
+    speaker_head: Gst.Element | None = None,
+) -> Gst.Bin:
+    """Build a bin splitting incoming audio to the speaker and the head wobbler."""
+    container = Gst.Bin.new("audio_tee_bin")
+    tee = Gst.ElementFactory.make("tee")
+    container.add(tee)
+    if speaker_head is not None:
+        container.add(speaker_head)
+    eq_speaker = make_speaker_eq(logger)
+    # Per-branch convert+resample: the wireless XMOS PCM falls back to an
+    # IEC958 that fails to open at anything but its native rate.
+    queue_speaker = Gst.ElementFactory.make("queue")
+    ac_speaker = Gst.ElementFactory.make("audioconvert")
+    ar_speaker = Gst.ElementFactory.make("audioresample")
+    queue_wobbler = Gst.ElementFactory.make("queue")
+    ac_wobbler = Gst.ElementFactory.make("audioconvert")
+    ar_wobbler = Gst.ElementFactory.make("audioresample")
+
+    for element in (
+        queue_speaker,
+        ac_speaker,
+        ar_speaker,
+        audiosink,
+        queue_wobbler,
+        ac_wobbler,
+        ar_wobbler,
+        wobbler_appsink,
+    ):
+        container.add(element)
+
+    tee.link(queue_speaker)
+    if speaker_head is not None:
+        queue_speaker.link(speaker_head)
+        speaker_head.link(ac_speaker)
+    else:
+        queue_speaker.link(ac_speaker)
+    ac_speaker.link(ar_speaker)
+    if eq_speaker is not None:
+        container.add(eq_speaker)
+        ar_speaker.link(eq_speaker)
+        eq_speaker.link(audiosink)
+    else:
+        ar_speaker.link(audiosink)
+
+    tee.link(queue_wobbler)
+    queue_wobbler.link(ac_wobbler)
+    ac_wobbler.link(ar_wobbler)
+    ar_wobbler.link(wobbler_appsink)
+
+    container.add_pad(Gst.GhostPad.new("sink", tee.get_static_pad("sink")))
+    return container
+
+
 class AudioBase(ABC):
     """Abstract audio backend.
 

--- a/src/reachy_mini/media/audio_gstreamer.py
+++ b/src/reachy_mini/media/audio_gstreamer.py
@@ -64,7 +64,7 @@ from reachy_mini.media.audio_base import (
     AEC_PROBE_NAME,
     AEC_RATE,
     AudioBase,
-    make_speaker_eq,
+    make_audiosink_tee_bin,
 )
 from reachy_mini.media.audio_utils import has_reachymini_asoundrc
 from reachy_mini.media.device_detection import get_audio_device
@@ -271,8 +271,6 @@ class GStreamerAudio(AudioBase):
         """
         appsink = Gst.ElementFactory.make("appsink")
         # Force mono so the speech tapper receives a 1-D float32 array.
-        # The per-branch audioconvert in _build_audiosink_tee_bin /
-        # _init_pipeline_playback handles the downmix.
         caps = Gst.Caps.from_string(
             f"audio/x-raw,format=F32LE,channels=1,"
             f"rate={self.SAMPLE_RATE},layout=interleaved"
@@ -299,67 +297,6 @@ class GStreamerAudio(AudioBase):
         pcm = np.frombuffer(data, dtype=np.float32)
         self._head_wobbler.feed(pcm, time.monotonic_ns())
         return Gst.FlowReturn.OK
-
-    def _build_audiosink_tee_bin(self) -> Gst.Bin:
-        """Build a Gst.Bin with a tee splitting audio to speaker and wobbler.
-
-        Per-branch audioconvert+audioresample isolate each leaf's caps
-        from the other (the wobbler appsink demands F32LE/2/16000; the
-        audiosink wants whatever the device prefers — e.g. on the
-        wireless XMOS PCM, anything but its native rate triggers an
-        IEC958 fallback that fails to open).
-
-        The bin exposes a single ghost sink pad for use as a playbin audio-sink::
-
-            ghost_sink → tee ─┬→ queue → audioconvert → audioresample → audiosink
-                               └→ queue → audioconvert → audioresample → appsink
-
-        """
-        audio_bin = Gst.Bin.new("audio_tee_bin")
-
-        tee = Gst.ElementFactory.make("tee")
-        queue_speaker = Gst.ElementFactory.make("queue")
-        ac_speaker = Gst.ElementFactory.make("audioconvert")
-        ar_speaker = Gst.ElementFactory.make("audioresample")
-        eq_speaker = make_speaker_eq(self.logger)
-        audiosink = self._build_audiosink_element()
-        queue_wobbler = Gst.ElementFactory.make("queue")
-        ac_wobbler = Gst.ElementFactory.make("audioconvert")
-        ar_wobbler = Gst.ElementFactory.make("audioresample")
-        appsink_wobbler = self._make_wobbler_appsink()
-
-        for el in (
-            tee,
-            queue_speaker,
-            ac_speaker,
-            ar_speaker,
-            audiosink,
-            queue_wobbler,
-            ac_wobbler,
-            ar_wobbler,
-            appsink_wobbler,
-        ):
-            audio_bin.add(el)
-
-        tee.link(queue_speaker)
-        queue_speaker.link(ac_speaker)
-        ac_speaker.link(ar_speaker)
-        if eq_speaker is not None:
-            audio_bin.add(eq_speaker)
-            ar_speaker.link(eq_speaker)
-            eq_speaker.link(audiosink)
-        else:
-            ar_speaker.link(audiosink)
-
-        tee.link(queue_wobbler)
-        queue_wobbler.link(ac_wobbler)
-        ac_wobbler.link(ar_wobbler)
-        ar_wobbler.link(appsink_wobbler)
-
-        ghost_pad = Gst.GhostPad.new("sink", tee.get_static_pad("sink"))
-        audio_bin.add_pad(ghost_pad)
-
-        return audio_bin
 
     def _init_pipeline_playback(self, pipeline: Gst.Pipeline) -> None:
         self._appsrc = Gst.ElementFactory.make("appsrc")
@@ -392,16 +329,9 @@ class GStreamerAudio(AudioBase):
         )
         silence_queue = Gst.ElementFactory.make("queue")
 
-        tee = Gst.ElementFactory.make("tee")
-        queue_speaker = Gst.ElementFactory.make("queue")
-        ac_speaker = Gst.ElementFactory.make("audioconvert")
-        ar_speaker = Gst.ElementFactory.make("audioresample")
-        eq_speaker = make_speaker_eq(self.logger)
-        audiosink = self._build_audiosink_element()
-        queue_wobbler = Gst.ElementFactory.make("queue")
-        ac_wobbler = Gst.ElementFactory.make("audioconvert")
-        ar_wobbler = Gst.ElementFactory.make("audioresample")
-        appsink_wobbler = self._make_wobbler_appsink()
+        audio_bin = make_audiosink_tee_bin(
+            self.logger, self._build_audiosink_element(), self._make_wobbler_appsink()
+        )
 
         for el in (
             self._appsrc,
@@ -410,19 +340,9 @@ class GStreamerAudio(AudioBase):
             silence_caps,
             silence_queue,
             mixer,
-            tee,
-            queue_speaker,
-            ac_speaker,
-            ar_speaker,
-            audiosink,
-            queue_wobbler,
-            ac_wobbler,
-            ar_wobbler,
-            appsink_wobbler,
+            audio_bin,
         ):
             pipeline.add(el)
-        if eq_speaker is not None:
-            pipeline.add(eq_speaker)
 
         self._appsrc.link(appsrc_queue)
         appsrc_queue.link(mixer)
@@ -448,22 +368,9 @@ class GStreamerAudio(AudioBase):
             ac_probe.link(ar_probe)
             ar_probe.link(cf_probe)
             cf_probe.link(self._webrtcechoprobe)
-            self._webrtcechoprobe.link(tee)
+            self._webrtcechoprobe.link(audio_bin)
         else:
-            mixer.link(tee)
-
-        tee.link(queue_speaker)
-        queue_speaker.link(ac_speaker)
-        ac_speaker.link(ar_speaker)
-        if eq_speaker is not None:
-            ar_speaker.link(eq_speaker)
-            eq_speaker.link(audiosink)
-        else:
-            ar_speaker.link(audiosink)
-        tee.link(queue_wobbler)
-        queue_wobbler.link(ac_wobbler)
-        ac_wobbler.link(ar_wobbler)
-        ar_wobbler.link(appsink_wobbler)
+            mixer.link(audio_bin)
 
     def _on_bus_message(
         self, bus: Gst.Bus, msg: Gst.Message, pipeline: Gst.Pipeline
@@ -563,7 +470,14 @@ class GStreamerAudio(AudioBase):
             uri = f"file://{file_path}"
         playbin.set_property("uri", uri)
 
-        playbin.set_property("audio-sink", self._build_audiosink_tee_bin())
+        playbin.set_property(
+            "audio-sink",
+            make_audiosink_tee_bin(
+                self.logger,
+                self._build_audiosink_element(),
+                self._make_wobbler_appsink(),
+            ),
+        )
         if self._head_wobbler is not None:
             self._head_wobbler.reset()
             self._head_wobbler.start()

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -43,7 +43,7 @@ from reachy_mini.media.audio_base import (
     AEC_CHANNELS,
     AEC_PROBE_NAME,
     AEC_RATE,
-    make_speaker_eq,
+    make_audiosink_tee_bin,
 )
 from reachy_mini.media.audio_control_utils import init_respeaker_usb
 from reachy_mini.media.audio_utils import has_reachymini_asoundrc
@@ -588,70 +588,24 @@ class GstMediaServer:
             return
         audiosink.set_property("sync", True)
 
-        # Per-branch audioconvert+audioresample so the wobbler appsink's
-        # F32LE/2/16000 caps don't drag the audiosink branch into a rate
-        # the device can't accept (e.g. wireless XMOS PCM falls back to
-        # IEC958 at non-native rates).
-        tee = Gst.ElementFactory.make("tee")
-        queue_speaker = Gst.ElementFactory.make("queue")
-        ac_speaker = Gst.ElementFactory.make("audioconvert")
-        ar_speaker = Gst.ElementFactory.make("audioresample")
-        eq_speaker = make_speaker_eq(self._logger)
-        queue_wobbler = Gst.ElementFactory.make("queue")
-        ac_wobbler = Gst.ElementFactory.make("audioconvert")
-        ar_wobbler = Gst.ElementFactory.make("audioresample")
-
-        appsink_wobbler = self._make_wobbler_appsink()
-
-        # Software AEC far-end reference: tap the speaker branch (what is
-        # physically played) with the shared echo probe. opusdec emits S16LE@48k,
-        # which the probe accepts, so no convert/resample is needed. The probe
-        # is reused across peers, so detach it from any previous pipeline first.
-        # Caveat: there is one probe (webrtcdsp binds a single far-end), so with
-        # several peers streaming at once AEC only references the most recently
-        # connected one. Fine for the usual single-conversation case.
+        # opusdec emits S16LE@48k, which the probe accepts as-is. Only one probe
+        # exists, so with several peers streaming at once the software AEC
+        # references the most recently connected one.
         webrtcechoprobe = self._webrtcechoprobe if self._aec_enabled else None
         if webrtcechoprobe is not None:
             old_parent = webrtcechoprobe.get_parent()
             if old_parent is not None:
                 old_parent.remove(webrtcechoprobe)
 
-        for elem in [
-            appsrc,
-            rtpopusdepay,
-            opusdec,
-            tee,
-            queue_speaker,
-            *([webrtcechoprobe] if webrtcechoprobe is not None else []),
-            ac_speaker,
-            ar_speaker,
-            *([eq_speaker] if eq_speaker is not None else []),
-            audiosink,
-            queue_wobbler,
-            ac_wobbler,
-            ar_wobbler,
-            appsink_wobbler,
-        ]:
+        audio_bin = make_audiosink_tee_bin(
+            self._logger, audiosink, self._make_wobbler_appsink(), webrtcechoprobe
+        )
+
+        for elem in (appsrc, rtpopusdepay, opusdec, audio_bin):
             self._pipeline_playback.add(elem)
         appsrc.link(rtpopusdepay)
         rtpopusdepay.link(opusdec)
-        opusdec.link(tee)
-        tee.link(queue_speaker)
-        if webrtcechoprobe is not None:
-            queue_speaker.link(webrtcechoprobe)
-            webrtcechoprobe.link(ac_speaker)
-        else:
-            queue_speaker.link(ac_speaker)
-        ac_speaker.link(ar_speaker)
-        if eq_speaker is not None:
-            ar_speaker.link(eq_speaker)
-            eq_speaker.link(audiosink)
-        else:
-            ar_speaker.link(audiosink)
-        tee.link(queue_wobbler)
-        queue_wobbler.link(ac_wobbler)
-        ac_wobbler.link(ar_wobbler)
-        ar_wobbler.link(appsink_wobbler)
+        opusdec.link(audio_bin)
 
         play_bus = self._pipeline_playback.get_bus()
         play_bus.add_watch(
@@ -1354,7 +1308,14 @@ class GstMediaServer:
             uri = f"file://{file_path}"
 
         playbin.set_property("uri", uri)
-        playbin.set_property("audio-sink", self._build_audiosink_tee_bin())
+        playbin.set_property(
+            "audio-sink",
+            make_audiosink_tee_bin(
+                self._logger,
+                self._build_audiosink_element(),
+                self._make_wobbler_appsink(),
+            ),
+        )
 
         if self._head_wobbler is not None:
             self._head_wobbler.reset()
@@ -1446,66 +1407,6 @@ class GstMediaServer:
         pcm = np.frombuffer(data, dtype=np.float32)
         self._head_wobbler.feed(pcm, time.monotonic_ns())
         return Gst.FlowReturn.OK
-
-    def _build_audiosink_tee_bin(self) -> Gst.Bin:
-        """Build a Gst.Bin splitting audio to speaker and wobbler appsink.
-
-        Per-branch audioconvert+audioresample isolate each leaf's caps
-        from the other (the wobbler appsink demands F32LE/2/16000; the
-        audiosink wants whatever the device prefers — e.g. on the
-        wireless XMOS PCM, anything but its native rate triggers an
-        IEC958 fallback that fails to open).
-
-        The bin exposes a single ghost sink pad for use as a playbin audio-sink::
-
-            ghost_sink → tee ─┬→ queue → audioconvert → audioresample → audiosink
-                               └→ queue → audioconvert → audioresample → appsink
-        """
-        audio_bin = Gst.Bin.new("audio_tee_bin")
-
-        tee = Gst.ElementFactory.make("tee")
-        queue_speaker = Gst.ElementFactory.make("queue")
-        ac_speaker = Gst.ElementFactory.make("audioconvert")
-        ar_speaker = Gst.ElementFactory.make("audioresample")
-        eq_speaker = make_speaker_eq(self._logger)
-        audiosink = self._build_audiosink_element()
-        queue_wobbler = Gst.ElementFactory.make("queue")
-        ac_wobbler = Gst.ElementFactory.make("audioconvert")
-        ar_wobbler = Gst.ElementFactory.make("audioresample")
-        appsink_wobbler = self._make_wobbler_appsink()
-
-        for el in (
-            tee,
-            queue_speaker,
-            ac_speaker,
-            ar_speaker,
-            audiosink,
-            queue_wobbler,
-            ac_wobbler,
-            ar_wobbler,
-            appsink_wobbler,
-        ):
-            audio_bin.add(el)
-
-        tee.link(queue_speaker)
-        queue_speaker.link(ac_speaker)
-        ac_speaker.link(ar_speaker)
-        if eq_speaker is not None:
-            audio_bin.add(eq_speaker)
-            ar_speaker.link(eq_speaker)
-            eq_speaker.link(audiosink)
-        else:
-            ar_speaker.link(audiosink)
-
-        tee.link(queue_wobbler)
-        queue_wobbler.link(ac_wobbler)
-        ac_wobbler.link(ar_wobbler)
-        ar_wobbler.link(appsink_wobbler)
-
-        ghost_pad = Gst.GhostPad.new("sink", tee.get_static_pad("sink"))
-        audio_bin.add_pad(ghost_pad)
-
-        return audio_bin
 
     def enable_wobbling(self, callback: Callable[[SpeechOffsets], None]) -> None:
         """Enable head wobbling driven by audio playback.

--- a/tests/unit_tests/test_speaker_eq.py
+++ b/tests/unit_tests/test_speaker_eq.py
@@ -1,7 +1,6 @@
 """Unit tests for the runtime speaker-EQ gains resolution and element builder."""
 
 import logging
-import types
 
 import gi
 import numpy as np
@@ -11,8 +10,10 @@ gi.require_version("Gst", "1.0")
 from gi.repository import Gst  # noqa: E402
 
 from reachy_mini.daemon import startup_app_config  # noqa: E402
-from reachy_mini.media.audio_base import make_speaker_eq  # noqa: E402
-from reachy_mini.media.audio_gstreamer import GStreamerAudio  # noqa: E402
+from reachy_mini.media.audio_base import (  # noqa: E402
+    make_audiosink_tee_bin,
+    make_speaker_eq,
+)
 from reachy_mini.media.audio_utils import (  # noqa: E402
     DEFAULT_SPEAKER_EQ_GAINS,
     resolve_speaker_eq_gains,
@@ -195,14 +196,11 @@ def _build_tee_bin(monkeypatch: pytest.MonkeyPatch) -> Gst.Bin:
     monkeypatch.setattr(
         "reachy_mini.media.audio_base.has_reachymini_asoundrc", lambda: True
     )
-    inst = object.__new__(GStreamerAudio)
-    inst.logger = _LOG
-    # Satisfy the wobbler callback and __del__/cleanup on this half-built instance.
-    inst._head_wobbler = None
-    inst._doa = types.SimpleNamespace(close=lambda: None)
-    inst._loop = types.SimpleNamespace(quit=lambda: None)
-    inst._bus = types.SimpleNamespace(remove_watch=lambda: None)
-    return GStreamerAudio._build_audiosink_tee_bin(inst)
+    return make_audiosink_tee_bin(
+        _LOG,
+        Gst.ElementFactory.make("fakesink"),
+        Gst.ElementFactory.make("appsink"),
+    )
 
 
 def test_playback_path_includes_eq(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -215,3 +213,17 @@ def test_playback_path_skips_eq_when_zero(monkeypatch: pytest.MonkeyPatch) -> No
     """The real speaker branch has no EQ when all gains are zero."""
     monkeypatch.setattr(startup_app_config, "get_speaker_eq_gains", lambda: [0.0] * 10)
     assert _find_element(_build_tee_bin(monkeypatch), "equalizer-10bands") is None
+
+
+def test_undecodable_config_keeps_the_speaker_working(
+    tmp_path: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A config the daemon cannot decode must not cost the robot its audio."""
+    from pathlib import Path
+
+    cfg = Path(str(tmp_path)) / "daemon_config.json"
+    cfg.write_bytes(b'{"speaker_eq_gains": [1,2,3,4,5,6,7,8,9,10], "x": "\xff"}')
+    monkeypatch.setattr(startup_app_config, "_config_path", lambda: cfg)
+
+    assert resolve_speaker_eq_gains() == DEFAULT_SPEAKER_EQ_GAINS
+    assert _find_element(_build_tee_bin(monkeypatch), "audioresample") is not None


### PR DESCRIPTION
## Issue

Closes https://github.com/pollen-robotics/reachy_mini/issues/1372

## Description

This PR makes an undecodable config harmless and builds every speaker branch through one function. `_read()` in `startup_app_config.py` now catches `UnicodeDecodeError` and both file handles use utf-8, so a bad byte no longer escapes the reader and reaches `make_speaker_eq()`, while the speaker is being built. `make_audiosink_tee_bin()` in `audio_base.py` returns the tee, both branches, and the optional AEC probe as one bin with a ghost pad, and the four places that built that graph now call it. The element order is unchanged everywhere, including the probe's position in the speaker branch.

## Testing

Tested on a wireless + macos. Passing an `appsink` as the `audiosink` measures the EQ inside the graph, and both platforms match: flat with the EQ off, then -4.27 dB at 440 Hz and +6.41 dB at 1 kHz against configured gains of -4.3 and +5.8. On the robot the `playbin` path measured 228 times the room noise and a pushed sample carried its tone. A config with invalid utf-8 logs a warning, every reader keeps working, and the speaker bin still builds.

## Tested on

- [x] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [ ] Not applicable (e.g. docs, typo)

## AI assistance

<!-- Tick exactly one. Assisted commits also carry the Assisted-by trailer, see docs/contributing.md. -->

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [ ] AI wrote code here, and I ran and reviewed it
- [ ] An agent produced this PR, and I have not run it myself

