### PR TITLE
Let webrtcsink drive v4l2h264enc itself on the Wireless

### DIFF
--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -851,11 +851,23 @@ class GstMediaServer:
         pipeline.add(queue_webrtc)
         tee.link(queue_webrtc)
 
-        if is_rpi:
-            # RPi: use hardware H264 encoder (webrtcsink doesn't have v4l2h264enc)
+        if is_rpi and not self._webrtcsink_handles_rpi_encoder():
+            # Old OS image: webrtcsink can't drive v4l2h264enc, encode explicitly
             self._build_rpi_encoder_branch(queue_webrtc, pipeline, webrtcsink)
         else:
-            # All other platforms: feed raw video, let webrtcsink handle encoding
+            if is_rpi:
+                # Force H264 so webrtcsink picks v4l2h264enc, not software vp8/vp9
+                webrtcsink.set_property(
+                    "video-caps", Gst.Caps.from_string("video/x-h264")
+                )
+                self._logger.info("webrtcsink drives v4l2h264enc itself")
+                if Gst.ElementFactory.find("rtpgccbwe") is None:
+                    # webrtcsink needs this element (gstrsrtp plugin) to adapt
+                    # the encoder bitrate to network conditions
+                    self._logger.warning(
+                        "rtpgccbwe not found: webrtcsink congestion control disabled"
+                    )
+            # Feed raw video, let webrtcsink handle encoding
             queue_webrtc.link(webrtcsink)
 
     def _build_sim_source(self) -> list[Gst.Element]:
@@ -1105,6 +1117,18 @@ class GstMediaServer:
             videoconvert_ipc.link(capsfilter_ipc)
             capsfilter_ipc.link(ipc_sink)
 
+    @staticmethod
+    def _webrtcsink_handles_rpi_encoder() -> bool:
+        """Check whether webrtcsink can drive the RPi hardware encoder itself.
+
+        Recent OS images (reachy-mini-os#65) ship a patched v4l2h264enc that
+        exposes a runtime-changeable `bitrate` property, which webrtcsink's
+        congestion control drives. Old images lack it, so we must build the
+        encoder branch explicitly.
+        """
+        enc = Gst.ElementFactory.make("v4l2h264enc")
+        return enc is not None and enc.find_property("bitrate") is not None
+
     def _build_rpi_encoder_branch(
         self,
         queue_webrtc: Gst.Element,
@@ -1113,7 +1137,8 @@ class GstMediaServer:
     ) -> None:
         """Build the RPi hardware H264 encoder branch.
 
-        webrtcsink does not have v4l2h264enc, so we encode explicitly on RPi.
+        Fallback for old OS images whose webrtcsink can't drive v4l2h264enc:
+        encode explicitly and feed H264 to webrtcsink.
         """
         v4l2h264enc = Gst.ElementFactory.make("v4l2h264enc")
         extra_controls_structure = Gst.Structure.new_empty("extra-controls")

--- a/tests/unit_tests/test_media_server_webrtc.py
+++ b/tests/unit_tests/test_media_server_webrtc.py
@@ -37,3 +37,31 @@ def test_enable_turn_false_starts_no_refresher() -> None:
         server._apply_turn_servers(None)  # type: ignore[arg-type]
     finally:
         server.close()
+
+
+def test_rpi_encoder_probe_requires_runtime_bitrate_property(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simplified pipeline only when v4l2h264enc exposes a `bitrate` property."""
+    from types import SimpleNamespace
+
+    from gi.repository import Gst
+
+    def fake_encoder(present: bool, has_bitrate: bool) -> None:
+        enc = SimpleNamespace(
+            find_property=lambda name: object()
+            if has_bitrate and name == "bitrate"
+            else None
+        )
+        monkeypatch.setattr(
+            Gst.ElementFactory, "make", lambda name: enc if present else None
+        )
+
+    fake_encoder(present=False, has_bitrate=False)
+    assert GstMediaServer._webrtcsink_handles_rpi_encoder() is False
+    # Old OS image: stock v4l2h264enc, bitrate only via extra-controls
+    fake_encoder(present=True, has_bitrate=False)
+    assert GstMediaServer._webrtcsink_handles_rpi_encoder() is False
+    # New OS image (reachy-mini-os#65): patched encoder with runtime bitrate
+    fake_encoder(present=True, has_bitrate=True)
+    assert GstMediaServer._webrtcsink_handles_rpi_encoder() is True


### PR DESCRIPTION
## Problem

On the Wireless, the daemon builds an explicit `v4l2h264enc` branch in front of webrtcsink, from a time when webrtcsink could not drive that encoder itself. So the hardware encoder is allocated at pipeline construction and runs even with **no WebRTC consumer connected** (related to #1277), and the bitrate is pinned at 5 Mbps, meaning webrtcsink's congestion control never engages and the stream cannot adapt to network conditions.

## Solution

Probe whether the installed stack lets webrtcsink drive the encoder (the `bitrate` property on `v4l2h264enc`; version strings are unreliable since the shipped `.pc` files are stale). If it does, feed raw video straight into webrtcsink with `video-caps` forced to H264 so software vp8/vp9 is never negotiated on the RPi. webrtcsink then allocates the hardware encoder per consumer and its congestion control owns the bitrate. Older images keep the explicit branch as a fallback, and a warning is logged when `rtpgccbwe` is missing.

## Validation

Tested on a Wireless unit, with the plugins from pollen-robotics/reachy-mini-os#89 installed:

- H264 negotiated, hardware `v4l2h264enc` allocated only while a consumer is connected (4 fds on `/dev/video11` during a session, 0 when idle), no software encoder mapped.
- Congestion control: bitrate ramps ~2 → 5.1 Mbps, drops to ~1.1 Mbps under a 3 Mbit `tc` limit and recovers to ~5.3 Mbps when lifted, with zero packet drops.

## Related

Congestion control needs the `rtpgccbwe` element from the `gstrsrtp` plugin, which no released OS image ships yet. pollen-robotics/reachy-mini-os#89 adds it (and builds the plugins in CI from a pinned tag). Until an image with it is released, this branch keeps the encoder-on-demand benefit and logs a warning that congestion control is unavailable.

Fixes #1382
