### PR TITLE
Cast JSON floats before packing int-typed XVF3800 registers

### DIFF
--- a/src/reachy_mini/media/audio_control_utils.py
+++ b/src/reachy_mini/media/audio_control_utils.py
@@ -216,18 +216,22 @@ class ReSpeaker:
                 if isinstance(data_list, str)
                 else bytearray(data_list)
             )
+        # Integer types cast explicitly, like the float branch does: values
+        # arriving through JSON (REST apply endpoint, JS applyAudioConfig over
+        # the data channel) are floats after pydantic's list[float] coercion,
+        # and struct.pack("i", 0.0) / float.to_bytes raise on them.
         elif data_type == "uint8":
             for i in range(data_cnt):
-                payload += data_list[i].to_bytes(1, byteorder="little")
+                payload += int(data_list[i]).to_bytes(1, byteorder="little")
         elif data_type == "uint32" or data_type == "int32":
             for i in range(data_cnt):
                 payload += struct.pack(
-                    b"I" if data_type == "uint32" else b"i", data_list[i]
+                    b"I" if data_type == "uint32" else b"i", int(data_list[i])
                 )
         else:
             # Default to int32 for other types
             for i in range(data_cnt):
-                payload += struct.pack(b"i", data_list[i])
+                payload += struct.pack(b"i", int(data_list[i]))
 
         logger.debug(
             "WriteCMD: cmdid: {}, resid: {}, payload: {}".format(

--- a/tests/unit_tests/test_audio_control_utils.py
+++ b/tests/unit_tests/test_audio_control_utils.py
@@ -38,6 +38,27 @@ def test_simulated_apply_audio_config_round_trip(fake_respeaker: ReSpeaker) -> N
         assert fake_respeaker.read_values(name) == pytest.approx(expected)
 
 
+def test_simulated_write_accepts_floats_for_int_parameters(
+    fake_respeaker: ReSpeaker,
+) -> None:
+    """Float values write cleanly to int-typed registers.
+
+    Values arriving through JSON (the REST apply endpoint, the JS SDK's
+    applyAudioConfig over the data channel) are floats after pydantic's
+    list[float] coercion. struct.pack("i", 0.0) raises, so before the explicit
+    int cast every int-typed parameter was unwritable through those paths —
+    the endpoint answered {"applied": false} for e.g. PP_ECHOONOFF=0.
+    """
+    config = (
+        ("PP_ECHOONOFF", (0.0,)),  # int32
+        ("AEC_FIXEDBEAMSGATING", (1.0,)),  # uint8
+        ("GPO_PIN_ACTIVE_LEVEL", (1.0,)),  # uint32
+    )
+    for name, values in config:
+        fake_respeaker.write(name, values)
+        assert fake_respeaker.read_values(name) == pytest.approx(values)
+
+
 @pytest.mark.audio
 @pytest.mark.respeaker
 def test_respeaker_read_values_reads_board_parameters() -> None:


### PR DESCRIPTION
## Problem

`POST /api/audio/config/apply` — and the JS SDK's `applyAudioConfig` over the WebRTC data channel, which shares the code path — returns `{"applied": false}` for every int-typed XVF3800 parameter (e.g. `PP_ECHOONOFF`). Only float-typed parameters were writable. Fixes #1394.

## Repro

```bash
curl -X POST http://reachy-mini.local:8000/api/audio/config/apply \
  -H 'Content-Type: application/json' \
  -d '{"config":[{"name":"PP_ECHOONOFF","values":[0]}],"verify":true}'
# -> {"applied": false}, register unchanged
```

## Solution

The request schema coerces values to `float` (pydantic `list[float]`), and `ReSpeaker.write` packed them raw — `struct.pack("i", 0.0)` raises, `float.to_bytes` doesn't exist. Cast to `int` in the integer packing branches, mirroring the existing `float(...)` cast in the float branch. Verified on a real Wireless (the apply now returns `{"applied": true}` and the register reads back changed); regression test on the fake board writes floats into int32/uint8/uint32 registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)