### PR TITLE
fix(tracking): prevent overshoot from stale camera frames

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -17,6 +17,7 @@ import threading
 import time
 import typing
 from abc import abstractmethod
+from collections import deque
 from pathlib import Path
 from typing import Annotated, Any, Callable, Dict, Optional
 
@@ -354,6 +355,10 @@ class Backend:
         self._tracking_lost_timeout = 2.0
         self._tracking_aim: Annotated[NDArray[np.float64], (4, 4)] | None = None
         self._tracking_target_pose: Annotated[NDArray[np.float64], (4, 4)] | None = None
+        self._tracking_pose_history: deque[
+            tuple[float, Annotated[NDArray[np.float64], (4, 4)]]
+        ] = deque()
+        self._tracking_pose_history_s = 3.0
         self._last_face_seen: float | None = None
         self._tracker: FaceTracker | None = None
         self._tracking_lock = threading.Lock()
@@ -684,7 +689,9 @@ class Backend:
                 return False
             if self._tracking_requested_weight > 0.0:
                 if self._tracker is None:
-                    self._tracker = FaceTracker()
+                    self._tracker = FaceTracker(
+                        self._media_server.pop_camera_frame_timestamp
+                    )
                 self._tracker.start(self._media_server.camera_specs)
                 self._tracker.set_active(True)
             else:
@@ -710,8 +717,54 @@ class Backend:
         self._tracking_target_pose = None
         self._tracking_weight = 0.0
         self._last_face_seen = None
+        self._tracking_pose_history.clear()
         self._face_target = FaceTarget()
         self.ik_required = True
+
+    def _record_tracking_pose(self, timestamp: float) -> None:
+        """Append the latest measured world-head pose to the bounded history."""
+        self._tracking_pose_history.append(
+            (float(timestamp), self.get_current_head_pose().copy())
+        )
+        oldest = float(timestamp) - self._tracking_pose_history_s
+        while (
+            len(self._tracking_pose_history) > 1
+            and self._tracking_pose_history[1][0] < oldest
+        ):
+            self._tracking_pose_history.popleft()
+
+    def _tracking_pose_at(
+        self, timestamp: float
+    ) -> Annotated[NDArray[np.float64], (4, 4)] | None:
+        """Interpolate the measured head pose at a camera-frame timestamp."""
+        if not self._tracking_pose_history:
+            return None
+
+        first_ts, first_pose = self._tracking_pose_history[0]
+        last_ts, last_pose = self._tracking_pose_history[-1]
+        # A frame can precede the first control tick by a small fraction of one
+        # 50 Hz period when tracking is enabled. Accept that boundary only.
+        boundary_tolerance_s = 0.05
+        if timestamp <= first_ts:
+            return (
+                first_pose.copy()
+                if first_ts - timestamp <= boundary_tolerance_s
+                else None
+            )
+        if timestamp >= last_ts:
+            return (
+                last_pose.copy()
+                if timestamp - last_ts <= boundary_tolerance_s
+                else None
+            )
+
+        previous_ts, previous_pose = self._tracking_pose_history[0]
+        for next_ts, next_pose in list(self._tracking_pose_history)[1:]:
+            if timestamp <= next_ts:
+                alpha = (timestamp - previous_ts) / (next_ts - previous_ts)
+                return linear_pose_interpolation(previous_pose, next_pose, alpha)
+            previous_ts, previous_pose = next_ts, next_pose
+        return None
 
     def step_head_tracking(self) -> None:
         """Ease the aim toward the latest target, holding then recentering on loss.
@@ -724,19 +777,23 @@ class Backend:
             if not self._tracking_enabled or self._tracking_requested_weight <= 0.0:
                 return
             now = time.monotonic()
+            self._record_tracking_pose(now)
             if self._tracker is not None:
                 obs = self._tracker.latest()
                 if obs is not None:
-                    self.set_tracking_face(
-                        obs.center,
-                        obs.roll,
-                        obs.width,
-                        obs.height,
-                        obs.camera_matrix,
-                        obs.distortion,
-                        obs.timestamp,
-                    )
-                    if obs.center is not None:
+                    frame_head_pose = self._tracking_pose_at(obs.timestamp)
+                    if obs.center is None or frame_head_pose is not None:
+                        self.set_tracking_face(
+                            obs.center,
+                            obs.roll,
+                            obs.width,
+                            obs.height,
+                            obs.camera_matrix,
+                            obs.distortion,
+                            obs.timestamp,
+                            T_world_head=frame_head_pose,
+                        )
+                    if obs.center is not None and frame_head_pose is not None:
                         self._last_face_seen = now
             if (
                 self._last_face_seen is not None
@@ -761,6 +818,7 @@ class Backend:
         camera_matrix: NDArray[np.float64],
         distortion: NDArray[np.float64],
         timestamp: float,
+        T_world_head: Annotated[NDArray[np.float64], (4, 4)] | None = None,
     ) -> None:
         """Latch the tracking target from a face observation in tracker-frame pixels."""
         if not self._tracking_enabled:
@@ -785,12 +843,14 @@ class Backend:
         u = (x_norm + 1.0) * 0.5 * max(width - 1, 1)
         v = (y_norm + 1.0) * 0.5 * max(height - 1, 1)
         try:
+            if T_world_head is None:
+                T_world_head = self.get_current_head_pose()
             self._tracking_target_pose = look_at_image_pose(
                 u=u,
                 v=v,
                 K=camera_matrix,
                 D=distortion,
-                T_world_head=self.get_current_head_pose(),
+                T_world_head=T_world_head,
                 T_head_cam=self.T_head_cam,
             )
         except Exception as e:

--- a/src/reachy_mini/media/camera_timestamps.py
+++ b/src/reachy_mini/media/camera_timestamps.py
@@ -1,0 +1,60 @@
+"""Match daemon camera frames to capture-time monotonic timestamps."""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+
+
+class CameraFrameTimestamps:
+    """Bounded, thread-safe timestamp handoff keyed by camera frame offset.
+
+    The daemon's outgoing camera pipeline and its local IPC readers share the
+    buffer ``offset`` even though ``unixfdsrc`` does not preserve the original
+    PTS. The media pipeline records the time here before IPC; the face tracker
+    consumes it after receiving the same frame offset.
+    """
+
+    def __init__(self, capacity: int = 128, max_source_age_s: float = 2.0) -> None:
+        """Create a bounded registry and maximum accepted producer-frame age."""
+        self._capacity = max(int(capacity), 1)
+        self._max_source_age_s = max(float(max_source_age_s), 0.0)
+        self._timestamps: OrderedDict[int, float] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def record(
+        self,
+        frame_offset: int,
+        handoff_monotonic: float,
+        *,
+        frame_running_time_s: float | None = None,
+        pipeline_running_time_s: float | None = None,
+    ) -> float:
+        """Record one frame and return the selected monotonic timestamp.
+
+        When the producer PTS is usable, its age relative to the producer
+        pipeline clock is subtracted from the handoff time. Otherwise the
+        handoff time itself is the closest reliable pre-IPC timestamp.
+        """
+        timestamp = float(handoff_monotonic)
+        if frame_running_time_s is not None and pipeline_running_time_s is not None:
+            age_s = float(pipeline_running_time_s) - float(frame_running_time_s)
+            if 0.0 <= age_s <= self._max_source_age_s:
+                timestamp -= age_s
+
+        with self._lock:
+            self._timestamps[int(frame_offset)] = timestamp
+            self._timestamps.move_to_end(int(frame_offset))
+            while len(self._timestamps) > self._capacity:
+                self._timestamps.popitem(last=False)
+        return timestamp
+
+    def pop(self, frame_offset: int) -> float | None:
+        """Consume the timestamp associated with ``frame_offset`` if present."""
+        with self._lock:
+            return self._timestamps.pop(int(frame_offset), None)
+
+    def clear(self) -> None:
+        """Discard timestamps from a stopped or rebuilt media pipeline."""
+        with self._lock:
+            self._timestamps.clear()

--- a/src/reachy_mini/media/media_server.py
+++ b/src/reachy_mini/media/media_server.py
@@ -53,6 +53,7 @@ from reachy_mini.media.camera_constants import (
     MujocoCameraSpecs,
     ReachyMiniLiteCamSpecs,
 )
+from reachy_mini.media.camera_timestamps import CameraFrameTimestamps
 from reachy_mini.media.device_detection import get_audio_device, get_video_device
 from reachy_mini.media.gstreamer_utils import handle_default_bus_message
 from reachy_mini.media.webrtc_utils import TurnCredentials
@@ -256,6 +257,10 @@ class GstMediaServer:
         # lock, a subscribe interleaved with a disarm could observe a stale
         # source id, skip the re-arm, and leave the stream permanently dead.
         self._pose_lock = Lock()
+        # ``unixfdsrc`` preserves the camera buffer offset but resets its PTS.
+        # Use the shared offset to hand the producer-side frame time to local
+        # consumers such as daemon face tracking.
+        self._camera_frame_timestamps = CameraFrameTimestamps()
         # Optional callback fired on the GStreamer thread when a peer
         # leaves; used by the backend to free per-peer resources such
         # as the journalctl subprocess for a `subscribe_logs` stream.
@@ -306,6 +311,7 @@ class GstMediaServer:
 
     def _build_pipeline(self) -> None:
         """Build (or rebuild) the GStreamer pipeline from scratch."""
+        self._camera_frame_timestamps.clear()
         self._pipeline_sender = Gst.Pipeline.new("reachymini_webrtc_sender")
         self._bus_sender = self._pipeline_sender.get_bus()
         self._bus_sender.add_watch(
@@ -1074,6 +1080,14 @@ class GstMediaServer:
                 os.remove(CAMERA_SOCKET_PATH)
             ipc_sink.set_property("socket-path", CAMERA_SOCKET_PATH)
 
+        sink_pad = ipc_sink.get_static_pad("sink")
+        if sink_pad is not None:
+            sink_pad.add_probe(
+                Gst.PadProbeType.BUFFER,
+                self._record_camera_frame_timestamp,
+                pipeline,
+            )
+
         # On RPi, libcamerasrc produces dmabuf FD-backed buffers natively,
         # so unixfdsink works directly.  On other platforms we need the
         # identity + videoconvert workaround described above.
@@ -1104,6 +1118,51 @@ class GstMediaServer:
             identity.link(videoconvert_ipc)
             videoconvert_ipc.link(capsfilter_ipc)
             capsfilter_ipc.link(ipc_sink)
+
+    def _record_camera_frame_timestamp(
+        self,
+        _pad: Gst.Pad,
+        info: Gst.PadProbeInfo,
+        pipeline: Gst.Pipeline,
+    ) -> int:
+        """Remember producer time for the exact frame handed to local IPC."""
+        buffer = info.get_buffer()
+        if buffer is None:
+            return int(Gst.PadProbeReturn.OK)
+
+        offset = int(buffer.offset)
+        if offset == int(Gst.BUFFER_OFFSET_NONE):
+            return int(Gst.PadProbeReturn.OK)
+
+        handoff_monotonic = time.monotonic()
+        frame_running_s: float | None = None
+        running_s: float | None = None
+        try:
+            pts = int(buffer.pts)
+            running = int(pipeline.get_current_running_time())
+            segment_event = _pad.get_sticky_event(Gst.EventType.SEGMENT, 0)
+            if segment_event is not None and pts != int(Gst.CLOCK_TIME_NONE):
+                segment = segment_event.parse_segment()
+                frame_running = int(segment.to_running_time(Gst.Format.TIME, pts))
+                if frame_running != int(Gst.CLOCK_TIME_NONE):
+                    frame_running_s = frame_running / float(Gst.SECOND)
+            if running != int(Gst.CLOCK_TIME_NONE):
+                running_s = running / float(Gst.SECOND)
+        except Exception:
+            # Timing metadata must never interrupt the camera path. The
+            # pre-IPC handoff instant remains a safe, slightly later fallback.
+            pass
+        self._camera_frame_timestamps.record(
+            offset,
+            handoff_monotonic,
+            frame_running_time_s=frame_running_s,
+            pipeline_running_time_s=running_s,
+        )
+        return int(Gst.PadProbeReturn.OK)
+
+    def pop_camera_frame_timestamp(self, frame_offset: int) -> float | None:
+        """Return and remove the producer-side timestamp for an IPC frame."""
+        return self._camera_frame_timestamps.pop(frame_offset)
 
     def _build_rpi_encoder_branch(
         self,

--- a/src/reachy_mini/vision/face_tracking.py
+++ b/src/reachy_mini/vision/face_tracking.py
@@ -7,6 +7,7 @@ import queue
 import threading
 import time
 from dataclasses import dataclass
+from typing import Callable
 
 import gi
 import numpy as np
@@ -173,7 +174,10 @@ def to_observation(
 class FaceTracker:
     """Run the face detector in a daemon thread and expose the latest observation."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        frame_timestamp_lookup: Callable[[int], float | None] | None = None,
+    ) -> None:
         """Initialize the tracker; no thread is started until ``start``."""
         self._thread: threading.Thread | None = None
         self._stop = threading.Event()
@@ -181,6 +185,20 @@ class FaceTracker:
         self._observations: queue.SimpleQueue[FaceObservation] = queue.SimpleQueue()
         self._selector = Tracker()
         self._center_filter = _AdaptiveCenterFilter()
+        self._frame_timestamp_lookup = frame_timestamp_lookup
+
+    def _frame_timestamp(self, buffer: Gst.Buffer) -> float | None:
+        """Return producer time, or reject a frame whose expected mapping is lost."""
+        arrival = time.monotonic()
+        if self._frame_timestamp_lookup is None:
+            return arrival
+        offset = int(buffer.offset)
+        if offset == int(Gst.BUFFER_OFFSET_NONE):
+            return None
+        timestamp = self._frame_timestamp_lookup(offset)
+        if timestamp is None or timestamp > arrival:
+            return None
+        return timestamp
 
     def start(self, camera_specs: CameraSpecs) -> None:
         """Start the detector thread if it is not already running."""
@@ -334,6 +352,9 @@ class FaceTracker:
                 frame_width = structure.get_value("width")
                 frame_height = structure.get_value("height")
                 buf = sample.get_buffer()
+                frame_timestamp = self._frame_timestamp(buf)
+                if frame_timestamp is None:
+                    continue
                 frame = np.frombuffer(
                     buf.extract_dup(0, buf.get_size()), dtype=np.uint8
                 ).reshape((frame_height, frame_width, 3))
@@ -347,7 +368,7 @@ class FaceTracker:
                     frame_height,
                     camera_matrix,
                     camera_specs.D,
-                    time.monotonic(),
+                    frame_timestamp,
                 )
         except Exception:
             # With no process boundary left, this is the only place a detector crash gets reported.

--- a/tests/unit_tests/test_camera_timestamps.py
+++ b/tests/unit_tests/test_camera_timestamps.py
@@ -1,0 +1,87 @@
+"""Tests for camera frame timestamp handoff across daemon local IPC."""
+
+from types import SimpleNamespace
+
+import gi
+import pytest
+
+from reachy_mini.media.camera_timestamps import CameraFrameTimestamps
+from reachy_mini.media.media_server import GstMediaServer
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst  # noqa: E402
+
+
+def test_source_pts_is_converted_to_monotonic_capture_time() -> None:
+    """Producer pipeline age is subtracted from the local handoff instant."""
+    timestamps = CameraFrameTimestamps()
+
+    selected = timestamps.record(
+        42,
+        100.0,
+        frame_running_time_s=9.8,
+        pipeline_running_time_s=10.0,
+    )
+
+    assert selected == pytest.approx(99.8)
+    assert timestamps.pop(42) == pytest.approx(99.8)
+    assert timestamps.pop(42) is None
+
+
+def test_invalid_source_age_falls_back_to_pre_ipc_handoff() -> None:
+    """Missing, future, or implausibly old PTS never creates a bogus clock."""
+    timestamps = CameraFrameTimestamps(max_source_age_s=2.0)
+
+    assert timestamps.record(1, 100.0) == 100.0
+    assert (
+        timestamps.record(
+            2, 100.0, frame_running_time_s=10.1, pipeline_running_time_s=10.0
+        )
+        == 100.0
+    )
+    assert (
+        timestamps.record(
+            3, 100.0, frame_running_time_s=1.0, pipeline_running_time_s=10.0
+        )
+        == 100.0
+    )
+
+
+def test_registry_is_bounded_and_clearable() -> None:
+    """Skipped camera consumers cannot grow the producer registry forever."""
+    timestamps = CameraFrameTimestamps(capacity=2)
+    timestamps.record(1, 1.0)
+    timestamps.record(2, 2.0)
+    timestamps.record(3, 3.0)
+
+    assert timestamps.pop(1) is None
+    assert timestamps.pop(2) == 2.0
+    timestamps.clear()
+    assert timestamps.pop(3) is None
+
+
+def test_media_server_converts_producer_pts_through_segment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The actual IPC pad callback maps segment PTS into monotonic time."""
+    registry = CameraFrameTimestamps()
+    server = SimpleNamespace(_camera_frame_timestamps=registry)
+    buffer = SimpleNamespace(offset=42, pts=int(9.8 * Gst.SECOND))
+    info = SimpleNamespace(get_buffer=lambda: buffer)
+    segment = SimpleNamespace(
+        to_running_time=lambda _format, pts: pts,
+    )
+    event = SimpleNamespace(parse_segment=lambda: segment)
+    pad = SimpleNamespace(get_sticky_event=lambda _event_type, _index: event)
+    pipeline = SimpleNamespace(get_current_running_time=lambda: int(10.0 * Gst.SECOND))
+    monkeypatch.setattr("reachy_mini.media.media_server.time.monotonic", lambda: 100.0)
+
+    result = GstMediaServer._record_camera_frame_timestamp(
+        server,  # type: ignore[arg-type]
+        pad,  # type: ignore[arg-type]
+        info,  # type: ignore[arg-type]
+        pipeline,  # type: ignore[arg-type]
+    )
+
+    assert result == int(Gst.PadProbeReturn.OK)
+    assert registry.pop(42) == pytest.approx(99.8)

--- a/tests/unit_tests/test_face_tracking.py
+++ b/tests/unit_tests/test_face_tracking.py
@@ -105,6 +105,39 @@ def test_face_tracker_resets_filter_after_target_loss() -> None:
     assert observation.center == pytest.approx((-0.8, 0.0))
 
 
+def test_face_tracker_uses_producer_timestamp_from_buffer_offset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The IPC frame offset recovers its pre-IPC timestamp before inference."""
+    buffer = SimpleNamespace(offset=42)
+    tracker = FaceTracker(lambda offset: 12.5 if offset == 42 else None)
+    monkeypatch.setattr(face_tracking.time, "monotonic", lambda: 13.0)
+
+    assert tracker._frame_timestamp(buffer) == 12.5  # type: ignore[arg-type]
+
+
+def test_face_tracker_without_producer_lookup_uses_pre_inference_arrival_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Standalone use without a producer map still timestamps before inference."""
+    buffer = SimpleNamespace(offset=43)
+    tracker = FaceTracker()
+    monkeypatch.setattr(face_tracking.time, "monotonic", lambda: 13.0)
+
+    assert tracker._frame_timestamp(buffer) == 13.0  # type: ignore[arg-type]
+
+
+def test_face_tracker_rejects_frame_when_expected_producer_mapping_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Daemon tracking never silently falls back to a later pose clock."""
+    buffer = SimpleNamespace(offset=43)
+    tracker = FaceTracker(lambda _offset: None)
+    monkeypatch.setattr(face_tracking.time, "monotonic", lambda: 13.0)
+
+    assert tracker._frame_timestamp(buffer) is None  # type: ignore[arg-type]
+
+
 def test_tracker_acquires_largest_above_min_size() -> None:
     """A fresh track picks the largest face once it clears the size gate."""
     tracker = Tracker(min_area_frac=0.0)

--- a/tests/unit_tests/test_head_tracking_backend.py
+++ b/tests/unit_tests/test_head_tracking_backend.py
@@ -4,8 +4,10 @@ import time
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 from scipy.spatial.transform import Rotation as R
 
+from reachy_mini.daemon.backend import abstract as backend_module
 from reachy_mini.daemon.backend.mockup_sim.backend import MockupSimBackend
 from reachy_mini.io.protocol import (
     GetTrackedFaceCmd,
@@ -246,3 +248,89 @@ def test_enable_head_tracking_weight_zero_pauses_without_stopping() -> None:
     assert tracker.active_calls[-1] is False
     assert backend._tracking_weight == 0.0
     assert tracker.stopped is False
+
+
+def test_tracking_pose_history_interpolates_capture_time() -> None:
+    """A frame between control ticks gets the measured pose from that instant."""
+    backend = _make_backend()
+    start = np.eye(4, dtype=np.float64)
+    end = np.eye(4, dtype=np.float64)
+    end[:3, :3] = R.from_euler("z", 0.4).as_matrix()
+    backend._tracking_pose_history.extend([(10.0, start), (11.0, end)])
+
+    pose = backend._tracking_pose_at(10.5)
+
+    assert pose is not None
+    assert R.from_matrix(pose[:3, :3]).as_euler("xyz")[2] == pytest.approx(0.2)
+
+
+def test_tracking_uses_head_pose_from_frame_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A delayed face observation is projected from capture pose, not current pose."""
+    backend = _make_backend()
+    backend._tracking_enabled = True
+    capture_pose = np.eye(4, dtype=np.float64)
+    current_pose = np.eye(4, dtype=np.float64)
+    current_pose[:3, :3] = R.from_euler("z", 0.5).as_matrix()
+    backend.current_head_pose = current_pose
+    backend._tracking_pose_history.append((10.0, capture_pose))
+    backend._tracker = SimpleNamespace(
+        latest=lambda: SimpleNamespace(
+            center=(0.25, 0.0),
+            roll=0.0,
+            width=640,
+            height=480,
+            camera_matrix=np.eye(3, dtype=np.float64),
+            distortion=np.zeros(5, dtype=np.float64),
+            timestamp=10.0,
+        )
+    )
+    projected_from: list[np.ndarray] = []
+
+    def fake_look_at_image_pose(**kwargs: object) -> np.ndarray:
+        pose = kwargs["T_world_head"]
+        assert isinstance(pose, np.ndarray)
+        projected_from.append(pose.copy())
+        return pose.copy()
+
+    monkeypatch.setattr(backend_module, "look_at_image_pose", fake_look_at_image_pose)
+    monkeypatch.setattr(backend_module.time, "monotonic", lambda: 10.1)
+
+    backend.step_head_tracking()
+
+    assert len(projected_from) == 1
+    np.testing.assert_allclose(projected_from[0], capture_pose)
+
+
+def test_tracking_drops_detected_observation_without_capture_pose(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Never silently project a detected face from the processing-time pose."""
+    backend = _make_backend()
+    backend._tracking_enabled = True
+    backend._tracker = SimpleNamespace(
+        latest=lambda: SimpleNamespace(
+            center=(0.25, 0.0),
+            roll=0.0,
+            width=640,
+            height=480,
+            camera_matrix=np.eye(3, dtype=np.float64),
+            distortion=np.zeros(5, dtype=np.float64),
+            timestamp=1.0,
+        )
+    )
+    projected = False
+
+    def fake_look_at_image_pose(**_kwargs: object) -> np.ndarray:
+        nonlocal projected
+        projected = True
+        return np.eye(4, dtype=np.float64)
+
+    monkeypatch.setattr(backend_module, "look_at_image_pose", fake_look_at_image_pose)
+    monkeypatch.setattr(backend_module.time, "monotonic", lambda: 10.0)
+
+    backend.step_head_tracking()
+
+    assert projected is False
+    assert backend.get_tracked_face().detected is False


### PR DESCRIPTION
## Issue

Closes #1331

## Description

Face tracking was projecting a detected face from the head pose at processing time, although the camera frame was captured earlier. While the head was moving, this made the target escalate and caused repeated overshoot/correction.

This records each producer-side camera frame timestamp by IPC buffer offset, retains a short measured head-pose history, and interpolates the pose at capture time before projecting the face into world coordinates. A detector configured for timestamps drops a frame when its timestamp is unavailable instead of silently using a later pose. No public API or daemon route changes.

## Testing

- `ruff check` and `mypy` pass for the changed source files.
- 68 focused unit tests pass, covering timestamp mapping, face tracking, backend pose history, and media-server pose/watchdog/WebRTC paths.
- Tested on one Reachy Mini Wireless running the 1.10.0 release. In three stationary-face positions, measured target overshoot fell from 12.1–14.9° to 0.7–3.9° and settling time fell from 2.46–5.04 s to 1.14–1.76 s.
- With instrumentation disabled, a normal daemon tracking run reacquired the operator after natural movement and brief occlusion, then held direct gaze.

## Tested on

- [x] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [ ] Not applicable (e.g. docs, typo)

## AI assistance

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [x] AI wrote code here, and I ran and reviewed it
- [ ] An agent produced this PR, and I have not run it myself

Assisted-by: OpenAI Codex: GPT-5