### PR TITLE
Add over-the-air BLE test suite runnable from an external host

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ markers = [
     "video: mark test as requiring video hardware",
     "wireless: mark test as requiring wireless Reachy Mini",
     "webrtc: mark test as requiring the gst-plugins-rs webrtc plugin (libgstrswebrtc.so)",
+    "ble: mark test as exercising the BLE provisioning service over the air from an external host with a Bluetooth adapter (e.g. a Raspberry Pi) in radio range of a powered robot",
     "ipc_resolution: override the resolution used by the ipc_video_source fixture",
 ]
 

--- a/src/reachy_mini_ble_test/README.md
+++ b/src/reachy_mini_ble_test/README.md
@@ -1,0 +1,82 @@
+# Over-the-air BLE tests
+
+Smoke tests for the robot's BLE provisioning service
+(`reachy_mini/daemon/app/services/bluetooth/bluetooth_service.py`), run
+**over the air from an external host** — not on the robot, and not in CI.
+Typical setup: a Raspberry Pi (or any Linux box with BlueZ and a Bluetooth
+adapter) in radio range of a powered Reachy Mini.
+
+The suite discovers the robot by itself: it scans for the advertised name
+(`ReachyMini`), connects, and exercises the GATT command protocol. Protocol
+constants (UUIDs, etc.) are imported from the firmware source shipped in the
+same package, so the suite fails loudly if the protocol drifts.
+
+## Scope
+
+Everything here is **read-only and safe**:
+
+- discovery, connection, GATT layout, Device Information service
+- status characteristics (network status, system status, available commands,
+  hardware ID)
+- synchronous command round-trips (`PING`, `ECHO`, journal streaming
+  start/read/stop)
+- public WiFi provisioning surface (`WIFI_STATUS` without the saved-network
+  list, `WIFI_KEYEX`)
+- auth gates: privileged commands (`WIFI_SCAN`, `CMD_*`) are refused without
+  a PIN session
+
+No PIN is ever sent (the robot-global wrong-PIN lockout is never armed), no
+robot state is mutated, and no `CMD_*` script is executed. Tests for commands
+the deployed firmware may predate skip with an explanation instead of failing.
+
+## Running
+
+On any Linux host with BlueZ (the suite needs nothing beyond `pytest` —
+scanning shells out to `bluetoothctl`, the connection uses a raw LE socket):
+
+```bash
+pip install reachy-mini pytest
+pytest --pyargs reachy_mini_ble_test -v
+```
+
+On a bare test host where the full dependency set won't build (e.g. a stock
+Raspberry Pi without PyGObject's system headers), a minimal install is
+enough — this package deliberately imports nothing from the rest of
+`reachy_mini`:
+
+```bash
+pip install --no-deps reachy-mini
+pip install pytest
+pytest --pyargs reachy_mini_ble_test -v
+```
+
+All the usual pytest options apply (`-k ping`, `-m ble`, `--tb=short`, …).
+From a repo checkout: `uv run pytest src/reachy_mini_ble_test -v`. The suite
+is outside `testpaths`, so a plain `pytest` run never collects it.
+
+## Configuration
+
+| Environment variable | Default | Meaning |
+| --- | --- | --- |
+| `REACHY_BLE_NAME` | `ReachyMini` | Advertised name to match (normalized, so `reachy-mini` also matches) |
+| `REACHY_BLE_ADDRESS` | *(any)* | Pin discovery to one MAC address, e.g. when several robots are in range |
+| `REACHY_BLE_SCAN_TIMEOUT` | `15` | BLE scan duration, seconds |
+| `REACHY_BLE_RESPONSE_TIMEOUT` | `25` | Max wait for a proxied command's notification, seconds |
+
+## Gotchas
+
+- The robot accepts a **single BLE central**: if a phone/laptop is already
+  connected (e.g. the web provisioning tool), discovery or connection fails.
+- Daemon-proxied commands ack immediately with `OK: working` and deliver the
+  real result as a notification on the response characteristic; the helper in
+  `ble_link.py` handles both shapes.
+- The suite connects through a raw LE ATT socket (`att_client.py`), not
+  through BlueZ's `Device1.Connect`. Reason: the robot's controller is
+  dual-mode and its advert lacks the "BR/EDR Not Supported" flag, so BlueZ
+  centrals pick the classic BR/EDR bearer and fail with
+  `br-connection-profile-unavailable`. Phones and Web Bluetooth are LE-only
+  and never hit this; the raw socket behaves like them and tests the robot
+  exactly as shipped.
+- Future authenticated tests must respect the robot-global wrong-PIN
+  throttle: a failed PIN arms a lockout (up to 300 s) that **survives
+  disconnects** and would poison subsequent tests.

--- a/src/reachy_mini_ble_test/__init__.py
+++ b/src/reachy_mini_ble_test/__init__.py
@@ -1,0 +1,13 @@
+"""Over-the-air BLE smoke tests for the Reachy Mini provisioning service.
+
+Run from any external Linux host with BlueZ and a Bluetooth adapter in radio
+range of a powered robot — NOT on the robot itself:
+
+    pip install reachy-mini pytest        # or: pip install --no-deps reachy-mini pytest
+    pytest --pyargs reachy_mini_ble_test -v
+
+This package deliberately depends on nothing but the standard library (plus
+pytest to run), so a minimal ``--no-deps`` install is enough on a bare test
+host like a Raspberry Pi. See README.md in this directory for scope,
+configuration, and gotchas.
+"""

--- a/src/reachy_mini_ble_test/att_client.py
+++ b/src/reachy_mini_ble_test/att_client.py
@@ -1,0 +1,324 @@
+"""Minimal GATT client over a raw LE L2CAP socket (the ATT channel).
+
+Why not connect through BlueZ's D-Bus API? The robot's controller is
+dual-mode and its advertisement does not carry the "BR/EDR Not Supported"
+flag, so ``org.bluez.Device1.Connect`` picks the classic BR/EDR bearer —
+where the robot has nothing listening — and fails with
+``br-connection-profile-unavailable``. Phones and Web Bluetooth are LE-only
+by construction, which is why they never hit this. This client does the
+same thing they do: it opens an LE-bearer L2CAP connection on the ATT
+channel (CID 4) directly, exactly like the classic ``gatttool``. It works
+unprivileged, needs no host or robot configuration, and exercises the
+robot's GATT service exactly as shipped.
+
+Python 3.12's socket module cannot express the LE address type in a
+BTPROTO_L2CAP sockaddr (3.13 added it), so bind/connect go through libc
+with a hand-packed ``struct sockaddr_l2``.
+
+Implements the small ATT subset the tests need: MTU exchange, service and
+characteristic discovery, reads (with blob continuation), writes, CCCD
+subscription, and notifications.
+"""
+
+import ctypes
+import os
+import queue
+import socket
+import struct
+import time
+from uuid import UUID
+
+BDADDR_LE_PUBLIC = 1
+BDADDR_LE_RANDOM = 2
+ATT_CID = 4
+
+# Linux-only socket constants, via getattr so type checking stays
+# platform-independent (the suite itself only runs on Linux/BlueZ hosts).
+_AF_BLUETOOTH: int = getattr(socket, "AF_BLUETOOTH", 31)
+_BTPROTO_L2CAP: int = getattr(socket, "BTPROTO_L2CAP", 0)
+
+# ATT opcodes
+_ERROR_RSP = 0x01
+_EXCHANGE_MTU_REQ, _EXCHANGE_MTU_RSP = 0x02, 0x03
+_FIND_INFO_REQ, _FIND_INFO_RSP = 0x04, 0x05
+_READ_BY_TYPE_REQ, _READ_BY_TYPE_RSP = 0x08, 0x09
+_READ_REQ, _READ_RSP = 0x0A, 0x0B
+_READ_BLOB_REQ, _READ_BLOB_RSP = 0x0C, 0x0D
+_WRITE_REQ, _WRITE_RSP = 0x12, 0x13
+_NOTIFICATION = 0x1B
+
+_ATT_ERR_ATTRIBUTE_NOT_FOUND = 0x0A
+_ATT_ERR_ATTRIBUTE_NOT_LONG = 0x0B
+
+_CHARACTERISTIC = 0x2803
+CCCD_UUID16 = 0x2902
+
+_PROPERTY_BITS = {
+    0x01: "broadcast",
+    0x02: "read",
+    0x04: "write-without-response",
+    0x08: "write",
+    0x10: "notify",
+    0x20: "indicate",
+}
+
+
+def _uuid128_to_str(le_bytes: bytes) -> str:
+    return str(UUID(bytes=bytes(reversed(le_bytes))))
+
+
+def _uuid16_to_str(value: int) -> str:
+    return f"{value:08x}-0000-1000-8000-00805f9b34fb"
+
+
+def _uuid_bytes_to_str(uuid_bytes: bytes) -> str:
+    if len(uuid_bytes) == 2:
+        return _uuid16_to_str(struct.unpack("<H", uuid_bytes)[0])
+    return _uuid128_to_str(uuid_bytes)
+
+
+def _bdaddr(mac: str) -> bytes:
+    return bytes(reversed(bytes.fromhex(mac.replace(":", ""))))
+
+
+def _sockaddr_l2(mac_le: bytes, addr_type: int) -> bytes:
+    # struct sockaddr_l2: family, psm, bdaddr[6], cid, bdaddr_type (+pad)
+    return struct.pack("<HH6sHBx", _AF_BLUETOOTH, 0, mac_le, ATT_CID, addr_type)
+
+
+class AttError(Exception):
+    """ATT Error Response from the server."""
+
+    def __init__(self, request_opcode: int, handle: int, code: int) -> None:
+        """Record the failed request opcode, target handle, and error code."""
+        self.request_opcode = request_opcode
+        self.handle = handle
+        self.code = code
+        super().__init__(
+            f"ATT error 0x{code:02x} for request 0x{request_opcode:02x} "
+            f"on handle 0x{handle:04x}"
+        )
+
+
+class Characteristic:
+    """A discovered characteristic: handles, UUID, decoded properties."""
+
+    def __init__(
+        self, decl_handle: int, properties_mask: int, value_handle: int, uuid: str
+    ) -> None:
+        """Store the discovery result for one characteristic declaration."""
+        self.decl_handle = decl_handle
+        self.value_handle = value_handle
+        self.uuid = uuid
+        self.properties = [
+            name for bit, name in _PROPERTY_BITS.items() if properties_mask & bit
+        ]
+
+
+class AttClient:
+    """Synchronous GATT client over a raw LE L2CAP (ATT) socket."""
+
+    def __init__(
+        self, address: str, address_type: str = "public", timeout: float = 10.0
+    ) -> None:
+        """Prepare a client for the peer at ``address`` (no I/O yet)."""
+        self.address = address
+        self.address_type = address_type
+        self.timeout = timeout
+        self.mtu = 23
+        self.characteristics: list[Characteristic] = []  # in handle order
+        self.notifications: queue.Queue[tuple[int, bytes]] = queue.Queue()
+        self._sock: socket.socket | None = None
+
+    # -- connection ----------------------------------------------------
+
+    def connect(self) -> None:
+        """Open the LE connection and discover the GATT database."""
+        peer_type = (
+            BDADDR_LE_RANDOM if self.address_type == "random" else BDADDR_LE_PUBLIC
+        )
+        libc = ctypes.CDLL(None, use_errno=True)
+        sock = socket.socket(_AF_BLUETOOTH, socket.SOCK_SEQPACKET, _BTPROTO_L2CAP)
+        try:
+            local = _sockaddr_l2(b"\x00" * 6, BDADDR_LE_PUBLIC)
+            if libc.bind(sock.fileno(), local, len(local)) != 0:
+                raise OSError(ctypes.get_errno(), os.strerror(ctypes.get_errno()))
+            peer = _sockaddr_l2(_bdaddr(self.address), peer_type)
+            if libc.connect(sock.fileno(), peer, len(peer)) != 0:
+                raise OSError(ctypes.get_errno(), os.strerror(ctypes.get_errno()))
+        except BaseException:
+            sock.close()
+            raise
+        sock.settimeout(self.timeout)
+        self._sock = sock
+        self._exchange_mtu()
+        self._discover()
+
+    def close(self) -> None:
+        """Close the LE connection."""
+        if self._sock is not None:
+            self._sock.close()
+            self._sock = None
+
+    # -- ATT plumbing --------------------------------------------------
+
+    def _socket(self) -> socket.socket:
+        if self._sock is None:
+            raise ConnectionError("not connected")
+        return self._sock
+
+    def _recv(self, deadline: float) -> bytes:
+        sock = self._socket()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("timed out waiting for ATT PDU")
+        sock.settimeout(remaining)
+        pdu = sock.recv(1024)
+        if not pdu:
+            raise ConnectionError("LE connection closed by peer")
+        return pdu
+
+    def _request(self, pdu: bytes, expected_opcode: int) -> bytes:
+        """Send one ATT request and return the matching response PDU.
+
+        Notifications interleaved with the response are queued, never lost.
+        """
+        self._socket().send(pdu)
+        deadline = time.monotonic() + self.timeout
+        while True:
+            rsp = self._recv(deadline)
+            opcode = rsp[0]
+            if opcode == _NOTIFICATION:
+                handle = int(struct.unpack_from("<H", rsp, 1)[0])
+                self.notifications.put((handle, rsp[3:]))
+            elif opcode == expected_opcode:
+                return rsp
+            elif opcode == _ERROR_RSP and rsp[1] == pdu[0]:
+                _, req_op, handle, code = struct.unpack("<BBHB", rsp)
+                raise AttError(req_op, handle, code)
+            # anything else (e.g. server-initiated exchange): ignore
+
+    def wait_notification(self, timeout: float) -> bytes:
+        """Return the next notification payload (bytes) within timeout.
+
+        Drains PDUs from the socket into the queue as needed.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                return self.notifications.get_nowait()[1]
+            except queue.Empty:
+                pass
+            rsp = self._recv(deadline)
+            if rsp[0] == _NOTIFICATION:
+                handle = int(struct.unpack_from("<H", rsp, 1)[0])
+                self.notifications.put((handle, rsp[3:]))
+
+    def drain_notifications(self) -> None:
+        """Discard any queued notifications (before sending a new command)."""
+        while True:
+            try:
+                self.notifications.get_nowait()
+            except queue.Empty:
+                return
+
+    # -- GATT operations -----------------------------------------------
+
+    def _exchange_mtu(self, mtu: int = 517) -> None:
+        rsp = self._request(
+            struct.pack("<BH", _EXCHANGE_MTU_REQ, mtu), _EXCHANGE_MTU_RSP
+        )
+        self.mtu = min(mtu, int(struct.unpack_from("<H", rsp, 1)[0]))
+
+    def _discover(self) -> None:
+        # Characteristics: Read By Type on the declaration UUID.
+        start = decl_handle = 0x0001
+        while start <= 0xFFFF:
+            try:
+                rsp = self._request(
+                    struct.pack(
+                        "<BHHH", _READ_BY_TYPE_REQ, start, 0xFFFF, _CHARACTERISTIC
+                    ),
+                    _READ_BY_TYPE_RSP,
+                )
+            except AttError as e:
+                if e.code == _ATT_ERR_ATTRIBUTE_NOT_FOUND:
+                    break
+                raise
+            entry_len, offset = rsp[1], 2
+            while offset + entry_len <= len(rsp):
+                decl_handle = int(struct.unpack_from("<H", rsp, offset)[0])
+                props, value_handle = struct.unpack_from("<BH", rsp, offset + 2)
+                uuid = _uuid_bytes_to_str(rsp[offset + 5 : offset + entry_len])
+                self.characteristics.append(
+                    Characteristic(decl_handle, int(props), int(value_handle), uuid)
+                )
+                offset += entry_len
+            start = decl_handle + 1
+
+    def characteristic(self, uuid: str) -> Characteristic | None:
+        """Return the first discovered characteristic with this UUID, or None."""
+        uuid = uuid.lower()
+        for char in self.characteristics:
+            if char.uuid == uuid:
+                return char
+        return None
+
+    def _descriptor_handle(self, char: Characteristic, uuid16: int) -> int | None:
+        """Find a descriptor of ``char`` by 16-bit UUID via Find Information."""
+        later = [
+            c.decl_handle
+            for c in self.characteristics
+            if c.decl_handle > char.decl_handle
+        ]
+        end = min(later) - 1 if later else 0xFFFF
+        start = handle = char.value_handle + 1
+        while start <= end:
+            try:
+                rsp = self._request(
+                    struct.pack("<BHH", _FIND_INFO_REQ, start, end), _FIND_INFO_RSP
+                )
+            except AttError as e:
+                if e.code == _ATT_ERR_ATTRIBUTE_NOT_FOUND:
+                    return None
+                raise
+            fmt, offset = rsp[1], 2
+            entry_len = 4 if fmt == 1 else 18
+            while offset + entry_len <= len(rsp):
+                handle = int(struct.unpack_from("<H", rsp, offset)[0])
+                if fmt == 1:
+                    if struct.unpack_from("<H", rsp, offset + 2)[0] == uuid16:
+                        return handle
+                offset += entry_len
+            start = handle + 1
+        return None
+
+    def read(self, handle: int) -> bytes:
+        """Read an attribute value, continuing with Read Blob when long."""
+        rsp = self._request(struct.pack("<BH", _READ_REQ, handle), _READ_RSP)
+        value = rsp[1:]
+        while len(value) % (self.mtu - 1) == 0 and value:
+            try:
+                rsp = self._request(
+                    struct.pack("<BHH", _READ_BLOB_REQ, handle, len(value)),
+                    _READ_BLOB_RSP,
+                )
+            except AttError as e:
+                if e.code == _ATT_ERR_ATTRIBUTE_NOT_LONG:
+                    break  # value was exactly a multiple of MTU-1
+                raise
+            if len(rsp) <= 1:
+                break
+            value += rsp[1:]
+        return bytes(value)
+
+    def write(self, handle: int, data: bytes) -> None:
+        """Write an attribute value (Write Request, acknowledged)."""
+        self._request(struct.pack("<BH", _WRITE_REQ, handle) + data, _WRITE_RSP)
+
+    def subscribe(self, char: Characteristic) -> None:
+        """Enable notifications on a characteristic via its CCCD."""
+        cccd = self._descriptor_handle(char, CCCD_UUID16)
+        if cccd is None:
+            raise RuntimeError(f"no CCCD found for characteristic {char.uuid}")
+        self.write(cccd, b"\x01\x00")

--- a/src/reachy_mini_ble_test/ble_link.py
+++ b/src/reachy_mini_ble_test/ble_link.py
@@ -1,0 +1,227 @@
+"""Plumbing for the over-the-air BLE test suite.
+
+This module gives the tests two things:
+
+1. The *protocol constants* (UUIDs), parsed from the real
+   ``bluetooth_service.py`` source shipped in the same wheel, so the suite
+   fails loudly (KeyError at import) if the firmware protocol drifts instead
+   of silently testing stale literals.
+
+2. ``ReachyBleLink`` — a synchronous client that scans for, connects to, and
+   exchanges commands with a live Reachy Mini over the air. Scanning shells
+   out to ``bluetoothctl`` (present on any BlueZ host, keeps the suite free
+   of third-party dependencies); the connection itself uses a raw LE ATT
+   socket (see att_client.py) because BlueZ's high-level Connect() picks the
+   classic BR/EDR bearer for the robot's dual-mode advertisement and fails —
+   phones and Web Bluetooth are LE-only and never hit this, and this client
+   behaves like them. The robot is exercised exactly as shipped.
+
+The suite is meant to run on an external Linux host with a BLE adapter (e.g.
+a Raspberry Pi) sitting in radio range of the robot — NOT on the robot.
+"""
+
+import importlib.util
+import re
+import subprocess
+from pathlib import Path
+
+from .att_client import AttClient, Characteristic
+
+
+def _reachy_mini_package_dir() -> Path:
+    """Locate the installed reachy_mini package WITHOUT importing it.
+
+    find_spec resolves the package location but does not execute its
+    __init__ (which chains into numpy/scipy and friends) — this keeps the
+    suite runnable on a minimal test host installed with ``pip install
+    --no-deps reachy-mini pytest``. Falls back to the sibling directory for
+    a plain source checkout.
+    """
+    spec = importlib.util.find_spec("reachy_mini")
+    if spec is not None and spec.submodule_search_locations:
+        return Path(next(iter(spec.submodule_search_locations)))
+    return Path(__file__).resolve().parents[1] / "reachy_mini"
+
+
+# The BLE service and its CMD_* scripts ship in the same wheel.
+_SERVICE_PATH = (
+    _reachy_mini_package_dir() / "daemon/app/services/bluetooth/bluetooth_service.py"
+)
+COMMANDS_DIR = _SERVICE_PATH.parent / "commands"
+
+# Protocol constants, parsed straight from the firmware source.
+_UUIDS: dict[str, str] = dict(
+    re.findall(r'^(\w+_UUID) = "([0-9a-f-]+)"', _SERVICE_PATH.read_text(), re.M)
+)
+COMMAND_CHAR_UUID = _UUIDS["COMMAND_CHAR_UUID"]
+RESPONSE_CHAR_UUID = _UUIDS["RESPONSE_CHAR_UUID"]
+REACHY_STATUS_SERVICE_UUID = _UUIDS["REACHY_STATUS_SERVICE_UUID"]
+MANUFACTURER_NAME_UUID = _UUIDS["MANUFACTURER_NAME_UUID"]
+MODEL_NUMBER_UUID = _UUIDS["MODEL_NUMBER_UUID"]
+FIRMWARE_REVISION_UUID = _UUIDS["FIRMWARE_REVISION_UUID"]
+NETWORK_STATUS_UUID = _UUIDS["NETWORK_STATUS_UUID"]
+SYSTEM_STATUS_UUID = _UUIDS["SYSTEM_STATUS_UUID"]
+AVAILABLE_COMMANDS_UUID = _UUIDS["AVAILABLE_COMMANDS_UUID"]
+HARDWARE_ID_UUID = _UUIDS["HARDWARE_ID_UUID"]
+
+# The advertised LocalName is "ReachyMini" but BlueZ may cache the GAP Device
+# Name ("reachy-mini", the hostname) instead, depending on scan history. Match
+# on a normalized form so both spellings pass.
+DEFAULT_DEVICE_NAME = "ReachyMini"
+
+
+def _normalize_name(name: str | None) -> str:
+    return re.sub(r"[^a-z0-9]", "", (name or "").lower())
+
+
+class BleLinkError(RuntimeError):
+    """Raised when the BLE link cannot be established or times out."""
+
+
+class ReachyBleLink:
+    """Synchronous BLE client for a Reachy Mini.
+
+    Discovery shells out to bluetoothctl (works unprivileged); the connection
+    uses a raw LE ATT socket (att_client.py) to force the LE bearer.
+    """
+
+    # Immediate ack returned by daemon-proxied commands; the real payload
+    # follows as a notification on the response characteristic.
+    ACK = "OK: working"
+
+    def __init__(
+        self,
+        name: str = DEFAULT_DEVICE_NAME,
+        address: str | None = None,
+        scan_timeout: float = 15.0,
+        response_timeout: float = 25.0,
+    ) -> None:
+        """Configure the link (no I/O happens until discover())."""
+        self.name = name
+        self.address = address
+        self.scan_timeout = scan_timeout
+        self.response_timeout = response_timeout
+        self.device_address: str | None = None
+        self.device_name: str | None = None
+        self.advertised_uuids: set[str] = set()
+        self._att: AttClient | None = None
+        self._command_char: Characteristic | None = None
+        self._response_char: Characteristic | None = None
+
+    # -- discovery / connection ----------------------------------------
+
+    @staticmethod
+    def _bluetoothctl(*args: str, timeout: float) -> str:
+        return subprocess.run(
+            ["bluetoothctl", *args], capture_output=True, text=True, timeout=timeout
+        ).stdout
+
+    def discover(self) -> str | None:
+        """Scan for the robot; returns its MAC address or None.
+
+        A device matches if its name normalizes to the expected name. When
+        ``address`` was given, only that address is considered. The UUIDs
+        BlueZ learned from the device's advertisement are captured too.
+        """
+        self._bluetoothctl(
+            "--timeout",
+            str(int(self.scan_timeout)),
+            "scan",
+            "on",
+            timeout=self.scan_timeout + 10,
+        )
+        wanted = _normalize_name(self.name)
+        for line in self._bluetoothctl("devices", timeout=10).splitlines():
+            match = re.fullmatch(r"Device ((?:[0-9A-F]{2}:){5}[0-9A-F]{2}) (.*)", line)
+            if not match:
+                continue
+            mac, name = match.groups()
+            if self.address and mac.lower() != self.address.lower():
+                continue
+            if self.address or _normalize_name(name) == wanted:
+                self.device_address, self.device_name = mac, name
+                info = self._bluetoothctl("info", mac, timeout=10)
+                self.advertised_uuids = set(
+                    re.findall(r"UUID:.*\(([0-9a-f-]{36})\)", info)
+                )
+                return mac
+        return None
+
+    def connect(self) -> None:
+        """Connect over the LE bearer and subscribe to command responses.
+
+        The robot advertises with its controller's public address; retry with
+        a random address type in case a robot ever uses one.
+        """
+        if self.device_address is None:
+            raise BleLinkError("discover() must find the robot before connect()")
+        try:
+            self._att = AttClient(
+                self.device_address, address_type="public", timeout=self.scan_timeout
+            )
+            self._att.connect()
+        except OSError:
+            self._att = AttClient(
+                self.device_address, address_type="random", timeout=self.scan_timeout
+            )
+            self._att.connect()
+        self._command_char = self._att.characteristic(COMMAND_CHAR_UUID)
+        self._response_char = self._att.characteristic(RESPONSE_CHAR_UUID)
+        if self._command_char is None or self._response_char is None:
+            raise BleLinkError(
+                "connected, but the BLE command service characteristics are "
+                f"missing (discovered: {[c.uuid for c in self._att.characteristics]})"
+            )
+        self._att.subscribe(self._response_char)
+
+    def stop(self) -> None:
+        """Close the LE connection (best effort)."""
+        if self._att is not None:
+            self._att.close()
+            self._att = None
+
+    # -- GATT helpers ---------------------------------------------------
+
+    def _require_att(self) -> AttClient:
+        if self._att is None:
+            raise BleLinkError("not connected")
+        return self._att
+
+    def characteristic(self, uuid: str) -> Characteristic | None:
+        """Return the discovered characteristic for a UUID, or None."""
+        return self._require_att().characteristic(uuid)
+
+    def read_char(self, uuid: str) -> str:
+        """Read a characteristic by UUID and decode it as UTF-8."""
+        att = self._require_att()
+        char = att.characteristic(uuid)
+        if char is None:
+            raise BleLinkError(f"characteristic {uuid} not found")
+        return att.read(char.value_handle).decode("utf-8", errors="replace")
+
+    # -- command protocol ----------------------------------------------
+
+    def command(self, cmd: str) -> str:
+        """Send a command string and return the final response string.
+
+        Synchronous firmware commands (PING, ECHO, JOURNAL_*, PIN_) place
+        their result directly in the response characteristic, which is read
+        back. Daemon-proxied commands ack with "OK: working" and deliver the
+        real payload as a notification, which is awaited with a timeout.
+        """
+        att = self._require_att()
+        assert self._command_char is not None and self._response_char is not None
+        att.drain_notifications()
+        att.write(self._command_char.value_handle, cmd.encode("utf-8"))
+        response = att.read(self._response_char.value_handle).decode(
+            "utf-8", errors="replace"
+        )
+        if response != self.ACK:
+            return response
+        try:
+            payload = att.wait_notification(self.response_timeout)
+        except TimeoutError:
+            raise BleLinkError(
+                f"No notification within {self.response_timeout}s for {cmd!r}"
+            ) from None
+        return payload.decode("utf-8", errors="replace")

--- a/src/reachy_mini_ble_test/conftest.py
+++ b/src/reachy_mini_ble_test/conftest.py
@@ -1,0 +1,62 @@
+"""Fixtures for the over-the-air BLE test suite.
+
+This package is NOT collected by a default ``pytest`` run (it sits outside
+``testpaths``). Run it explicitly, from a Linux host with BlueZ and a BLE
+adapter in radio range of a powered robot:
+
+    pytest --pyargs reachy_mini_ble_test -v    (installed package)
+    pytest src/reachy_mini_ble_test -v         (from a checkout)
+
+Configuration (environment variables):
+    REACHY_BLE_NAME              advertised name to match (default "ReachyMini")
+    REACHY_BLE_ADDRESS           pin discovery to one MAC address (optional)
+    REACHY_BLE_SCAN_TIMEOUT      BLE scan duration in seconds (default 15)
+    REACHY_BLE_RESPONSE_TIMEOUT  max wait for a command's notification (default 25)
+"""
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from .ble_link import DEFAULT_DEVICE_NAME, ReachyBleLink
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the ble marker (needed when running outside the repo)."""
+    config.addinivalue_line(
+        "markers", "ble: mark test as exercising the BLE service over the air"
+    )
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Tag every test in this package with the ``ble`` marker."""
+    for item in items:
+        item.add_marker(pytest.mark.ble)
+
+
+@pytest.fixture(scope="session")
+def link() -> Iterator[ReachyBleLink]:
+    """A connected BLE link to the robot, shared by the whole session.
+
+    Fails (rather than skips) when no robot is found: this suite only runs
+    when explicitly targeted, so an unreachable robot is a real failure.
+    """
+    lk = ReachyBleLink(
+        name=os.environ.get("REACHY_BLE_NAME", DEFAULT_DEVICE_NAME),
+        address=os.environ.get("REACHY_BLE_ADDRESS") or None,
+        scan_timeout=float(os.environ.get("REACHY_BLE_SCAN_TIMEOUT", "15")),
+        response_timeout=float(os.environ.get("REACHY_BLE_RESPONSE_TIMEOUT", "25")),
+    )
+    try:
+        if lk.discover() is None:
+            pytest.fail(
+                f"No Reachy Mini found over BLE (name {lk.name!r}, "
+                f"address {lk.address or 'any'}, scanned {lk.scan_timeout}s). "
+                "Is the robot powered, in range, and not already connected "
+                "to another BLE central?"
+            )
+        lk.connect()
+        yield lk
+    finally:
+        lk.stop()

--- a/src/reachy_mini_ble_test/test_ble_smoke.py
+++ b/src/reachy_mini_ble_test/test_ble_smoke.py
@@ -1,0 +1,172 @@
+"""Read-only smoke tests for the Reachy Mini BLE provisioning service.
+
+Run over the air from an external host (see conftest.py). Every test here is
+safe by construction: no PIN is ever sent (so the robot-global wrong-PIN
+lockout is never armed), no state on the robot is mutated, and no CMD_*
+script is executed. The auth-gate tests assert that privileged commands are
+REFUSED without a session — which is exactly the unauthenticated path.
+
+Commands the deployed firmware may predate (sealed WiFi provisioning, the
+Hardware ID characteristic) skip with an explanation instead of failing:
+unknown commands are echoed back by design, which is how a client detects an
+older robot.
+"""
+
+import base64
+import json
+import re
+import uuid
+
+import pytest
+
+from .ble_link import (
+    AVAILABLE_COMMANDS_UUID,
+    COMMAND_CHAR_UUID,
+    COMMANDS_DIR,
+    FIRMWARE_REVISION_UUID,
+    HARDWARE_ID_UUID,
+    MANUFACTURER_NAME_UUID,
+    MODEL_NUMBER_UUID,
+    NETWORK_STATUS_UUID,
+    REACHY_STATUS_SERVICE_UUID,
+    RESPONSE_CHAR_UUID,
+    SYSTEM_STATUS_UUID,
+    ReachyBleLink,
+)
+
+AUTH_ERROR = "ERROR: Not connected. Please authenticate first."
+
+
+def _skip_if_unsupported(response: str, command: str) -> None:
+    if response.startswith("ECHO:"):
+        pytest.skip(f"robot firmware predates {command} (command echoed back)")
+
+
+# -- discovery / GATT layout -------------------------------------------
+
+
+def test_robot_is_discoverable(link: ReachyBleLink) -> None:
+    """The robot is found by a plain BLE scan, with no prior knowledge."""
+    assert link.device_address is not None
+    assert link.device_name is not None and "reachy" in link.device_name.lower()
+
+
+def test_advertises_status_service_uuid(link: ReachyBleLink) -> None:
+    """The advertisement carries the Reachy Status service UUID."""
+    assert REACHY_STATUS_SERVICE_UUID in link.advertised_uuids
+
+
+def test_command_service_gatt_layout(link: ReachyBleLink) -> None:
+    """Command service exposes write-only command + read/notify response."""
+    command_char = link.characteristic(COMMAND_CHAR_UUID)
+    response_char = link.characteristic(RESPONSE_CHAR_UUID)
+    assert command_char is not None and "write" in command_char.properties
+    assert response_char is not None
+    assert {"read", "notify"} <= set(response_char.properties)
+
+
+def test_device_information_service(link: ReachyBleLink) -> None:
+    """Standard DIS identifies the robot; firmware rev encodes hotspot IP."""
+    assert link.read_char(MANUFACTURER_NAME_UUID) == "Pollen Robotics"
+    assert link.read_char(MODEL_NUMBER_UUID) == "Reachy Mini"
+    assert link.read_char(FIRMWARE_REVISION_UUID).startswith("[HOTSPOT]:")
+
+
+# -- status characteristics --------------------------------------------
+
+
+def test_system_status_is_online(link: ReachyBleLink) -> None:
+    """System status characteristic reads as Online."""
+    assert link.read_char(SYSTEM_STATUS_UUID) == "Online"
+
+
+def test_network_status_format(link: ReachyBleLink) -> None:
+    """Network status matches the documented MODE [iface] ip format."""
+    status = link.read_char(NETWORK_STATUS_UUID)
+    assert re.fullmatch(
+        r"OFFLINE|ERROR|(HOTSPOT|CONNECTED)( \[\S+\] \S+( ;)?)+", status
+    ), f"unexpected network status: {status!r}"
+
+
+def test_available_commands_match_repo(link: ReachyBleLink) -> None:
+    """The robot reports at least every CMD_* script shipped in this repo."""
+    reported = {c.strip() for c in link.read_char(AVAILABLE_COMMANDS_UUID).split(",")}
+    expected = {p.stem for p in COMMANDS_DIR.glob("*.sh")}
+    assert expected, "no commands/*.sh found in the installed package"
+    missing = expected - reported
+    assert not missing, (
+        f"robot does not expose {sorted(missing)} (has {sorted(reported)})"
+    )
+
+
+def test_hardware_id_characteristic(link: ReachyBleLink) -> None:
+    """Hardware ID reads as 16 lowercase hex chars (or 'unknown')."""
+    if link.characteristic(HARDWARE_ID_UUID) is None:
+        pytest.skip("robot firmware predates the Hardware ID characteristic")
+    hardware_id = link.read_char(HARDWARE_ID_UUID)
+    assert hardware_id == "unknown" or re.fullmatch(r"[0-9a-f]{16}", hardware_id), (
+        f"unexpected hardware id: {hardware_id!r}"
+    )
+
+
+# -- synchronous command round-trips -----------------------------------
+
+
+def test_ping(link: ReachyBleLink) -> None:
+    """PING returns PONG."""
+    assert link.command("PING") == "PONG"
+
+
+def test_echo_roundtrip(link: ReachyBleLink) -> None:
+    """Unknown commands are echoed back verbatim — proves the write/read path."""
+    nonce = f"smoke-{uuid.uuid4().hex[:12]}"
+    assert link.command(nonce) == f"ECHO: {nonce}"
+
+
+def test_journal_stream_lifecycle(link: ReachyBleLink) -> None:
+    """JOURNAL_START/READ/STOP round-trip, leaving streaming stopped."""
+    started = link.command("JOURNAL_START")
+    assert started in ("OK: Journal streaming started", "OK: Journal already streaming")
+    try:
+        read = link.command("JOURNAL_READ")
+        assert not read.startswith("ERROR"), f"journal read failed: {read!r}"
+    finally:
+        assert link.command("JOURNAL_STOP") == "OK: Journal streaming stopped"
+    assert link.command("JOURNAL_READ") == "ERROR: Journal not running"
+
+
+# -- WiFi provisioning, public surface ---------------------------------
+
+
+def test_wifi_status_public_omits_known_networks(link: ReachyBleLink) -> None:
+    """Unauthenticated WIFI_STATUS must NOT leak the saved-network list."""
+    response = link.command("WIFI_STATUS")
+    _skip_if_unsupported(response, "WIFI_STATUS")
+    status = json.loads(response)
+    assert {"mode", "connected"} <= set(status), status
+    assert "known" not in status, "saved networks leaked without authentication"
+
+
+def test_wifi_keyex_returns_fresh_x25519_key(link: ReachyBleLink) -> None:
+    """WIFI_KEYEX is public and returns a valid provisioning pubkey."""
+    response = link.command("WIFI_KEYEX")
+    _skip_if_unsupported(response, "WIFI_KEYEX")
+    key = json.loads(response)
+    assert key.get("alg") == "x25519-hkdf-sha256-aesgcm", key
+    assert key.get("kid"), key
+    assert len(base64.b64decode(key["pk"])) == 32
+
+
+# -- auth gates (no PIN is ever sent) ----------------------------------
+
+
+def test_wifi_scan_requires_auth(link: ReachyBleLink) -> None:
+    """WIFI_SCAN is refused without a PIN session."""
+    response = link.command("WIFI_SCAN")
+    _skip_if_unsupported(response, "WIFI_SCAN")
+    assert response == AUTH_ERROR
+
+
+def test_cmd_scripts_require_auth(link: ReachyBleLink) -> None:
+    """CMD_* scripts are refused without a session (nothing is executed)."""
+    assert link.command("CMD_RESTART_DAEMON") == AUTH_ERROR


### PR DESCRIPTION
New tests/bluetooth_tests suite: read-only smoke tests for the BLE provisioning service, run from an external Linux host with a Bluetooth adapter (e.g. a Raspberry Pi) against a robot in radio range. The suite discovers the robot on its own (advertised name / status-service UUID), imports protocol constants from the firmware source so it fails loudly on protocol drift, and covers GATT layout, the Device Information service, status characteristics, PING/ECHO round-trips, the journal streaming lifecycle, the public WiFi provisioning surface (including the saved-networks-must-not-leak invariant), and the auth gates on privileged commands. No PIN is ever sent (the robot-global wrong-PIN lockout is never armed) and nothing on the robot is mutated.

Scanning goes through BlueZ (bleak), but the connection uses a minimal ATT client over a raw LE L2CAP socket (att_client.py): the robot's dual-mode advertisement makes BlueZ's Device1.Connect pick the classic BR/EDR bearer and fail with br-connection-profile-unavailable, while phones and Web Bluetooth are LE-only and never hit this. The raw socket behaves like them, works unprivileged, and tests the robot exactly as shipped.

Kept outside testpaths with a new 'ble' marker and a 'ble-test' dependency group (bleak); run_on_pi.sh rsyncs the repo to a Pi, bootstraps a minimal venv (handles hosts without python3-venv/pip), and runs the suite. Validated end-to-end: 15/15 passing from a Raspberry Pi against a live robot.

<!-- Read docs/contributing.md before opening your PR. -->

## Issue

Closes #

<!-- The problem, and how to reproduce it.
     If there is no issue yet, describe the problem here and drop the "Closes #" line. -->

## Description

<!-- What the PR does, and why this approach. -->

## Testing

<!-- Evidence it works: test name, log, before/after.
     Measurements on a physical robot are highly encouraged whenever they make sense.
     Paste the logs, charts and how to reproduce them as an annex below this message.
     Good examples: #1294, #1343, #1267. -->

## Tested on

- [ ] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [ ] Not applicable (e.g. docs, typo)

## AI assistance

<!-- Tick exactly one. Assisted commits also carry the Assisted-by trailer, see docs/contributing.md. -->

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [ ] AI wrote code here, and I ran and reviewed it
- [ ] An agent produced this PR, and I have not run it myself

