### PR TITLE
fix(tracking): pitch the head-tracking aim 15° down

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -120,6 +120,11 @@ from reachy_mini.vision.look_at import (
     look_at_image_pose,
 )
 
+# Gaze trim added to lower head-tracking aim pitch. This pose feels better
+# (subjective) and also improves the orientation of the microphone when
+# speaking to it.
+_TRACKING_PITCH_TRIM_RAD = float(np.radians(15.0))
+
 
 class _PlaybackCancelToken:
     """Per-run cancellation handle for ``Backend.play_move``.
@@ -785,7 +790,7 @@ class Backend:
         u = (x_norm + 1.0) * 0.5 * max(width - 1, 1)
         v = (y_norm + 1.0) * 0.5 * max(height - 1, 1)
         try:
-            self._tracking_target_pose = look_at_image_pose(
+            target_pose = look_at_image_pose(
                 u=u,
                 v=v,
                 K=camera_matrix,
@@ -793,6 +798,11 @@ class Backend:
                 T_world_head=self.get_current_head_pose(),
                 T_head_cam=self.T_head_cam,
             )
+            roll_a, pitch_a, yaw_a = R.from_matrix(target_pose[:3, :3]).as_euler("xyz")
+            target_pose[:3, :3] = R.from_euler(
+                "xyz", [roll_a, pitch_a + _TRACKING_PITCH_TRIM_RAD, yaw_a]
+            ).as_matrix()
+            self._tracking_target_pose = target_pose
         except Exception as e:
             self.logger.warning("Head-tracking aim update failed: %s", e)
 

--- a/tests/unit_tests/test_head_tracking_backend.py
+++ b/tests/unit_tests/test_head_tracking_backend.py
@@ -246,3 +246,26 @@ def test_enable_head_tracking_weight_zero_pauses_without_stopping() -> None:
     assert tracker.active_calls[-1] is False
     assert backend._tracking_weight == 0.0
     assert tracker.stopped is False
+
+
+def test_tracking_aim_pitches_down_by_the_trim() -> None:
+    """A face at the image center aims 15 degrees below the camera axis."""
+    backend = _make_backend()
+    backend._tracking_enabled = True
+    backend.set_tracking_face(
+        center=(0.0, 0.0),  # principal point for this camera matrix
+        roll=0.0,
+        width=641,
+        height=481,
+        camera_matrix=np.array(
+            [[640.0, 0.0, 320.0], [0.0, 640.0, 240.0], [0.0, 0.0, 1.0]],
+            dtype=np.float64,
+        ),
+        distortion=np.zeros(5, dtype=np.float64),
+        timestamp=1.0,
+    )
+
+    assert backend._tracking_target_pose is not None
+    _, pitch, yaw = R.from_matrix(backend._tracking_target_pose[:3, :3]).as_euler("xyz")
+    assert abs(pitch - np.radians(15.0)) < 1e-6
+    assert abs(yaw) < 1e-6


### PR DESCRIPTION
Head tracking aims above the face (the look-at ray ignores the camera offset, and the nose target sits above the perceived face center), so the robot stares at hairlines. This pitches the aim 15° down, a value tuned on a wireless robot.

Tested on a Wireless unit.

Also did a performance test, no visible impact of the (minor) extra calculation.