### PR TITLE
docs(wireless): link mainland China HF login community guide

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -371,6 +371,16 @@ export HF_ENDPOINT=https://hf-mirror.com/
 
 Note that you may also need to use mirrors to reach services like PyPI and GitHub.
 
+On **Reachy Mini Wireless**, Hugging Face login timeouts and an empty app store
+are often not a missing mirror. The robot itself must reach Hugging Face (fixing
+the PC is not enough), SSH may be off from the factory (some batches also have
+no host keys, so port 22 refuses), and the daemon's aiohttp `ClientSession()`
+ships with `trust_env` disabled — so `HTTP_PROXY` / `HTTPS_PROXY` alone may do
+nothing.
+
+Community walkthrough (Chinese, one-click wizard + rpiboot SSH rescue without
+reflash): [reachy-mini-cn-survival-guide](https://github.com/DrDavidDa/reachy-mini-cn-survival-guide)
+
 </details>
 
 <details>


### PR DESCRIPTION
## Issue

Closes #1403

Official China FAQ only mentions `hf-mirror.com` / `HF_ENDPOINT`. On Wireless, HF login timeout and an empty app store are usually three stacked issues: the robot's own connection, SSH off / missing host keys, aiohttp `trust_env` off so proxy env vars do nothing.

## Description

One short paragraph under **How to access to HuggingFace services from China?** pointing at the community walkthrough:

https://github.com/DrDavidDa/reachy-mini-cn-survival-guide

Wizard + rpiboot SSH rescue (no reflash) + sitecustomize patch, tested on Wireless daemon 1.10.0.

## Testing

Docs-only. The linked guide was run on a physical Wireless unit.

## Tested on

- [x] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [x] Not applicable (e.g. docs, typo)

## AI assistance

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [x] AI wrote code here, and I ran and reviewed it
- [ ] An agent produced this PR, and I have not run it myself

Made with [Cursor](https://cursor.com)