### PR TITLE
fix(daemon): only start the central relay while the daemon runs

### DIFF
--- a/src/reachy_mini/daemon/app/routers/hf_auth.py
+++ b/src/reachy_mini/daemon/app/routers/hf_auth.py
@@ -334,7 +334,7 @@ async def get_device_oauth_status(session_id: str, request: Request) -> dict[str
         daemon = getattr(request.app.state, "daemon", None)
         if daemon is not None:
             try:
-                await daemon._start_central_signaling_relay()
+                await daemon.start_central_relay_if_running()
             except Exception as e:
                 logger.warning("[oauth/device] relay start failed: %r", e)
 
@@ -404,7 +404,7 @@ async def oauth_callback(
         daemon = getattr(request.app.state, "daemon", None)
         if daemon is not None:
             try:
-                await daemon._start_central_signaling_relay()
+                await daemon.start_central_relay_if_running()
             except Exception as e:
                 logger.warning("[oauth/callback] relay start failed: %r", e)
 

--- a/src/reachy_mini/daemon/daemon.py
+++ b/src/reachy_mini/daemon/daemon.py
@@ -168,6 +168,17 @@ class Daemon:
         self._status.media_released = False
         self.logger.info("Media hardware re-acquired.")
 
+    async def start_central_relay_if_running(self) -> None:
+        """Start the relay after a login, but only while RUNNING with media acquired.
+
+        Elsewhere the local signalling server is down and the relay would loop
+        on connection errors; start()/acquire_media() start it themselves.
+        """
+        if self._status.state != DaemonState.RUNNING or self._media_released:
+            self.logger.info("Daemon not running, relay starts with it")
+            return
+        await self._start_central_signaling_relay()
+
     def _setup_jsonrpc_relay(
         self, backend: "Backend", app_manager: "AppManager"
     ) -> None:

--- a/tests/unit_tests/test_daemon_relay_start.py
+++ b/tests/unit_tests/test_daemon_relay_start.py
@@ -1,0 +1,31 @@
+"""Daemon.start_central_relay_if_running: the login routes' relay hook."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from reachy_mini.daemon.daemon import Daemon
+from reachy_mini.io.protocol import DaemonState
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "media_released", "expected_calls"),
+    [
+        (DaemonState.STOPPED, False, 0),
+        (DaemonState.RUNNING, True, 0),
+        (DaemonState.RUNNING, False, 1),
+    ],
+)
+async def test_relay_started_only_when_daemon_runs(
+    state: DaemonState, media_released: bool, expected_calls: int
+) -> None:
+    """The relay starter runs only when the daemon is RUNNING with media acquired."""
+    daemon = Daemon(no_media=True)
+    daemon._start_central_signaling_relay = AsyncMock()  # type: ignore[method-assign]
+    daemon._status.state = state
+    daemon._media_released = media_released
+
+    await daemon.start_central_relay_if_running()
+
+    assert daemon._start_central_signaling_relay.await_count == expected_calls


### PR DESCRIPTION
<!-- Read docs/contributing.md before opening your PR. -->

## Issue

Closes #1405

## Description

The HF login routes called `_start_central_signaling_relay()` unconditionally. On a stopped daemon there is no local signalling server (it lives with the media stack), so the relay looped on `ws://127.0.0.1:8443` until something restarted the daemon.

`start()` and `acquire_media()` already bring the relay up themselves, so the login hook only has to cover the one case they miss: a token-less boot of an already-running daemon. New `Daemon.start_central_relay_if_running()` does exactly that and both login routes call it.

Counterpart on the wizard side, which brings a stopped daemon back up before waiting on central: pollen-robotics/reachy_mini_mobile_app#93.

## Testing

- `tests/unit_tests/test_daemon_relay_start.py`: three cases (stopped, running with media released, running). `uv run pytest tests/unit_tests/test_daemon_relay_start.py` passes; ruff, ruff format and mypy clean on the touched files.
- On a Wireless robot (1.10.0 with these two files hot-swapped): with the daemon running, HF login still brings the relay to `connected` (`/api/hf-auth/relay-status`). With the daemon stopped by the desktop app, login no longer spawns a relay, and the robot came online once the wizard restarted the daemon (mobile app PR above), reaching `done` on Firefox and Chrome.

## Tested on

- [x] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [ ] Not applicable (e.g. docs, typo)

## AI assistance

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [x] AI wrote code here, and I ran and reviewed it
- [ ] An agent produced this PR, and I have not run it myself
