### PR TITLE
media(turn): point the default TURN credentials URL at the live proxy

### DIFF
--- a/docs/source/SDK/cloud-backend-consumer.md
+++ b/docs/source/SDK/cloud-backend-consumer.md
@@ -122,14 +122,16 @@ candidate of its own (see `_apply_turn_servers` in
 If you need the consumer to allocate its own relay (e.g. when neither
 side can hole-punch), pass an `ice_servers_provider` returning
 `aiortc.RTCIceServer` objects with TURN credentials. The HF-hosted
-Cloudflare TURN proxy at `https://turn.fastrtc.org/credentials` is a
-reasonable default for HF Spaces:
+Cloudflare TURN proxy at `https://fastrtc-turn-service.hf.space/credentials`
+is a reasonable default for HF Spaces. Use a token the visitor owns where
+you can: the free allowance is metered per Hugging Face account, so a
+shared Space secret spends one quota for every visitor.
 
 ```python
 async def _ice():
     async with aiohttp.ClientSession() as s:
         r = await s.get(
-            "https://turn.fastrtc.org/credentials",
+            "https://fastrtc-turn-service.hf.space/credentials",
             headers={"Authorization": f"Bearer {space_secret_hf_token}"},
             params={"ttl": 600},
         )

--- a/src/reachy_mini/media/webrtc_utils.py
+++ b/src/reachy_mini/media/webrtc_utils.py
@@ -29,8 +29,11 @@ logger = logging.getLogger(__name__)
 # STUN. So there is no central-server change and no consumer-side
 # credential to manage (which matters because aiortc's STUN client works
 # while its TURN client does not).
+#
+# turn.fastrtc.org (this default until 2026-09) has dead DNS since June 2026;
+# address the fastrtc/turn-service Space directly.
 TURN_CREDENTIALS_URL = os.getenv(
-    "REACHY_TURN_URL", "https://turn.fastrtc.org/credentials"
+    "REACHY_TURN_URL", "https://fastrtc-turn-service.hf.space/credentials"
 )
 TURN_TTL_SECONDS = int(os.getenv("REACHY_TURN_TTL", "600"))
 


### PR DESCRIPTION
## Problem

`turn.fastrtc.org`, the default `REACHY_TURN_URL`, has had dead DNS since June 2026. The `.org` registry still delegates the zone to four Route53 nameservers, but the hosted zone behind them is gone, so they answer `REFUSED` and resolvers return SERVFAIL (gradio-app/fastrtc#429, unanswered).

Every logged-in robot logs `Failed to fetch TURN credentials` every 30 s and offers host/srflx candidates only, so remote WebRTC has no fallback behind symmetric NAT, CGNAT or a UDP-blocking firewall. Direct and STUN paths still work, which is why demos passed and nobody noticed.

## Repro

```
$ dig +short turn.fastrtc.org        # SERVFAIL
$ journalctl -u reachy-mini-daemon | grep TURN
... WARNING - Failed to fetch TURN credentials: ... Failed to resolve 'turn.fastrtc.org'
```

## Solution

The service behind that alias, the `fastrtc/turn-service` Space, is still up. Address it directly.

Note this resolves #1356 differently from the issue's own proposal (drop the default, make the relay opt-in). A working default gives every robot relay coverage with no configuration, which seems worth more than opting out of an endpoint that now works. Happy to switch to the opt-in version if you disagree.

Verified on a Wireless: the daemon logs `Refreshed 5 TURN server(s)` on a 5 min cadence, and a session to an HF Space backend selected the relay pair and pushed ~2.2 Mbps of video through `turn.cloudflare.com`.

No new test: a default the validator rejects already fails four tests that construct `TurnCredentials()` with no url (checked with `REACHY_TURN_URL=http://evil.example`). A well-formed but dead host is what bit us, and catching that needs live DNS, which belongs in the physical CI workflow.

Fixes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)