### PR TITLE
perf(vision): make face tracking's control-loop cost rate-independent

### DIFF
--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -11,6 +11,7 @@ each type of backend.
 import asyncio
 import json
 import logging
+import math
 import os
 import tempfile
 import threading
@@ -115,10 +116,7 @@ from reachy_mini.utils.interpolation import (
     time_trajectory,
 )
 from reachy_mini.vision.face_tracking import FaceTracker
-from reachy_mini.vision.look_at import (
-    default_head_to_camera_transform,
-    look_at_image_pose,
-)
+from reachy_mini.vision.look_at import default_head_to_camera_transform
 
 
 class _PlaybackCancelToken:
@@ -350,10 +348,17 @@ class Backend:
         self._tracking_enabled = False
         self._tracking_requested_weight = 1.0
         self._tracking_weight = 0.0
-        self._tracking_alpha = 0.15
+        # Aim servo: each control tick moves the aim angles by
+        # clip(p * error, +/-max_step) toward the latest absolute target
+        # angles published by the detector process. p sets responsiveness;
+        # max_step is a hard per-tick velocity limit (~90 deg/s at 50 Hz).
+        self._tracking_p = 0.15
+        self._tracking_max_step_rad = float(np.radians(1.8))
         self._tracking_lost_timeout = 2.0
         self._tracking_aim: Annotated[NDArray[np.float64], (4, 4)] | None = None
-        self._tracking_target_pose: Annotated[NDArray[np.float64], (4, 4)] | None = None
+        self._tracking_aim_rpy: tuple[float, float, float] | None = None
+        self._tracking_target_rpy: tuple[float, float, float] | None = None
+        self._tracking_seq = 0
         self._last_face_seen: float | None = None
         self._tracker: FaceTracker | None = None
         self._tracking_lock = threading.Lock()
@@ -707,94 +712,94 @@ class Backend:
     def clear_tracking_aim(self) -> None:
         """Clear the tracking aim, latched target, and latest detected face."""
         self._tracking_aim = None
-        self._tracking_target_pose = None
+        self._tracking_aim_rpy = None
+        self._tracking_target_rpy = None
+        self._tracking_seq = 0
         self._tracking_weight = 0.0
         self._last_face_seen = None
         self._face_target = FaceTarget()
         self.ik_required = True
 
-    def step_head_tracking(self) -> None:
-        """Ease the aim toward the latest target, holding then recentering on loss.
+    @staticmethod
+    def _pose_rpy(
+        pose: Annotated[NDArray[np.float64], (4, 4)],
+    ) -> tuple[float, float, float]:
+        """Extract (roll, pitch, yaw), extrinsic x-y-z radians, from a pose."""
+        roll, pitch, yaw = R.from_matrix(pose[:3, :3]).as_euler("xyz")
+        return (float(roll), float(pitch), float(yaw))
 
-        A brief detection gap holds the last aim; a sustained loss returns the aim
-        to the neutral head pose so the robot recenters instead of freezing where
-        the person left the frame.
+    def step_head_tracking(self) -> None:
+        """Servo the aim one bounded step toward the latest target angles.
+
+        The detector process publishes absolute head angles ("the face is at
+        these angles in the robot frame"); this method treats the latest
+        publication as where the person is now and moves the aim by
+        ``clip(p * error, +/-max_step)`` per tick. Re-applying a stale absolute
+        target converges and stops, so no timestamps are needed. A brief
+        detection gap holds the last target; a sustained loss retargets the
+        neutral pose so the robot recenters instead of freezing where the
+        person left the frame.
         """
         with self._tracking_lock:
             if not self._tracking_enabled or self._tracking_requested_weight <= 0.0:
                 return
             now = time.monotonic()
             if self._tracker is not None:
-                obs = self._tracker.latest()
-                if obs is not None:
-                    self.set_tracking_face(
-                        obs.center,
-                        obs.roll,
-                        obs.width,
-                        obs.height,
-                        obs.camera_matrix,
-                        obs.distortion,
-                        obs.timestamp,
-                    )
-                    if obs.center is not None:
+                # Share the current head orientation so the detector can turn
+                # a face pixel into absolute angles.
+                self._tracker.publish_head_pose(
+                    *self._pose_rpy(self.get_current_head_pose())
+                )
+                target = self._tracker.latest()
+                if target is not None and target.seq != self._tracking_seq:
+                    self._tracking_seq = target.seq
+                    if target.detected:
+                        self._tracking_target_rpy = (
+                            target.roll,
+                            target.pitch,
+                            target.yaw,
+                        )
+                        self._tracking_weight = self._tracking_requested_weight
                         self._last_face_seen = now
+                        self._face_target = FaceTarget(
+                            detected=True,
+                            x=target.x,
+                            y=target.y,
+                            roll=target.face_roll,
+                            ts=now,
+                        )
+                    else:
+                        # Hold the last target on a transient loss so the head
+                        # doesn't lurch to neutral.
+                        self._face_target = FaceTarget(detected=False, ts=now)
             if (
                 self._last_face_seen is not None
                 and now - self._last_face_seen >= self._tracking_lost_timeout
             ):
-                self._tracking_target_pose = self.INIT_HEAD_POSE.copy()
-            if self._tracking_target_pose is None:
+                self._tracking_target_rpy = (0.0, 0.0, 0.0)
+            if self._tracking_target_rpy is None:
                 return
-            if self._tracking_aim is None:
-                self._tracking_aim = self.get_current_head_pose()
-            self._tracking_aim = linear_pose_interpolation(
-                self._tracking_aim, self._tracking_target_pose, self._tracking_alpha
+            if self._tracking_aim_rpy is None:
+                self._tracking_aim_rpy = self._pose_rpy(self.get_current_head_pose())
+            max_step = self._tracking_max_step_rad
+            roll, pitch, yaw = (
+                current
+                + min(
+                    max(
+                        self._tracking_p * math.remainder(target - current, math.tau),
+                        -max_step,
+                    ),
+                    max_step,
+                )
+                for current, target in zip(
+                    self._tracking_aim_rpy, self._tracking_target_rpy
+                )
+            )
+            self._tracking_aim_rpy = (roll, pitch, yaw)
+            self._tracking_aim = create_head_pose(
+                roll=roll, pitch=pitch, yaw=yaw, degrees=False
             )
             self.ik_required = True
-
-    def set_tracking_face(
-        self,
-        center: tuple[float, float] | None,
-        roll: float | None,
-        width: int,
-        height: int,
-        camera_matrix: NDArray[np.float64],
-        distortion: NDArray[np.float64],
-        timestamp: float,
-    ) -> None:
-        """Latch the tracking target from a face observation in tracker-frame pixels."""
-        if not self._tracking_enabled:
-            return
-
-        if center is None:
-            # Hold the last target on a transient loss so the head doesn't lurch to neutral.
-            self._face_target = FaceTarget(detected=False, ts=timestamp)
-            return
-
-        x_norm = float(center[0])
-        y_norm = float(center[1])
-        self._tracking_weight = self._tracking_requested_weight
-        self._face_target = FaceTarget(
-            detected=True,
-            x=x_norm,
-            y=y_norm,
-            roll=roll,
-            ts=timestamp,
-        )
-
-        u = (x_norm + 1.0) * 0.5 * max(width - 1, 1)
-        v = (y_norm + 1.0) * 0.5 * max(height - 1, 1)
-        try:
-            self._tracking_target_pose = look_at_image_pose(
-                u=u,
-                v=v,
-                K=camera_matrix,
-                D=distortion,
-                T_world_head=self.get_current_head_pose(),
-                T_head_cam=self.T_head_cam,
-            )
-        except Exception as e:
-            self.logger.warning("Head-tracking aim update failed: %s", e)
 
     def get_tracked_face(self) -> FaceTarget:
         """Return the latest face target observed by daemon-side tracking."""

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -736,9 +736,10 @@ class Backend:
     def step_head_tracking(self) -> None:
         """Servo the aim one bounded step toward the latest target angles.
 
-        The detector process publishes absolute head angles ("the face is at
-        these angles in the robot frame"); this method treats the latest
-        publication as where the person is now and moves the aim by
+        The detector process publishes the absolute head orientation that
+        looks at the face; this method converts it to angles, adds the gaze
+        trim, treats the latest publication as where the person is now and
+        moves the aim by
         ``clip(p * error, +/-max_step)`` per tick. Re-applying a stale absolute
         target converges and stops, so no timestamps are needed. A brief
         detection gap holds the last target; a sustained loss retargets the
@@ -751,18 +752,17 @@ class Backend:
             now = time.monotonic()
             if self._tracker is not None:
                 # Share the current head orientation so the detector can turn
-                # a face pixel into absolute angles.
-                self._tracker.publish_head_pose(
-                    *self._pose_rpy(self.get_current_head_pose())
-                )
+                # a face pixel into an absolute orientation.
+                self._tracker.publish_head_pose(self.get_current_head_pose()[:3, :3])
                 target = self._tracker.latest()
                 if target is not None and target.seq != self._tracking_seq:
                     self._tracking_seq = target.seq
                     if target.detected:
+                        roll, pitch, yaw = R.from_matrix(target.rotation).as_euler("xyz")
                         self._tracking_target_rpy = (
-                            target.roll,
-                            target.pitch,
-                            target.yaw,
+                            float(roll),
+                            float(pitch) + _TRACKING_PITCH_TRIM_RAD,
+                            float(yaw),
                         )
                         self._tracking_weight = self._tracking_requested_weight
                         self._last_face_seen = now

--- a/src/reachy_mini/vision/face_tracking.py
+++ b/src/reachy_mini/vision/face_tracking.py
@@ -1,80 +1,125 @@
-"""Face tracking: a YuNet detector thread feeding the daemon the latest observation."""
+"""Face tracking: a detector process publishing absolute head angles to aim at.
+
+Detection runs in a separate *process*, not a thread: YuNet's pre/post
+processing holds the GIL in chunks that measurably stall the daemon's 50 Hz
+control loop when they share an interpreter. The exchange with the daemon is
+two fixed-size "latest value" mailboxes, deliberately without timestamps or
+queues:
+
+- daemon -> detector: the current head orientation (roll, pitch, yaw), so the
+  detector can turn a face pixel into *absolute* target angles in the robot
+  frame;
+- detector -> daemon: "a face is at these absolute head angles" (plus the
+  normalized face position as telemetry for ``get_tracked_face``).
+
+The daemon treats the latest published target as where the person is *now* and
+servos toward it with a small bounded step per control tick. Re-applying a
+stale absolute target converges toward it and stops; this is what makes the
+no-timestamp design safe (a stale *delta* would instead be integrated over and
+over and overshoot).
+"""
 
 import logging
+import math
+import multiprocessing
 import os
 import platform
-import queue
-import threading
 import time
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
 
 import gi
 import numpy as np
 from numpy.typing import NDArray
+from scipy.spatial.transform import Rotation
 
 from reachy_mini.daemon.utils import CAMERA_PIPE_NAME, CAMERA_SOCKET_PATH
 from reachy_mini.media.camera_constants import CameraSpecs
 from reachy_mini.media.camera_utils import intrinsics_for_size
 from reachy_mini.vision.face_detector import Face, FaceDetector
+from reachy_mini.vision.look_at import look_at_image_pose
 
 gi.require_version("Gst", "1.0")
 gi.require_version("GstApp", "1.0")
 # GstApp is unused directly but installs appsink.try_pull_sample().
 from gi.repository import Gst, GstApp  # noqa: E402, F401
 
+if TYPE_CHECKING:
+    from multiprocessing.process import BaseProcess
+    from multiprocessing.sharedctypes import SynchronizedArray
+
 logger = logging.getLogger(__name__)
 
 # Detector input width; smaller trades recall for CPU.
 _TRACKING_WIDTH = 320
 
+# The detector's own detection-rate cap. The local IPC feed is itself capped at
+# 10 FPS today, so this is redundant until the feed rate becomes configurable
+# (https://github.com/pollen-robotics/reachy_mini/issues/1263); at that point
+# this constant should read the configured rate instead of being hardcoded.
+_DETECTION_FPS = 10
 
-@dataclass
-class FaceObservation:
-    """A face target in ``set_tracking_face`` form (face center normalized to [-1, 1])."""
+# Gaze trim: added to the target pitch so the robot looks at the face rather
+# than above it. The raw look-at consistently aims high (the geometry ignores
+# the camera's offset from the head center, and the nose target sits above the
+# perceived face center), so positive values pitch the gaze DOWN. Tune on
+# hardware.
+_PITCH_OFFSET_RAD = float(np.radians(15.0))
 
-    center: tuple[float, float] | None
-    roll: float | None
-    width: int
-    height: int
-    camera_matrix: NDArray[np.float64]
-    distortion: NDArray[np.float64]
-    timestamp: float
+# Target mailbox layout (detector -> daemon), all doubles:
+# [seq, detected, roll, pitch, yaw, x_norm, y_norm, face_roll]
+_TARGET_SLOTS = 8
+# Head-pose mailbox layout (daemon -> detector): [valid, roll, pitch, yaw]
+_POSE_SLOTS = 4
 
 
-class _AdaptiveCenterFilter:
-    """Internal face-center smoother with fixed tracking parameters."""
+class _RateGate:
+    """Time-based frame gate allowing at most ``fps`` detections per second.
 
-    _ALPHA = 0.3
-    _FAST_ALPHA = 0.6
-    _MOVEMENT_THRESHOLD = 0.15
-    _DEAD_ZONE = 0.02
+    The cap must live here, in the consumer loop, not in a GStreamer
+    ``videorate``: buffers cross the unixfd IPC boundary with PTS 0 (verified
+    on wireless hardware), so any timestamp-based dropping passes the first
+    frame and then drops every one after it, silently disabling tracking.
+    """
 
-    def __init__(self) -> None:
-        self._value: NDArray[np.float64] | None = None
-        self._previous_input: NDArray[np.float64] | None = None
+    def __init__(self, fps: float) -> None:
+        self._interval = 1.0 / fps
+        self._next: float | None = None
 
-    def update(self, center: tuple[float, float]) -> tuple[float, float]:
-        """Consume one raw center and return the filtered center."""
-        current = np.asarray(center, dtype=np.float64)
-        if self._value is None or self._previous_input is None:
-            self._value = current.copy()
-            self._previous_input = current.copy()
-            return center
+    def ready(self, now: float) -> bool:
+        """Whether a frame arriving at ``now`` should be processed."""
+        if self._next is None:
+            self._next = now + self._interval
+            return True
+        # Quarter-interval tolerance so feed jitter at exactly the cap rate
+        # does not drop every other frame.
+        if now < self._next - 0.25 * self._interval:
+            return False
+        # Advance by whole intervals so a fast feed settles at the cap and a
+        # slow feed passes straight through.
+        self._next = max(self._next + self._interval, now)
+        return True
 
-        movement = float(np.linalg.norm(current - self._previous_input))
-        self._previous_input = current.copy()
-        delta = current - self._value
-        if float(np.linalg.norm(delta)) < self._DEAD_ZONE:
-            return (float(self._value[0]), float(self._value[1]))
 
-        alpha = self._FAST_ALPHA if movement > self._MOVEMENT_THRESHOLD else self._ALPHA
-        self._value += alpha * delta
-        return (float(self._value[0]), float(self._value[1]))
+@dataclass(frozen=True)
+class TrackingTarget:
+    """One published aim target: absolute head angles plus face telemetry.
 
-    def reset(self) -> None:
-        """Forget filter history so the next observation is accepted immediately."""
-        self._value = None
-        self._previous_input = None
+    ``seq`` increments on every processed frame; the daemon uses it to tell a
+    fresh publication from the previous one. Angles are radians, extrinsic
+    x-y-z (roll, pitch, yaw) in the robot frame. ``x``/``y``/``face_roll`` are
+    telemetry for ``get_tracked_face`` (normalized face center in [-1, 1] and
+    the eye-line roll), None when no face is detected.
+    """
+
+    seq: int
+    detected: bool
+    roll: float
+    pitch: float
+    yaw: float
+    x: float | None
+    y: float | None
+    face_roll: float | None
 
 
 def _area(face: Face) -> float:
@@ -140,87 +185,77 @@ class Tracker:
         return self._center is not None
 
 
-def to_observation(
-    face: Face | None,
-    width: int,
-    height: int,
-    camera_matrix: NDArray[np.float64],
-    distortion: NDArray[np.float64],
-    timestamp: float,
-) -> FaceObservation:
-    """Reduce the tracked face (or its absence) to one normalized observation."""
-    if face is None:
-        return FaceObservation(
-            None, None, width, height, camera_matrix, distortion, timestamp
-        )
-    roll = float(
-        np.arctan2(
-            face.left_eye[1] - face.right_eye[1],
-            face.left_eye[0] - face.right_eye[0],
-        )
-    )
-    return FaceObservation(
-        _center(face, width, height),
-        roll,
-        width,
-        height,
-        camera_matrix,
-        distortion,
-        timestamp,
-    )
+class _EventLike(Protocol):
+    """The Event subset shared by threading and multiprocessing events."""
+
+    def is_set(self) -> bool:
+        """Whether the event is set."""
+        ...
+
+    def wait(self, timeout: float | None = None) -> bool:
+        """Wait up to ``timeout`` for the event; return whether it is set."""
+        ...
 
 
-class FaceTracker:
-    """Run the face detector in a daemon thread and expose the latest observation."""
+class _DetectionWorker:
+    """Detector-side pipeline, detection, selection, and target publication.
 
-    def __init__(self) -> None:
-        """Initialize the tracker; no thread is started until ``start``."""
-        self._thread: threading.Thread | None = None
-        self._stop = threading.Event()
-        self._active = threading.Event()
-        self._observations: queue.SimpleQueue[FaceObservation] = queue.SimpleQueue()
+    Runs in the detector process in production; unit tests run it in a thread
+    (the shared arrays and events work identically in-process), which is why
+    the events are duck-typed.
+    """
+
+    def __init__(
+        self,
+        camera_specs: CameraSpecs,
+        target_mailbox: "SynchronizedArray[float]",
+        pose_mailbox: "SynchronizedArray[float]",
+        active: _EventLike,
+        stop: _EventLike,
+    ) -> None:
+        """Wire the worker to its camera specs, mailboxes, and control events."""
+        self._camera_specs = camera_specs
+        self._target_mailbox = target_mailbox
+        self._pose_mailbox = pose_mailbox
+        self._active = active
+        self._stop = stop
         self._selector = Tracker()
-        self._center_filter = _AdaptiveCenterFilter()
+        self._seq = 0
 
-    def start(self, camera_specs: CameraSpecs) -> None:
-        """Start the detector thread if it is not already running."""
-        if self._thread is not None and self._thread.is_alive():
-            return
-        self._stop.clear()
-        # Drop observations left over from a previous run.
-        self._observations = queue.SimpleQueue()
-        self._selector = Tracker()
-        self._center_filter.reset()
-        self._thread = threading.Thread(
-            target=self._run, args=(camera_specs,), daemon=True, name="face-tracker"
-        )
-        self._thread.start()
+    def _current_head_pose(self) -> NDArray[np.float64] | None:
+        """Rebuild the daemon's last published head pose, or None if none yet."""
+        with self._pose_mailbox.get_lock():
+            valid = self._pose_mailbox[0]
+            roll, pitch, yaw = (
+                self._pose_mailbox[1],
+                self._pose_mailbox[2],
+                self._pose_mailbox[3],
+            )
+        if valid == 0.0:
+            return None
+        pose = np.eye(4, dtype=np.float64)
+        pose[:3, :3] = Rotation.from_euler("xyz", [roll, pitch, yaw]).as_matrix()
+        return pose
 
-    def set_active(self, active: bool) -> None:
-        """Pause or resume detection; a paused tracker disconnects from the camera feed."""
-        if active:
-            self._active.set()
-        else:
-            self._active.clear()
-
-    def latest(self) -> FaceObservation | None:
-        """Return the most recent observation, draining any backlog."""
-        obs: FaceObservation | None = None
-        while not self._observations.empty():
-            obs = self._observations.get_nowait()
-        return obs
-
-    def stop(self) -> None:
-        """Stop the detector thread."""
-        self._stop.set()
-        if self._thread is None:
-            return
-        self._thread.join(timeout=2.0)
-        if self._thread.is_alive():
-            # Keep the handle: forgetting a live thread lets start() clear its stop flag and double-run.
-            logger.warning("Face tracker thread did not stop in time.")
-        else:
-            self._thread = None
+    def _publish(
+        self,
+        detected: bool,
+        rpy: tuple[float, float, float] = (0.0, 0.0, 0.0),
+        x: float = math.nan,
+        y: float = math.nan,
+        face_roll: float = math.nan,
+    ) -> None:
+        """Publish one target to the mailbox (latest value wins)."""
+        self._seq += 1
+        with self._target_mailbox.get_lock():
+            self._target_mailbox[0] = float(self._seq)
+            self._target_mailbox[1] = 1.0 if detected else 0.0
+            self._target_mailbox[2] = rpy[0]
+            self._target_mailbox[3] = rpy[1]
+            self._target_mailbox[4] = rpy[2]
+            self._target_mailbox[5] = x
+            self._target_mailbox[6] = y
+            self._target_mailbox[7] = face_roll
 
     def _process_detections(
         self,
@@ -229,23 +264,44 @@ class FaceTracker:
         height: int,
         camera_matrix: NDArray[np.float64],
         distortion: NDArray[np.float64],
-        timestamp: float,
     ) -> None:
-        """Select, filter, and emit one observation from a detection frame."""
+        """Select a face and publish the absolute head angles that aim at it."""
         face = self._selector.select(faces, width, height)
-        if face is None and not self._selector.has_target:
-            self._center_filter.reset()
-        observation = to_observation(
-            face, width, height, camera_matrix, distortion, timestamp
+        if face is None:
+            self._publish(detected=False)
+            return
+        head_pose = self._current_head_pose()
+        if head_pose is None:
+            # The daemon has not published its head pose yet; without it a
+            # pixel cannot become an absolute angle, so report a miss.
+            self._publish(detected=False)
+            return
+        target_pose = look_at_image_pose(
+            u=face.nose[0],
+            v=face.nose[1],
+            K=camera_matrix,
+            D=distortion,
+            T_world_head=head_pose,
         )
-        if observation.center is not None:
-            observation.center = self._center_filter.update(observation.center)
-        self._observations.put(observation)
+        rpy = Rotation.from_matrix(target_pose[:3, :3]).as_euler("xyz")
+        rpy[1] += _PITCH_OFFSET_RAD
+        face_roll = float(
+            np.arctan2(
+                face.left_eye[1] - face.right_eye[1],
+                face.left_eye[0] - face.right_eye[0],
+            )
+        )
+        x, y = _center(face, width, height)
+        self._publish(
+            detected=True,
+            rpy=(float(rpy[0]), float(rpy[1]), float(rpy[2])),
+            x=x,
+            y=y,
+            face_roll=face_roll,
+        )
 
-    def _run(self, camera_specs: CameraSpecs) -> None:
-        # Lowest priority (Linux-only per-thread nice) so the detector yields CPU to the rest of the daemon.
-        if platform.system() == "Linux":
-            os.setpriority(os.PRIO_PROCESS, threading.get_native_id(), 19)
+    def run(self) -> None:
+        """Consume the camera feed and publish aim targets until stopped."""
         Gst.init([])
         windows = platform.system() == "Windows"
         source = Gst.ElementFactory.make("win32ipcvideosrc" if windows else "unixfdsrc")
@@ -271,7 +327,7 @@ class FaceTracker:
             source.set_property("socket-path", CAMERA_SOCKET_PATH)
         queue_frames.set_property("leaky", 2)
         queue_frames.set_property("max-size-buffers", 1)
-        src_w, src_h = camera_specs.default_resolution.value[:2]
+        src_w, src_h = self._camera_specs.default_resolution.value[:2]
         width = min(_TRACKING_WIDTH, src_w)
         height = max(2, round(width * src_h / src_w / 2) * 2)
         capsfilter.set_property(
@@ -296,15 +352,16 @@ class FaceTracker:
                 )
                 return
 
-        crop_scale = camera_specs.default_resolution.value[3]
+        crop_scale = self._camera_specs.default_resolution.value[3]
         camera_matrix: NDArray[np.float64] | None = None
+        bus = pipeline.get_bus()
+        rate_gate = _RateGate(_DETECTION_FPS)
         playing = False
         feed_lost = False
         try:
             detector = FaceDetector()
             while not self._stop.is_set():
                 if not self._active.is_set():
-                    self._center_filter.reset()
                     if playing:
                         # Disconnect while paused so the daemon serves nothing to this client.
                         pipeline.set_state(Gst.State.NULL)
@@ -329,6 +386,24 @@ class FaceTracker:
                     playing = True
                 sample = appsink.try_pull_sample(200 * Gst.MSECOND)
                 if sample is None:
+                    # A pipeline error (lost feed, failed negotiation) leaves the
+                    # appsink returning None forever; surface it and reconnect
+                    # instead of dying silently.
+                    message = bus.timed_pop_filtered(0, Gst.MessageType.ERROR)
+                    if message is not None:
+                        error, _ = message.parse_error()
+                        logger.warning(
+                            "Face tracking pipeline error: %s; reconnecting.",
+                            error.message,
+                        )
+                        pipeline.set_state(Gst.State.NULL)
+                        playing = False
+                        self._stop.wait(1.0)
+                    continue
+                # Cap the detection rate before the frame copy and inference.
+                # The conversion upstream still runs per frame, but on the RPi
+                # that is offloaded to the ISP; the CPU cost lives below here.
+                if not rate_gate.ready(time.monotonic()):
                     continue
                 structure = sample.get_caps().get_structure(0)
                 frame_width = structure.get_value("width")
@@ -339,18 +414,145 @@ class FaceTracker:
                 ).reshape((frame_height, frame_width, 3))
                 if camera_matrix is None:
                     camera_matrix = intrinsics_for_size(
-                        camera_specs.K, crop_scale, (frame_width, frame_height)
+                        self._camera_specs.K, crop_scale, (frame_width, frame_height)
                     )
                 self._process_detections(
                     detector.detect(frame),
                     frame_width,
                     frame_height,
                     camera_matrix,
-                    camera_specs.D,
-                    time.monotonic(),
+                    self._camera_specs.D,
                 )
         except Exception:
-            # With no process boundary left, this is the only place a detector crash gets reported.
+            # Logged in the detector process (stderr -> journal); the parent
+            # additionally notices the dead process in FaceTracker.latest().
             logger.exception("Face tracker crashed.")
         finally:
             pipeline.set_state(Gst.State.NULL)
+
+
+def _worker_entry(
+    camera_specs: CameraSpecs,
+    target_mailbox: "SynchronizedArray[float]",
+    pose_mailbox: "SynchronizedArray[float]",
+    active: _EventLike,
+    stop: _EventLike,
+) -> None:
+    """Run the detection worker; entry point of the detector process."""
+    logging.basicConfig(level=logging.INFO)
+    if hasattr(os, "nice"):
+        try:
+            # The whole detector process yields to the daemon's control loop.
+            os.nice(19)
+        except OSError:
+            pass
+    _DetectionWorker(camera_specs, target_mailbox, pose_mailbox, active, stop).run()
+
+
+class FaceTracker:
+    """Run the face detector in a child process and expose the latest aim target."""
+
+    def __init__(self) -> None:
+        """Initialize the tracker; no process is started until ``start``."""
+        # spawn, not fork: forking the daemon would duplicate its GStreamer,
+        # asyncio, and motor-controller state into the child.
+        self._ctx = multiprocessing.get_context("spawn")
+        self._process: BaseProcess | None = None
+        self._target_mailbox: "SynchronizedArray[float]" = self._ctx.Array(
+            "d", _TARGET_SLOTS
+        )
+        self._pose_mailbox: "SynchronizedArray[float]" = self._ctx.Array(
+            "d", _POSE_SLOTS
+        )
+        self._active = self._ctx.Event()
+        self._stop = self._ctx.Event()
+        self._death_logged = False
+
+    def start(self, camera_specs: CameraSpecs) -> None:
+        """Start the detector process if it is not already running."""
+        if self._process is not None and self._process.is_alive():
+            return
+        self._stop = self._ctx.Event()
+        # Zero the mailboxes so stale targets from a previous run are dropped.
+        with self._target_mailbox.get_lock():
+            for i in range(_TARGET_SLOTS):
+                self._target_mailbox[i] = 0.0
+        with self._pose_mailbox.get_lock():
+            for i in range(_POSE_SLOTS):
+                self._pose_mailbox[i] = 0.0
+        self._death_logged = False
+        self._process = self._ctx.Process(
+            target=_worker_entry,
+            args=(
+                camera_specs,
+                self._target_mailbox,
+                self._pose_mailbox,
+                self._active,
+                self._stop,
+            ),
+            daemon=True,
+            name="face-tracker",
+        )
+        self._process.start()
+
+    def set_active(self, active: bool) -> None:
+        """Pause or resume detection; a paused tracker disconnects from the camera feed."""
+        if active:
+            self._active.set()
+        else:
+            self._active.clear()
+
+    def publish_head_pose(self, roll: float, pitch: float, yaw: float) -> None:
+        """Share the daemon's current head orientation with the detector."""
+        with self._pose_mailbox.get_lock():
+            self._pose_mailbox[0] = 1.0
+            self._pose_mailbox[1] = roll
+            self._pose_mailbox[2] = pitch
+            self._pose_mailbox[3] = yaw
+
+    def latest(self) -> TrackingTarget | None:
+        """Return the latest published aim target, or None before the first one."""
+        if (
+            self._process is not None
+            and not self._process.is_alive()
+            and not self._stop.is_set()
+            and not self._death_logged
+        ):
+            self._death_logged = True
+            logger.warning(
+                "Face tracker process died (exit code %s); no more targets.",
+                self._process.exitcode,
+            )
+        with self._target_mailbox.get_lock():
+            values = [self._target_mailbox[i] for i in range(_TARGET_SLOTS)]
+        seq = int(values[0])
+        if seq == 0:
+            return None
+        detected = values[1] != 0.0
+        return TrackingTarget(
+            seq=seq,
+            detected=detected,
+            roll=values[2],
+            pitch=values[3],
+            yaw=values[4],
+            x=values[5] if detected else None,
+            y=values[6] if detected else None,
+            face_roll=values[7] if detected else None,
+        )
+
+    def stop(self) -> None:
+        """Stop the detector process."""
+        self._stop.set()
+        process = self._process
+        if process is None:
+            return
+        process.join(timeout=2.0)
+        if process.is_alive():
+            # Unlike a thread, a wedged child can be reclaimed by force.
+            process.terminate()
+            process.join(timeout=1.0)
+        if process.is_alive():
+            # Keep the handle: forgetting a live process lets start() double-run.
+            logger.warning("Face tracker process did not stop in time.")
+            return
+        self._process = None

--- a/src/reachy_mini/vision/face_tracking.py
+++ b/src/reachy_mini/vision/face_tracking.py
@@ -6,11 +6,16 @@ control loop when they share an interpreter. The exchange with the daemon is
 two fixed-size "latest value" mailboxes, deliberately without timestamps or
 queues:
 
-- daemon -> detector: the current head orientation (roll, pitch, yaw), so the
-  detector can turn a face pixel into *absolute* target angles in the robot
-  frame;
-- detector -> daemon: "a face is at these absolute head angles" (plus the
-  normalized face position as telemetry for ``get_tracked_face``).
+- daemon -> detector: the current head orientation (a 3x3 rotation), so the
+  detector can turn a face pixel into an *absolute* target orientation in the
+  robot frame;
+- detector -> daemon: "looking at the face means this absolute head
+  orientation" (plus the normalized face position as telemetry for
+  ``get_tracked_face``).
+
+Both mailboxes carry plain rotation matrices, so the detector needs no Euler
+conversion and no rotation library; the daemon converts the target to angles
+for its servo.
 
 The daemon treats the latest published target as where the person is *now* and
 servos toward it with a small bounded step per control tick. Re-applying a
@@ -31,7 +36,6 @@ from typing import TYPE_CHECKING, Protocol
 import gi
 import numpy as np
 from numpy.typing import NDArray
-from scipy.spatial.transform import Rotation
 
 from reachy_mini.daemon.utils import CAMERA_PIPE_NAME, CAMERA_SOCKET_PATH
 from reachy_mini.media.camera_constants import CameraSpecs
@@ -59,18 +63,11 @@ _TRACKING_WIDTH = 320
 # this constant should read the configured rate instead of being hardcoded.
 _DETECTION_FPS = 10
 
-# Gaze trim: added to the target pitch so the robot looks at the face rather
-# than above it. The raw look-at consistently aims high (the geometry ignores
-# the camera's offset from the head center, and the nose target sits above the
-# perceived face center), so positive values pitch the gaze DOWN. Tune on
-# hardware.
-_PITCH_OFFSET_RAD = float(np.radians(15.0))
-
 # Target mailbox layout (detector -> daemon), all doubles:
-# [seq, detected, roll, pitch, yaw, x_norm, y_norm, face_roll]
-_TARGET_SLOTS = 8
-# Head-pose mailbox layout (daemon -> detector): [valid, roll, pitch, yaw]
-_POSE_SLOTS = 4
+# [seq, detected, R00 .. R22 (row-major 3x3 rotation), x_norm, y_norm, face_roll]
+_TARGET_SLOTS = 14
+# Head-pose mailbox layout (daemon -> detector): [valid, R00 .. R22]
+_POSE_SLOTS = 10
 
 
 class _RateGate:
@@ -103,20 +100,19 @@ class _RateGate:
 
 @dataclass(frozen=True)
 class TrackingTarget:
-    """One published aim target: absolute head angles plus face telemetry.
+    """One published aim target: absolute head orientation plus face telemetry.
 
     ``seq`` increments on every processed frame; the daemon uses it to tell a
-    fresh publication from the previous one. Angles are radians, extrinsic
-    x-y-z (roll, pitch, yaw) in the robot frame. ``x``/``y``/``face_roll`` are
-    telemetry for ``get_tracked_face`` (normalized face center in [-1, 1] and
-    the eye-line roll), None when no face is detected.
+    fresh publication from the previous one. ``rotation`` is the 3x3 world
+    orientation the head should take to look at the face (identity on a
+    miss). ``x``/``y``/``face_roll`` are telemetry for ``get_tracked_face``
+    (normalized face center in [-1, 1] and the eye-line roll), None when no
+    face is detected.
     """
 
     seq: int
     detected: bool
-    roll: float
-    pitch: float
-    yaw: float
+    rotation: NDArray[np.float64]
     x: float | None
     y: float | None
     face_roll: float | None
@@ -225,37 +221,32 @@ class _DetectionWorker:
     def _current_head_pose(self) -> NDArray[np.float64] | None:
         """Rebuild the daemon's last published head pose, or None if none yet."""
         with self._pose_mailbox.get_lock():
-            valid = self._pose_mailbox[0]
-            roll, pitch, yaw = (
-                self._pose_mailbox[1],
-                self._pose_mailbox[2],
-                self._pose_mailbox[3],
-            )
-        if valid == 0.0:
+            values = [self._pose_mailbox[i] for i in range(_POSE_SLOTS)]
+        if values[0] == 0.0:
             return None
         pose = np.eye(4, dtype=np.float64)
-        pose[:3, :3] = Rotation.from_euler("xyz", [roll, pitch, yaw]).as_matrix()
+        pose[:3, :3] = np.asarray(values[1:10], dtype=np.float64).reshape(3, 3)
         return pose
 
     def _publish(
         self,
         detected: bool,
-        rpy: tuple[float, float, float] = (0.0, 0.0, 0.0),
+        rotation: NDArray[np.float64] | None = None,
         x: float = math.nan,
         y: float = math.nan,
         face_roll: float = math.nan,
     ) -> None:
         """Publish one target to the mailbox (latest value wins)."""
         self._seq += 1
+        flat = (np.eye(3) if rotation is None else np.asarray(rotation)).reshape(-1)
         with self._target_mailbox.get_lock():
             self._target_mailbox[0] = float(self._seq)
             self._target_mailbox[1] = 1.0 if detected else 0.0
-            self._target_mailbox[2] = rpy[0]
-            self._target_mailbox[3] = rpy[1]
-            self._target_mailbox[4] = rpy[2]
-            self._target_mailbox[5] = x
-            self._target_mailbox[6] = y
-            self._target_mailbox[7] = face_roll
+            for i, value in enumerate(flat):
+                self._target_mailbox[2 + i] = float(value)
+            self._target_mailbox[11] = x
+            self._target_mailbox[12] = y
+            self._target_mailbox[13] = face_roll
 
     def _process_detections(
         self,
@@ -265,7 +256,7 @@ class _DetectionWorker:
         camera_matrix: NDArray[np.float64],
         distortion: NDArray[np.float64],
     ) -> None:
-        """Select a face and publish the absolute head angles that aim at it."""
+        """Select a face and publish the absolute head orientation that aims at it."""
         face = self._selector.select(faces, width, height)
         if face is None:
             self._publish(detected=False)
@@ -283,8 +274,6 @@ class _DetectionWorker:
             D=distortion,
             T_world_head=head_pose,
         )
-        rpy = Rotation.from_matrix(target_pose[:3, :3]).as_euler("xyz")
-        rpy[1] += _PITCH_OFFSET_RAD
         face_roll = float(
             np.arctan2(
                 face.left_eye[1] - face.right_eye[1],
@@ -294,7 +283,7 @@ class _DetectionWorker:
         x, y = _center(face, width, height)
         self._publish(
             detected=True,
-            rpy=(float(rpy[0]), float(rpy[1]), float(rpy[2])),
+            rotation=target_pose[:3, :3],
             x=x,
             y=y,
             face_roll=face_roll,
@@ -502,13 +491,13 @@ class FaceTracker:
         else:
             self._active.clear()
 
-    def publish_head_pose(self, roll: float, pitch: float, yaw: float) -> None:
-        """Share the daemon's current head orientation with the detector."""
+    def publish_head_pose(self, rotation: NDArray[np.float64]) -> None:
+        """Share the daemon's current head orientation (3x3) with the detector."""
+        flat = np.asarray(rotation, dtype=np.float64).reshape(-1)
         with self._pose_mailbox.get_lock():
             self._pose_mailbox[0] = 1.0
-            self._pose_mailbox[1] = roll
-            self._pose_mailbox[2] = pitch
-            self._pose_mailbox[3] = yaw
+            for i, value in enumerate(flat):
+                self._pose_mailbox[1 + i] = float(value)
 
     def latest(self) -> TrackingTarget | None:
         """Return the latest published aim target, or None before the first one."""
@@ -532,12 +521,10 @@ class FaceTracker:
         return TrackingTarget(
             seq=seq,
             detected=detected,
-            roll=values[2],
-            pitch=values[3],
-            yaw=values[4],
-            x=values[5] if detected else None,
-            y=values[6] if detected else None,
-            face_roll=values[7] if detected else None,
+            rotation=np.asarray(values[2:11], dtype=np.float64).reshape(3, 3),
+            x=values[11] if detected else None,
+            y=values[12] if detected else None,
+            face_roll=values[13] if detected else None,
         )
 
     def stop(self) -> None:

--- a/tests/unit_tests/test_face_tracking.py
+++ b/tests/unit_tests/test_face_tracking.py
@@ -1,6 +1,8 @@
-"""Tests for face-tracking selection, observation reduction, and thread lifecycle."""
+"""Tests for face-tracking selection, target publication, and process lifecycle."""
 
+import multiprocessing
 import threading
+import time
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
@@ -9,10 +11,18 @@ import pytest
 
 from reachy_mini.media.camera_constants import ReachyMiniLiteCamSpecs
 from reachy_mini.vision import face_tracking
-from reachy_mini.vision.face_tracking import FaceTracker, Tracker, to_observation
+from reachy_mini.vision.face_tracking import (
+    FaceTracker,
+    Tracker,
+    TrackingTarget,
+    _DetectionWorker,
+)
 
 if TYPE_CHECKING:
+    from multiprocessing.sharedctypes import SynchronizedArray
+
     from reachy_mini.media.camera_constants import CameraSpecs
+    from reachy_mini.vision.face_tracking import _EventLike
 
 
 def _face(
@@ -24,85 +34,80 @@ def _face(
     return SimpleNamespace(bbox=bbox, right_eye=right_eye, left_eye=left_eye, nose=nose)
 
 
-def test_to_observation_no_face_reports_undetected() -> None:
-    """No face yields an undetected observation that still carries frame metadata."""
-    obs = to_observation(None, 640, 480, np.eye(3), np.zeros(5), 2.0)
-    assert obs.center is None
-    assert obs.roll is None
-    assert obs.timestamp == 2.0
-
-
-def test_to_observation_normalizes_nose_and_roll() -> None:
-    """The aim point is the normalized nose and roll is the signed eye angle."""
-    obs = to_observation(
-        _face((0.0, 0.0, 2.0, 2.0), (0.0, 0.0), (2.0, 2.0), (1.0, 1.0)),
-        3,
-        3,
-        np.eye(3),
-        np.zeros(5),
-        1.0,
+def _make_worker() -> tuple[
+    _DetectionWorker, "SynchronizedArray[float]", "SynchronizedArray[float]"
+]:
+    target_mailbox = multiprocessing.Array("d", face_tracking._TARGET_SLOTS)
+    pose_mailbox = multiprocessing.Array("d", face_tracking._POSE_SLOTS)
+    worker = _DetectionWorker(
+        ReachyMiniLiteCamSpecs(),
+        target_mailbox,
+        pose_mailbox,
+        threading.Event(),
+        threading.Event(),
     )
-    assert obs.center == (0.0, 0.0)
-    assert obs.roll == float(np.arctan2(2.0, 2.0))
+    return worker, target_mailbox, pose_mailbox
 
 
-def test_face_tracker_filters_emitted_detection_sequence() -> None:
-    """FaceTracker applies its slow, fast, and dead-zone paths to emitted observations."""
-    face_tracker = FaceTracker()
-    camera_matrix = np.eye(3)
-    distortion = np.zeros(5)
-
-    def emit(nose_x: float, timestamp: float) -> tuple[float, float] | None:
-        face = _face(
-            (nose_x - 5.0, 45.0, 10.0, 10.0),
-            (nose_x - 2.0, 48.0),
-            (nose_x + 2.0, 48.0),
-            (nose_x, 50.0),
-        )
-        face_tracker._process_detections(
-            [face], 101, 101, camera_matrix, distortion, timestamp
-        )
-        observation = face_tracker.latest()
-        assert observation is not None
-        return observation.center
-
-    assert emit(50.0, 1.0) == (0.0, 0.0)
-    assert emit(50.5, 2.0) == (0.0, 0.0)  # radial dead zone
-    assert emit(55.0, 3.0) == pytest.approx((0.03, 0.0))  # slow EMA
-    assert emit(75.0, 4.0) == pytest.approx((0.312, 0.0))  # fast EMA
+def _read_target(mailbox: "SynchronizedArray[float]") -> list[float]:
+    with mailbox.get_lock():
+        return list(mailbox)
 
 
-def test_face_tracker_resets_filter_after_target_loss() -> None:
-    """A reacquired face is emitted immediately instead of blending with stale aim."""
-    face_tracker = FaceTracker()
-    camera_matrix = np.eye(3)
-    distortion = np.zeros(5)
-    old_face = _face(
-        (45.0, 45.0, 10.0, 10.0),
-        (48.0, 48.0),
-        (52.0, 48.0),
-        (50.0, 50.0),
-    )
-    new_face = _face(
-        (5.0, 45.0, 10.0, 10.0),
-        (8.0, 48.0),
-        (12.0, 48.0),
-        (10.0, 50.0),
-    )
-    face_tracker._process_detections(
-        [old_face], 101, 101, camera_matrix, distortion, 1.0
-    )
-    for timestamp in range(2, 23):
-        face_tracker._process_detections(
-            [], 101, 101, camera_matrix, distortion, float(timestamp)
-        )
-    face_tracker._process_detections(
-        [new_face], 101, 101, camera_matrix, distortion, 23.0
-    )
+# Principal point at (50, 50): a nose there looks straight along the camera axis.
+_K = np.array([[100.0, 0.0, 50.0], [0.0, 100.0, 50.0], [0.0, 0.0, 1.0]])
+_D = np.zeros(5)
+_CENTERED_FACE = _face(
+    (45.0, 45.0, 10.0, 10.0), (48.0, 48.0), (52.0, 48.0), (50.0, 50.0)
+)
 
-    observation = face_tracker.latest()
-    assert observation is not None
-    assert observation.center == pytest.approx((-0.8, 0.0))
+
+def test_worker_publishes_absolute_angles_with_pitch_trim() -> None:
+    """A centered face with an identity head pose yields yaw 0 and the pitch trim.
+
+    The camera axis coincides with the head's forward axis for an identity
+    pose, so the only pitch in the published target is the deliberate
+    look-lower trim.
+    """
+    worker, target_mailbox, pose_mailbox = _make_worker()
+    with pose_mailbox.get_lock():
+        pose_mailbox[0] = 1.0  # valid, angles all zero (identity head pose)
+
+    worker._process_detections([_CENTERED_FACE], 101, 101, _K, _D)
+
+    values = _read_target(target_mailbox)
+    assert values[0] == 1.0  # seq
+    assert values[1] == 1.0  # detected
+    assert values[2] == pytest.approx(0.0, abs=1e-6)  # roll
+    assert values[3] == pytest.approx(face_tracking._PITCH_OFFSET_RAD, abs=1e-6)
+    assert values[4] == pytest.approx(0.0, abs=1e-6)  # yaw
+    assert values[5] == pytest.approx(0.0, abs=1e-9)  # x_norm
+    assert values[6] == pytest.approx(0.0, abs=1e-9)  # y_norm
+
+
+def test_worker_without_head_pose_reports_a_miss() -> None:
+    """Before the daemon publishes its head pose, a face cannot become a target."""
+    worker, target_mailbox, _ = _make_worker()
+
+    worker._process_detections([_CENTERED_FACE], 101, 101, _K, _D)
+
+    values = _read_target(target_mailbox)
+    assert values[0] == 1.0  # the publication still happened
+    assert values[1] == 0.0  # but as a miss
+
+
+def test_worker_publishes_miss_and_increments_seq_without_faces() -> None:
+    """Every processed frame publishes, so the daemon can distinguish fresh misses."""
+    worker, target_mailbox, pose_mailbox = _make_worker()
+    with pose_mailbox.get_lock():
+        pose_mailbox[0] = 1.0
+
+    worker._process_detections([_CENTERED_FACE], 101, 101, _K, _D)
+    worker._process_detections([], 101, 101, _K, _D)
+
+    values = _read_target(target_mailbox)
+    assert values[0] == 2.0
+    assert values[1] == 0.0
 
 
 def test_tracker_acquires_largest_above_min_size() -> None:
@@ -141,72 +146,182 @@ def test_tracker_drops_track_after_misses_then_reacquires() -> None:
     assert tracker.select([far], 200, 200) is far  # re-acquired
 
 
-def test_face_tracker_falls_back_when_v4l2convert_is_missing(
+def _run_worker_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_find: "object | None" = None,
+) -> dict[str, object]:
+    """Build the worker pipeline with a fake detector; return created elements."""
+    pipeline_ready = threading.Event()
+    created: dict[str, object] = {}
+    element_factory = face_tracking.Gst.ElementFactory
+    original_make = element_factory.make
+
+    def fake_make(factory_name: str, name: str | None = None) -> object:
+        if factory_name == "v4l2convert" and fake_find is not None:
+            raise RuntimeError("No such element: v4l2convert")
+        element = original_make(factory_name, name)
+        created.setdefault(factory_name, element)
+        return element
+
+    class FakeFaceDetector:
+        """Signal that the worker pipeline was built successfully."""
+
+        def __init__(self) -> None:
+            pipeline_ready.set()
+
+    if fake_find is not None:
+        monkeypatch.setattr(element_factory, "find", staticmethod(fake_find))
+    monkeypatch.setattr(element_factory, "make", staticmethod(fake_make))
+    monkeypatch.setattr(face_tracking, "FaceDetector", FakeFaceDetector)
+
+    worker, _, _ = _make_worker()
+    stop = threading.Event()
+    worker._stop = stop
+    thread = threading.Thread(target=worker.run, daemon=True)
+    thread.start()
+    try:
+        assert pipeline_ready.wait(5.0)
+    finally:
+        stop.set()
+        thread.join(5.0)
+    assert not thread.is_alive()
+    return created
+
+
+def test_worker_falls_back_when_v4l2convert_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A missing Linux converter falls back to the portable software chain."""
-    pipeline_ready = threading.Event()
-    created_factories: list[str] = []
     element_factory = face_tracking.Gst.ElementFactory
     original_find = element_factory.find
-    original_make = element_factory.make
 
     def fake_find(factory_name: str) -> object | None:
         if factory_name == "v4l2convert":
             return None
         return original_find(factory_name)
 
-    def fake_make(factory_name: str, name: str | None = None) -> object:
-        if factory_name == "v4l2convert":
-            raise RuntimeError("No such element: v4l2convert")
-        created_factories.append(factory_name)
-        return original_make(factory_name, name)
-
-    class FakeFaceDetector:
-        """Signal that the tracker pipeline was built successfully."""
-
-        def __init__(self) -> None:
-            pipeline_ready.set()
-
-    monkeypatch.setattr(element_factory, "find", staticmethod(fake_find))
-    monkeypatch.setattr(element_factory, "make", staticmethod(fake_make))
-    monkeypatch.setattr(face_tracking, "FaceDetector", FakeFaceDetector)
-
-    tracker = FaceTracker()
-    tracker.start(ReachyMiniLiteCamSpecs())
-    try:
-        assert pipeline_ready.wait(5.0)
-    finally:
-        tracker.stop()
-
-    assert "v4l2convert" not in created_factories
-    assert "videoscale" in created_factories
-    assert "videoconvert" in created_factories
+    created = _run_worker_pipeline(monkeypatch, fake_find=fake_find)
+    assert "v4l2convert" not in created
+    assert "videoscale" in created
+    assert "videoconvert" in created
 
 
-def test_stuck_stop_never_double_spawns(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A stop() that times out keeps the thread handle so restarts stay single."""
-    release = threading.Event()
-    runs: list[threading.Thread] = []
+def test_rate_gate_caps_a_fast_feed_and_passes_a_slow_one() -> None:
+    """The gate settles a 30 Hz feed at the cap and passes a slower feed through."""
+    gate = face_tracking._RateGate(10.0)
+    accepted = [t for t in np.arange(0.0, 2.0, 1 / 30) if gate.ready(float(t))]
+    rate = (len(accepted) - 1) / (accepted[-1] - accepted[0])
+    assert rate == pytest.approx(10.0, rel=0.05)
 
-    def fake_run(self: FaceTracker, camera_specs: "CameraSpecs") -> None:
-        runs.append(threading.current_thread())
-        release.wait(10.0)
+    gate = face_tracking._RateGate(10.0)
+    slow = [t for t in np.arange(0.0, 2.0, 1 / 5) if gate.ready(float(t))]
+    assert len(slow) == 10  # every 5 Hz frame passes
 
-    monkeypatch.setattr(FaceTracker, "_run", fake_run)
+
+def test_rate_gate_tolerates_jitter_at_the_cap_rate() -> None:
+    """Feed jitter at exactly the cap rate must not drop every other frame."""
+    gate = face_tracking._RateGate(10.0)
+    rng = np.random.default_rng(0)
+    times = np.cumsum(0.1 + rng.uniform(-0.005, 0.005, 100))
+    accepted = [t for t in times if gate.ready(float(t))]
+    assert len(accepted) >= 97
+
+
+def _sleepy_worker(
+    camera_specs: "CameraSpecs",
+    target_mailbox: "SynchronizedArray[float]",
+    pose_mailbox: "SynchronizedArray[float]",
+    active: "_EventLike",
+    stop: "_EventLike",
+) -> None:
+    """Stub detector process: hold until asked to stop."""
+    stop.wait(30.0)
+
+
+def _emit_one_worker(
+    camera_specs: "CameraSpecs",
+    target_mailbox: "SynchronizedArray[float]",
+    pose_mailbox: "SynchronizedArray[float]",
+    active: "_EventLike",
+    stop: "_EventLike",
+) -> None:
+    """Stub detector process: publish one target, then hold."""
+    with target_mailbox.get_lock():
+        target_mailbox[0] = 1.0  # seq
+        target_mailbox[1] = 1.0  # detected
+        target_mailbox[2] = 0.1  # roll
+        target_mailbox[3] = 0.2  # pitch
+        target_mailbox[4] = 0.3  # yaw
+        target_mailbox[5] = 0.25  # x
+        target_mailbox[6] = -0.5  # y
+        target_mailbox[7] = 0.05  # face roll
+    stop.wait(30.0)
+
+
+def test_start_is_idempotent_and_stop_reaps_the_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """start() on a live tracker is a no-op and stop() reliably reaps the child."""
+    monkeypatch.setattr(face_tracking, "_worker_entry", _sleepy_worker)
     specs = cast("CameraSpecs", None)
     tracker = FaceTracker()
     tracker.start(specs)
+    first = tracker._process
+    assert first is not None and first.is_alive()
     tracker.start(specs)
-    assert len(runs) == 1  # start on a running tracker is a no-op
+    assert tracker._process is first  # no second detector
 
-    tracker.stop()  # the stub ignores the stop event, so the join times out
-    tracker.start(specs)
-    assert len(runs) == 1  # the live thread is kept; no second detector
-
-    release.set()
-    runs[0].join(timeout=5.0)
-    assert not runs[0].is_alive()
-    tracker.start(specs)
-    assert len(runs) == 2  # once the thread has exited, restart works
     tracker.stop()
+    assert tracker._process is None
+    assert not first.is_alive()
+
+    tracker.start(specs)  # a stopped tracker can be restarted
+    assert tracker._process is not None and tracker._process.is_alive()
+    tracker.stop()
+
+
+def test_latest_returns_target_from_detector_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A target published by the child round-trips through the mailbox intact."""
+    monkeypatch.setattr(face_tracking, "_worker_entry", _emit_one_worker)
+    tracker = FaceTracker()
+    tracker.start(cast("CameraSpecs", None))
+    try:
+        deadline = time.monotonic() + 15.0
+        target: TrackingTarget | None = None
+        while target is None and time.monotonic() < deadline:
+            target = tracker.latest()
+            time.sleep(0.05)
+        assert target is not None
+        assert target.detected is True
+        assert (target.roll, target.pitch, target.yaw) == (0.1, 0.2, 0.3)
+        assert (target.x, target.y, target.face_roll) == (0.25, -0.5, 0.05)
+    finally:
+        tracker.stop()
+
+
+def test_publish_head_pose_reaches_the_pose_mailbox() -> None:
+    """The daemon's head angles land in the mailbox the worker reads."""
+    tracker = FaceTracker()
+    tracker.publish_head_pose(0.1, -0.2, 0.3)
+    with tracker._pose_mailbox.get_lock():
+        assert list(tracker._pose_mailbox) == [1.0, 0.1, -0.2, 0.3]
+
+
+def test_start_hides_stale_target_from_a_previous_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """start() zeroes the mailboxes so a previous run's target is not replayed."""
+    monkeypatch.setattr(face_tracking, "_worker_entry", _sleepy_worker)
+    tracker = FaceTracker()
+    with tracker._target_mailbox.get_lock():
+        tracker._target_mailbox[0] = 7.0
+        tracker._target_mailbox[1] = 1.0
+    assert tracker.latest() is not None
+
+    tracker.start(cast("CameraSpecs", None))
+    try:
+        assert tracker.latest() is None
+    finally:
+        tracker.stop()

--- a/tests/unit_tests/test_face_tracking.py
+++ b/tests/unit_tests/test_face_tracking.py
@@ -62,27 +62,43 @@ _CENTERED_FACE = _face(
 )
 
 
-def test_worker_publishes_absolute_angles_with_pitch_trim() -> None:
-    """A centered face with an identity head pose yields yaw 0 and the pitch trim.
+def _set_head_pose(pose_mailbox: "SynchronizedArray[float]", rotation: np.ndarray) -> None:
+    with pose_mailbox.get_lock():
+        pose_mailbox[0] = 1.0
+        for i, value in enumerate(np.asarray(rotation).reshape(-1)):
+            pose_mailbox[1 + i] = float(value)
+
+
+def test_worker_publishes_the_absolute_look_at_orientation() -> None:
+    """A centered face with an identity head pose yields the identity target.
 
     The camera axis coincides with the head's forward axis for an identity
-    pose, so the only pitch in the published target is the deliberate
-    look-lower trim.
+    pose, so looking at a face on that axis means keeping the identity
+    orientation. The gaze trim is the daemon's business, not the detector's.
     """
     worker, target_mailbox, pose_mailbox = _make_worker()
-    with pose_mailbox.get_lock():
-        pose_mailbox[0] = 1.0  # valid, angles all zero (identity head pose)
+    _set_head_pose(pose_mailbox, np.eye(3))
 
     worker._process_detections([_CENTERED_FACE], 101, 101, _K, _D)
 
     values = _read_target(target_mailbox)
     assert values[0] == 1.0  # seq
     assert values[1] == 1.0  # detected
-    assert values[2] == pytest.approx(0.0, abs=1e-6)  # roll
-    assert values[3] == pytest.approx(face_tracking._PITCH_OFFSET_RAD, abs=1e-6)
-    assert values[4] == pytest.approx(0.0, abs=1e-6)  # yaw
-    assert values[5] == pytest.approx(0.0, abs=1e-9)  # x_norm
-    assert values[6] == pytest.approx(0.0, abs=1e-9)  # y_norm
+    np.testing.assert_allclose(np.array(values[2:11]).reshape(3, 3), np.eye(3), atol=1e-6)
+    assert values[11] == pytest.approx(0.0, abs=1e-9)  # x_norm
+    assert values[12] == pytest.approx(0.0, abs=1e-9)  # y_norm
+
+
+def test_worker_target_is_absolute_in_the_world_frame() -> None:
+    """The same centered face seen from a yawed head yields that yawed orientation."""
+    worker, target_mailbox, pose_mailbox = _make_worker()
+    yawed = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    _set_head_pose(pose_mailbox, yawed)
+
+    worker._process_detections([_CENTERED_FACE], 101, 101, _K, _D)
+
+    values = _read_target(target_mailbox)
+    np.testing.assert_allclose(np.array(values[2:11]).reshape(3, 3), yawed, atol=1e-6)
 
 
 def test_worker_without_head_pose_reports_a_miss() -> None:
@@ -99,8 +115,7 @@ def test_worker_without_head_pose_reports_a_miss() -> None:
 def test_worker_publishes_miss_and_increments_seq_without_faces() -> None:
     """Every processed frame publishes, so the daemon can distinguish fresh misses."""
     worker, target_mailbox, pose_mailbox = _make_worker()
-    with pose_mailbox.get_lock():
-        pose_mailbox[0] = 1.0
+    _set_head_pose(pose_mailbox, np.eye(3))
 
     worker._process_detections([_CENTERED_FACE], 101, 101, _K, _D)
     worker._process_detections([], 101, 101, _K, _D)
@@ -249,12 +264,11 @@ def _emit_one_worker(
     with target_mailbox.get_lock():
         target_mailbox[0] = 1.0  # seq
         target_mailbox[1] = 1.0  # detected
-        target_mailbox[2] = 0.1  # roll
-        target_mailbox[3] = 0.2  # pitch
-        target_mailbox[4] = 0.3  # yaw
-        target_mailbox[5] = 0.25  # x
-        target_mailbox[6] = -0.5  # y
-        target_mailbox[7] = 0.05  # face roll
+        for i in range(9):  # rotation: 1..9 row-major
+            target_mailbox[2 + i] = float(i + 1)
+        target_mailbox[11] = 0.25  # x
+        target_mailbox[12] = -0.5  # y
+        target_mailbox[13] = 0.05  # face roll
     stop.wait(30.0)
 
 
@@ -295,7 +309,7 @@ def test_latest_returns_target_from_detector_process(
             time.sleep(0.05)
         assert target is not None
         assert target.detected is True
-        assert (target.roll, target.pitch, target.yaw) == (0.1, 0.2, 0.3)
+        np.testing.assert_array_equal(target.rotation, np.arange(1.0, 10.0).reshape(3, 3))
         assert (target.x, target.y, target.face_roll) == (0.25, -0.5, 0.05)
     finally:
         tracker.stop()
@@ -304,9 +318,10 @@ def test_latest_returns_target_from_detector_process(
 def test_publish_head_pose_reaches_the_pose_mailbox() -> None:
     """The daemon's head angles land in the mailbox the worker reads."""
     tracker = FaceTracker()
-    tracker.publish_head_pose(0.1, -0.2, 0.3)
+    rotation = np.arange(1.0, 10.0).reshape(3, 3)
+    tracker.publish_head_pose(rotation)
     with tracker._pose_mailbox.get_lock():
-        assert list(tracker._pose_mailbox) == [1.0, 0.1, -0.2, 0.3]
+        assert list(tracker._pose_mailbox) == [1.0, *range(1, 10)]
 
 
 def test_start_hides_stale_target_from_a_previous_run(

--- a/tests/unit_tests/test_head_tracking_backend.py
+++ b/tests/unit_tests/test_head_tracking_backend.py
@@ -12,6 +12,7 @@ from reachy_mini.io.protocol import (
     SetHeadTrackingCmd,
     command_adapter,
 )
+from reachy_mini.vision.face_tracking import TrackingTarget
 
 
 class DummyKinematics:
@@ -30,11 +31,13 @@ class DummyKinematics:
 class DummyTracker:
     """Spy standing in for the face tracker."""
 
-    def __init__(self) -> None:
-        """Initialize spy state."""
+    def __init__(self, target: TrackingTarget | None = None) -> None:
+        """Initialize spy state, optionally with a canned target."""
         self.started = False
         self.stopped = False
         self.active_calls: list[bool] = []
+        self.published_poses: list[tuple[float, float, float]] = []
+        self.target = target
 
     def start(self, camera_specs: object) -> None:
         """Record that the tracker was started."""
@@ -44,9 +47,13 @@ class DummyTracker:
         """Record pause/resume toggles."""
         self.active_calls.append(active)
 
-    def latest(self) -> None:
-        """Report no observation."""
-        return None
+    def publish_head_pose(self, roll: float, pitch: float, yaw: float) -> None:
+        """Record the head pose shared with the detector."""
+        self.published_poses.append((roll, pitch, yaw))
+
+    def latest(self) -> TrackingTarget | None:
+        """Report the canned target."""
+        return self.target
 
     def stop(self) -> None:
         """Record that the tracker was stopped."""
@@ -57,6 +64,19 @@ def _make_backend() -> MockupSimBackend:
     backend = MockupSimBackend(use_audio=False)
     backend.current_head_pose = np.eye(4, dtype=np.float64)
     return backend
+
+
+def _detected_target(seq: int = 1, yaw: float = 0.0) -> TrackingTarget:
+    return TrackingTarget(
+        seq=seq,
+        detected=True,
+        roll=0.0,
+        pitch=0.0,
+        yaw=yaw,
+        x=0.25,
+        y=-0.5,
+        face_roll=0.1,
+    )
 
 
 def test_set_head_tracking_command_toggles_tracking() -> None:
@@ -97,57 +117,67 @@ def test_set_head_tracking_command_toggles_tracking() -> None:
 
 
 def test_get_tracked_face_command_returns_latest_face() -> None:
-    """The query command returns the latest normalized face target."""
+    """The query command returns the latest normalized face telemetry."""
     backend = _make_backend()
     backend._tracking_enabled = True
-    backend.set_tracking_face(
-        center=(0.25, -0.5),
-        roll=0.1,
-        width=640,
-        height=480,
-        camera_matrix=np.array(
-            [[640.0, 0.0, 320.0], [0.0, 640.0, 240.0], [0.0, 0.0, 1.0]],
-            dtype=np.float64,
-        ),
-        distortion=np.zeros(5, dtype=np.float64),
-        timestamp=123.0,
-    )
+    backend._tracker = DummyTracker(target=_detected_target())
+
+    backend.step_head_tracking()
 
     responses: list[dict[str, object]] = []
     backend.process_command(GetTrackedFaceCmd(), send_response=responses.append)
 
-    assert responses == [
-        {
-            "command": "get_tracked_face",
-            "face_target": {
-                "detected": True,
-                "x": 0.25,
-                "y": -0.5,
-                "roll": 0.1,
-                "ts": 123.0,
-            },
-        }
-    ]
+    face_target = responses[0]["face_target"]
+    assert isinstance(face_target, dict)
+    assert face_target["detected"] is True
+    assert face_target["x"] == 0.25
+    assert face_target["y"] == -0.5
+    assert face_target["roll"] == 0.1
+    assert face_target["ts"] is not None
 
 
-def test_step_head_tracking_eases_toward_target() -> None:
-    """The commanded aim glides toward the latched target rather than snapping."""
+def test_step_head_tracking_publishes_head_pose_to_detector() -> None:
+    """Each tracking step shares the current head angles with the detector."""
     backend = _make_backend()
     backend._tracking_enabled = True
-    target = np.eye(4, dtype=np.float64)
-    target[:3, :3] = R.from_euler("z", 0.5).as_matrix()
-    backend._tracking_target_pose = target
-    full = np.linalg.norm(R.from_matrix(target[:3, :3]).as_rotvec())
+    tracker = DummyTracker()
+    backend._tracker = tracker
 
     backend.step_head_tracking()
-    assert backend._tracking_aim is not None
-    angle1 = np.linalg.norm(R.from_matrix(backend._tracking_aim[:3, :3]).as_rotvec())
-    assert 0.0 < angle1 < full
+
+    assert tracker.published_poses == [(0.0, 0.0, 0.0)]
+
+
+def test_step_head_tracking_servos_toward_target_angles() -> None:
+    """The aim converges toward the target with a proportional step per tick."""
+    backend = _make_backend()
+    backend._tracking_enabled = True
+    backend._tracking_target_rpy = (0.0, 0.0, 0.05)
 
     backend.step_head_tracking()
-    angle2 = np.linalg.norm(R.from_matrix(backend._tracking_aim[:3, :3]).as_rotvec())
-    assert angle1 < angle2 < full
+    assert backend._tracking_aim_rpy is not None
+    first_yaw = backend._tracking_aim_rpy[2]
+    assert first_yaw == backend._tracking_p * 0.05  # unclamped proportional step
+
+    backend.step_head_tracking()
+    second_yaw = backend._tracking_aim_rpy[2]
+    assert first_yaw < second_yaw < 0.05
     assert backend.ik_required is True
+    assert backend._tracking_aim is not None
+    aim_yaw = float(R.from_matrix(backend._tracking_aim[:3, :3]).as_euler("xyz")[2])
+    assert aim_yaw == second_yaw
+
+
+def test_step_head_tracking_trims_large_jumps() -> None:
+    """A distant target moves the aim at most max_step per tick (velocity limit)."""
+    backend = _make_backend()
+    backend._tracking_enabled = True
+    backend._tracking_target_rpy = (0.0, 0.0, 1.0)
+
+    backend.step_head_tracking()
+
+    assert backend._tracking_aim_rpy is not None
+    assert backend._tracking_aim_rpy[2] == backend._tracking_max_step_rad
 
 
 def test_tracking_blend_respects_zero_and_full_weight() -> None:
@@ -200,36 +230,37 @@ def test_tracking_face_loss_holds_last_target() -> None:
     """A transient face loss holds the target so the head doesn't lurch to neutral."""
     backend = _make_backend()
     backend._tracking_enabled = True
-    target = np.eye(4, dtype=np.float64)
-    backend._tracking_target_pose = target
-
-    backend.set_tracking_face(
-        center=None,
-        roll=None,
-        width=640,
-        height=480,
-        camera_matrix=np.eye(3, dtype=np.float64),
-        distortion=np.zeros(5, dtype=np.float64),
-        timestamp=10.0,
+    backend._tracking_target_rpy = (0.0, 0.0, 0.4)
+    backend._last_face_seen = time.monotonic()
+    backend._tracker = DummyTracker(
+        target=TrackingTarget(
+            seq=5,
+            detected=False,
+            roll=0.0,
+            pitch=0.0,
+            yaw=0.0,
+            x=None,
+            y=None,
+            face_roll=None,
+        )
     )
 
+    backend.step_head_tracking()
+
     assert backend.get_tracked_face().detected is False
-    assert backend._tracking_target_pose is target
+    assert backend._tracking_target_rpy == (0.0, 0.0, 0.4)
 
 
 def test_tracking_sustained_loss_recenters_to_neutral() -> None:
-    """After the lost timeout the aim target returns to the neutral head pose."""
+    """After the lost timeout the aim target returns to the neutral angles."""
     backend = _make_backend()
     backend._tracking_enabled = True
-    target = np.eye(4, dtype=np.float64)
-    target[:3, :3] = R.from_euler("z", 0.5).as_matrix()
-    backend._tracking_target_pose = target
-    backend._tracking_aim = target.copy()
+    backend._tracking_target_rpy = (0.0, 0.0, 0.5)
     backend._last_face_seen = time.monotonic() - (backend._tracking_lost_timeout + 1.0)
 
     backend.step_head_tracking()
 
-    np.testing.assert_allclose(backend._tracking_target_pose, np.eye(4), atol=1e-9)
+    assert backend._tracking_target_rpy == (0.0, 0.0, 0.0)
 
 
 def test_enable_head_tracking_weight_zero_pauses_without_stopping() -> None:

--- a/tests/unit_tests/test_head_tracking_backend.py
+++ b/tests/unit_tests/test_head_tracking_backend.py
@@ -36,7 +36,7 @@ class DummyTracker:
         self.started = False
         self.stopped = False
         self.active_calls: list[bool] = []
-        self.published_poses: list[tuple[float, float, float]] = []
+        self.published_poses: list[np.ndarray] = []
         self.target = target
 
     def start(self, camera_specs: object) -> None:
@@ -47,9 +47,9 @@ class DummyTracker:
         """Record pause/resume toggles."""
         self.active_calls.append(active)
 
-    def publish_head_pose(self, roll: float, pitch: float, yaw: float) -> None:
-        """Record the head pose shared with the detector."""
-        self.published_poses.append((roll, pitch, yaw))
+    def publish_head_pose(self, rotation: np.ndarray) -> None:
+        """Record the head orientation shared with the detector."""
+        self.published_poses.append(np.array(rotation))
 
     def latest(self) -> TrackingTarget | None:
         """Report the canned target."""
@@ -70,9 +70,7 @@ def _detected_target(seq: int = 1, yaw: float = 0.0) -> TrackingTarget:
     return TrackingTarget(
         seq=seq,
         detected=True,
-        roll=0.0,
-        pitch=0.0,
-        yaw=yaw,
+        rotation=R.from_euler("z", yaw).as_matrix(),
         x=0.25,
         y=-0.5,
         face_roll=0.1,
@@ -137,7 +135,7 @@ def test_get_tracked_face_command_returns_latest_face() -> None:
 
 
 def test_step_head_tracking_publishes_head_pose_to_detector() -> None:
-    """Each tracking step shares the current head angles with the detector."""
+    """Each tracking step shares the current head orientation with the detector."""
     backend = _make_backend()
     backend._tracking_enabled = True
     tracker = DummyTracker()
@@ -145,7 +143,8 @@ def test_step_head_tracking_publishes_head_pose_to_detector() -> None:
 
     backend.step_head_tracking()
 
-    assert tracker.published_poses == [(0.0, 0.0, 0.0)]
+    assert len(tracker.published_poses) == 1
+    np.testing.assert_array_equal(tracker.published_poses[0], np.eye(3))
 
 
 def test_step_head_tracking_servos_toward_target_angles() -> None:
@@ -236,9 +235,7 @@ def test_tracking_face_loss_holds_last_target() -> None:
         target=TrackingTarget(
             seq=5,
             detected=False,
-            roll=0.0,
-            pitch=0.0,
-            yaw=0.0,
+            rotation=np.eye(3),
             x=None,
             y=None,
             face_roll=None,
@@ -280,23 +277,15 @@ def test_enable_head_tracking_weight_zero_pauses_without_stopping() -> None:
 
 
 def test_tracking_aim_pitches_down_by_the_trim() -> None:
-    """A face at the image center aims 15 degrees below the camera axis."""
+    """A detector target looking straight ahead becomes a 15 degree look-down."""
     backend = _make_backend()
     backend._tracking_enabled = True
-    backend.set_tracking_face(
-        center=(0.0, 0.0),  # principal point for this camera matrix
-        roll=0.0,
-        width=641,
-        height=481,
-        camera_matrix=np.array(
-            [[640.0, 0.0, 320.0], [0.0, 640.0, 240.0], [0.0, 0.0, 1.0]],
-            dtype=np.float64,
-        ),
-        distortion=np.zeros(5, dtype=np.float64),
-        timestamp=1.0,
-    )
+    backend._tracker = DummyTracker(target=_detected_target(yaw=0.2))
 
-    assert backend._tracking_target_pose is not None
-    _, pitch, yaw = R.from_matrix(backend._tracking_target_pose[:3, :3]).as_euler("xyz")
-    assert abs(pitch - np.radians(15.0)) < 1e-6
-    assert abs(yaw) < 1e-6
+    backend.step_head_tracking()
+
+    assert backend._tracking_target_rpy is not None
+    roll, pitch, yaw = backend._tracking_target_rpy
+    assert abs(roll) < 1e-9
+    assert abs(pitch - np.radians(15.0)) < 1e-9
+    assert abs(yaw - 0.2) < 1e-9


### PR DESCRIPTION
## Issue

Face tracking runs inside the daemon: the YuNet detector is a thread of the daemon process (#1177), and every observation is turned into a target pose and eased inside the 50 Hz control loop. Both costs scale with the camera feed rate. The local IPC feed is capped at 10 fps today, but that cap is on its way to becoming configurable (#1241, #1263), and at 30 fps the detector doubles the daemon's CPU and pushes control-loop ticks past budget (numbers below). #1288 is an earlier attempt at the rate part. On top of that, users see the head overshoot and correct on fast swings (#1331, #1396).

## Description

Same tracking behaviour, different plumbing, plus the overshoot fix:

1. **Detection-rate cap** in the detector's pull loop (`_DETECTION_FPS = 10`, wall-clock gate, applied before the frame copy and the inference). Not a GStreamer `videorate`: buffers cross the unixfd socket with PTS 0 on the robot, so timestamp-based dropping passes one frame and then drops everything. The pipeline bus is drained for errors so a lost feed is logged and retried instead of the tracker silently pulling `None`.
2. **Constant-cost control-loop step.** The detector turns the face pixel into the absolute head orientation that looks at it (using the head orientation the daemon shares through a latest-value mailbox) and publishes a 3x3 rotation into a fixed-size slot: no queue, no timestamps, no rotation library in the detector. `step_head_tracking` converts it once, adds the #1399 gaze trim, and servos `aim += clip(p * error, +/-max_step)` per tick: one pose build and one IK regardless of detection rate. Re-applying a stale absolute target converges and stops, which is what makes the timestamp-free exchange safe.
3. **Overshoot fix** (last commit). A target is "head orientation now + face offset in a ~150 ms old frame", so while the head swings the offset is stale and every fresh target lands past the face. Fresh targets are adopted only once the aim is within 1.5 degrees of the previous one, the velocity cap drops from ~90 to ~60 deg/s, and the detector samples the head orientation when the frame arrives rather than after inference.

The detector stays a nice(19) daemon thread, as on main. An earlier revision of this branch ran it in a child process; `multiprocessing` `spawn` re-imports the daemon entry module in the child (5.6 s on the CM4), so enabling tracking took 6 to 7 s instead of 0.2 s, and the measurements below show the cap and the servo carry the gain on their own.

Behaviour otherwise: `p = 0.15` per tick is main's easing constant; main's image-space smoother is gone (slightly less lag). The 15 degree look-down trim from #1399 is unchanged. No public API or daemon route changes. The "when should the robot look at you during a conversation" policy is deliberately not here; it lives on `feat/face-tracking-modes`, stacked on this branch.

## Testing

Unit: `tests/unit_tests/test_face_tracking.py` (rate gate, worker geometry, thread lifecycle, mailbox round trip) and `tests/unit_tests/test_head_tracking_backend.py` (servo, velocity cap, settle gate, loss handling, trim). ruff, mypy and the CI pytest selection pass.

Wireless robot (CM4), no face in frame, tracking enabled, 30 one-second samples of `max_control_loop_interval` from `/api/daemon/status` (the daemon resets it every second, so each sample is that second's worst tick; period 20 ms). `spikes` counts seconds whose worst tick exceeded 25 ms. 30 fps obtained by setting `IPC_FPS = 30` in the installed `media_server.py`.

| daemon | IPC feed | p90 | worst | spikes | daemon CPU | enable -> first detector output |
|---|---|---|---|---|---|---|
| main | 10 fps | 25.6 | 27.0 | 5/30 | 93% | 0.2 s |
| main | 30 fps | 30.4 | 30.9 | 11/30 | 188% | |
| this branch | 10 fps | 25.8 | 27.8 | 5/30 | 93% | 0.2 s |
| this branch | 30 fps | 26.4 | 32.2 | 5/30 | 108% | |
| detector in a child process (previous revision) | 10 fps | 24.9 | 27.0 | 2/30 | 57% + 37% child | 6.4 to 7.0 s |
| detector in a child process (previous revision) | 30 fps | 23.5 | 31.9 | 2/30 | 60% + 49% child | |

Idle (tracking off) is identical for all: p90 22 to 23 ms, no spikes.

Still to do: a behavioural A/B with a person in frame (same head movements, main vs this branch).

## Tested on

- [x] Reachy Mini Wireless
- [ ] Reachy Mini Lite
- [ ] MuJoCo simulation (`--sim`)
- [ ] Mockup simulation (`--mockup-sim`)
- [ ] Not applicable (e.g. docs, typo)

## AI assistance

- [ ] No AI involvement
- [ ] AI helped with wording or boilerplate
- [x] AI wrote code here, and I ran and reviewed it
- [ ] An agent produced this PR, and I have not run it myself
