### PR TITLE
docs: document the Reachy Mini Flasher app on the reflash page

### DIFF
--- a/docs/assets/flasher-found.png
+++ b/docs/assets/flasher-found.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3731adedb972356a78291565239d47b404b4622a14ac4cdb99aed1ebc12518af
+size 72407

--- a/docs/assets/flasher-progress.png
+++ b/docs/assets/flasher-progress.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aeefba3ab11efa94dc46dc0c6c319b1f9b1b8f467e704d3116d96e3d8a714a19
+size 58556

--- a/docs/assets/flasher-switch.png
+++ b/docs/assets/flasher-switch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:beee53d71794f094cfdd3a1874f102d57672ddcc2d02f35303d4f8b09c875972
+size 143942

--- a/docs/assets/flasher-welcome.png
+++ b/docs/assets/flasher-welcome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b67bcfc4559d85098088d352e4e70171ab9cbc5479a40355f3bcd110cf4dff33
+size 148765

--- a/docs/source/platforms/reachy_mini/reflash_the_rpi_ISO.md
+++ b/docs/source/platforms/reachy_mini/reflash_the_rpi_ISO.md
@@ -9,6 +9,36 @@
 
 ---
 
+## The easy way: the Reachy Mini Flasher app (macOS / Windows)
+
+On macOS and Windows, the [**Reachy Mini Flasher**](https://github.com/pollen-robotics/reachy_mini_flasher) does everything described on this page for you: it downloads the latest OS image, runs `rpiboot` to expose the CM4 eMMC (installing the USB driver first, on Windows), and writes the image to it.
+
+Download the latest build for your system from the [releases page](https://github.com/pollen-robotics/reachy_mini_flasher/releases/latest) — a `.dmg` on macOS, a `.msi` or `.exe` installer on Windows — and open it.
+
+> [!TIP]
+> The installers are unsigned, so your system warns you the first time: on macOS, right-click the app and choose **Open**; on Windows, click **More info** then **Run anyway** in the SmartScreen dialog.
+
+![Flasher welcome screen](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/flasher-welcome.png)
+
+The app walks you through the hardware steps (open the head, set **SW1** to **DOWNLOAD**, plug **USB2**, power on):
+
+![Flasher connect step](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/flasher-switch.png)
+
+Once the robot is in download mode, it shows up in the app. Select it and continue:
+
+![Reachy detected by the flasher](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/flasher-found.png)
+
+Your system asks for permission (raw disk writes need admin rights: an administrator password on macOS, a UAC prompt on Windows), then the image is written. Keep the robot plugged in until it finishes:
+
+![Flashing progress](https://github.com/pollen-robotics/reachy_mini/raw/main/docs/assets/flasher-progress.png)
+
+The app then guides you through restoring the normal boot mode (switch back to **DEBUG**, unplug USB, close the head).
+
+> [!NOTE]
+> There is no Linux build. On Linux, follow the manual procedure below — which is also what the app automates, if you'd rather do it by hand.
+
+---
+
 ## Download the OS image (and bmap)
 
 First, download the latest OS image and `.bmap` file from:  


### PR DESCRIPTION
## Problem

The reflash page only documented the manual procedure: install `rpiboot`, run it
by hand, then write the image with `bmaptool` or Raspberry Pi Imager. The
[Reachy Mini Flasher](https://github.com/pollen-robotics/reachy_mini_flasher)
does all of that for you on macOS and Windows, and nothing in the docs pointed at
it.

## Solution

Add the app as the first option on that page, with screenshots of the four steps
that matter (welcome, the SW1/DOWNLOAD hardware step, detection, flashing), plus
a note about the first-run warning on unsigned installers. The manual procedure
stays below, unchanged, for Linux and for anyone who prefers it by hand.

Screenshots are from flasher v0.2.4/v0.3.0, taken at the app's own window size.

Fixes #1410
