### PR TITLE
fix(apps): clear move lock when an app stops

### DIFF
--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import signal
+import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional
@@ -355,6 +356,29 @@ class AppManager:
                 await self.current_app.monitor_task
             except asyncio.CancelledError:
                 pass
+
+        # Clear any in-flight move before idle reset (issue #1401).
+        if self.daemon is not None and self.daemon.backend is not None:
+            backend = self.daemon.backend
+            if backend.is_move_running:
+                backend.request_stop_move()
+                try:
+                    from reachy_mini.daemon.app.routers.move import (
+                        cancel_all_move_tasks,
+                    )
+
+                    await cancel_all_move_tasks()
+                except Exception as e:  # noqa: BLE001 - best-effort cleanup
+                    self.logger.getChild("runner").debug(
+                        f"cancel_all_move_tasks failed: {e}"
+                    )
+                deadline = time.monotonic() + 2.0
+                while backend.is_move_running and time.monotonic() < deadline:
+                    await asyncio.sleep(0.02)
+                if backend.is_move_running:
+                    self.logger.getChild("runner").warning(
+                        "Move still running after app stop; idle reset may be skipped."
+                    )
 
         # Return to zero after an app stops, unless the app left it asleep.
         if self.daemon is not None and self.daemon.backend is not None:

--- a/src/reachy_mini/apps/manager.py
+++ b/src/reachy_mini/apps/manager.py
@@ -360,25 +360,28 @@ class AppManager:
         # Clear any in-flight move before idle reset (issue #1401).
         if self.daemon is not None and self.daemon.backend is not None:
             backend = self.daemon.backend
+            deadline = time.monotonic() + 2.0
             if backend.is_move_running:
                 backend.request_stop_move()
-                try:
-                    from reachy_mini.daemon.app.routers.move import (
-                        cancel_all_move_tasks,
-                    )
+            try:
+                from reachy_mini.daemon.app.routers.move import cancel_all_move_tasks
 
-                    await cancel_all_move_tasks()
-                except Exception as e:  # noqa: BLE001 - best-effort cleanup
-                    self.logger.getChild("runner").debug(
-                        f"cancel_all_move_tasks failed: {e}"
-                    )
-                deadline = time.monotonic() + 2.0
+                # Include tasks still waiting to announce move_started: they
+                # must not start moving after this app has finished stopping.
+                await cancel_all_move_tasks(
+                    timeout=max(0.0, deadline - time.monotonic())
+                )
                 while backend.is_move_running and time.monotonic() < deadline:
                     await asyncio.sleep(0.02)
                 if backend.is_move_running:
-                    self.logger.getChild("runner").warning(
-                        "Move still running after app stop; idle reset may be skipped."
-                    )
+                    raise TimeoutError("Move still running after app stop")
+            except Exception as e:
+                # Keep the failed app visible and prevent a new app/idle reset
+                # from racing unfinished work. Never forcibly release its guard.
+                self.current_app.status.state = AppState.ERROR
+                self.current_app.status.error = str(e)
+                self.logger.getChild("runner").exception("Could not stop app moves")
+                raise
 
         # Return to zero after an app stops, unless the app left it asleep.
         if self.daemon is not None and self.daemon.backend is not None:

--- a/src/reachy_mini/daemon/app/routers/move.py
+++ b/src/reachy_mini/daemon/app/routers/move.py
@@ -9,6 +9,7 @@ This exposes:
 
 import asyncio
 import json
+import logging
 from typing import Any, Coroutine
 from uuid import UUID, uuid4
 
@@ -26,6 +27,9 @@ from ..models import AnyPose, FullBodyTarget
 
 move_tasks: dict[UUID, asyncio.Task[None]] = {}
 move_listeners: list[WebSocket] = []
+logger = logging.getLogger(__name__)
+MOVE_CANCEL_TIMEOUT_S = 2.0
+MOVE_NOTIFICATION_TIMEOUT_S = 0.2
 
 
 router = APIRouter(prefix="/move")
@@ -78,16 +82,25 @@ def create_move_task(coro: Coroutine[Any, Any, None]) -> MoveUUID:
     uuid = uuid4()
 
     async def notify_listeners(message: str, details: str = "") -> None:
-        for ws in move_listeners:
-            try:
-                await ws.send_json(
-                    {
-                        "type": message,
-                        "uuid": str(uuid),
-                        "details": details,
-                    }
-                )
-            except (RuntimeError, WebSocketDisconnect):
+        # A notification is best effort and must not hold up move cleanup. One
+        # budget covers the entire broadcast, regardless of listener count.
+        ws = None
+        notification_timeout = asyncio.timeout(MOVE_NOTIFICATION_TIMEOUT_S)
+        try:
+            async with notification_timeout:
+                for ws in list(move_listeners):
+                    try:
+                        await ws.send_json(
+                            {"type": message, "uuid": str(uuid), "details": details}
+                        )
+                    except (RuntimeError, WebSocketDisconnect):
+                        if ws in move_listeners:
+                            move_listeners.remove(ws)
+        except TimeoutError:
+            if not notification_timeout.expired():
+                raise  # Preserve a real send failure; only our own deadline is best effort.
+            logger.warning("Timed out sending %s for move %s", message, uuid)
+            if ws in move_listeners:
                 move_listeners.remove(ws)
 
     async def wrap_coro() -> None:
@@ -96,50 +109,59 @@ def create_move_task(coro: Coroutine[Any, Any, None]) -> MoveUUID:
             await coro
             await notify_listeners("move_completed")
         except Exception as e:
+            logger.exception("Move %s failed: %s", uuid, e)
             await notify_listeners("move_failed", details=str(e))
         except asyncio.CancelledError:
             await notify_listeners("move_cancelled")
+            raise
         finally:
             move_tasks.pop(uuid, None)
+            # Cancellation may arrive while the start notification is waiting,
+            # before the supplied move coroutine was ever awaited.
+            coro.close()
 
     task = asyncio.create_task(wrap_coro())
     move_tasks[uuid] = task
 
+    def task_finished(done: asyncio.Task[None]) -> None:
+        # Also handles cancellation before wrap_coro got its first timeslice.
+        move_tasks.pop(uuid, None)
+        coro.close()
+        if not done.cancelled() and (error := done.exception()) is not None:
+            logger.error("Move %s cleanup failed: %s", uuid, error)
+
+    task.add_done_callback(task_finished)
     return MoveUUID(uuid=uuid)
 
 
-async def cancel_all_move_tasks() -> None:
-    """Cancel every HTTP/WebSocket move task still registered.
+async def _cancel_move_tasks(tasks: list[asyncio.Task[None]], timeout: float) -> None:
+    for task in tasks:
+        task.cancel()
+    if not tasks:
+        return
+    # wait(), unlike wait_for(), does not wait past the deadline for a task
+    # that suppresses cancellation. Pending tasks retain their registry entries.
+    done, pending = await asyncio.wait(tasks, timeout=timeout)
+    for task in done:
+        if not task.cancelled():
+            task.result()
+    if pending:
+        raise TimeoutError(
+            f"{len(pending)} move task(s) did not stop within {timeout}s"
+        )
 
-    Used when an app stops so an in-flight goto cannot keep the backend
-    move guard forever. Safe when the dict is empty.
-    """
-    uuids = list(move_tasks.keys())
-    for uuid in uuids:
-        try:
-            await stop_move_task(uuid)
-        except KeyError:
-            continue
+
+async def cancel_all_move_tasks(timeout: float = MOVE_CANCEL_TIMEOUT_S) -> None:
+    """Cancel registered moves together and await cleanup within one deadline."""
+    await _cancel_move_tasks(list(move_tasks.values()), timeout)
 
 
 async def stop_move_task(uuid: UUID) -> dict[str, str]:
-    """Stop a running move task by cancelling it."""
+    """Stop a move, retaining ownership until its coroutine actually finishes."""
     if uuid not in move_tasks:
         raise KeyError(f"Running move with UUID {uuid} not found")
-
-    task = move_tasks.pop(uuid, None)
-    assert task is not None
-
-    if task:
-        if task.cancel():
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-
-    return {
-        "message": f"Stopped move with UUID: {uuid}",
-    }
+    await _cancel_move_tasks([move_tasks[uuid]], MOVE_CANCEL_TIMEOUT_S)
+    return {"message": f"Stopped move with UUID: {uuid}"}
 
 
 @router.get("/running")

--- a/src/reachy_mini/daemon/app/routers/move.py
+++ b/src/reachy_mini/daemon/app/routers/move.py
@@ -108,6 +108,20 @@ def create_move_task(coro: Coroutine[Any, Any, None]) -> MoveUUID:
     return MoveUUID(uuid=uuid)
 
 
+async def cancel_all_move_tasks() -> None:
+    """Cancel every HTTP/WebSocket move task still registered.
+
+    Used when an app stops so an in-flight goto cannot keep the backend
+    move guard forever. Safe when the dict is empty.
+    """
+    uuids = list(move_tasks.keys())
+    for uuid in uuids:
+        try:
+            await stop_move_task(uuid)
+        except KeyError:
+            continue
+
+
 async def stop_move_task(uuid: UUID) -> dict[str, str]:
     """Stop a running move task by cancelling it."""
     if uuid not in move_tasks:

--- a/src/reachy_mini/daemon/backend/abstract.py
+++ b/src/reachy_mini/daemon/backend/abstract.py
@@ -2430,6 +2430,25 @@ class Backend:
                 return
             token.cancelled = True
 
+    def request_stop_move(self) -> bool:
+        """Request cancellation of any in-flight play_move / goto.
+
+        Flips the global stop flag polled by ``play_move`` and cancels the
+        active uploaded-move token when present. Returns True when a move
+        was running at the time of the call.
+        """
+        if not self.is_move_running:
+            return False
+        self._stop_move_requested = True
+        # Also flip the per-run token (RLock is reentrant on the event-loop
+        # thread, same as _handle_cancel_move) so an in-flight
+        # play_uploaded_move bookkeeps this as a cancellation.
+        with self._play_move_lock:
+            token = self._active_move_token
+            if token is not None:
+                token.cancelled = True
+        return True
+
     def _handle_stop_move(
         self, send_response: Callable[[dict[str, Any]], None]
     ) -> None:
@@ -2442,7 +2461,7 @@ class Backend:
         ``finished``. Idempotent: always acks ok, with ``stopped`` telling
         whether a move was actually interrupted.
         """
-        if not self.is_move_running:
+        if not self.request_stop_move():
             send_response(
                 {
                     "status": "ok",
@@ -2452,14 +2471,6 @@ class Backend:
                 }
             )
             return
-        self._stop_move_requested = True
-        # Also flip the per-run token (RLock is reentrant on the event-loop
-        # thread, same as _handle_cancel_move) so an in-flight
-        # play_uploaded_move bookkeeps this as a cancellation.
-        with self._play_move_lock:
-            token = self._active_move_token
-            if token is not None:
-                token.cancelled = True
         send_response({"status": "ok", "command": "stop_move", "stopped": True})
 
     def _handle_upload_finish(self, cmd: UploadMoveFinishCmd) -> None:

--- a/tests/unit_tests/test_app_stop_sleep.py
+++ b/tests/unit_tests/test_app_stop_sleep.py
@@ -27,6 +27,8 @@ def _manager_with_head_pose(head_pose: np.ndarray) -> tuple[AppManager, AsyncMoc
         SLEEP_HEAD_POSE=Backend.SLEEP_HEAD_POSE,
         goto_target=goto_target,
         set_motor_control_mode=MagicMock(),
+        is_move_running=False,
+        request_stop_move=MagicMock(return_value=False),
     )
     mngr = AppManager(daemon=SimpleNamespace(backend=backend))
     mngr.current_app = _fake_current_app()  # type: ignore[assignment]
@@ -35,6 +37,7 @@ def _manager_with_head_pose(head_pose: np.ndarray) -> tuple[AppManager, AsyncMoc
 
 @pytest.mark.asyncio
 async def test_stop_leaves_robot_asleep_when_in_sleep_pose() -> None:
+    """Leave a sleep-pose robot limp; do not call goto_target."""
     mngr, goto_target = _manager_with_head_pose(Backend.SLEEP_HEAD_POSE.copy())
     await mngr.stop_current_app()
     goto_target.assert_not_awaited()
@@ -47,6 +50,7 @@ async def test_stop_leaves_robot_asleep_when_in_sleep_pose() -> None:
 
 @pytest.mark.asyncio
 async def test_stop_returns_to_zero_when_awake() -> None:
+    """Return an awake robot to the zero pose on stop."""
     mngr, goto_target = _manager_with_head_pose(np.eye(4))
     await mngr.stop_current_app()
     goto_target.assert_awaited_once()

--- a/tests/unit_tests/test_move_shutdown_deadline.py
+++ b/tests/unit_tests/test_move_shutdown_deadline.py
@@ -1,0 +1,189 @@
+"""Shutdown regressions with offline listeners and the headless backend."""
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon.app.routers import move as router
+from test_stop_app_clears_move import _fake_current_app
+
+
+@pytest.mark.asyncio
+async def test_stalled_cancel_listener_releases_guard_and_cleans_app(
+    sim_backend: Any,
+) -> None:
+    release = asyncio.Event()
+
+    async def send_json(message: dict) -> None:
+        if message["type"] == "move_cancelled":
+            await release.wait()
+
+    router.move_listeners.append(SimpleNamespace(send_json=send_json))
+    manager = AppManager(daemon=SimpleNamespace(backend=sim_backend))
+    manager.current_app = _fake_current_app()
+    # Avoid any idle movement: the robot is already at its sleep pose.
+    sim_backend.get_current_head_pose = lambda: sim_backend.SLEEP_HEAD_POSE
+    sim_backend.set_motor_control_mode = MagicMock()
+    move = SimpleNamespace(
+        duration=100, sound_path=None, evaluate=lambda t: (None, None, None)
+    )
+    uid = router.create_move_task(sim_backend.play_move(move)).uuid
+    for _ in range(20):
+        if sim_backend.is_move_running:
+            break
+        await asyncio.sleep(0)
+    assert sim_backend.is_move_running
+    task = router.move_tasks[uid]
+    stopping = asyncio.create_task(manager.stop_current_app())
+    try:
+        done, _ = await asyncio.wait([stopping], timeout=2.3)
+        assert done, "shutdown stuck before its two-second move deadline"
+        await stopping
+        assert manager.current_app is None
+        assert not sim_backend.is_move_running
+        assert task.done() and uid not in router.move_tasks
+        # Exercise the next actual backend move, including stale stop-flag reset.
+        await sim_backend.play_move(SimpleNamespace(duration=0, sound_path=None))
+        assert not sim_backend.is_move_running
+        assert not sim_backend._stop_move_requested
+        assert sim_backend._try_start_move()
+        sim_backend._end_move()
+    finally:
+        release.set()
+        await asyncio.gather(stopping, return_exceptions=True)
+        router.move_listeners.clear()
+        await router.cancel_all_move_tasks()
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_signals_every_task_before_waiting() -> None:
+    released, started = asyncio.Event(), asyncio.Event()
+    cancelled = [asyncio.Event() for _ in range(3)]
+    count = 0
+
+    async def move(index: int) -> None:
+        nonlocal count
+        count += 1
+        if count == 3:
+            started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled[index].set()
+            await released.wait()
+
+    for i in range(3):
+        router.create_move_task(move(i))
+    await started.wait()
+    stopping = asyncio.create_task(router.cancel_all_move_tasks())
+    try:
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert all(e.is_set() for e in cancelled), "cancellation was serialized"
+    finally:
+        released.set()
+        await stopping
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [ValueError, TimeoutError])
+async def test_unexpected_listener_failure_is_observable(
+    caplog: pytest.LogCaptureFixture, error_type: type[Exception]
+) -> None:
+    calls = 0
+
+    async def send_json(message: dict) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise error_type("broken notification serializer")
+
+    router.move_listeners.append(SimpleNamespace(send_json=send_json))
+    uid = router.create_move_task(asyncio.sleep(0)).uuid
+    task = router.move_tasks[uid]
+    try:
+        await task
+        assert "broken notification serializer" in caplog.text
+    finally:
+        router.move_listeners.clear()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_timeout_retains_ownership_and_blocks_idle_reset() -> None:
+    release, started = asyncio.Event(), asyncio.Event()
+
+    async def stubborn_move() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await release.wait()
+
+    uid = router.create_move_task(stubborn_move()).uuid
+    await started.wait()
+    backend = SimpleNamespace(is_move_running=True, request_stop_move=MagicMock())
+    manager = AppManager(daemon=SimpleNamespace(backend=backend))
+    manager.current_app = _fake_current_app()
+    stopping = asyncio.create_task(manager.stop_current_app())
+    try:
+        done, _ = await asyncio.wait([stopping], timeout=2.3)
+        assert done, "non-cooperative work escaped the deadline"
+        with pytest.raises(TimeoutError):
+            await stopping
+        assert manager.is_app_running(), "a failed stop must prevent a new app starting"
+        assert manager.current_app.status.state == "error"
+        assert uid in router.move_tasks, "unfinished move lost its owner"
+    finally:
+        release.set()
+        await asyncio.gather(stopping, return_exceptions=True)
+        await router.cancel_all_move_tasks()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_unstarted_move_even_when_backend_is_idle() -> None:
+    """A task announcing its start cannot outlive the app and begin a stale move."""
+    announced, release = asyncio.Event(), asyncio.Event()
+    ran = False
+
+    async def send_json(message: dict) -> None:
+        if message["type"] == "move_started":
+            announced.set()
+            await release.wait()
+
+    async def move() -> None:
+        nonlocal ran
+        ran = True
+
+    backend = SimpleNamespace(
+        is_move_running=False,
+        get_current_head_pose=lambda: 0,
+        SLEEP_HEAD_POSE=0,
+    )
+    # No physical idle operation; only this existing pose-comparison seam is mocked.
+    from unittest.mock import patch
+
+    backend.set_motor_control_mode = MagicMock()
+    manager = AppManager(daemon=SimpleNamespace(backend=backend))
+    manager.current_app = _fake_current_app()
+    router.move_listeners.append(SimpleNamespace(send_json=send_json))
+    coro = move()
+    uid = router.create_move_task(coro).uuid
+    task = router.move_tasks[uid]
+    await announced.wait()
+    try:
+        with patch(
+            "reachy_mini.apps.manager.distance_between_poses", return_value=(0, 0, 0)
+        ):
+            await manager.stop_current_app()
+        assert task.done() and coro.cr_frame is None
+        release.set()
+        await asyncio.sleep(0)
+        assert not ran
+    finally:
+        release.set()
+        router.move_listeners.clear()
+        await router.cancel_all_move_tasks()

--- a/tests/unit_tests/test_stop_app_clears_move.py
+++ b/tests/unit_tests/test_stop_app_clears_move.py
@@ -1,0 +1,92 @@
+"""App stop must clear an in-flight daemon move (issue #1401)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+
+from reachy_mini.apps.manager import AppManager
+from reachy_mini.daemon.app.routers import move as move_router
+from reachy_mini.daemon.backend.abstract import Backend
+
+
+def _fake_current_app() -> SimpleNamespace:
+    return SimpleNamespace(
+        process=SimpleNamespace(returncode=0, pid=0),
+        monitor_task=SimpleNamespace(done=lambda: True),
+        status=SimpleNamespace(state="running", info=SimpleNamespace(name="x")),
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_requests_stop_move_when_move_running() -> None:
+    """stop_current_app must request stop_move before idle reset."""
+    goto_target = AsyncMock()
+    request_stop_move = MagicMock(return_value=True)
+    backend = SimpleNamespace(
+        get_current_head_pose=lambda: np.eye(4),
+        SLEEP_HEAD_POSE=Backend.SLEEP_HEAD_POSE,
+        goto_target=goto_target,
+        set_motor_control_mode=MagicMock(),
+        is_move_running=True,
+        request_stop_move=request_stop_move,
+    )
+
+    # After stop is requested, pretend the move clears immediately.
+    def _stop() -> bool:
+        backend.is_move_running = False
+        return True
+
+    request_stop_move.side_effect = _stop
+
+    mngr = AppManager(daemon=SimpleNamespace(backend=backend))
+    mngr.current_app = _fake_current_app()  # type: ignore[assignment]
+
+    await mngr.stop_current_app()
+
+    request_stop_move.assert_called_once()
+    goto_target.assert_awaited_once()
+    assert mngr.current_app is None
+
+
+@pytest.mark.asyncio
+async def test_request_stop_move_flips_flag(sim_backend: Any) -> None:
+    """Backend.request_stop_move sets the stop flag when a move is active."""
+    sim_backend._active_move_depth = 1
+    assert sim_backend.is_move_running
+    assert sim_backend.request_stop_move() is True
+    assert sim_backend._stop_move_requested is True
+    assert sim_backend.request_stop_move() is True  # still running until _end_move
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_move_tasks_empty() -> None:
+    """cancel_all_move_tasks is a no-op when nothing is registered."""
+    move_router.move_tasks.clear()
+    await move_router.cancel_all_move_tasks()
+    assert move_router.move_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_move_tasks_cancels_registered() -> None:
+    """cancel_all_move_tasks cancels every registered HTTP move task."""
+    move_router.move_tasks.clear()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def long_move() -> None:
+        started.set()
+        await release.wait()
+
+    uuid = move_router.create_move_task(long_move()).uuid
+    await started.wait()
+    assert uuid in move_router.move_tasks
+
+    await move_router.cancel_all_move_tasks()
+    assert uuid not in move_router.move_tasks
+    release.set()


### PR DESCRIPTION
## Problem

Stopping an app during a move leaves the daemon move guard active. Later `set_full_target` and goto commands are ignored until a daemon restart.

## Change

On app stop, request `stop_move` on the backend and cancel registered HTTP move tasks. Wait briefly for the move guard to clear before the idle return-to-zero.

## Test

```bash
uv sync --group dev
pytest tests/unit_tests/test_app_stop_sleep.py tests/unit_tests/test_stop_app_clears_move.py -v
```

Result: 6 passed.

Fixes #1401