### PR TITLE
fix(media): make WebRTC webrtcbin latency configurable

### DIFF
--- a/src/reachy_mini/media/webrtc_client_gstreamer.py
+++ b/src/reachy_mini/media/webrtc_client_gstreamer.py
@@ -76,22 +76,25 @@ def resolve_webrtcbin_latency_ms(latency_ms: int | None = None) -> int:
     2. ``REACHY_WEBRTC_LATENCY_MS`` environment variable.
     3. ``DEFAULT_WEBRTCBIN_LATENCY_MS`` (10).
     """
-    if latency_ms is not None:
-        if latency_ms < 0:
-            raise ValueError(f"webrtc latency_ms must be >= 0, got {latency_ms}")
-        return latency_ms
-    raw = os.getenv(ENV_WEBRTCBIN_LATENCY_MS)
-    if raw is None or raw.strip() == "":
-        return DEFAULT_WEBRTCBIN_LATENCY_MS
-    try:
-        value = int(raw)
-    except ValueError as e:
-        raise ValueError(
-            f"{ENV_WEBRTCBIN_LATENCY_MS} must be an integer, got {raw!r}"
-        ) from e
-    if value < 0:
-        raise ValueError(f"{ENV_WEBRTCBIN_LATENCY_MS} must be >= 0, got {value}")
-    return value
+    source = "webrtc latency_ms"
+    if latency_ms is None:
+        raw = os.getenv(ENV_WEBRTCBIN_LATENCY_MS)
+        if raw is None or raw.strip() == "":
+            return DEFAULT_WEBRTCBIN_LATENCY_MS
+        source = ENV_WEBRTCBIN_LATENCY_MS
+        try:
+            latency_ms = int(raw)
+        except ValueError as e:
+            raise ValueError(f"{source} must be an integer, got {raw!r}") from e
+    if isinstance(latency_ms, bool) or not isinstance(latency_ms, int):
+        raise ValueError(f"{source} must be an integer, got {latency_ms!r}")
+    if latency_ms < 0:
+        raise ValueError(f"{source} must be >= 0, got {latency_ms}")
+    # webrtcbin.latency is a guint. Reject overflow before starting runtime
+    # resources, rather than failing later in the pad-added signal callback.
+    if latency_ms > GLib.MAXUINT:
+        raise ValueError(f"{source} must be <= {GLib.MAXUINT}, got {latency_ms}")
+    return latency_ms
 
 
 class GstWebRTCClient(CameraBase, AudioBase):
@@ -125,7 +128,8 @@ class GstWebRTCClient(CameraBase, AudioBase):
                 with a warning.
             webrtcbin_latency_ms: Jitter-buffer latency for ``webrtcbin`` in
                 milliseconds. When ``None``, uses ``REACHY_WEBRTC_LATENCY_MS``
-                or the default of 10 ms.
+                or the default of 10 ms. Must be an integer in the unsigned
+                32-bit range (0 through 4294967295).
 
         """
         CameraBase.__init__(self, log_level=log_level)
@@ -706,6 +710,10 @@ class GstWebRTCClient(CameraBase, AudioBase):
 
     def __del__(self) -> None:
         """Ensure GStreamer resources are released."""
-        self.cleanup()
-        self._loop.quit()
-        self._bus_record.remove_watch()
+        # Invalid constructor arguments can fail before these resources exist.
+        if getattr(self, "_doa", None) is not None:
+            self.cleanup()
+        if (loop := getattr(self, "_loop", None)) is not None:
+            loop.quit()
+        if (bus := getattr(self, "_bus_record", None)) is not None:
+            bus.remove_watch()

--- a/src/reachy_mini/media/webrtc_client_gstreamer.py
+++ b/src/reachy_mini/media/webrtc_client_gstreamer.py
@@ -64,6 +64,35 @@ gi.require_version("Gst", "1.0")
 gi.require_version("GstApp", "1.0")
 from gi.repository import GLib, GObject, Gst, GstApp  # noqa: E402, F401
 
+DEFAULT_WEBRTCBIN_LATENCY_MS = 10
+ENV_WEBRTCBIN_LATENCY_MS = "REACHY_WEBRTC_LATENCY_MS"
+
+
+def resolve_webrtcbin_latency_ms(latency_ms: int | None = None) -> int:
+    """Return webrtcbin jitter-buffer latency in milliseconds.
+
+    Preference order:
+    1. Explicit ``latency_ms`` argument when provided.
+    2. ``REACHY_WEBRTC_LATENCY_MS`` environment variable.
+    3. ``DEFAULT_WEBRTCBIN_LATENCY_MS`` (10).
+    """
+    if latency_ms is not None:
+        if latency_ms < 0:
+            raise ValueError(f"webrtc latency_ms must be >= 0, got {latency_ms}")
+        return latency_ms
+    raw = os.getenv(ENV_WEBRTCBIN_LATENCY_MS)
+    if raw is None or raw.strip() == "":
+        return DEFAULT_WEBRTCBIN_LATENCY_MS
+    try:
+        value = int(raw)
+    except ValueError as e:
+        raise ValueError(
+            f"{ENV_WEBRTCBIN_LATENCY_MS} must be an integer, got {raw!r}"
+        ) from e
+    if value < 0:
+        raise ValueError(f"{ENV_WEBRTCBIN_LATENCY_MS} must be >= 0, got {value}")
+    return value
+
 
 class GstWebRTCClient(CameraBase, AudioBase):
     """WebRTC client that provides both camera frames and audio.
@@ -82,6 +111,7 @@ class GstWebRTCClient(CameraBase, AudioBase):
         signaling_host: str = "",
         signaling_port: int = 8443,
         camera_specs: Optional[CameraSpecs] = None,
+        webrtcbin_latency_ms: int | None = None,
     ):
         """Initialize the WebRTC client.
 
@@ -93,10 +123,14 @@ class GstWebRTCClient(CameraBase, AudioBase):
             camera_specs: Camera specifications detected by the daemon.
                 When ``None`` falls back to ``ReachyMiniLiteCamSpecs``
                 with a warning.
+            webrtcbin_latency_ms: Jitter-buffer latency for ``webrtcbin`` in
+                milliseconds. When ``None``, uses ``REACHY_WEBRTC_LATENCY_MS``
+                or the default of 10 ms.
 
         """
         CameraBase.__init__(self, log_level=log_level)
         AudioBase.__init__(self, log_level=log_level)
+        self.webrtcbin_latency_ms = resolve_webrtcbin_latency_ms(webrtcbin_latency_ms)
 
         self._loop = GLib.MainLoop()
         self._thread_bus_calls = Thread(target=lambda: self._loop.run(), daemon=True)
@@ -252,7 +286,7 @@ class GstWebRTCClient(CameraBase, AudioBase):
             assert webrtcbin is not None, (
                 "Could not find webrtcbin element in webrtcsrc"
             )
-            webrtcbin.set_property("latency", 10)
+            webrtcbin.set_property("latency", self.webrtcbin_latency_ms)
 
     def _webrtcsrc_pad_added_cb(self, webrtcsrc: Gst.Element, pad: Gst.Pad) -> None:
         self._configure_webrtcbin(webrtcsrc)

--- a/tests/unit_tests/test_webrtc_latency_config.py
+++ b/tests/unit_tests/test_webrtc_latency_config.py
@@ -1,0 +1,48 @@
+"""Unit tests for WebRTC webrtcbin latency configuration (issue #1407)."""
+
+from __future__ import annotations
+
+import pytest
+
+from reachy_mini.media.webrtc_client_gstreamer import (
+    DEFAULT_WEBRTCBIN_LATENCY_MS,
+    ENV_WEBRTCBIN_LATENCY_MS,
+    resolve_webrtcbin_latency_ms,
+)
+
+
+def test_resolve_default_latency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default latency is 10 ms when no arg or env is set."""
+    monkeypatch.delenv(ENV_WEBRTCBIN_LATENCY_MS, raising=False)
+    assert resolve_webrtcbin_latency_ms(None) == DEFAULT_WEBRTCBIN_LATENCY_MS
+    assert DEFAULT_WEBRTCBIN_LATENCY_MS == 10
+
+
+def test_resolve_explicit_latency_overrides_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Constructor argument wins over the environment variable."""
+    monkeypatch.setenv(ENV_WEBRTCBIN_LATENCY_MS, "200")
+    assert resolve_webrtcbin_latency_ms(100) == 100
+
+
+def test_resolve_env_latency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment variable is used when no explicit argument is given."""
+    monkeypatch.setenv(ENV_WEBRTCBIN_LATENCY_MS, "100")
+    assert resolve_webrtcbin_latency_ms(None) == 100
+
+
+def test_resolve_rejects_negative(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Negative latency values are rejected."""
+    with pytest.raises(ValueError, match=">= 0"):
+        resolve_webrtcbin_latency_ms(-1)
+    monkeypatch.setenv(ENV_WEBRTCBIN_LATENCY_MS, "-5")
+    with pytest.raises(ValueError, match=">= 0"):
+        resolve_webrtcbin_latency_ms(None)
+
+
+def test_resolve_rejects_non_integer_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-integer environment values are rejected."""
+    monkeypatch.setenv(ENV_WEBRTCBIN_LATENCY_MS, "abc")
+    with pytest.raises(ValueError, match="integer"):
+        resolve_webrtcbin_latency_ms(None)

--- a/tests/unit_tests/test_webrtc_latency_config.py
+++ b/tests/unit_tests/test_webrtc_latency_config.py
@@ -46,3 +46,17 @@ def test_resolve_rejects_non_integer_env(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setenv(ENV_WEBRTCBIN_LATENCY_MS, "abc")
     with pytest.raises(ValueError, match="integer"):
         resolve_webrtcbin_latency_ms(None)
+
+
+@pytest.mark.parametrize("value", [2**32, 1.5, True, "invalid"])
+def test_resolve_rejects_invalid_explicit_values(value) -> None:
+    """Reject overflow and lossy GObject conversions before runtime startup."""
+    with pytest.raises(ValueError):
+        resolve_webrtcbin_latency_ms(value)
+
+
+def test_resolve_rejects_env_overflow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The environment has the same guint limit as an explicit argument."""
+    monkeypatch.setenv(ENV_WEBRTCBIN_LATENCY_MS, str(2**32))
+    with pytest.raises(ValueError, match="<="):
+        resolve_webrtcbin_latency_ms()

--- a/tests/unit_tests/test_webrtc_latency_runtime.py
+++ b/tests/unit_tests/test_webrtc_latency_runtime.py
@@ -1,0 +1,119 @@
+"""Real webrtcbin configuration, with a local bin replacing remote signaling.
+
+No pipeline enters PLAYING and no capture/network source is used. These tests
+verify configuration and property readback, not live jitter or media quality.
+"""
+
+from typing import Any
+
+import pytest
+
+from reachy_mini.media.webrtc_client_gstreamer import (
+    ENV_WEBRTCBIN_LATENCY_MS,
+    Gst,
+    GstWebRTCClient,
+)
+
+
+pytestmark = pytest.mark.webrtc
+
+
+@pytest.fixture
+def client_factory(monkeypatch: pytest.MonkeyPatch):
+    # AudioBase otherwise probes for a physical ReSpeaker during construction.
+    from reachy_mini.media import audio_doa
+
+    monkeypatch.setattr(audio_doa, "init_respeaker_usb", lambda: None)
+    Gst.init(None)
+    if Gst.ElementFactory.find("webrtcbin") is None:
+        pytest.fail("real webrtcbin plugin is required for this runtime test")
+    clients = []
+
+    def make(latency: Any = None, name: str = "webrtcbin0"):
+        source = Gst.Bin.new("offline_source")
+        element = Gst.ElementFactory.make("webrtcbin", name)
+        assert element is not None
+        source.add(element)
+        # Only signaling and physical USB discovery are replaced. The constructor, GLib loop,
+        # Gst pipeline/appsinks, latency resolver and setter all run normally.
+        monkeypatch.setattr(GstWebRTCClient, "_configure_webrtcsrc", lambda *a: source)
+        client = GstWebRTCClient(webrtcbin_latency_ms=latency)
+        clients.append(client)
+        return client, element
+
+    yield make
+    for client in clients:
+        client.close()
+        client._loop.quit()
+        client._thread_bus_calls.join(timeout=2)
+        assert not client._thread_bus_calls.is_alive()
+        client._bus_record.remove_watch()
+
+
+@pytest.mark.parametrize(
+    "env,explicit,expected",
+    [
+        (None, None, 10),
+        ("", None, 10),
+        ("  ", None, 10),
+        ("100", None, 100),
+        (" 200 ", None, 200),
+        ("200", 0, 0),
+        ("200", 50, 50),
+        ("invalid", 10, 10),
+    ],
+)
+@pytest.mark.parametrize("name", ["webrtcbin0", "alternate_webrtcbin"])
+def test_application_latency_precedence_real_element(
+    monkeypatch, client_factory, env, explicit, expected, name
+):
+    if env is None:
+        monkeypatch.delenv(ENV_WEBRTCBIN_LATENCY_MS, raising=False)
+    else:
+        monkeypatch.setenv(ENV_WEBRTCBIN_LATENCY_MS, env)
+    client, element = client_factory(explicit, name)
+    assert client.webrtcbin_latency_ms == expected
+    assert element.get_property("latency") == 200
+    client._configure_webrtcbin(client._webrtcsrc)
+    assert element.get_property("latency") == expected
+    assert client._pipeline_record.get_state(0).state == Gst.State.NULL
+    print(f"env={env!r} explicit={explicit!r} name={name} readback={expected}")
+
+
+@pytest.mark.parametrize("value", [0, 10, 100, 200, 2**32 - 1])
+def test_real_property_limits_and_supported_values(client_factory, value):
+    client, element = client_factory(value)
+    spec = element.find_property("latency")
+    assert (spec.value_type.name, spec.minimum, spec.maximum, spec.default_value) == (
+        "guint",
+        0,
+        2**32 - 1,
+        200,
+    )
+    client._configure_webrtcbin(client._webrtcsrc)
+    assert element.get_property("latency") == value
+    print(f"supported latency={value} readback={element.get_property('latency')}")
+
+
+@pytest.mark.parametrize("value", [-1, 2**32, 1.5, True, "bad"])
+def test_invalid_explicit_rejected_at_constructor(client_factory, value):
+    with pytest.raises(ValueError):
+        client_factory(value)
+
+
+@pytest.mark.parametrize("value", ["-1", str(2**32), "1.5", "bad"])
+def test_invalid_env_rejected_at_constructor(monkeypatch, client_factory, value):
+    monkeypatch.setenv(ENV_WEBRTCBIN_LATENCY_MS, value)
+    with pytest.raises(ValueError):
+        client_factory()
+
+
+def test_invalid_constructor_can_be_finalized(monkeypatch):
+    from reachy_mini.media import audio_doa
+
+    monkeypatch.setattr(audio_doa, "init_respeaker_usb", lambda: None)
+    client = GstWebRTCClient.__new__(GstWebRTCClient)
+    with pytest.raises(ValueError):
+        client.__init__(webrtcbin_latency_ms=-1)
+    # Python also invokes __del__ when __init__ raises, before _loop exists.
+    client.__del__()


### PR DESCRIPTION
## Problem

`GstWebRTCClient` hard-codes `webrtcbin` latency to 10 ms. On some wireless links the video smears between keyframes.

## Change

Accept `webrtcbin_latency_ms` on the client, or `REACHY_WEBRTC_LATENCY_MS`. Keep the default at 10 ms.

## Test

```bash
pytest tests/unit_tests/test_webrtc_latency_config.py -v
```

Result: 5 passed.

Fixes #1407